### PR TITLE
Dogfood fixes: terminal, Hermes health/lifecycle/detection, honest update, updateAvailable semver

### DIFF
--- a/.github/workflows/release-node-agent.yml
+++ b/.github/workflows/release-node-agent.yml
@@ -18,6 +18,10 @@ jobs:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest
     strategy:
+      # Don't let one arch's transient runner failure cancel the others and skip
+      # the dependent SHA256SUMS/static-asset jobs (which produced an incomplete
+      # release on v0.1.7, needing a manual `gh run rerun --failed`).
+      fail-fast: false
       matrix:
         include:
           - goos: linux

--- a/apps/hub/src/services/agent-version.ts
+++ b/apps/hub/src/services/agent-version.ts
@@ -68,3 +68,26 @@ export async function getLatestAgentVersion(
     return _cache.value;
   }
 }
+
+/**
+ * Return true iff `latest` is a STRICTLY newer version than `current`.
+ *
+ * Versions are "vMAJOR.MINOR.PATCH" (leading "v" optional). Anything that does
+ * not parse (e.g. "unknown", null) yields false. Using a real ordering — rather
+ * than plain inequality — means a stale/older cached "latest" never produces a
+ * spurious "update available" (which would read as a downgrade in the UI).
+ */
+export function isNewerVersion(latest: string, current: string): boolean {
+  const parse = (v: string): [number, number, number] | null => {
+    const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(v.trim());
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const a = parse(latest);
+  const b = parse(current);
+  if (!a || !b) return false;
+  // Compare major, then minor, then patch. Literal tuple indices keep each
+  // element typed as a definite number (no noUncheckedIndexedAccess widening).
+  if (a[0] !== b[0]) return a[0] > b[0];
+  if (a[1] !== b[1]) return a[1] > b[1];
+  return a[2] > b[2];
+}

--- a/apps/hub/src/services/node-registry.test.ts
+++ b/apps/hub/src/services/node-registry.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit test: annotateWithVersion updateAvailable logic.
+ *
+ * Pure function — no DB. DATABASE_URL is set defensively because importing
+ * node-registry pulls in db/drizzle (which builds a lazy postgres client but
+ * does not connect at import).
+ */
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect } from "bun:test";
+import { annotateWithVersion } from "./node-registry";
+
+test("updateAvailable is true only when the node is BEHIND the latest version", () => {
+  const rows = [
+    { agentVersion: "v0.1.7" }, // behind v0.1.9 → update available
+    { agentVersion: "v0.1.9" }, // equal → no update
+    { agentVersion: "v0.2.0" }, // AHEAD of a stale cached latest → NOT a downgrade prompt
+    { agentVersion: null }, // unknown → no update
+  ];
+
+  const out = annotateWithVersion(rows, "v0.1.9");
+
+  expect(out.map((n) => n.updateAvailable)).toEqual([true, false, false, false]);
+  // latestVersion is still surfaced on every row.
+  expect(out.every((n) => n.latestVersion === "v0.1.9")).toBe(true);
+});
+
+test("updateAvailable is false when latestVersion is unknown (null)", () => {
+  const out = annotateWithVersion([{ agentVersion: "v0.1.7" }], null);
+  expect(out.map((n) => n.updateAvailable)).toEqual([false]);
+});
+
+test("version ordering is numeric, not lexical (v0.1.10 is newer than v0.1.9)", () => {
+  const out = annotateWithVersion([{ agentVersion: "v0.1.9" }], "v0.1.10");
+  expect(out.map((n) => n.updateAvailable)).toEqual([true]);
+});

--- a/apps/hub/src/services/node-registry.ts
+++ b/apps/hub/src/services/node-registry.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { nodes, provisionedRuntimes } from "../db/schema/nodes";
 import type { NodeSummary } from "@agentpod/contract";
