### PR TITLE
v0.1.12: macOS LaunchAgent installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Versioning: [S
 
 ---
 
+## v0.1.12 - TBD
+
+macOS installer rootless improvements and launchd-native update restart.
+
+### Added
+
+- **macOS rootless installer** (#193)
+  - Installs are now per-user and rootless; sets up a persistent launchd LaunchAgent (`~/Library/LaunchAgents/dev.agentpod.node.plist`) with RunAtLoad and KeepAlive enabled.
+  - Logs are written to `~/Library/Logs/agentpod-node.log`.
+  - Sudo invocations re-exec as the invoking user; installations are idempotent (bootout then bootstrap, with `load -w` fallback).
+  - KeepAlive enables one-click self-updates on macOS: the node exits on update, and launchd respawns it.
+
+### Changed
+
+- **Update restart on macOS** (#193)
+  - `apn update` now restarts via `launchctl kickstart -k gui/<uid>/dev.agentpod.node` on macOS instead of failing with a systemctl hint; Linux behavior unchanged.
+
+### Limitations
+
+- LaunchAgent runs only while the user is logged in; sleep suspends the node until wake (shown offline until login/wake).
+
+---
+
 ## [0.1.10] - 2026-08-07
 
 Trustworthy fleet: reconciliation, self-healing enrollment, and release hardening.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Versioning: [S
 
 ---
 
-## v0.1.12 - TBD
+## v0.1.12 - 2026-08-08
 
 macOS installer rootless improvements and launchd-native update restart.
 

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -75,7 +75,11 @@ func main() {
     if err != nil {
       if errors.Is(err, selfupdate.ErrRestartFailed) {
         fmt.Fprintln(os.Stderr, "update: binary swapped but service restart failed:", err)
-        fmt.Fprintln(os.Stderr, "restart the service manually: systemctl restart agentpod-node")
+        if runtime.GOOS == "darwin" {
+          fmt.Fprintf(os.Stderr, "restart it manually: launchctl kickstart -k gui/%d/dev.agentpod.node  (or re-run: apn run)\n", os.Getuid())
+        } else {
+          fmt.Fprintln(os.Stderr, "restart the service manually: systemctl restart agentpod-node")
+        }
         os.Exit(1)
       }
       fmt.Fprintln(os.Stderr, "update:", err)

--- a/apps/node-agent/internal/selfupdate/selfupdate.go
+++ b/apps/node-agent/internal/selfupdate/selfupdate.go
@@ -214,18 +214,23 @@ func swapBinary(targetPath, tmpPath string) error {
 	return nil
 }
 
-// restartService restarts the agentpod-node service.
-// It probes for a user-scoped unit first; if active it uses --user, otherwise
-// it falls back to the system-scoped unit. Returns a wrapped ErrRestartFailed
-// when the restart command itself fails (binary already swapped at that point).
-func restartService(run func(name string, args ...string) error) error {
+// restartService restarts the agentpod-node service for the given GOOS.
+//
+// linux: probes for a user-scoped systemd unit first; if active uses --user,
+// else the system unit. darwin: the installer runs the agent as the LaunchAgent
+// gui/<uid>/dev.agentpod.node — kickstart -k kills and restarts it. Returns a
+// wrapped ErrRestartFailed when the restart command fails (the binary is
+// already swapped at that point).
+func restartService(goos string, run func(name string, args ...string) error) error {
 	if run == nil {
 		run = func(name string, args ...string) error {
 			return exec.Command(name, args...).Run()
 		}
 	}
 	var restartErr error
-	if run("systemctl", "--user", "is-active", "agentpod-node") == nil {
+	if goos == "darwin" {
+		restartErr = run("launchctl", "kickstart", "-k", fmt.Sprintf("gui/%d/dev.agentpod.node", os.Getuid()))
+	} else if run("systemctl", "--user", "is-active", "agentpod-node") == nil {
 		restartErr = run("systemctl", "--user", "restart", "agentpod-node")
 	} else {
 		restartErr = run("systemctl", "restart", "agentpod-node")
@@ -346,7 +351,7 @@ func Update(ctx context.Context, opts Options) (Result, error) {
 	}
 
 	// Restart the service. Even if this fails the binary has been updated.
-	if err := restartService(opts.RunCommand); err != nil {
+	if err := restartService(runtime.GOOS, opts.RunCommand); err != nil {
 		return updated, err
 	}
 

--- a/apps/node-agent/internal/selfupdate/selfupdate_test.go
+++ b/apps/node-agent/internal/selfupdate/selfupdate_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -251,7 +252,7 @@ func TestRestartService(t *testing.T) {
 			// All calls succeed
 			return nil
 		}
-		if err := restartService(run); err != nil {
+		if err := restartService("linux", run); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		// Expected: is-active probe (succeeds) → user restart
@@ -279,7 +280,7 @@ func TestRestartService(t *testing.T) {
 			}
 			return nil
 		}
-		if err := restartService(run); err != nil {
+		if err := restartService("linux", run); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(calls) != 2 {
@@ -296,7 +297,7 @@ func TestRestartService(t *testing.T) {
 			// is-active fails, then restart also fails
 			return fmt.Errorf("systemctl error")
 		}
-		err := restartService(run)
+		err := restartService("linux", run)
 		if err == nil {
 			t.Fatal("expected error when restart fails")
 		}
@@ -324,6 +325,31 @@ func TestRestartService(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRestartServiceDarwinUsesLaunchctlKickstart(t *testing.T) {
+	var calls [][]string
+	run := func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+
+	if err := restartService("darwin", run); err != nil {
+		t.Fatalf("restartService: %v", err)
+	}
+
+	want := []string{"launchctl", "kickstart", "-k", fmt.Sprintf("gui/%d/dev.agentpod.node", os.Getuid())}
+	if len(calls) != 1 || !reflect.DeepEqual(calls[0], want) {
+		t.Fatalf("calls = %v, want exactly [%v]", calls, want)
+	}
+}
+
+func TestRestartServiceDarwinFailureWrapsErrRestartFailed(t *testing.T) {
+	run := func(name string, args ...string) error { return errors.New("no such service") }
+	err := restartService("darwin", run)
+	if !errors.Is(err, ErrRestartFailed) {
+		t.Fatalf("err = %v, want ErrRestartFailed", err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -478,8 +504,13 @@ func TestUpdate(t *testing.T) {
 		if string(got) != string(content) {
 			t.Errorf("target: got %q want %q", got, content)
 		}
-		// Restart was called
-		if len(runCalls) < 2 {
+		// Restart was called. Update() passes the real runtime.GOOS through to
+		// restartService, so the exact call count is platform-dependent (linux:
+		// is-active probe + restart = 2; darwin: single launchctl kickstart = 1).
+		// The systemd- and launchd-specific call sequences are covered in detail
+		// by TestRestartService and TestRestartServiceDarwin*; here we only
+		// assert that Update() actually attempted a restart.
+		if len(runCalls) < 1 {
 			t.Errorf("expected restart calls, got %d", len(runCalls))
 		}
 	})

--- a/apps/node-agent/scripts/install.sh
+++ b/apps/node-agent/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # install.sh — curl-based installer for the AgentPod node-agent.
 #
-# System-wide (needs root; installs a systemd service):
+# System-wide (needs root; installs a systemd service on Linux):
 #   curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/install.sh \
 #     | sudo bash -s -- <HUB_URL> <TOKEN>
 #
@@ -12,6 +12,10 @@
 #   HUB_URL   e.g. https://hub.agentpod.dev
 #   TOKEN     enrollment token issued by the hub
 #   --user    rootless install (no sudo): binary in ~/.local/bin, config in ~/.config
+#
+# macOS: always a rootless per-user install, regardless of sudo/--user — binary
+# in ~/.local/bin, service as a per-user LaunchAgent (~/Library/LaunchAgents).
+# A sudo invocation re-execs as the invoking (non-root) user automatically.
 #
 # Optional env:
 #   VERSION                 pin a release tag (e.g. v0.2.0); default: latest release
@@ -58,6 +62,22 @@ elif command -v sudo >/dev/null 2>&1; then
   exec sudo VERSION="${VERSION:-}" bash "$0" "$HUB_URL" "$TOKEN"
 else
   echo "INFO: not root and 'sudo' not found — falling back to a rootless --user install."
+  MODE=user
+fi
+
+# ---------------------------------------------------------------------------
+# macOS: always a rootless per-user install (binary in ~/.local/bin, config in
+# the user's dir, service as a per-user LaunchAgent). A sudo invocation (the
+# console's copy-paste one-liner) re-execs as the invoking user.
+# ---------------------------------------------------------------------------
+if [ "$(uname -s)" = "Darwin" ]; then
+  if [ "$(id -u)" = "0" ]; then
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+      echo "INFO: macOS install runs per-user — re-executing as ${SUDO_USER}."
+      exec sudo -u "$SUDO_USER" VERSION="${VERSION:-}" AGENTPOD_USER_INSTALL=1 bash "$0" "$HUB_URL" "$TOKEN"
+    fi
+    echo "ERROR: macOS install must run as a regular user (not root)." >&2; exit 1
+  fi
   MODE=user
 fi
 
@@ -143,6 +163,50 @@ path_hint() {
   esac
 }
 
+install_launch_agent() {
+  # Per-user LaunchAgent: survives reboot/terminal close, respawns on crash —
+  # and respawns after self-update's exit, which is what makes console
+  # one-click updates work on macOS (KeepAlive plays systemd Restart=always).
+  local plist_dir="$HOME/Library/LaunchAgents"
+  local plist="$plist_dir/dev.agentpod.node.plist"
+  local log="$HOME/Library/Logs/agentpod-node.log"
+  mkdir -p "$plist_dir" "$HOME/Library/Logs"
+  cat > "$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.agentpod.node</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${DEST_BIN}</string>
+    <string>run</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${log}</string>
+  <key>StandardErrorPath</key><string>${log}</string>
+</dict>
+</plist>
+EOF
+  local uid; uid="$(id -u)"
+  # Idempotent re-install: tear down any loaded copy first (ignore failures).
+  launchctl bootout "gui/${uid}/dev.agentpod.node" >/dev/null 2>&1 || true
+  if launchctl bootstrap "gui/${uid}" "$plist" 2>/dev/null || launchctl load -w "$plist" 2>/dev/null; then
+    echo ""
+    echo "Running as a launchd LaunchAgent (survives reboot while you're logged in):"
+    echo "  status:     launchctl print gui/${uid}/dev.agentpod.node | head -20"
+    echo "  logs:       tail -f ${log}"
+    echo "  restart:    launchctl kickstart -k gui/${uid}/dev.agentpod.node"
+    echo "  uninstall:  launchctl bootout gui/${uid}/dev.agentpod.node && rm ${plist}"
+    echo "NOTE: a LaunchAgent only runs while you are logged in; system sleep"
+    echo "      suspends it — the node shows offline until wake (by design)."
+    return 0
+  fi
+  echo "WARNING: could not bootstrap the LaunchAgent — start manually with: apn run" >&2
+  return 1
+}
+
 if [ "$MODE" = "user" ]; then
   echo ""
   echo "Done. agentpod-node installed to ${DEST_BIN} (rootless — no sudo used)."
@@ -167,6 +231,8 @@ WantedBy=default.target
 EOF
     systemctl --user daemon-reload
     if systemctl --user enable --now agentpod-node >/dev/null 2>&1; then SVC_OK=1; fi
+  elif [ "$OS" = "darwin" ]; then
+    if install_launch_agent; then SVC_OK=1; fi
   fi
   echo ""
   if [ "$SVC_OK" = "1" ]; then
@@ -194,12 +260,4 @@ elif [ "$OS" = "linux" ]; then
   echo "Done. agentpod-node is running as a systemd service."
   echo "  status:  systemctl status agentpod-node"
   echo "  logs:    journalctl -u agentpod-node -f"
-
-elif [ "$OS" = "darwin" ]; then
-  # ---- system + macOS: no systemd ----
-  echo ""
-  echo "Done. agentpod-node is installed and enrolled."
-  echo "  Run interactively:  apn run"
-  echo "  Or set up a launchd plist (LaunchDaemon/LaunchAgent) with"
-  echo "    ProgramArguments: [\"${DEST_BIN}\", \"run\"]"
 fi

--- a/apps/node-agent/scripts/install.sh
+++ b/apps/node-agent/scripts/install.sh
@@ -236,10 +236,14 @@ EOF
   fi
   echo ""
   if [ "$SVC_OK" = "1" ]; then
-    echo "Running as a systemd --user service:"
-    echo "  status:  systemctl --user status agentpod-node"
-    echo "  logs:    journalctl --user -u agentpod-node -f"
-    echo "  To survive logout/reboot, an admin runs once:  sudo loginctl enable-linger $USER"
+    # install_launch_agent already printed the full darwin summary; only
+    # linux's systemd --user path needs its own summary here.
+    if [ "$OS" = "linux" ]; then
+      echo "Running as a systemd --user service:"
+      echo "  status:  systemctl --user status agentpod-node"
+      echo "  logs:    journalctl --user -u agentpod-node -f"
+      echo "  To survive logout/reboot, an admin runs once:  sudo loginctl enable-linger $USER"
+    fi
   else
     echo "To start it now:       apn run"
     echo "Persist without root:  tmux new -s apn 'apn run'   (or)   nohup apn run >~/agentpod-node.log 2>&1 &"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -300,3 +300,12 @@ curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/in
   | sudo bash -s -- https://hub.<your-domain> <TOKEN>
 ```
 Or, from a repo checkout: `sudo bash apps/node-agent/scripts/install-node-agent.sh https://hub.<your-domain> <TOKEN>`.
+
+On macOS the same command always installs rootless (regardless of `sudo`) and (re)installs a per-user LaunchAgent — `~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`:
+```bash
+launchctl print gui/$(id -u)/dev.agentpod.node | head -20   # status
+tail -f ~/Library/Logs/agentpod-node.log                    # logs
+launchctl kickstart -k gui/$(id -u)/dev.agentpod.node       # restart
+launchctl bootout gui/$(id -u)/dev.agentpod.node && rm ~/Library/LaunchAgents/dev.agentpod.node.plist   # uninstall
+```
+It only runs while the user is logged in; system sleep suspends it and the node shows offline until wake.

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -27,6 +27,17 @@ curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/in
 ```
 (If not root and `sudo` is absent, the installer auto-falls back to this rootless mode. For a `systemd --user` service to survive logout/reboot, run `sudo loginctl enable-linger <user>` once.)
 
+**macOS** — the same one-liner (with or without `sudo`/`--user`) always installs rootless: binary in `~/.local/bin`, enrolled as the invoking user, service registered as a per-user LaunchAgent (`~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`). A `sudo ... | bash` invocation re-execs itself as `$SUDO_USER` automatically.
+
+```bash
+launchctl print gui/$(id -u)/dev.agentpod.node | head -20                        # status
+tail -f ~/Library/Logs/agentpod-node.log                                         # logs
+launchctl kickstart -k gui/$(id -u)/dev.agentpod.node                            # restart
+launchctl bootout gui/$(id -u)/dev.agentpod.node && rm ~/Library/LaunchAgents/dev.agentpod.node.plist   # uninstall
+```
+
+A LaunchAgent only runs while you're logged in — system sleep suspends it, and the node shows offline until wake (by design).
+
 The installer downloads the prebuilt binary for your platform (linux/darwin × amd64/arm64) from the latest GitHub Release, then:
 1. Installs it to `/usr/local/bin/agentpod-node`.
 2. Runs `agentpod-node enroll --hub <HUB_URL> --token <TOKEN>` — writes config to `/root/.config/agentpod-node/config.json`.

--- a/docs/superpowers/plans/2026-08-08-macos-launchd-installer.md
+++ b/docs/superpowers/plans/2026-08-08-macos-launchd-installer.md
@@ -1,0 +1,298 @@
+# macOS LaunchAgent Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `install.sh` on macOS installs a persistent per-user LaunchAgent, and `apn update` restarts correctly under launchd. Ships as v0.1.12.
+
+**Architecture:** Spec: `docs/superpowers/specs/2026-08-08-macos-launchd-installer-design.md`. Two independent changes — a darwin branch in `restartService` (Go, behind the existing injected `RunCommand` seam) and a darwin service section in `install.sh` (plist + `launchctl bootstrap`) — then a release + live dogfood on the real Mac node.
+
+**Tech Stack:** Go (node-agent), bash, launchd.
+
+## Global Constraints
+
+- Branch: `develop`. Commit style: `feat(node-agent): …` / `fix(node-agent): …` (match `git log`).
+- Node-agent tests: `cd apps/node-agent && go test -race ./...`; gofmt-clean on changed files.
+- Linux behavior must stay byte-identical: systemd paths in both `restartService` and `install.sh` untouched.
+- Plist label is exactly `dev.agentpod.node`; plist path `~/Library/LaunchAgents/dev.agentpod.node.plist`; logs `~/Library/Logs/agentpod-node.log`.
+- Board workflow: file one issue for the feature (Task 1 Step 1), close it with a summary comment when Task 3's live verify passes.
+- The live Mac node (`node_161e685104dc488ebd11`) currently runs via a nohup'd process started from a Claude session — Task 3 replaces it with the LaunchAgent; do not leave both running.
+
+---
+
+### Task 1: selfupdate darwin restart branch
+
+**Files:**
+- Modify: `apps/node-agent/internal/selfupdate/selfupdate.go:217-237` (restartService) and its two call sites
+- Modify: `apps/node-agent/cmd/agentpod-node/main.go` (the ErrRestartFailed hint text)
+- Test: `apps/node-agent/internal/selfupdate/selfupdate_test.go` (extend the Steps 9–10 section)
+
+**Interfaces:**
+- Consumes: existing `Options.RunCommand` seam; `ErrRestartFailed`.
+- Produces: `restartService(goos string, run func(name string, args ...string) error) error` — call sites pass `runtime.GOOS`; existing tests pass `"linux"`. Darwin runs exactly: `launchctl kickstart -k gui/<uid>/dev.agentpod.node` where `<uid> = os.Getuid()`.
+
+- [ ] **Step 1: File the issue**
+
+```bash
+gh issue create --repo rakeshgangwar/agentpod \
+  --title "installer: macOS LaunchAgent (persistent node-agent) + launchd-aware apn update restart" \
+  --body "install.sh on darwin currently prints 'set up a launchd plist yourself' and apn update tries systemctl on macOS (misleading ErrRestartFailed hint). Add: (1) install.sh darwin branch that installs ~/.local/bin binary + writes ~/Library/LaunchAgents/dev.agentpod.node.plist (RunAtLoad+KeepAlive, logs to ~/Library/Logs/agentpod-node.log) and bootstraps it idempotently; sudo invocations re-exec as SUDO_USER. (2) selfupdate restartService darwin branch: launchctl kickstart -k gui/<uid>/dev.agentpod.node. KeepAlive also makes console one-click updates work on macOS (exit -> respawn). Spec: docs/superpowers/specs/2026-08-08-macos-launchd-installer-design.md" \
+  --label "enhancement" 2>/dev/null || \
+gh issue create --repo rakeshgangwar/agentpod \
+  --title "installer: macOS LaunchAgent (persistent node-agent) + launchd-aware apn update restart" \
+  --body "See docs/superpowers/specs/2026-08-08-macos-launchd-installer-design.md"
+```
+
+Note the issue number `<N>` for commits/comments.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `apps/node-agent/internal/selfupdate/selfupdate_test.go` (the file already has a `run`-recording pattern in its Steps 9–10 section — mirror it):
+
+```go
+func TestRestartServiceDarwinUsesLaunchctlKickstart(t *testing.T) {
+	var calls [][]string
+	run := func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+
+	if err := restartService("darwin", run); err != nil {
+		t.Fatalf("restartService: %v", err)
+	}
+
+	want := []string{"launchctl", "kickstart", "-k", fmt.Sprintf("gui/%d/dev.agentpod.node", os.Getuid())}
+	if len(calls) != 1 || !reflect.DeepEqual(calls[0], want) {
+		t.Fatalf("calls = %v, want exactly [%v]", calls, want)
+	}
+}
+
+func TestRestartServiceDarwinFailureWrapsErrRestartFailed(t *testing.T) {
+	run := func(name string, args ...string) error { return errors.New("no such service") }
+	err := restartService("darwin", run)
+	if !errors.Is(err, ErrRestartFailed) {
+		t.Fatalf("err = %v, want ErrRestartFailed", err)
+	}
+}
+```
+
+(Add `"reflect"`, `"os"`, `"fmt"`, `"errors"` to the test file's imports if missing.)
+
+- [ ] **Step 3: Run — expect FAIL** (`restartService` takes 1 arg / undefined behavior)
+
+Run: `cd apps/node-agent && go test ./internal/selfupdate/ -run TestRestartServiceDarwin`
+
+- [ ] **Step 4: Implement**
+
+Replace `restartService` in `apps/node-agent/internal/selfupdate/selfupdate.go`:
+
+```go
+// restartService restarts the agentpod-node service for the given GOOS.
+//
+// linux: probes for a user-scoped systemd unit first; if active uses --user,
+// else the system unit. darwin: the installer runs the agent as the LaunchAgent
+// gui/<uid>/dev.agentpod.node — kickstart -k kills and restarts it. Returns a
+// wrapped ErrRestartFailed when the restart command fails (the binary is
+// already swapped at that point).
+func restartService(goos string, run func(name string, args ...string) error) error {
+	if run == nil {
+		run = func(name string, args ...string) error {
+			return exec.Command(name, args...).Run()
+		}
+	}
+	var restartErr error
+	if goos == "darwin" {
+		restartErr = run("launchctl", "kickstart", "-k", fmt.Sprintf("gui/%d/dev.agentpod.node", os.Getuid()))
+	} else if run("systemctl", "--user", "is-active", "agentpod-node") == nil {
+		restartErr = run("systemctl", "--user", "restart", "agentpod-node")
+	} else {
+		restartErr = run("systemctl", "restart", "agentpod-node")
+	}
+	if restartErr != nil {
+		return fmt.Errorf("%w: %v", ErrRestartFailed, restartErr)
+	}
+	return nil
+}
+```
+
+Update the two call sites (`selfupdate.go:349` area) to `restartService(runtime.GOOS, opts.RunCommand)` (add `"runtime"` import if missing), and update every existing test call from `restartService(run)` to `restartService("linux", run)`.
+
+In `apps/node-agent/cmd/agentpod-node/main.go`, the `ErrRestartFailed` hint currently says `restart the service manually: systemctl restart agentpod-node`. Make it platform-aware:
+
+```go
+			if errors.Is(err, selfupdate.ErrRestartFailed) {
+				fmt.Fprintln(os.Stderr, "update: binary swapped but service restart failed:", err)
+				if runtime.GOOS == "darwin" {
+					fmt.Fprintf(os.Stderr, "restart it manually: launchctl kickstart -k gui/%d/dev.agentpod.node  (or re-run: apn run)\n", os.Getuid())
+				} else {
+					fmt.Fprintln(os.Stderr, "restart the service manually: systemctl restart agentpod-node")
+				}
+				os.Exit(1)
+			}
+```
+
+(`runtime` is already imported in main.go for the `version` command.)
+
+- [ ] **Step 5: Run — expect PASS**, then full suite
+
+Run: `cd apps/node-agent && go test -race ./...` — all green; `gofmt -l internal/selfupdate/` clean for changed files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/node-agent
+git commit -m "feat(node-agent): launchd-aware self-update restart on macOS (#<N>)"
+```
+
+---
+
+### Task 2: install.sh darwin LaunchAgent
+
+**Files:**
+- Modify: `apps/node-agent/scripts/install.sh` (header comment; sudo handling ~line 50-62; the final darwin section at lines 198-205; the `MODE=user` darwin fallback at 146-180)
+- Modify: `docs/DEPLOYMENT.md` + `docs/OPERATING.md` (macOS service section)
+
+**Interfaces:**
+- Consumes: `DEST_BIN` (absolute binary path), existing enroll flow.
+- Produces: on darwin (any mode), after enroll: `install_launch_agent` writes `~/Library/LaunchAgents/dev.agentpod.node.plist` and bootstraps it. Task 3 relies on exactly the label `dev.agentpod.node`.
+
+- [ ] **Step 1: Force darwin installs to user mode (sudo → re-exec as SUDO_USER)**
+
+In the mode-detection block (after line 62), add:
+
+```bash
+# ---------------------------------------------------------------------------
+# macOS: always a rootless per-user install (binary in ~/.local/bin, config in
+# the user's dir, service as a per-user LaunchAgent). A sudo invocation (the
+# console's copy-paste one-liner) re-execs as the invoking user.
+# ---------------------------------------------------------------------------
+if [ "$(uname -s)" = "Darwin" ]; then
+  if [ "$(id -u)" = "0" ]; then
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+      echo "INFO: macOS install runs per-user — re-executing as ${SUDO_USER}."
+      exec sudo -u "$SUDO_USER" VERSION="${VERSION:-}" AGENTPOD_USER_INSTALL=1 bash "$0" "$HUB_URL" "$TOKEN"
+    fi
+    echo "ERROR: macOS install must run as a regular user (not root)." >&2; exit 1
+  fi
+  MODE=user
+fi
+```
+
+This makes the old `MODE=system && darwin` enroll special-case at lines 128-132 dead on macOS — leave the enroll block as-is (the condition simply never fires), but delete the now-unreachable `elif [ "$OS" = "darwin" ]` section at lines 198-205.
+
+- [ ] **Step 2: Add the LaunchAgent installer function and wire it**
+
+Add near `path_hint()`:
+
+```bash
+install_launch_agent() {
+  # Per-user LaunchAgent: survives reboot/terminal close, respawns on crash —
+  # and respawns after self-update's exit, which is what makes console
+  # one-click updates work on macOS (KeepAlive plays systemd Restart=always).
+  local plist_dir="$HOME/Library/LaunchAgents"
+  local plist="$plist_dir/dev.agentpod.node.plist"
+  local log="$HOME/Library/Logs/agentpod-node.log"
+  mkdir -p "$plist_dir" "$HOME/Library/Logs"
+  cat > "$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.agentpod.node</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${DEST_BIN}</string>
+    <string>run</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${log}</string>
+  <key>StandardErrorPath</key><string>${log}</string>
+</dict>
+</plist>
+EOF
+  local uid; uid="$(id -u)"
+  # Idempotent re-install: tear down any loaded copy first (ignore failures).
+  launchctl bootout "gui/${uid}/dev.agentpod.node" >/dev/null 2>&1 || true
+  if launchctl bootstrap "gui/${uid}" "$plist" 2>/dev/null || launchctl load -w "$plist" 2>/dev/null; then
+    echo ""
+    echo "Running as a launchd LaunchAgent (survives reboot while you're logged in):"
+    echo "  status:     launchctl print gui/${uid}/dev.agentpod.node | head -20"
+    echo "  logs:       tail -f ${log}"
+    echo "  restart:    launchctl kickstart -k gui/${uid}/dev.agentpod.node"
+    echo "  uninstall:  launchctl bootout gui/${uid}/dev.agentpod.node && rm ${plist}"
+    echo "NOTE: a LaunchAgent only runs while you are logged in; system sleep"
+    echo "      suspends it — the node shows offline until wake (by design)."
+    return 0
+  fi
+  echo "WARNING: could not bootstrap the LaunchAgent — start manually with: apn run" >&2
+  return 1
+}
+```
+
+In the `MODE=user` result section (lines 146-180), wire darwin in alongside the linux systemd branch:
+
+```bash
+  SVC_OK=0
+  if [ "$OS" = "linux" ] && command -v systemctl >/dev/null 2>&1 && systemctl --user daemon-reload >/dev/null 2>&1; then
+    ... (existing linux block, unchanged) ...
+  elif [ "$OS" = "darwin" ]; then
+    if install_launch_agent; then SVC_OK=1; fi
+  fi
+```
+
+and gate the existing tmux/nohup fallback echo so it only prints when `SVC_OK=0` (it already does). Update the header comment (lines 1-17) to mention the macOS LaunchAgent.
+
+- [ ] **Step 3: Lint the script**
+
+Run: `bash -n apps/node-agent/scripts/install.sh && (command -v shellcheck >/dev/null && shellcheck -S warning apps/node-agent/scripts/install.sh || echo "shellcheck unavailable — bash -n only")`
+Expected: no syntax errors; no new shellcheck warnings beyond any pre-existing ones (compare against `git stash` baseline if unsure).
+
+- [ ] **Step 4: Docs**
+
+`docs/DEPLOYMENT.md` (node install section) + `docs/OPERATING.md`: add the macOS service bullet — same one-liner installs a LaunchAgent; status/logs/restart/uninstall commands from Step 2's output; the logged-in/sleep limitation sentence from the spec.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/node-agent/scripts/install.sh docs/DEPLOYMENT.md docs/OPERATING.md
+git commit -m "feat(installer): macOS LaunchAgent — persistent node-agent via install.sh (#<N>)"
+```
+
+---
+
+### Task 3: Release v0.1.12 + live dogfood on the Mac node
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Interfaces:** consumes everything above; produces v0.1.12 live, the Mac node running under launchd.
+
+- [ ] **Step 1: Verify + CHANGELOG + PR**
+
+```bash
+cd apps/node-agent && go test -race ./...
+```
+
+Add a `## v0.1.12` CHANGELOG section (macOS LaunchAgent installer, launchd-aware update restart; issue ref). Commit `docs: changelog for v0.1.12`, push `develop`, open PR → `main` titled `v0.1.12: macOS LaunchAgent installer`, wait for the 4 checks, merge (the controller/user merges per session convention).
+
+- [ ] **Step 2: Tag and release**
+
+```bash
+git checkout main && git pull && git tag v0.1.12 && git push origin v0.1.12
+```
+
+Watch `release-node-agent.yml`; expect 4 binaries + install.sh (the NEW one) + .service + SHA256SUMS.
+
+- [ ] **Step 3: Live dogfood on this Mac**
+
+1. Mint an enrollment token in the console (needed as an installer arg; enroll itself will KEEP the existing identity via credential-check — the token goes unused, which is the #161 design working).
+2. Kill the nohup'd agent: `pkill -f "local/bin/agentpod-node run"` (and any scratchpad copy).
+3. Run the real one-liner: `curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/install.sh | bash -s -- --user https://hub.agentpod.dev <TOKEN>`.
+4. Expect: binary v0.1.12 installed, `already enrolled: node_161e685104dc488ebd11 (credential verified)`, LaunchAgent bootstrapped, node online in the console within ~30s showing `v: v0.1.12`.
+5. Kickstart test: `launchctl kickstart -k gui/$(id -u)/dev.agentpod.node` → node blips offline→online (honest close + reconnect).
+6. Terminal-independence test: the agent has no controlling terminal — confirm `ps -o ppid= -p $(pgrep -f 'agentpod-node run')` shows ppid 1 (launchd).
+7. Roll superchotu + molt-bot to v0.1.12 from the console (uniform fleet; hub restart first if the version cache hides the button).
+
+- [ ] **Step 4: Close out**
+
+Summary comment on #<N> with commits + live evidence; close it. Verify board card Done. Update the session memory file with the launchd facts (label, plist path, uninstall, restart semantics).

--- a/docs/superpowers/specs/2026-08-08-macos-launchd-installer-design.md
+++ b/docs/superpowers/specs/2026-08-08-macos-launchd-installer-design.md
@@ -1,0 +1,50 @@
+# macOS LaunchAgent Installer — Design
+
+**Date:** 2026-08-08
+**Goal:** `install.sh` on macOS produces a persistent node-agent (survives reboot, terminal close, crashes) via a per-user LaunchAgent, and `apn update` restarts correctly under launchd. Ships as v0.1.12.
+
+## Scope
+
+- `apps/node-agent/scripts/install.sh` — darwin branch installs and bootstraps a LaunchAgent.
+- `apps/node-agent/internal/selfupdate` — darwin restart path via launchctl.
+- Docs: DEPLOYMENT/OPERATING notes for the macOS service (status, logs, uninstall) and the logged-in/sleep limitation.
+
+Out of scope: LaunchDaemon (pre-login root service), Windows, changes to the linux systemd paths.
+
+## 1. install.sh darwin path
+
+macOS installs are always rootless-per-user:
+
+- Invoked via `sudo` (the console one-liner): re-exec the entire script as `$SUDO_USER` (extends the existing darwin enroll-as-`$SUDO_USER` special case to the whole install). Invoked as a normal user: proceed directly.
+- Binary → `~/.local/bin/agentpod-node` (+ `apn` symlink), config → the user config dir, enroll as that user. The self-healing enroll (#161) makes re-runs safe: valid credential → keep, stale → re-enroll.
+- Write `~/Library/LaunchAgents/dev.agentpod.node.plist`:
+  - `Label` = `dev.agentpod.node`
+  - `ProgramArguments` = [`<abs home>/.local/bin/agentpod-node`, `run`] (absolute path — launchd has no PATH)
+  - `RunAtLoad` = true, `KeepAlive` = true
+  - `StandardOutPath`/`StandardErrorPath` = `~/Library/Logs/agentpod-node.log`
+- Bootstrap idempotently: `launchctl bootout gui/$UID/dev.agentpod.node` first (ignore failure), then `launchctl bootstrap gui/$UID <plist>`; if `bootstrap` is unsupported (older macOS), fall back to `launchctl load -w <plist>`.
+- Final output tells the operator: status (`launchctl print gui/$UID/dev.agentpod.node`), logs path, uninstall (`launchctl bootout … && rm <plist>`).
+
+`KeepAlive=true` also makes console one-click self-update work on macOS with no extra code: the update handler's delayed `os.Exit(0)` is respawned by launchd (same role systemd `Restart=always` plays on linux).
+
+## 2. selfupdate restart on darwin
+
+`restartService` currently shells to `systemctl` only; on macOS `apn update` swaps the binary then fails with a misleading "systemctl restart" hint. Add a darwin branch:
+
+- `launchctl kickstart -k gui/<uid>/dev.agentpod.node` via the existing injected `RunCommand` seam (table-testable, no real launchctl in tests).
+- On failure (agent not under launchd, e.g. a bare `apn run` terminal), the existing `ErrRestartFailed` path applies with a platform-correct message: restart it yourself (`launchctl kickstart -k gui/$UID/dev.agentpod.node` or re-run `apn run`).
+- Runtime OS selects the branch (`runtime.GOOS`), keeping linux behavior byte-identical.
+
+## Limitation (documented, by design)
+
+A LaunchAgent runs only while the user is logged in, and system sleep suspends it. The node then reads honestly offline (45s sweeper) and reconnects on wake — correct behavior for a laptop node, not a defect.
+
+## Testing / verification
+
+- Go: table tests for the darwin restart branch through the injected RunCommand (asserting the exact launchctl argv), plus the existing linux cases stay green.
+- Shell: install.sh has no test harness; keep the darwin branch small and verify live.
+- Live dogfood on the Mac node: run the installer one-liner (existing valid credential → enroll keeps identity), kill the nohup'd agent, confirm the LaunchAgent connects (node online, `v: v0.1.12`), `launchctl kickstart -k` respawns it, and a console one-click update onto the NEXT release works when available.
+
+## Release
+
+Tag v0.1.12 (release assets carry the updated install.sh). Fleet linux nodes are unaffected but roll anyway to stay uniform.

--- a/docs/superpowers/specs/2026-08-08-ui-revamp-design.md
+++ b/docs/superpowers/specs/2026-08-08-ui-revamp-design.md
@@ -1,0 +1,103 @@
+# UI Revamp — Crisp Console
+
+**Date:** 2026-08-08
+**Status:** Approved
+**Branch:** `ui-revamp`
+
+## Problem
+
+The console's components feel homemade in both directions: the heavy views (file browser, logs, terminal) lack table-stakes capability (search, filtering, tabs, resizable panes), and the everyday primitives (cards, tables, lists, forms) carry hand-rolled `.cyber-*` styling instead of leaning on a well-built base. The cyberpunk layer (noise, scanlines, glitch, corner accents) is a large part of why: every component fights custom CSS in a 1,748-line `app.css`.
+
+## Goals
+
+- **Better components everywhere** — both more capable and more refined. All screens, including admin/login/settings.
+- **Evolve to a cleaner look** — the "Crisp Console" direction (see below), dropping the cyberpunk effect layer.
+- **Keep the customization layer intact** — the theme store, ~20 color schemes, font pairings, and light/dark/system/auto modes continue to work unchanged. They keep writing the same token names.
+
+## Non-goals
+
+- No information-architecture changes: the route structure and nav grouping (Fleet: Overview/Agents/Nodes/Runtimes/Activity; System: Settings/Admin) stay as-is.
+- No consolidation into `packages/ui` — it stays unused; that is a separate later decision.
+- No backend (hub/node-agent) changes beyond what existing APIs already provide.
+
+## Visual direction: Crisp Console
+
+Chosen over "Quiet Terminal" (all-mono, denser) and "Soft Professional" (full SaaS, terminal DNA gone). Linear-style hybrid:
+
+- **Sans-serif for headings and UI text; monospace reserved for data** — IDs, counts, paths, log lines, terminal. Terminal DNA kept where it carries meaning.
+- **Crisp 1px borders, no shadows, 6px radius** (radius token changes to `0.375rem`), dense but breathable spacing.
+- **Deleted:** noise overlay, grid/mesh backgrounds, scanlines, glitch/glow/ticker keyframes, `.cyber-card`/`.cyber-btn`/corner accents, `[bracket]` and `//` label motifs, uppercase-tracked mono headings.
+- **Status colors become first-class theme tokens** (running/degraded/starting/stopped/error/sleeping) so badges, dots, heatmap, log levels, and terminal palette all derive from one place per scheme.
+
+## Foundation layer
+
+**Tokens & CSS.** `app.css` keeps: font-face blocks, `:root`/`.dark` oklch token set, `@theme inline` mapping, and a small app-utility layer. The ~650-line cyber design system is deleted incrementally — each class removed when its last consumer screen is migrated. New status-color tokens added to every theme scheme.
+
+**Primitive refresh.** Vendored shadcn-svelte components in `apps/console/src/lib/components/ui/` are re-pulled from the current upstream registry. New primitives added:
+
+- `Table` + a data-table pattern (sorting, filtering, pagination) — replaces hand-rolled tables in Agents, Activity, and Admin.
+- `Resizable` panes (file browser split).
+- `Breadcrumb` (file browser path).
+- `Command` (upgrades the command palette).
+- `Empty` state, `Field`/form composition, and a consistent `Spinner`/skeleton loading convention.
+
+Custom keepers restyled to match: bottom-nav, inline-tabs, ConfirmDialog, TypeToConfirmDialog, monaco-editor, markdown viewer.
+
+**`page-header` slims down.** From 344 lines to a simple title/actions/tabs bar. Emoji and Lottie icon support removed (Lucide only); collapsible mode removed.
+
+**Dead weight removed** (after verifying no live usage): `@assistant-ui/react`, `react`, `react-dom`, `svelte-preprocess-react`, `@xyflow/svelte`, `@dagrejs/dagre`, and their CSS imports. `lottie-web` removed if page-header was its last consumer.
+
+## Workhorse components
+
+**File browser** (`stations/FileBrowser.svelte`, currently 502 lines):
+
+- Resizable tree/preview split with drag handle.
+- Multiple open files as tabs.
+- Breadcrumb path with click-to-navigate.
+- Fuzzy "go to file" (⌘P), integrated with the command palette.
+- Rich preview: Monaco with syntax highlight for code, image preview, **markdown files render with a rendered/source toggle** (reusing the existing markdown component), binary fallback with metadata.
+- File metadata strip: type, size, mtime.
+
+**Log viewer** (`stations/LogTail.svelte`):
+
+- Virtualized scrollback (10k+ lines without jank).
+- Text search with match highlighting.
+- Log-level detection + filter chips with counts (Error/Warn/Info/All).
+- Follow-tail toggle that auto-pauses on scroll-up, with an "N new lines" resume pill.
+- Line-wrap toggle, timestamp normalization, export/download of visible range.
+
+**Terminal** (`stations/Terminal.svelte`):
+
+- Scrollback search with match navigation (xterm search addon).
+- Copy-on-select + right-click paste working across browsers.
+- Terminal palette driven by the active theme's tokens (all schemes carry through).
+- Fullscreen mode keeps the toolbar; inline reconnect status instead of silent drops.
+- WebGL renderer where available.
+
+## Screen sweep (order)
+
+Each screen moves fully onto the new base; cyber classes are deleted with their last consumer. Each step ends in a mergeable, green state.
+
+1. **App shell + navigation** — sidebar, bottom nav, command palette (on `Command`), slimmed page-header.
+2. **Station detail** — showcase screen: health/logs/files/terminal/cleanup/activity tabs; all three workhorses land here.
+3. **Overview** — stat tiles, heatmap, needs-attention, recent activity on new card/table primitives.
+4. **Agents + Activity** — real data-table pattern (sorting, filtering, pagination).
+5. **Nodes + Node detail + Runtimes** — list/detail cards, station tree, New Runtime dialog on new form primitives.
+6. **Settings + Login** — new form/field pattern; theme customization UI kept and restyled; login two-step flow cleaned; OpenCode-era vestiges removed.
+7. **Admin** — users page (792 lines) decomposed onto data-table + form primitives; user detail rebuilt.
+
+## State contract (every screen)
+
+- Every list/table has an `Empty` state.
+- Every async view has a skeleton.
+- Failures render an inline error card with retry — no silent blank panes.
+
+## Testing & verification
+
+- Colocated vitest/@testing-library tests updated per screen: behavior assertions stay, selectors change with markup.
+- Playwright screenshot pass (desktop + mobile) at each phase, compared against the June ui-unification baseline shots in `docs/superpowers/screenshots/`.
+- `pnpm check` and the full test suite green at every phase boundary.
+
+## Delivery
+
+Work happens on `ui-revamp`, PR'd, merged after CI passes, and deployed via the existing Cloudflare pipeline.


### PR DESCRIPTION
Closes #193. install.sh on macOS now installs a persistent per-user LaunchAgent (RunAtLoad + KeepAlive, idempotent bootstrap, sudo re-execs as the invoking user), and apn update restarts via launchctl kickstart on darwin. Linux paths byte-identical. Also carries the UI revamp design spec (d3f64af).
Spec: docs/superpowers/specs/2026-08-08-macos-launchd-installer-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)