### PR TITLE
fix(installer): piped-invocation-safe re-exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,18 @@ macOS installer rootless improvements and launchd-native update restart.
 - **macOS rootless installer** (#193)
   - Installs are now per-user and rootless; sets up a persistent launchd LaunchAgent (`~/Library/LaunchAgents/dev.agentpod.node.plist`) with RunAtLoad and KeepAlive enabled.
   - Logs are written to `~/Library/Logs/agentpod-node.log`.
-  - Sudo invocations re-exec as the invoking user; installations are idempotent (bootout then bootstrap, with `load -w` fallback).
+  - Sudo invocations re-exec as the invoking user, including when the installer is piped (`curl | sudo bash`); installations are idempotent (bootout then bootstrap, with `load -w` fallback).
   - KeepAlive enables one-click self-updates on macOS: the node exits on update, and launchd respawns it.
 
 ### Changed
 
 - **Update restart on macOS** (#193)
   - `apn update` now restarts via `launchctl kickstart -k gui/<uid>/dev.agentpod.node` on macOS instead of failing with a systemctl hint; Linux behavior unchanged.
+
+### Fixed
+
+- **Piped-invocation re-exec** (#193)
+  - The sudo/darwin re-exec added by this release used `bash "$0"`, which resolves to the literal string `"bash"` (not a file) under a piped `curl | bash` invocation — every re-exec case (macOS root-with-`SUDO_USER`, and the generic Linux sudo escalation) failed with `bash: bash: cannot execute binary file`. Re-exec now re-fetches a runnable copy of the installer when `$0` isn't a real file on disk, so the documented piped one-liners work as shipped. A non-root macOS invocation also no longer wastes a needless sudo re-exec before dropping back to a user install.
 
 ### Limitations
 

--- a/apps/node-agent/scripts/install.sh
+++ b/apps/node-agent/scripts/install.sh
@@ -49,36 +49,77 @@ TOKEN="${ARGS[1]:-}"
 [[ -n "$TOKEN" ]] || { echo "ERROR: TOKEN is required" >&2; usage; }
 
 # ---------------------------------------------------------------------------
-# Install mode: system (root) vs user (rootless)
+# Release URL base (needed early: the re-exec helper below re-fetches this
+# script from here whenever $0 isn't a real file on disk).
 # ---------------------------------------------------------------------------
-if [ "$(id -u)" = "0" ]; then
-  MODE=system
-elif [ -n "$USER_INSTALL" ]; then
-  MODE=user
-elif command -v sudo >/dev/null 2>&1; then
-  echo "INFO: not running as root — re-executing with sudo for a system-wide install."
-  echo "      No sudo password on this host? Re-run rootless instead:"
-  echo "        curl -fsSL .../install.sh | bash -s -- --user $HUB_URL <TOKEN>"
-  exec sudo VERSION="${VERSION:-}" bash "$0" "$HUB_URL" "$TOKEN"
-else
-  echo "INFO: not root and 'sudo' not found — falling back to a rootless --user install."
-  MODE=user
-fi
+REPO="rakeshgangwar/agentpod"
+BASE_URL="https://github.com/${REPO}/releases"
+
+# ---------------------------------------------------------------------------
+# Re-exec helper. When this script runs as `curl … | bash`, $0 is the literal
+# string "bash" — not a path to a script file — so `exec … bash "$0" …`
+# becomes `bash bash …`, which fails with "cannot execute binary file" (exit
+# 126). Detect that case and re-fetch a runnable copy of the installer to
+# re-exec instead. Sets SCRIPT_PATH for the caller to use in its exec.
+# ---------------------------------------------------------------------------
+reexec_script_path() {
+  SCRIPT_PATH="$0"
+  if [ ! -f "$SCRIPT_PATH" ]; then
+    if [ -n "${VERSION:-}" ]; then
+      INSTALL_SH_URL="${BASE_URL}/download/${VERSION}/install.sh"
+    else
+      INSTALL_SH_URL="${BASE_URL}/latest/download/install.sh"
+    fi
+    # No trailing suffix after the X run: BSD mktemp (macOS's default — the
+    # OS this darwin re-exec path targets) only randomizes a run of X's at
+    # the very end of the template and silently returns the template
+    # unexpanded (a fixed, non-unique path) if anything follows it, e.g.
+    # ".sh". GNU mktemp handles a trailing suffix fine, but this form works
+    # identically on both.
+    SCRIPT_PATH="$(mktemp /tmp/agentpod-install.XXXXXX)"
+    curl -fsSL "$INSTALL_SH_URL" -o "$SCRIPT_PATH" || { echo "ERROR: cannot re-fetch installer for re-exec" >&2; exit 1; }
+  fi
+}
 
 # ---------------------------------------------------------------------------
 # macOS: always a rootless per-user install (binary in ~/.local/bin, config in
-# the user's dir, service as a per-user LaunchAgent). A sudo invocation (the
-# console's copy-paste one-liner) re-execs as the invoking user.
+# the user's dir, service as a per-user LaunchAgent). Handled before the
+# generic sudo-escalation block below so a non-root macOS run goes straight
+# to MODE=user with no sudo prompt at all. A root invocation (the console's
+# copy-paste `sudo bash …` one-liner) re-execs as the invoking user.
 # ---------------------------------------------------------------------------
 if [ "$(uname -s)" = "Darwin" ]; then
   if [ "$(id -u)" = "0" ]; then
     if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
       echo "INFO: macOS install runs per-user — re-executing as ${SUDO_USER}."
-      exec sudo -u "$SUDO_USER" VERSION="${VERSION:-}" AGENTPOD_USER_INSTALL=1 bash "$0" "$HUB_URL" "$TOKEN"
+      reexec_script_path
+      exec sudo -u "$SUDO_USER" VERSION="${VERSION:-}" AGENTPOD_USER_INSTALL=1 bash "$SCRIPT_PATH" "$HUB_URL" "$TOKEN"
     fi
     echo "ERROR: macOS install must run as a regular user (not root)." >&2; exit 1
   fi
   MODE=user
+fi
+
+# ---------------------------------------------------------------------------
+# Install mode: system (root) vs user (rootless). Only reached when the macOS
+# block above didn't already set MODE — i.e. on Linux, or other non-Darwin
+# hosts (the macOS root paths above always exec or exit).
+# ---------------------------------------------------------------------------
+if [ -z "${MODE:-}" ]; then
+  if [ "$(id -u)" = "0" ]; then
+    MODE=system
+  elif [ -n "$USER_INSTALL" ]; then
+    MODE=user
+  elif command -v sudo >/dev/null 2>&1; then
+    echo "INFO: not running as root — re-executing with sudo for a system-wide install."
+    echo "      No sudo password on this host? Re-run rootless instead:"
+    echo "        curl -fsSL .../install.sh | bash -s -- --user $HUB_URL <TOKEN>"
+    reexec_script_path
+    exec sudo VERSION="${VERSION:-}" bash "$SCRIPT_PATH" "$HUB_URL" "$TOKEN"
+  else
+    echo "INFO: not root and 'sudo' not found — falling back to a rootless --user install."
+    MODE=user
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -100,10 +141,9 @@ esac
 echo "    OS=$OS  ARCH=$ARCH  MODE=$MODE"
 
 # ---------------------------------------------------------------------------
-# Release URL base
+# Release download base (REPO/BASE_URL are defined earlier, before the
+# mode/re-exec logic above that needs them)
 # ---------------------------------------------------------------------------
-REPO="rakeshgangwar/agentpod"
-BASE_URL="https://github.com/${REPO}/releases"
 if [[ -n "${VERSION:-}" ]]; then
   DOWNLOAD_BASE="${BASE_URL}/download/${VERSION}"; echo "    Pinned version: ${VERSION}"
 else

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -301,7 +301,7 @@ curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/in
 ```
 Or, from a repo checkout: `sudo bash apps/node-agent/scripts/install-node-agent.sh https://hub.<your-domain> <TOKEN>`.
 
-On macOS the same command always installs rootless (regardless of `sudo`) and (re)installs a per-user LaunchAgent — `~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`:
+On macOS the same command — piped and all — always installs rootless (regardless of `sudo`, re-execing as the invoking user) and (re)installs a per-user LaunchAgent — `~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`:
 ```bash
 launchctl print gui/$(id -u)/dev.agentpod.node | head -20   # status
 tail -f ~/Library/Logs/agentpod-node.log                    # logs

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -27,7 +27,7 @@ curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/in
 ```
 (If not root and `sudo` is absent, the installer auto-falls back to this rootless mode. For a `systemd --user` service to survive logout/reboot, run `sudo loginctl enable-linger <user>` once.)
 
-**macOS** — the same one-liner (with or without `sudo`/`--user`) always installs rootless: binary in `~/.local/bin`, enrolled as the invoking user, service registered as a per-user LaunchAgent (`~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`). A `sudo ... | bash` invocation re-execs itself as `$SUDO_USER` automatically.
+**macOS** — the same one-liner (with or without `sudo`/`--user`) always installs rootless: binary in `~/.local/bin`, enrolled as the invoking user, service registered as a per-user LaunchAgent (`~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`). The `curl | sudo bash` form above re-execs itself as `$SUDO_USER` automatically, piped invocation included.
 
 ```bash
 launchctl print gui/$(id -u)/dev.agentpod.node | head -20                        # status
@@ -38,10 +38,12 @@ launchctl bootout gui/$(id -u)/dev.agentpod.node && rm ~/Library/LaunchAgents/de
 
 A LaunchAgent only runs while you're logged in — system sleep suspends it, and the node shows offline until wake (by design).
 
-The installer downloads the prebuilt binary for your platform (linux/darwin × amd64/arm64) from the latest GitHub Release, then:
+The installer downloads the prebuilt binary for your platform (linux/darwin × amd64/arm64) from the latest GitHub Release, then — for a **system-wide Linux install (root, no `--user`)**:
 1. Installs it to `/usr/local/bin/agentpod-node`.
 2. Runs `agentpod-node enroll --hub <HUB_URL> --token <TOKEN>` — writes config to `/root/.config/agentpod-node/config.json`.
 3. Installs and enables the systemd unit `agentpod-node.service`.
+
+(Rootless and macOS installs use the different paths and service mechanism described above instead.)
 
 The installer is idempotent: re-running upgrades the binary and re-enrolls. Binaries are published on every `v*` tag by `.github/workflows/release-node-agent.yml`.
 


### PR DESCRIPTION
Final-review catch on #193: curl|bash piping makes \$0 the literal string "bash", so both re-exec sites (new darwin block AND the pre-existing linux sudo escalation) hard-failed with exit 126 — the console's copy-paste one-liner never worked piped+sudo on macOS. Fix: darwin non-root path needs no re-exec at all; remaining re-execs capture a runnable script (real \$0, else re-fetch from the release URL honoring VERSION, BSD-safe mktemp). Docs/CHANGELOG corrected to match. Linux systemd logic untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)