-import { getLatestAgentVersion } from "./agent-version";
+import { getLatestAgentVersion, isNewerVersion } from "./agent-version";
 
 export type NodeWithProvisioning = NodeSummary & {
   provisioned: { runtimeId: string; provider: string } | null;
@@ -26,7 +26,7 @@ export function annotateWithVersion<
     updateAvailable:
       n.agentVersion != null &&
       latestVersion != null &&
-      n.agentVersion !== latestVersion,
+      isNewerVersion(latestVersion, n.agentVersion),
   }));
 }
 

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -150,6 +150,17 @@ func (h *hermesDescriptor) Health(key string) (Health, error) {
 	// Best-effort process check via pgrep.
 	health.Running, _ = hermesProcessRunning(key)
 
+	// Live process metrics: best-effort — when the profile is running, resolve
+	// its PID and gather CPU/memory/uptime. Hermes runs a separate process per
+	// profile, so these are honest PER-AGENT numbers. Any failure leaves the
+	// metric fields nil; Health() never fails on a ps hiccup.
+	if health.Running {
+		if pid, err := hermesPID(key); err == nil {
+			health.PID = &pid
+			health.CpuPct, health.MemBytes, health.UptimeSec = gatherPidMetrics(pid)
+		}
+	}
+
 	return health, nil
 }
 

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -257,13 +257,33 @@ func (h *hermesDescriptor) Start(key string) error {
 	if hermesUnitKnown(unit) {
 		return exec.Command("systemctl", "--user", "start", unit).Run()
 	}
-	// Fallback: run the configured start command.
-	if h.startCmd == "" {
-		return fmt.Errorf("no start command configured for hermes (set hermesStartCmd in node config)")
+	// An operator-configured start command takes precedence over the native
+	// fallback (it can encode a site-specific launcher).
+	if h.startCmd != "" {
+		cmd := exec.Command("sh", "-c", h.startCmd)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		return cmd.Start()
 	}
-	cmd := exec.Command("sh", "-c", h.startCmd)
+	// Native fallback: launch the profile gateway the way the Hermes supervisor
+	// does — `hermes -p <name> gateway run --replace` — detached so it outlives
+	// the node-agent. This covers process-tree (non-systemd, e.g. root) Hermes
+	// deployments where no unit exists and no startCmd is configured; without it
+	// a restart would Stop the profile and then fail to Start it. The `-p <name>`
+	// form keeps the launched process matchable by hermesPattern(), which
+	// Health/Stop rely on via pgrep.
+	cmd := exec.Command("hermes", hermesNativeStartArgs(key)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	return cmd.Start()
+}
+
+// hermesNativeStartArgs builds the argv (after the `hermes` binary) to launch a
+// profile gateway natively. For the root key it omits the profile selector.
+func hermesNativeStartArgs(key string) []string {
+	if key == "hermes" {
+		return []string{"gateway", "run", "--replace"}
+	}
+	name := strings.TrimPrefix(key, "hermes:")
+	return []string{"-p", name, "gateway", "run", "--replace"}
 }
 
 // ListDir lists the directory at rel (relative to the station's workspace).

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -209,11 +209,6 @@ func hermesPattern(key string) string {
 // or an error if no matching process is found.
 func hermesPID(key string) (int, error) {
 	out, err := exec.Command("pgrep", "-f", hermesPattern(key)).Output()
-	if os.Getenv("APN_DIAG") != "" { // TEMP diagnostic
-		af, _ := exec.Command("pgrep", "-af", hermesPattern(key)).Output()
-		fmt.Fprintf(os.Stderr, "DIAG hermesPID key=%q pattern=%q pgrep-out=%q err=%v pgrep-af=%q\n",
-			key, hermesPattern(key), out, err, af)
-	}
 	if err != nil {
 		return 0, fmt.Errorf("no hermes process for key %q", key)
 	}
@@ -309,7 +304,16 @@ func startDetached(name string, args ...string) error {
 	}
 	cmd := exec.Command(name, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Reap the child in the background so a short-lived process does not linger
+	// as a defunct (zombie) entry under the node-agent. The launched gateway is
+	// normally long-lived, so Wait simply blocks harmlessly until it exits; if it
+	// exits promptly (or in tests with a fast stub), this prevents a leaked
+	// zombie — one whose comm can otherwise be matched by pgrep.
+	go func() { _ = cmd.Wait() }()
+	return nil
 }
 
 // hermesNativeStartArgs builds the argv (after the `hermes` binary) to launch a

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -209,6 +209,11 @@ func hermesPattern(key string) string {
 // or an error if no matching process is found.
 func hermesPID(key string) (int, error) {
 	out, err := exec.Command("pgrep", "-f", hermesPattern(key)).Output()
+	if os.Getenv("APN_DIAG") != "" { // TEMP diagnostic
+		af, _ := exec.Command("pgrep", "-af", hermesPattern(key)).Output()
+		fmt.Fprintf(os.Stderr, "DIAG hermesPID key=%q pattern=%q pgrep-out=%q err=%v pgrep-af=%q\n",
+			key, hermesPattern(key), out, err, af)
+	}
 	if err != nil {
 		return 0, fmt.Errorf("no hermes process for key %q", key)
 	}

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -189,13 +189,20 @@ func hermesUnitKnown(unit string) bool {
 	return exec.Command("systemctl", "--user", "cat", unit).Run() == nil
 }
 
-// hermesPattern returns the pgrep pattern for a Hermes station key.
+// hermesPattern returns the pgrep -f (ERE) pattern for a Hermes station key.
+// It matches BOTH profile-gateway invocation forms:
+//
+//	hermes -p <name> gateway ...                       (direct binary, short flag)
+//	... hermes_cli.main --profile <name> gateway ...   (supervisor respawn, long flag)
+//
+// The long form is used when the Hermes main gateway restarts a profile;
+// matching only the short form reported such profiles as stopped while running.
 func hermesPattern(key string) string {
 	if key == "hermes" {
 		return "hermes"
 	}
 	name := strings.TrimPrefix(key, "hermes:")
-	return fmt.Sprintf("hermes -p %s gateway", name)
+	return fmt.Sprintf("(-p|--profile)[ =]%s gateway", name)
 }
 
 // hermesPID returns the PID of the running Hermes process for key,

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -278,7 +278,31 @@ func (h *hermesDescriptor) Start(key string) error {
 	// a restart would Stop the profile and then fail to Start it. The `-p <name>`
 	// form keeps the launched process matchable by hermesPattern(), which
 	// Health/Stop rely on via pgrep.
-	cmd := exec.Command("hermes", hermesNativeStartArgs(key)...)
+	return startDetached("hermes", hermesNativeStartArgs(key)...)
+}
+
+// startDetached launches a background process that must OUTLIVE a node-agent
+// restart. The node-agent's own systemd unit uses KillMode=control-group, so a
+// plain child we fork lives in our cgroup and is SIGKILLed when the node-agent
+// restarts (e.g. self-update). To escape that cgroup we launch via `systemd-run`,
+// which starts the command as a transient systemd service in its own cgroup,
+// reparented to PID 1. On hosts without systemd-run there is no cgroup-kill
+// concern, so we fall back to a plain detached (Setsid) child.
+//
+// The target binary is resolved to an absolute path first: a systemd-run
+// transient service does not inherit our PATH, so a bare name might not resolve.
+func startDetached(name string, args ...string) error {
+	if runner, err := exec.LookPath("systemd-run"); err == nil {
+		bin := name
+		if abs, lpErr := exec.LookPath(name); lpErr == nil {
+			bin = abs
+		}
+		// --collect reaps the transient unit when it exits; --quiet suppresses the
+		// "Running as unit: …" notice.
+		runArgs := append([]string{"--collect", "--quiet", bin}, args...)
+		return exec.Command(runner, runArgs...).Run()
+	}
+	cmd := exec.Command(name, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	return cmd.Start()
 }

--- a/apps/node-agent/internal/descriptor/hermes_health_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_health_test.go
@@ -1,0 +1,67 @@
+package descriptor
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestHermesHealth_PopulatesMetricsWhenRunning proves the Hermes descriptor
+// reports live per-profile process metrics (PID/CPU/Mem/Uptime), not just
+// Running/Disk. Hermes runs a SEPARATE process per profile, so these are honest
+// per-agent numbers (unlike OpenClaw's shared gateway).
+//
+// We stand up a stand-in process whose command line contains the profile's
+// pgrep pattern ("hermes -p <name> gateway") so hermesProcessRunning/hermesPID
+// match it, then assert Health() fills in the metric fields.
+func TestHermesHealth_PopulatesMetricsWhenRunning(t *testing.T) {
+	home := testdataHermesHome(t)
+	d := NewHermes(home)
+
+	// The marker "hermes -p coder-kai gateway" lives inside the -c script (argv),
+	// so pgrep -f matches it. The compound command (`sleep …; true`) keeps the
+	// shell from exec-replacing itself, preserving the marker in the command line.
+	// Setpgid lets cleanup reap the shell AND its sleep child without touching the
+	// test's own process group.
+	proc := exec.Command("/bin/sh", "-c", "sleep 30; true # hermes -p coder-kai gateway")
+	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := proc.Start(); err != nil {
+		t.Fatalf("start stand-in process: %v", err)
+	}
+	t.Cleanup(func() {
+		if proc.Process != nil {
+			if pgid, err := syscall.Getpgid(proc.Process.Pid); err == nil {
+				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			} else {
+				_ = proc.Process.Kill()
+			}
+		}
+		_ = proc.Wait()
+	})
+
+	// Give the OS a moment to make the process visible to pgrep.
+	time.Sleep(150 * time.Millisecond)
+
+	h, err := d.Health("hermes:coder-kai")
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if !h.Running {
+		t.Fatal("expected Running=true with stand-in process alive")
+	}
+	if h.PID == nil {
+		t.Error("expected PID to be populated when running")
+	}
+	if h.CpuPct == nil {
+		t.Error("expected CpuPct to be populated when running")
+	}
+	if h.MemBytes == nil {
+		t.Error("expected MemBytes to be populated when running")
+	} else if *h.MemBytes <= 0 {
+		t.Errorf("MemBytes should be > 0, got %d", *h.MemBytes)
+	}
+	if h.UptimeSec == nil {
+		t.Error("expected UptimeSec to be populated when running")
+	}
+}

--- a/apps/node-agent/internal/descriptor/hermes_health_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_health_test.go
@@ -16,11 +16,15 @@ import (
 func TestHermesProcessRunning_MatchesProfileLongForm(t *testing.T) {
 	name := "tddprof-longform"
 
-	// Stand-in process whose command line carries the long-form marker. The
-	// compound `sleep …; true` keeps the shell alive (no exec-replace) so the
-	// marker stays in argv; Setpgid lets cleanup reap it via the process group.
+	// Stand-in process whose command line carries the long-form marker
+	// (`--profile <name> gateway`). We deliberately OMIT the "hermes"/
+	// "hermes_cli.main" token: the profile pattern does not need it, and
+	// including it would make this fixture match the broad root-key
+	// `pgrep -f "hermes"` used by other lifecycle tests. The compound
+	// `sleep …; true` keeps the shell alive (no exec-replace) so the marker
+	// stays in argv; Setpgid lets cleanup reap it via the process group.
 	proc := exec.Command("/bin/sh", "-c",
-		"sleep 30; true # python -m hermes_cli.main --profile "+name+" gateway run --replace")
+		"sleep 30; true # --profile "+name+" gateway run --replace")
 	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := proc.Start(); err != nil {
 		t.Fatalf("start stand-in process: %v", err)
@@ -55,12 +59,14 @@ func TestHermesHealth_PopulatesMetricsWhenRunning(t *testing.T) {
 	home := testdataHermesHome(t)
 	d := NewHermes(home)
 
-	// The marker "hermes -p coder-kai gateway" lives inside the -c script (argv),
-	// so pgrep -f matches it. The compound command (`sleep …; true`) keeps the
-	// shell from exec-replacing itself, preserving the marker in the command line.
-	// Setpgid lets cleanup reap the shell AND its sleep child without touching the
-	// test's own process group.
-	proc := exec.Command("/bin/sh", "-c", "sleep 30; true # hermes -p coder-kai gateway")
+	// The marker "-p coder-kai gateway" lives inside the -c script (argv), so
+	// pgrep -f matches the profile pattern. We deliberately OMIT the "hermes"
+	// token — it is not needed for the profile pattern, and including it would
+	// make this fixture match the broad root-key `pgrep -f "hermes"` used by
+	// other lifecycle tests (a cross-test collision). The compound command
+	// (`sleep …; true`) keeps the shell from exec-replacing itself, preserving
+	// the marker; Setpgid lets cleanup reap the shell AND its sleep child.
+	proc := exec.Command("/bin/sh", "-c", "sleep 30; true # -p coder-kai gateway run")
 	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := proc.Start(); err != nil {
 		t.Fatalf("start stand-in process: %v", err)

--- a/apps/node-agent/internal/descriptor/hermes_health_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_health_test.go
@@ -7,6 +7,42 @@ import (
 	"time"
 )
 
+// TestHermesProcessRunning_MatchesProfileLongForm proves the process detector
+// recognises a profile launched in the supervisor's LONG form
+// (`... hermes_cli.main --profile <name> gateway ...`), not only the direct
+// `hermes -p <name> gateway` short form. When the Hermes main gateway respawns a
+// profile it uses the long form; before this fix such profiles were reported
+// stopped in the console while actually running (observed live: analyst-echo).
+func TestHermesProcessRunning_MatchesProfileLongForm(t *testing.T) {
+	name := "tddprof-longform"
+
+	// Stand-in process whose command line carries the long-form marker. The
+	// compound `sleep …; true` keeps the shell alive (no exec-replace) so the
+	// marker stays in argv; Setpgid lets cleanup reap it via the process group.
+	proc := exec.Command("/bin/sh", "-c",
+		"sleep 30; true # python -m hermes_cli.main --profile "+name+" gateway run --replace")
+	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := proc.Start(); err != nil {
+		t.Fatalf("start stand-in process: %v", err)
+	}
+	t.Cleanup(func() {
+		if proc.Process != nil {
+			if pgid, err := syscall.Getpgid(proc.Process.Pid); err == nil {
+				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			} else {
+				_ = proc.Process.Kill()
+			}
+		}
+		_ = proc.Wait()
+	})
+	time.Sleep(150 * time.Millisecond)
+
+	running, _ := hermesProcessRunning("hermes:" + name)
+	if !running {
+		t.Errorf("hermesProcessRunning should match the --profile long form for %q", name)
+	}
+}
+
 // TestHermesHealth_PopulatesMetricsWhenRunning proves the Hermes descriptor
 // reports live per-profile process metrics (PID/CPU/Mem/Uptime), not just
 // Running/Disk. Hermes runs a SEPARATE process per profile, so these are honest

--- a/apps/node-agent/internal/descriptor/hermes_lifecycle_systemd_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_lifecycle_systemd_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // writeFakeSystemctl writes an executable shell script named "systemctl" in
@@ -168,20 +169,31 @@ func TestHermesStart_KnownUnit_UsesSystemctl(t *testing.T) {
 	}
 }
 
-// TestHermesStart_AbsentUnit_FallsBackToStartCmd asserts that Start falls back
-// to the configured startCmd when the systemd unit is absent.
+// TestHermesStart_AbsentUnit_FallsBackToStartCmd asserts that, when the systemd
+// unit is absent, a configured startCmd is executed and takes precedence over
+// the native `hermes ... gateway run` fallback.
 func TestHermesStart_AbsentUnit_FallsBackToStartCmd(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeFakeSystemctl(t, tmpDir, false /* unit absent */)
 	prependPath(t, tmpDir)
 
-	// With no startCmd configured, Start must return a descriptive error.
-	h := &hermesDescriptor{home: t.TempDir(), startCmd: ""}
-	err := h.Start("hermes:analyst-echo")
-	if err == nil {
-		t.Fatal("Start with absent unit + no startCmd: expected error, got nil")
+	// With a startCmd configured, Start must run it (not the native fallback).
+	marker := filepath.Join(tmpDir, "startcmd-ran")
+	h := &hermesDescriptor{home: t.TempDir(), startCmd: "touch " + marker}
+	if err := h.Start("hermes:analyst-echo"); err != nil {
+		t.Fatalf("Start with absent unit + startCmd: unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "start command") && !strings.Contains(err.Error(), "startCmd") {
-		t.Errorf("error message should mention start command; got: %v", err)
+
+	// startCmd runs detached (Setsid, not waited on); poll for the marker file.
+	found := false
+	for i := 0; i < 100; i++ {
+		if _, err := os.Stat(marker); err == nil {
+			found = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !found {
+		t.Error("expected the configured startCmd to run when the unit is absent")
 	}
 }

--- a/apps/node-agent/internal/descriptor/hermes_start_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_start_test.go
@@ -1,0 +1,57 @@
+package descriptor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHermesStart_NativeFallbackLaunchesGatewayRun verifies that on a
+// process-tree (non-systemd) Hermes deployment with no configured startCmd,
+// Start falls back to launching the profile the native way —
+// `hermes -p <name> gateway run --replace` — instead of erroring.
+//
+// The `-p <name>` form matters: the launched process must match
+// hermesPattern() so Health/Stop (which pgrep on the same pattern) recognise
+// it. Before this fix, restart (= Stop then Start) killed the profile on root
+// deployments and the failed Start left it down (the 502 + outage seen live).
+func TestHermesStart_NativeFallbackLaunchesGatewayRun(t *testing.T) {
+	home := testdataHermesHome(t)
+	d := NewHermes(home) // no startCmd configured
+
+	// Inject a stub `hermes` on PATH that records its args. On macOS/dev there is
+	// no `systemctl`, so hermesUnitKnown() is false and Start reaches the native
+	// fallback, which resolves `hermes` via PATH to our stub.
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	stub := filepath.Join(dir, "hermes")
+	script := "#!/bin/sh\nprintf '%s ' \"$@\" > " + argsFile + "\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	lc, ok := d.(Lifecycle)
+	if !ok {
+		t.Fatal("hermes descriptor must implement Lifecycle")
+	}
+	if err := lc.Start("hermes:coder-kai"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Start launches detached (Setsid) and does not Wait; poll for the stub args.
+	var got string
+	for i := 0; i < 100; i++ {
+		if b, err := os.ReadFile(argsFile); err == nil && len(b) > 0 {
+			got = strings.TrimSpace(string(b))
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	want := "-p coder-kai gateway run --replace"
+	if got != want {
+		t.Errorf("native start args:\n got %q\nwant %q", got, want)
+	}
+}

--- a/apps/node-agent/internal/descriptor/hermes_start_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_start_test.go
@@ -21,17 +21,14 @@ func TestHermesStart_NativeFallbackLaunchesGatewayRun(t *testing.T) {
 	home := testdataHermesHome(t)
 	d := NewHermes(home) // no startCmd configured
 
-	// Inject a stub `hermes` on PATH that records its args. On macOS/dev there is
-	// no `systemctl`, so hermesUnitKnown() is false and Start reaches the native
-	// fallback, which resolves `hermes` via PATH to our stub.
+	// Inject a stub `hermes` on PATH that records its args. PATH is set to ONLY
+	// the stub dir so `systemd-run` is not found → Start takes the plain-detached
+	// fallback and resolves `hermes` to our stub. (systemctl is likewise absent,
+	// so hermesUnitKnown() is false and Start reaches the native fallback.)
 	dir := t.TempDir()
 	argsFile := filepath.Join(dir, "args.txt")
-	stub := filepath.Join(dir, "hermes")
-	script := "#!/bin/sh\nprintf '%s ' \"$@\" > " + argsFile + "\n"
-	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeRecorderStub(t, filepath.Join(dir, "hermes"), argsFile)
+	t.Setenv("PATH", dir)
 
 	lc, ok := d.(Lifecycle)
 	if !ok {
@@ -54,4 +51,57 @@ func TestHermesStart_NativeFallbackLaunchesGatewayRun(t *testing.T) {
 	if got != want {
 		t.Errorf("native start args:\n got %q\nwant %q", got, want)
 	}
+}
+
+// TestHermesStart_UsesSystemdRunWhenAvailable verifies that when `systemd-run`
+// exists, Start launches the profile through it (a transient systemd service in
+// its OWN cgroup) rather than as a direct child. The node-agent unit runs with
+// KillMode=control-group, so a direct child would be SIGKILLed when the
+// node-agent restarts (e.g. self-update); systemd-run makes the profile survive.
+func TestHermesStart_UsesSystemdRunWhenAvailable(t *testing.T) {
+	home := testdataHermesHome(t)
+	lc := NewHermes(home).(Lifecycle)
+
+	dir := t.TempDir()
+	sysdArgs := filepath.Join(dir, "systemd-run.args")
+	writeRecorderStub(t, filepath.Join(dir, "systemd-run"), sysdArgs)
+	// Stub `hermes` too so the fix can resolve it to an absolute path (systemd-run
+	// transient services do not inherit our PATH).
+	writeRecorderStub(t, filepath.Join(dir, "hermes"), filepath.Join(dir, "hermes.args"))
+	t.Setenv("PATH", dir) // only our stubs — no real systemd-run/hermes
+
+	if err := lc.Start("hermes:coder-kai"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := waitForStubArgs(t, sysdArgs)
+	if !strings.Contains(got, "--collect") {
+		t.Errorf("systemd-run should be invoked with --collect; got %q", got)
+	}
+	if !strings.HasSuffix(got, "hermes -p coder-kai gateway run --replace") {
+		t.Errorf("systemd-run should launch the native gateway command; got %q", got)
+	}
+}
+
+// writeRecorderStub writes an executable stub at path that records its args
+// (space-joined) to argsFile and exits 0.
+func writeRecorderStub(t *testing.T, path, argsFile string) {
+	t.Helper()
+	script := "#!/bin/sh\nprintf '%s ' \"$@\" > " + argsFile + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", path, err)
+	}
+}
+
+// waitForStubArgs polls argsFile (a stub launched detached) until it has content.
+func waitForStubArgs(t *testing.T, argsFile string) string {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		if b, err := os.ReadFile(argsFile); err == nil && len(b) > 0 {
+			return strings.TrimSpace(string(b))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("stub did not record args to %s", argsFile)
+	return ""
 }

--- a/apps/node-agent/internal/descriptor/lifecycle_test.go
+++ b/apps/node-agent/internal/descriptor/lifecycle_test.go
@@ -108,7 +108,6 @@ func TestLifecycle_Restart_StopThenStart(t *testing.T) {
 // --- hermesDescriptor lifecycle ---
 
 func TestHermesLifecycle_StopNoProcess_ReturnsError(t *testing.T) {
-	t.Setenv("APN_DIAG", "1") // TEMP: make hermesPID print what its pgrep matches
 	h := &hermesDescriptor{home: t.TempDir()}
 	// No hermes process is running in CI; Stop must return an error.
 	err := h.Stop("hermes")

--- a/apps/node-agent/internal/descriptor/lifecycle_test.go
+++ b/apps/node-agent/internal/descriptor/lifecycle_test.go
@@ -108,16 +108,13 @@ func TestLifecycle_Restart_StopThenStart(t *testing.T) {
 // --- hermesDescriptor lifecycle ---
 
 func TestHermesLifecycle_StopNoProcess_ReturnsError(t *testing.T) {
-	// DIAGNOSTIC v3 (temporary): capture the FIRST `systemctl --user` behavior,
-	// which is what hermesUnitKnown/Stop hit on a cold test binary.
-	unit := hermesUnitName("hermes")
-	catOut, catErr := exec.Command("systemctl", "--user", "cat", unit).CombinedOutput()
-	stopOut, stopErr := exec.Command("systemctl", "--user", "stop", unit).CombinedOutput()
-
+	t.Setenv("APN_DIAG", "1") // TEMP: make hermesPID print what its pgrep matches
 	h := &hermesDescriptor{home: t.TempDir()}
+	// No hermes process is running in CI; Stop must return an error.
 	err := h.Stop("hermes")
-	t.Fatalf("Stop err=%v\n`systemctl --user cat %s`: exit-nil=%v err=%v out=%q\n`systemctl --user stop %s`: exit-nil=%v err=%v out=%q",
-		err, unit, catErr == nil, catErr, catOut, unit, stopErr == nil, stopErr, stopOut)
+	if err == nil {
+		t.Fatal("expected error when no hermes process is running")
+	}
 }
 
 func TestHermesLifecycle_StartNoCommand_ReturnsError(t *testing.T) {

--- a/apps/node-agent/internal/descriptor/lifecycle_test.go
+++ b/apps/node-agent/internal/descriptor/lifecycle_test.go
@@ -2,6 +2,7 @@ package descriptor
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -112,7 +113,13 @@ func TestHermesLifecycle_StopNoProcess_ReturnsError(t *testing.T) {
 	// No hermes process is running in CI; Stop must return an error.
 	err := h.Stop("hermes")
 	if err == nil {
-		t.Fatal("expected error when no hermes process is running")
+		// DIAGNOSTIC (temporary): reveal why Stop found a match.
+		unit := hermesUnitName("hermes")
+		pg, _ := exec.Command("pgrep", "-af", hermesPattern("hermes")).Output()
+		selfCmd, _ := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", os.Getpid()))
+		t.Fatalf("expected error when no hermes process is running.\n"+
+			"hermesUnitKnown(%q)=%v\npattern=%q\npgrep -af:\n%s\ntest cmdline: %q",
+			unit, hermesUnitKnown(unit), hermesPattern("hermes"), pg, string(selfCmd))
 	}
 }
 

--- a/apps/node-agent/internal/descriptor/lifecycle_test.go
+++ b/apps/node-agent/internal/descriptor/lifecycle_test.go
@@ -2,8 +2,8 @@ package descriptor
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -113,13 +113,21 @@ func TestHermesLifecycle_StopNoProcess_ReturnsError(t *testing.T) {
 	// No hermes process is running in CI; Stop must return an error.
 	err := h.Stop("hermes")
 	if err == nil {
-		// DIAGNOSTIC (temporary): reveal why Stop found a match.
-		unit := hermesUnitName("hermes")
-		pg, _ := exec.Command("pgrep", "-af", hermesPattern("hermes")).Output()
-		selfCmd, _ := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", os.Getpid()))
+		// DIAGNOSTIC (temporary): the match is transient. Re-run Stop while
+		// sampling pgrep to catch which fleeting "hermes" process it hits.
+		seen := map[string]bool{}
+		var caught []string
+		for i := 0; i < 300; i++ {
+			out, _ := exec.Command("pgrep", "-af", "hermes").Output()
+			if s := strings.TrimSpace(string(out)); s != "" && !seen[s] {
+				seen[s] = true
+				caught = append(caught, s)
+			}
+			_ = h.Stop("hermes")
+		}
 		t.Fatalf("expected error when no hermes process is running.\n"+
-			"hermesUnitKnown(%q)=%v\npattern=%q\npgrep -af:\n%s\ntest cmdline: %q",
-			unit, hermesUnitKnown(unit), hermesPattern("hermes"), pg, string(selfCmd))
+			"distinct transient pgrep -af hermes matches: %d\n%s",
+			len(caught), strings.Join(caught, "\n---\n"))
 	}
 }
 

--- a/apps/node-agent/internal/descriptor/lifecycle_test.go
+++ b/apps/node-agent/internal/descriptor/lifecycle_test.go
@@ -3,7 +3,6 @@ package descriptor
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -109,26 +108,16 @@ func TestLifecycle_Restart_StopThenStart(t *testing.T) {
 // --- hermesDescriptor lifecycle ---
 
 func TestHermesLifecycle_StopNoProcess_ReturnsError(t *testing.T) {
+	// DIAGNOSTIC v3 (temporary): capture the FIRST `systemctl --user` behavior,
+	// which is what hermesUnitKnown/Stop hit on a cold test binary.
+	unit := hermesUnitName("hermes")
+	catOut, catErr := exec.Command("systemctl", "--user", "cat", unit).CombinedOutput()
+	stopOut, stopErr := exec.Command("systemctl", "--user", "stop", unit).CombinedOutput()
+
 	h := &hermesDescriptor{home: t.TempDir()}
-	// No hermes process is running in CI; Stop must return an error.
 	err := h.Stop("hermes")
-	if err == nil {
-		// DIAGNOSTIC (temporary): the match is transient. Re-run Stop while
-		// sampling pgrep to catch which fleeting "hermes" process it hits.
-		seen := map[string]bool{}
-		var caught []string
-		for i := 0; i < 300; i++ {
-			out, _ := exec.Command("pgrep", "-af", "hermes").Output()
-			if s := strings.TrimSpace(string(out)); s != "" && !seen[s] {
-				seen[s] = true
-				caught = append(caught, s)
-			}
-			_ = h.Stop("hermes")
-		}
-		t.Fatalf("expected error when no hermes process is running.\n"+
-			"distinct transient pgrep -af hermes matches: %d\n%s",
-			len(caught), strings.Join(caught, "\n---\n"))
-	}
+	t.Fatalf("Stop err=%v\n`systemctl --user cat %s`: exit-nil=%v err=%v out=%q\n`systemctl --user stop %s`: exit-nil=%v err=%v out=%q",
+		err, unit, catErr == nil, catErr, catOut, unit, stopErr == nil, stopErr, stopOut)
 }
 
 func TestHermesLifecycle_StartNoCommand_ReturnsError(t *testing.T) {

--- a/apps/node-agent/internal/descriptor/openclaw.go
+++ b/apps/node-agent/internal/descriptor/openclaw.go
@@ -184,18 +184,12 @@ func (o *openclawDescriptor) Health(key string) (Health, error) {
 	// swallowed so Health() never crashes.
 	if running {
 		if pid, pidErr := openclawGatewayPID(); pidErr == nil {
-			psOut, psErr := exec.Command(
-				"ps", "-p", strconv.Itoa(pid), "-o", "%cpu=,rss=,etime=",
-			).Output()
-			if psErr == nil {
-				if cpuPct, rssKB, uptimeSec, parseErr := parsePsMetrics(string(psOut)); parseErr == nil {
-					health.PID = &pid
-					health.CpuPct = &cpuPct
-					memBytes := rssKB * 1024
-					health.MemBytes = &memBytes
-					health.UptimeSec = &uptimeSec
-					note = fmt.Sprintf("shared gateway (PID %d)", pid)
-				}
+			if cpuPct, memBytes, uptimeSec := gatherPidMetrics(pid); cpuPct != nil {
+				health.PID = &pid
+				health.CpuPct = cpuPct
+				health.MemBytes = memBytes
+				health.UptimeSec = uptimeSec
+				note = fmt.Sprintf("shared gateway (PID %d)", pid)
 			}
 		}
 	}

--- a/apps/node-agent/internal/descriptor/process_metrics.go
+++ b/apps/node-agent/internal/descriptor/process_metrics.go
@@ -1,0 +1,26 @@
+package descriptor
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+// gatherPidMetrics runs `ps` for pid and returns the parsed CPU%, resident
+// memory (bytes), and uptime (seconds) as pointers. Metrics are best-effort:
+// any failure (ps unavailable, unexpected output, parse error) yields all-nil
+// so callers never fail Health() over a transient ps hiccup.
+//
+// Shared by the Hermes (per-profile process) and OpenClaw (shared gateway
+// process) descriptors so the `ps -o %cpu,rss,etime` gathering lives in one place.
+func gatherPidMetrics(pid int) (cpuPct *float64, memBytes *int64, uptimeSec *int64) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "%cpu=,rss=,etime=").Output()
+	if err != nil {
+		return nil, nil, nil
+	}
+	cpu, rssKB, up, perr := parsePsMetrics(string(out))
+	if perr != nil {
+		return nil, nil, nil
+	}
+	mem := rssKB * 1024
+	return &cpu, &mem, &up
+}

--- a/apps/node-agent/internal/gateway/update_handler.go
+++ b/apps/node-agent/internal/gateway/update_handler.go
@@ -50,7 +50,7 @@ func (h *updateHandler) Handle(
 
 	res, err := h.apply(ctx, selfupdate.Options{CurrentVersion: h.version})
 	if err != nil {
-		return map[string]any{"ok": false, "error": err.Error()}, true, nil
+		return map[string]any{"ok": false, "error": err.Error()}, false, nil
 	}
 
 	// Respond to the hub before exiting so it can mark the node as updating.
@@ -60,7 +60,7 @@ func (h *updateHandler) Handle(
 		h.exit(0)
 	}()
 
-	return map[string]any{"ok": true, "updating": true, "tag": res.LatestTag}, true, nil
+	return map[string]any{"ok": true, "updating": true, "tag": res.LatestTag}, false, nil
 }
 
 // HandleFrame forwards inbound terminal input/resize frames to the inner handler

--- a/apps/node-agent/internal/gateway/update_handler.go
+++ b/apps/node-agent/internal/gateway/update_handler.go
@@ -62,3 +62,16 @@ func (h *updateHandler) Handle(
 
 	return map[string]any{"ok": true, "updating": true, "tag": res.LatestTag}, true, nil
 }
+
+// HandleFrame forwards inbound terminal input/resize frames to the inner handler
+// when it implements FrameHandler. The dispatcher (serve) routes such frames via
+// a type assertion on the OUTERMOST handler; without this forwarder, wrapping a
+// terminalHandler in updateHandler would erase the FrameHandler interface and
+// every keystroke would be silently dropped (terminal connects but ignores
+// input). Returns nil when the inner handler has no frame support.
+func (h *updateHandler) HandleFrame(frameType, id string, raw json.RawMessage) error {
+	if fh, ok := h.inner.(FrameHandler); ok {
+		return fh.HandleFrame(frameType, id, raw)
+	}
+	return nil
+}

--- a/apps/node-agent/internal/gateway/update_handler_test.go
+++ b/apps/node-agent/internal/gateway/update_handler_test.go
@@ -74,6 +74,47 @@ func TestUpdateHandler_UpdateVerb(t *testing.T) {
 	}
 }
 
+// frameRecorder is a Handler that ALSO implements FrameHandler, recording the
+// last HandleFrame call. Used to prove updateHandler forwards inbound terminal
+// input/resize frames to its inner handler instead of erasing the interface.
+type frameRecorder struct {
+	stubInner
+	gotType string
+	gotID   string
+	gotRaw  json.RawMessage
+}
+
+func (f *frameRecorder) HandleFrame(frameType, id string, raw json.RawMessage) error {
+	f.gotType = frameType
+	f.gotID = id
+	f.gotRaw = raw
+	return nil
+}
+
+// TestUpdateHandler_ForwardsFrames guards against the decorator dropping the
+// FrameHandler interface. In run.go updateHandler wraps a terminalHandler, and
+// the dispatcher routes terminal keystrokes via `h.(FrameHandler)` on the
+// OUTERMOST handler. If updateHandler does not forward HandleFrame, that
+// assertion fails and every input/resize frame is silently discarded — the
+// terminal connects but accepts no input.
+func TestUpdateHandler_ForwardsFrames(t *testing.T) {
+	inner := &frameRecorder{}
+	h := NewUpdateHandler(inner, "v0.1.2")
+
+	fh, ok := h.(FrameHandler)
+	if !ok {
+		t.Fatal("updateHandler must implement FrameHandler so wrapping a terminalHandler does not drop terminal input/resize frames")
+	}
+
+	raw := json.RawMessage(`{"type":"input","id":"attach-1","data":"aGk="}`)
+	if err := fh.HandleFrame("input", "attach-1", raw); err != nil {
+		t.Fatalf("HandleFrame: %v", err)
+	}
+	if inner.gotType != "input" || inner.gotID != "attach-1" {
+		t.Errorf("frame not forwarded to inner: gotType=%q gotID=%q", inner.gotType, inner.gotID)
+	}
+}
+
 func TestUpdateHandler_DelegatesNonUpdate(t *testing.T) {
 	inner := &stubInner{result: map[string]any{"pong": true}}
 

--- a/apps/node-agent/internal/gateway/update_handler_test.go
+++ b/apps/node-agent/internal/gateway/update_handler_test.go
@@ -44,8 +44,13 @@ func TestUpdateHandler_UpdateVerb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !handled {
-		t.Error("expected handled=true")
+	// update must NOT be streamed: it is a one-shot RPC whose result map is sent
+	// as a `res` frame. The hub issues it via broker.request(), which only
+	// resolves on a `res` frame — a streamed (stream-eof) reply is never matched,
+	// so the request hangs until the node exits to restart and is then reported
+	// as a false "node disconnected" failure even though the update succeeded.
+	if handled {
+		t.Error("update must return streamed=false so the dispatcher emits a res frame the hub can resolve")
 	}
 
 	m, ok := result.(map[string]any)


### PR DESCRIPTION
Fixes found and verified while dogfooding the live fleet (console.agentpod.dev, molt-bot + superchotu). Each is TDD'd; node-agent fixes shipped as tagged releases and rolled; this PR resyncs `main` (which had drifted behind `develop`) and carries the hub fix that needs to deploy to the VPS.

## node-agent (released v0.1.6 – v0.1.9, fleet rolled + verified live)
- **A — terminal accepted no input** (`471911c`): `updateHandler` wrapped `terminalHandler` but didn't forward the `FrameHandler` interface, so the dispatcher's `h.(FrameHandler)` assertion failed and every input/resize frame was dropped. Verified: keystroke round-trips.
- **B — Hermes agents showed no CPU/Mem/Uptime** (`471911c`): `Health()` set only Disk+Running. Added shared `gatherPidMetrics`; honest per-profile metrics. Verified live.
- **C — false "node disconnected" on update** (`e4a4364`): the `update` verb returned `streamed=true` (stream-eof) but the hub's `request()` only resolves on a `res` frame → hung until the node exited → false failure. Now returns `streamed=false`. Verified: honest `ok:true`.
- **D — Hermes `restart` killed the agent on root/process-tree deploys** (`c1966b1`): no systemd unit + no startCmd → Start errored, so restart (Stop then Start) left the agent down. Added native fallback `hermes -p <name> gateway run --replace`.
- **E — supervisor-respawned profiles shown STOPPED while running** (`f046a3f`): `hermesPattern` only matched `-p`; the supervisor uses `--profile`. Broadened to `(-p|--profile)[ =]<name> gateway`. Verified: analyst-echo reads running.
- **F — AgentPod-launched profiles died on node-agent restart** (`38bcc5c`): native-fallback child lived in the node-agent's cgroup (`KillMode=control-group`). Now launched via `systemd-run` (own cgroup, survives restart). Validated live: transient units land in a separate `system.slice` cgroup.
- **CI** (`ca5b504`): `fail-fast: false` on the release matrix so one arch's flake doesn't cancel siblings.

## hub
- **updateAvailable used inequality, not ordering** (`296b0ac`): a node updated past the ~1h-cached "latest" showed a downgrade prompt (nodes on v0.1.9, cache still v0.1.7). Now uses semver `isNewerVersion` — true only when strictly behind. Needs a hub redeploy to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)