### PR TITLE
v0.1.11: fix Health workspace-walk timeout + activity [object Object]

### DIFF
--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -202,7 +202,9 @@ export type StationAuditRow = {
   nodeId: string;
   stationKey: string;
   verb: string;
-  paramsSummary: string | null;
+  // jsonb object from the hub (apps/hub/src/db/schema/audit.ts); string kept
+  // for backward compatibility with older rows.
+  paramsSummary: Record<string, unknown> | string | null;
   result: string;
   error: string | null;
   createdAt: string | Date;

--- a/apps/console/src/lib/components/stations/ActivityPanel.svelte
+++ b/apps/console/src/lib/components/stations/ActivityPanel.svelte
@@ -47,6 +47,15 @@
     return d.toLocaleString();
   }
 
+  // The hub returns paramsSummary as a jsonb OBJECT; older rows/mocks may be
+  // strings. Render objects as compact JSON, hide empty ones.
+  function fmtParams(value: unknown): string | null {
+    if (value == null) return null;
+    if (typeof value === "string") return value || null;
+    const json = JSON.stringify(value);
+    return json === "{}" ? null : json;
+  }
+
   function resultBadgeClass(result: string): string {
     if (result === "ok") return statusBadgeClass("running");   // chart-2 green
     if (result === "error") return statusBadgeClass("error");  // destructive red
@@ -90,12 +99,12 @@
             <span class="shrink-0 font-mono text-xs font-semibold text-foreground">
               {row.verb}
             </span>
-            {#if row.paramsSummary}
+            {#if fmtParams(row.paramsSummary)}
               <span
                 class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px] text-muted-foreground"
-                title={row.paramsSummary}
+                title={fmtParams(row.paramsSummary)}
               >
-                {row.paramsSummary}
+                {fmtParams(row.paramsSummary)}
               </span>
             {/if}
             <Badge

--- a/apps/console/src/lib/components/stations/ActivityPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/ActivityPanel.svelte.test.ts
@@ -117,3 +117,43 @@ test("ActivityPanel Refresh button re-fetches activity", async () => {
 
   await waitFor(() => expect(api.activity).toHaveBeenCalledTimes(2));
 });
+
+test("ActivityPanel renders object paramsSummary as readable JSON, never [object Object]", async () => {
+  // The hub stores params_summary as jsonb and returns an OBJECT (see
+  // apps/hub/src/db/schema/audit.ts) — not the string the older mocks used.
+  vi.spyOn(api, "activity").mockResolvedValue([
+    {
+      id: "row_obj",
+      userId: "user_a",
+      nodeId: "node_1",
+      stationKey: "claude-code:abc",
+      verb: "cleanup.plan",
+      paramsSummary: { path: "/workspace", dryRun: true },
+      result: "ok",
+      error: null,
+      createdAt: "2026-08-07T14:00:00Z",
+    },
+    {
+      id: "row_empty",
+      userId: "user_a",
+      nodeId: "node_1",
+      stationKey: "claude-code:abc",
+      verb: "term.open",
+      paramsSummary: {},
+      result: "ok",
+      error: null,
+      createdAt: "2026-08-07T14:01:00Z",
+    },
+  ] as never);
+
+  const { getByText, container } = render(ActivityPanel, {
+    props: { stationId: "station_1" },
+  });
+
+  await waitFor(() => getByText("cleanup.plan"));
+  expect(container.textContent).not.toContain("[object Object]");
+  // Object params render as compact JSON…
+  getByText('{"path":"/workspace","dryRun":true}');
+  // …and an empty object renders nothing at all.
+  expect(container.textContent).not.toContain("{}");
+});

--- a/apps/console/src/lib/components/stations/CleanupPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/CleanupPanel.svelte.test.ts
@@ -6,14 +6,7 @@ import * as api from "$lib/api/client";
 import CleanupPanel from "./CleanupPanel.svelte";
 
 beforeEach(() => vi.restoreAllMocks());
-afterEach(async () => {
-  cleanup();
-  // bits-ui's body-scroll-lock schedules a 24ms cleanup setTimeout when the
-  // confirm dialog unmounts; let it fire while the DOM still exists or it
-  // crashes with "document is not defined" after vitest tears the env down
-  // (deterministic on CI's Node 24).
-  await new Promise((r) => setTimeout(r, 40));
-});
+afterEach(cleanup); // scroll-lock timer flush lives in src/vitest-setup.ts
 
 const mockPlanItems = [
   { path: "/workspace/.cache/pip", size: 52428800, kind: "cache" },

--- a/apps/console/src/lib/components/stations/CleanupPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/CleanupPanel.svelte.test.ts
@@ -6,7 +6,14 @@ import * as api from "$lib/api/client";
 import CleanupPanel from "./CleanupPanel.svelte";
 
 beforeEach(() => vi.restoreAllMocks());
-afterEach(cleanup);
+afterEach(async () => {
+  cleanup();
+  // bits-ui's body-scroll-lock schedules a 24ms cleanup setTimeout when the
+  // confirm dialog unmounts; let it fire while the DOM still exists or it
+  // crashes with "document is not defined" after vitest tears the env down
+  // (deterministic on CI's Node 24).
+  await new Promise((r) => setTimeout(r, 40));
+});
 
 const mockPlanItems = [
   { path: "/workspace/.cache/pip", size: 52428800, kind: "cache" },

--- a/apps/console/src/vitest-setup.ts
+++ b/apps/console/src/vitest-setup.ts
@@ -1,0 +1,13 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/svelte";
+
+// Unmount components, then let bits-ui's 24ms body-scroll-lock cleanup timer
+// fire while the DOM still exists. Without the flush, the last dialog-using
+// test in a file races vitest's environment teardown and crashes with
+// "document is not defined" (deterministic on CI's Node 24 — seen from
+// CleanupPanel and NewRuntimeDialog test files). Global because ANY test that
+// mounts a bits-ui dialog can be the one holding the pending timer.
+afterEach(async () => {
+  cleanup();
+  await new Promise((r) => setTimeout(r, 40));
+});

--- a/apps/console/vitest.config.ts
+++ b/apps/console/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    setupFiles: ["./src/vitest-setup.ts"],
     // Disable vite CSS processing — Svelte <style> blocks (including those in
     // transitively imported components like code-block.svelte) trigger
     // preprocessCSS which fails in the jsdom environment with vite 6 +

--- a/apps/node-agent/internal/descriptor/claudecode.go
+++ b/apps/node-agent/internal/descriptor/claudecode.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -226,20 +227,81 @@ func (c *claudeCodeDescriptor) Health(key string) (Health, error) {
 // claudeProcessRunning checks for a running claude process whose working
 // directory is projPath. Returns false with a note when the check is
 // unavailable (e.g. lsof not installed). This is always best-effort.
+// parseLsofCwds parses `lsof -Fn -d cwd` field output (p<pid> / f<fd> /
+// n<path> line groups) into pid→cwd.
+func parseLsofCwds(out []byte) map[int]string {
+	cwds := map[int]string{}
+	pid := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			pid, _ = strconv.Atoi(line[1:])
+		case 'n':
+			if pid != 0 {
+				cwds[pid] = line[1:]
+			}
+		}
+	}
+	return cwds
+}
+
+// cwdWithinWorkspace reports whether cwd is the workspace itself or nested
+// inside it (a session that cd'd into a subdirectory still counts). Both
+// sides are symlink-resolved when possible — lsof reports resolved paths
+// (e.g. /private/var on macOS for a /var workspace), so a literal compare
+// would miss real matches.
+func cwdWithinWorkspace(cwd, workspace string) bool {
+	resolve := func(p string) string {
+		if r, err := filepath.EvalSymlinks(p); err == nil {
+			return r
+		}
+		return filepath.Clean(p)
+	}
+	cwd = resolve(cwd)
+	workspace = resolve(workspace)
+	return cwd == workspace || strings.HasPrefix(cwd, workspace+string(filepath.Separator))
+}
+
+// claudeProcessRunning reports whether a claude CLI session is running with
+// its working directory inside projPath.
+//
+// Detection is cwd-based: `pgrep '^claude'` finds candidate pids by process
+// name (ps/pgrep see "claude"), then one lsof call resolves their cwds.
+// Selecting by name inside lsof (-c claude) does NOT work — the claude CLI
+// rewrites its process title to its version string (e.g. "2.1.222"), and
+// lsof's `+d dir` does not match a process whose cwd is the directory anyway.
+// lsof's exit code is ignored when it produced output: it exits 1 on benign
+// per-file warnings even with valid matches (the old code read that as
+// "stopped" while sessions were running).
 func claudeProcessRunning(projPath string) (running bool, note string) {
-	// Attempt: lsof -t -c claude +d projPath  (macOS / Linux).
-	// +d (not +D) avoids deep recursion; lists open files in the dir itself.
-	cmd := exec.Command("lsof", "-t", "-c", "claude", "+d", projPath)
-	out, err := cmd.Output()
+	out, err := exec.Command("pgrep", "^claude").Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			// lsof exit 1 = no match.
-			return false, ""
+			return false, "" // no claude processes at all
 		}
-		// lsof unavailable or unexpected error.
+		return false, "process check unavailable (pgrep not found or failed)"
+	}
+	pids := strings.Fields(strings.TrimSpace(string(out)))
+	if len(pids) == 0 {
+		return false, ""
+	}
+
+	lsofOut, err := exec.Command("lsof", "-a", "-p", strings.Join(pids, ","), "-d", "cwd", "-Fn").Output()
+	if err != nil && len(lsofOut) == 0 {
+		if _, ok := err.(*exec.ExitError); ok {
+			return false, "" // ran but matched nothing
+		}
 		return false, "process check unavailable (lsof not found or failed)"
 	}
-	return strings.TrimSpace(string(out)) != "", ""
+	for _, cwd := range parseLsofCwds(lsofOut) {
+		if cwdWithinWorkspace(cwd, projPath) {
+			return true, ""
+		}
+	}
+	return false, ""
 }
 
 // newestMtime returns the newest modification time among all regular files

--- a/apps/node-agent/internal/descriptor/claudecode.go
+++ b/apps/node-agent/internal/descriptor/claudecode.go
@@ -202,21 +202,9 @@ func (c *claudeCodeDescriptor) Health(key string) (Health, error) {
 
 	health := Health{}
 
-	// Disk usage by walking the workspace directory.
-	var diskBytes int64
-	_ = filepath.WalkDir(projPath, func(_ string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip unreadable entries
-		}
-		if !d.IsDir() {
-			info, err := d.Info()
-			if err == nil {
-				diskBytes += info.Size()
-			}
-		}
-		return nil
-	})
-	health.DiskBytes = &diskBytes
+	// Disk usage from the shared async cache — never walk on the request path
+	// (a node_modules-laden workspace walk can exceed the hub's timeout).
+	health.DiskBytes = diskUsage(projPath)
 
 	// Best-effort: detect a running claude process.
 	running, note := claudeProcessRunning(projPath)

--- a/apps/node-agent/internal/descriptor/claudecode_test.go
+++ b/apps/node-agent/internal/descriptor/claudecode_test.go
@@ -261,15 +261,14 @@ func TestClaudeCodeHealth_ReturnsDiskBytes(t *testing.T) {
 	d := NewClaudeCode(home)
 
 	key := expectedClaudeKey(projA)
+	// DiskBytes populates asynchronously (cached background walk).
+	disk := waitForHealthDiskBytes(t, func() (Health, error) { return d.Health(key) })
+	if disk < 0 {
+		t.Errorf("DiskBytes should be >= 0, got %d", disk)
+	}
 	h, err := d.Health(key)
 	if err != nil {
 		t.Fatalf("Health: %v", err)
-	}
-	if h.DiskBytes == nil {
-		t.Fatal("DiskBytes should be set")
-	}
-	if *h.DiskBytes < 0 {
-		t.Errorf("DiskBytes should be >= 0, got %d", *h.DiskBytes)
 	}
 	// Running is best-effort; just ensure no panic.
 	_ = h.Running

--- a/apps/node-agent/internal/descriptor/claudecode_test.go
+++ b/apps/node-agent/internal/descriptor/claudecode_test.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // buildClaudeCodeFixture creates a temporary Claude Code home and project
@@ -152,8 +154,8 @@ func TestClaudeCodeDetect_NonexistentProjectSkipped(t *testing.T) {
 	// Rewrite .claude.json with the ghost path.
 	claudeJSON := map[string]interface{}{
 		"projects": map[string]interface{}{
-			projA:  map[string]interface{}{},
-			ghost:  map[string]interface{}{},
+			projA: map[string]interface{}{},
+			ghost: map[string]interface{}{},
 		},
 	}
 	data, _ := json.Marshal(claudeJSON)
@@ -313,5 +315,98 @@ func TestClaudeCodeTailLogs_EmitsSessionJsonl(t *testing.T) {
 	}
 	if !strings.Contains(all, "proj-a") {
 		t.Errorf("expected session content referencing proj-a, got: %s", all)
+	}
+}
+
+// --- claude process detection (cwd-based) ---
+
+func TestParseLsofCwds(t *testing.T) {
+	// lsof -a -p <pids> -d cwd -Fn output: p<pid>, f<fd>, n<path> groups.
+	out := []byte("p2286\nfcwd\nn/Users/x/proj\np7938\nfcwd\nn/Users/x/other\n")
+	got := parseLsofCwds(out)
+	if got[2286] != "/Users/x/proj" || got[7938] != "/Users/x/other" {
+		t.Fatalf("parseLsofCwds = %v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %v", got)
+	}
+}
+
+func TestCwdWithinWorkspace(t *testing.T) {
+	cases := []struct {
+		cwd, ws string
+		want    bool
+	}{
+		{"/a/proj", "/a/proj", true},
+		{"/a/proj/sub", "/a/proj", true},
+		{"/a/project", "/a/proj", false}, // sibling with shared prefix
+		{"/a", "/a/proj", false},
+		{"/a/proj/", "/a/proj", true},
+	}
+	for _, c := range cases {
+		if got := cwdWithinWorkspace(c.cwd, c.ws); got != c.want {
+			t.Errorf("cwdWithinWorkspace(%q, %q) = %v, want %v", c.cwd, c.ws, got, c.want)
+		}
+	}
+}
+
+// TestMain lets this test binary act as its own "claude" stub: when
+// re-exec'd with CLAUDE_STUB_SLEEP set it just sleeps. Copying /bin/sleep is
+// not an option — macOS SIGKILLs relocated platform binaries (trust cache),
+// and a shell script's process name is "sh", invisible to pgrep '^claude'.
+func TestMain(m *testing.M) {
+	if os.Getenv("CLAUDE_STUB_SLEEP") != "" {
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// TestClaudeProcessRunning_DetectsSessionByCwd spawns a stub process named
+// "claude" with its cwd inside the workspace and expects detection; the old
+// `lsof -c claude +d` approach missed real sessions entirely (the claude CLI
+// rewrites its process title to a version string, and lsof exit 1 with valid
+// output was treated as no-match).
+func TestClaudeProcessRunning_DetectsSessionByCwd(t *testing.T) {
+	ws := t.TempDir()
+
+	// Stage the test binary itself under the name "claude" and run it with
+	// cwd = workspace (see TestMain).
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := os.ReadFile(self)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := filepath.Join(t.TempDir(), "claude")
+	if err := os.WriteFile(stub, src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(stub)
+	cmd.Dir = ws
+	cmd.Env = append(os.Environ(), "CLAUDE_STUB_SLEEP=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Give the stub a moment to exec (and die loudly if it was killed).
+	time.Sleep(200 * time.Millisecond)
+	if cmd.ProcessState != nil {
+		t.Fatalf("stub exited prematurely: %v", cmd.ProcessState)
+	}
+	// Reap on cleanup — an unreaped defunct child named "claude" would leak
+	// into other pgrep-based tests (see the v0.1.9 zombie war story).
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+
+	running, note := claudeProcessRunning(ws)
+	if !running {
+		t.Fatalf("expected running=true for stub claude with cwd in workspace (note=%q)", note)
+	}
+
+	// And a workspace with no session reports stopped.
+	running, _ = claudeProcessRunning(t.TempDir())
+	if running {
+		t.Fatal("expected running=false for empty workspace")
 	}
 }

--- a/apps/node-agent/internal/descriptor/diskusage.go
+++ b/apps/node-agent/internal/descriptor/diskusage.go
@@ -1,0 +1,77 @@
+package descriptor
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Cached, asynchronous workspace disk usage.
+//
+// Health() must never block on a filesystem walk: a large workspace (e.g. one
+// containing node_modules) can take >10s to walk, which times out the hub's
+// on-demand health request and stalls the 30s health push loop. Instead,
+// diskUsage returns the last computed value immediately (nil before the first
+// walk completes) and refreshes stale entries in the background — at most one
+// walk per directory at a time.
+
+var diskUsageTTL = 5 * time.Minute
+
+type diskEntry struct {
+	bytes      int64
+	computedAt time.Time
+	refreshing bool
+}
+
+var (
+	diskMu    sync.Mutex
+	diskCache = map[string]*diskEntry{}
+)
+
+// diskUsage returns the cached size of dir in bytes, or nil when no walk has
+// completed yet. Missing or stale entries trigger a background refresh.
+func diskUsage(dir string) *int64 {
+	diskMu.Lock()
+	defer diskMu.Unlock()
+
+	e, ok := diskCache[dir]
+	if !ok {
+		diskCache[dir] = &diskEntry{refreshing: true}
+		go refreshDiskUsage(dir)
+		return nil
+	}
+
+	var result *int64
+	if !e.computedAt.IsZero() {
+		b := e.bytes
+		result = &b
+	}
+	if !e.refreshing && time.Since(e.computedAt) > diskUsageTTL {
+		e.refreshing = true
+		go refreshDiskUsage(dir)
+	}
+	return result
+}
+
+func refreshDiskUsage(dir string) {
+	var total int64
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		if !d.IsDir() {
+			if info, err := d.Info(); err == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+
+	diskMu.Lock()
+	e := diskCache[dir]
+	e.bytes = total
+	e.computedAt = time.Now()
+	e.refreshing = false
+	diskMu.Unlock()
+}

--- a/apps/node-agent/internal/descriptor/diskusage_test.go
+++ b/apps/node-agent/internal/descriptor/diskusage_test.go
@@ -1,0 +1,93 @@
+package descriptor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// waitForDisk polls diskUsage until it returns a non-nil value or times out.
+func waitForDisk(t *testing.T, dir string, timeout time.Duration) int64 {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if v := diskUsage(dir); v != nil {
+			return *v
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("diskUsage(%s) never returned a value within %s", dir, timeout)
+	return 0
+}
+
+// waitForHealthDiskBytes polls a descriptor's Health until the async disk
+// cache populates DiskBytes, then returns it. Used by descriptor Health tests
+// since DiskBytes is nil until the first background walk completes.
+func waitForHealthDiskBytes(t *testing.T, get func() (Health, error)) int64 {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h, err := get()
+		if err != nil {
+			t.Fatalf("Health: %v", err)
+		}
+		if h.DiskBytes != nil {
+			return *h.DiskBytes
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("Health.DiskBytes never populated within 2s")
+	return 0
+}
+
+func TestDiskUsageFirstCallReturnsNilThenPopulates(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.bin"), make([]byte, 1234), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First call must NOT block on the walk — it returns nil immediately and
+	// kicks a background refresh.
+	if v := diskUsage(dir); v != nil {
+		t.Fatalf("first call returned %d, want nil (walk must be async)", *v)
+	}
+
+	if got := waitForDisk(t, dir, 2*time.Second); got != 1234 {
+		t.Fatalf("cached disk usage = %d, want 1234", got)
+	}
+}
+
+func TestDiskUsageStaleReturnsOldValueAndRefreshes(t *testing.T) {
+	oldTTL := diskUsageTTL
+	diskUsageTTL = time.Millisecond
+	t.Cleanup(func() { diskUsageTTL = oldTTL })
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.bin"), make([]byte, 100), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diskUsage(dir) // kick first walk
+	if got := waitForDisk(t, dir, 2*time.Second); got != 100 {
+		t.Fatalf("initial disk usage = %d, want 100", got)
+	}
+
+	// Grow the dir; entry is now stale (TTL 1ms). The next call must still
+	// return the OLD value immediately (never block) while refreshing.
+	if err := os.WriteFile(filepath.Join(dir, "b.bin"), make([]byte, 400), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Millisecond) // ensure past TTL
+	if v := diskUsage(dir); v == nil || (*v != 100 && *v != 500) {
+		t.Fatalf("stale call = %v, want old value 100 (or already-refreshed 500)", v)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := diskUsage(dir); v != nil && *v == 500 {
+			return // refreshed
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("stale entry never refreshed to 500")
+}

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -131,21 +131,8 @@ func (h *hermesDescriptor) Health(key string) (Health, error) {
 
 	health := Health{}
 
-	// Compute disk usage by walking the workspace.
-	var diskBytes int64
-	_ = filepath.WalkDir(workspace, func(_ string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip unreadable entries
-		}
-		if !d.IsDir() {
-			info, err := d.Info()
-			if err == nil {
-				diskBytes += info.Size()
-			}
-		}
-		return nil
-	})
-	health.DiskBytes = &diskBytes
+	// Disk usage from the shared async cache — never walk on the request path.
+	health.DiskBytes = diskUsage(workspace)
 
 	// Best-effort process check via pgrep.
 	health.Running, _ = hermesProcessRunning(key)

--- a/apps/node-agent/internal/descriptor/openclaw.go
+++ b/apps/node-agent/internal/descriptor/openclaw.go
@@ -159,21 +159,8 @@ func (o *openclawDescriptor) Health(key string) (Health, error) {
 
 	health := Health{}
 
-	// Compute disk usage by walking the workspace.
-	var diskBytes int64
-	_ = filepath.WalkDir(workspace, func(_ string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip unreadable entries
-		}
-		if !d.IsDir() {
-			info, err := d.Info()
-			if err == nil {
-				diskBytes += info.Size()
-			}
-		}
-		return nil
-	})
-	health.DiskBytes = &diskBytes
+	// Disk usage from the shared async cache — never walk on the request path.
+	health.DiskBytes = diskUsage(workspace)
 
 	// Best-effort process check against the gateway.
 	running, note := openclawGatewayRunning()

--- a/apps/node-agent/internal/descriptor/openclaw_test.go
+++ b/apps/node-agent/internal/descriptor/openclaw_test.go
@@ -190,15 +190,15 @@ func TestOpenClawHealth_ReturnsHealthStruct(t *testing.T) {
 	home := testdataOpenClawHome(t)
 	d := NewOpenClaw(home)
 
+	// DiskBytes populates asynchronously (cached background walk); files exist
+	// in testdata so it must be non-negative once computed.
+	disk := waitForHealthDiskBytes(t, func() (Health, error) { return d.Health("openclaw:hanuman") })
+	if disk < 0 {
+		t.Errorf("DiskBytes should be >= 0, got %d", disk)
+	}
 	h, err := d.Health("openclaw:hanuman")
 	if err != nil {
 		t.Fatalf("Health: %v", err)
-	}
-	// DiskBytes should be non-nil and non-negative (files exist in testdata).
-	if h.DiskBytes == nil {
-		t.Error("expected DiskBytes to be set")
-	} else if *h.DiskBytes < 0 {
-		t.Errorf("DiskBytes should be >= 0, got %d", *h.DiskBytes)
 	}
 	// Running is a best-effort bool; just verify no panic/error.
 	_ = h.Running

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -256,21 +256,8 @@ func (o *openCodeDescriptor) Health(key string) (Health, error) {
 
 	health := Health{}
 
-	// Disk usage by walking the workspace directory.
-	var diskBytes int64
-	_ = filepath.WalkDir(projPath, func(_ string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip unreadable entries
-		}
-		if !d.IsDir() {
-			info, err := d.Info()
-			if err == nil {
-				diskBytes += info.Size()
-			}
-		}
-		return nil
-	})
-	health.DiskBytes = &diskBytes
+	// Disk usage from the shared async cache — never walk on the request path.
+	health.DiskBytes = diskUsage(projPath)
 
 	// Best-effort: detect a running opencode process.
 	running, note := openCodeProcessRunning()

--- a/apps/node-agent/internal/descriptor/opencode_test.go
+++ b/apps/node-agent/internal/descriptor/opencode_test.go
@@ -194,15 +194,14 @@ func TestOpenCodeHealth_ReturnsDiskBytes(t *testing.T) {
 	d := NewOpenCode(dataDir)
 
 	key := expectedOpenCodeKey(projPath)
+	// DiskBytes populates asynchronously (cached background walk).
+	disk := waitForHealthDiskBytes(t, func() (Health, error) { return d.Health(key) })
+	if disk <= 0 {
+		t.Errorf("DiskBytes should be > 0 for a workspace with a file, got %d", disk)
+	}
 	h, err := d.Health(key)
 	if err != nil {
 		t.Fatalf("Health: %v", err)
-	}
-	if h.DiskBytes == nil {
-		t.Fatal("DiskBytes should be set")
-	}
-	if *h.DiskBytes <= 0 {
-		t.Errorf("DiskBytes should be > 0 for a workspace with a file, got %d", *h.DiskBytes)
 	}
 	// Running is best-effort; just ensure no panic.
 	_ = h.Running

--- a/apps/node-agent/internal/gateway/client.go
+++ b/apps/node-agent/internal/gateway/client.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"math/rand"
 	"strings"
 	"sync"
@@ -114,6 +115,9 @@ func runWithOpts(ctx context.Context, cfg config.Config, h Handler, opts runOpti
 			if opts.jitterFn != nil {
 				d += opts.jitterFn(d)
 			}
+			// Operators need the disconnect reason — a silent reconnect loop
+			// makes flapping connections undiagnosable.
+			log.Printf("gateway: connection lost: %v (reconnecting in %s)", err, d.Round(time.Millisecond))
 			attempt++
 			if !opts.sleepFn(ctx, d) {
 				break

--- a/apps/node-agent/internal/gateway/dispatch.go
+++ b/apps/node-agent/internal/gateway/dispatch.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"sync"
 	"sync/atomic"
 
@@ -85,6 +86,12 @@ func serve(ctx context.Context, c *websocket.Conn, h Handler, mus ...*sync.Mutex
 		}
 		_, raw, err := c.Read(ctx)
 		if err != nil {
+			// Surface WHY the connection died (close code, EOF, reset) — the
+			// caller only ever sees a later "use of closed network connection"
+			// write failure, which hides the real cause.
+			if ctx.Err() == nil {
+				log.Printf("gateway: read loop closed: %v", err)
+			}
 			return
 		}
 

--- a/apps/node-agent/internal/gateway/dispatch.go
+++ b/apps/node-agent/internal/gateway/dispatch.go
@@ -124,6 +124,17 @@ func serve(ctx context.Context, c *websocket.Conn, h Handler, mus ...*sync.Mutex
 				var seqNext int64
 
 				emit := func(seq int, chunk string, eof bool, enc string) error {
+					// Stop streaming once the request is cancelled — and never
+					// pass reqCtx to the write itself: coder/websocket CLOSES
+					// THE WHOLE CONNECTION when a Write's ctx is cancelled
+					// mid-write (conn.go setupWriteTimeout → c.close()), so a
+					// single stream cancel (console navigating away from a
+					// logs tail) would tear down the entire gateway. Writes
+					// ride the connection-lifetime ctx instead; a few frames
+					// may land after cancel and are dropped by the hub.
+					if reqCtx.Err() != nil {
+						return reqCtx.Err()
+					}
 					atomic.StoreInt64(&seqNext, int64(seq)+1)
 					m := map[string]any{
 						"type":  "stream",
@@ -135,7 +146,7 @@ func serve(ctx context.Context, c *websocket.Conn, h Handler, mus ...*sync.Mutex
 					if enc != "" {
 						m["enc"] = enc
 					}
-					return writeMsg(reqCtx, m)
+					return writeMsg(ctx, m)
 				}
 
 				// Embed the request ID in context so handlers such as

--- a/apps/node-agent/internal/gateway/dispatch_test.go
+++ b/apps/node-agent/internal/gateway/dispatch_test.go
@@ -1,10 +1,13 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -65,5 +68,44 @@ func TestDispatchCancelRequest(t *testing.T) {
 		// handler saw cancellation — pass
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler context never cancelled")
+	}
+}
+
+// TestServeLogsReadLoopExit verifies the read loop logs why it stopped —
+// the underlying WS close error was previously discarded, hiding the real
+// disconnect cause behind a later "use of closed network connection" write
+// failure.
+func TestServeLogsReadLoopExit(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, _ := websocket.Accept(w, r, nil)
+		// Abruptly close the underlying connection from the server side.
+		c.CloseNow()
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	c, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.CloseNow()
+
+	done := make(chan struct{})
+	go func() {
+		serve(ctx, c, stubHandler)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after server closed the connection")
+	}
+	if !strings.Contains(buf.String(), "read loop closed") {
+		t.Fatalf("read-loop exit not logged; log output: %q", buf.String())
 	}
 }

--- a/apps/node-agent/internal/gateway/dispatch_test.go
+++ b/apps/node-agent/internal/gateway/dispatch_test.go
@@ -109,3 +109,96 @@ func TestServeLogsReadLoopExit(t *testing.T) {
 		t.Fatalf("read-loop exit not logged; log output: %q", buf.String())
 	}
 }
+
+// TestCancelStreamDoesNotKillConnection reproduces the fleet-wide disconnect
+// bug: cancelling an active stream while a chunk write is in flight closed
+// the ENTIRE gateway connection (coder/websocket closes the conn when a
+// Write's ctx is cancelled mid-write — conn.go setupWriteTimeout). The
+// connection must survive a stream cancel and keep serving other requests.
+func TestCancelStreamDoesNotKillConnection(t *testing.T) {
+	type serverConn struct {
+		c *websocket.Conn
+	}
+	connCh := make(chan serverConn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		connCh <- serverConn{c}
+		// Keep the handler alive; the test drives the conn.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cli, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.CloseNow()
+	cli.SetReadLimit(-1)
+
+	// Streaming handler: emits 64KB chunks until emit errors (like a log tail).
+	chunk := strings.Repeat("x", 64*1024)
+	h := HandlerFunc(func(hctx context.Context, verb string, _ json.RawMessage, emit func(int, string, bool, string) error) (any, bool, error) {
+		if verb == "ping" {
+			return "pong", false, nil
+		}
+		for i := 0; ; i++ {
+			if err := emit(i, chunk, false, ""); err != nil {
+				return nil, true, nil
+			}
+		}
+	})
+	go serve(ctx, cli, h)
+
+	sc := <-connCh
+	sc.c.SetReadLimit(-1)
+	srvCtx := context.Background()
+
+	// Start the stream.
+	req, _ := json.Marshal(map[string]any{"type": "req", "id": "s1", "verb": "tail", "params": map[string]any{}})
+	if err := sc.c.Write(srvCtx, websocket.MessageText, req); err != nil {
+		t.Fatal(err)
+	}
+	// Read ONE frame, then stop reading so the agent's stream writes block on
+	// TCP backpressure — guaranteeing a write is in flight when cancel lands.
+	if _, _, err := sc.c.Read(srvCtx); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond) // let buffers fill and a write block
+
+	cancelMsg, _ := json.Marshal(map[string]any{"type": "cancel", "id": "s1"})
+	if err := sc.c.Write(srvCtx, websocket.MessageText, cancelMsg); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond) // window where the old code closed the conn
+
+	// Drain stream frames and send a ping; the connection must still answer.
+	ping, _ := json.Marshal(map[string]any{"type": "req", "id": "p1", "verb": "ping", "params": map[string]any{}})
+	if err := sc.c.Write(srvCtx, websocket.MessageText, ping); err != nil {
+		t.Fatalf("ping write failed — connection already dead: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		readCtx, rcancel := context.WithTimeout(srvCtx, time.Second)
+		_, raw, err := sc.c.Read(readCtx)
+		rcancel()
+		if err != nil {
+			t.Fatalf("connection died after stream cancel: %v", err)
+		}
+		var m map[string]any
+		_ = json.Unmarshal(raw, &m)
+		if m["type"] == "res" && m["id"] == "p1" {
+			if ok, _ := m["ok"].(bool); !ok {
+				t.Fatalf("ping res not ok: %v", m)
+			}
+			return // connection survived the cancel
+		}
+	}
+	t.Fatal("never received ping res after stream cancel")
+}

--- a/apps/node-agent/internal/gateway/reconnect_test.go
+++ b/apps/node-agent/internal/gateway/reconnect_test.go
@@ -1,8 +1,13 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"log"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -211,5 +216,40 @@ func TestReconnectOnConnectedResetsAttempt(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not exit after cancel")
+	}
+}
+
+// TestReconnectLogsDisconnectReason verifies that each connection loss is
+// logged with the underlying error and the computed backoff — operators were
+// previously blind to why an agent kept reconnecting.
+func TestReconnectLogsDisconnectReason(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	done := make(chan error, 1)
+	go func() {
+		done <- runWithOpts(ctx, config.Config{}, stubHandler, runOptions{
+			dialFn: func(context.Context, config.Config, Handler, func()) error {
+				calls++
+				if calls >= 2 {
+					cancel()
+				}
+				return errors.New("websocket: close 1006 abnormal closure")
+			},
+			sleepFn:  func(ctx context.Context, d time.Duration) bool { return ctx.Err() == nil },
+			jitterFn: nil,
+		})
+	}()
+	<-done
+
+	out := buf.String()
+	if !strings.Contains(out, "close 1006 abnormal closure") {
+		t.Fatalf("disconnect reason not logged; log output: %q", out)
+	}
+	if !strings.Contains(out, "reconnecting in") {
+		t.Fatalf("backoff not logged; log output: %q", out)
 	}
 }


### PR DESCRIPTION
Two dogfood fixes from the Mac claude-code station (closes #190, closes #191):
- node-agent: descriptors' Health() no longer walks the workspace on the request path — shared async per-directory disk cache (5min TTL). Fixes the console Health tab timing out (13s walks) and the 30s push loop re-walking every workspace.
- console: ActivityPanel renders jsonb paramsSummary objects as compact JSON instead of [object Object].

Tests: node-agent go -race green (new diskusage tests + async-contract updates), console 235 + svelte-check 0, hub 308/0 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)