### PR TITLE
v0.1.13: apn service CLI — stop/start/restart/status/logs, service install, help system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Versioning: [S
 
 ---
 
+## v0.1.13 - 2026-08-08
+
+`apn` service CLI: status/stop/start/restart/logs, `service install`/`uninstall`, a grouped help system, and a thinner installer.
+
+### Added
+
+- **Service verbs** (#199)
+  - `apn status [--json]`, `apn stop`, `apn start`, `apn restart`, `apn logs [-f] [-n N]` operate the node-agent's OS service (systemd on Linux, launchd LaunchAgent on macOS) through a new `internal/service.Manager`.
+  - `apn stop` is sticky: it stops **and disables** the service so it doesn't respawn on its own; `apn start` re-enables and starts it.
+  - `apn status` reports local service state (installed/enabled/running/version) plus hub reachability and credential validity; exits 0 only when both are healthy.
+- **`apn service install` / `apn service uninstall`** (#199) — install or remove the platform service directly from the binary, backed by embedded service templates (systemd user/system units, launchd plist).
+- **Help system** (#199) — grouped top-level help (`apn`, `apn help`, `-h`/`--help`), per-command help (`apn help <command>`), and did-you-mean suggestions for unknown commands. `-h`/`--help` now gates every command, including `stop`/`start`/`restart`/`run`/`detect`/`version`/`service` — previously only the four commands with a `flag.FlagSet` (enroll, update, status, logs) recognized `-h`; the others executed the real action (e.g. `apn stop -h` used to actually stop the service).
+
+### Changed
+
+- **Installer thinning** (#199) — `install.sh` no longer inlines the systemd unit heredoc or the LaunchAgent plist heredoc, and no longer downloads `agentpod-node.service` for a system install; it downloads the binary, enrolls, then delegates service setup to `"$DEST_BIN" service install`. The `.service` release asset still ships (for direct consumers) — the installer just stops fetching it.
+- **`apn update`'s restart delegates to `internal/service`** (#199) — the darwin/linux restart logic in selfupdate now goes through `service.NewManagerForRestart` instead of hand-built `launchctl`/`systemctl` argv.
+
+---
+
 ## v0.1.12 - 2026-08-08
 
 macOS installer rootless improvements and launchd-native update restart.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ cd apps/console && pnpm check && pnpm test && pnpm build
 
 Hub tests REQUIRE both: a **pgvector** postgres on `:5434` (`docker run -d --name agentpod-test-postgres -e POSTGRES_USER=agentpod -e POSTGRES_PASSWORD=agentpod-dev-password -e POSTGRES_DB=agentpod -p 5434:5432 pgvector/pgvector:pg16`) and the explicit `DATABASE_URL` override — bun auto-loads `apps/hub/.env`, which may pin a dev DB. Details: `TESTING.md`.
 
+On an enrolled node, `apn status|stop|start|restart|logs [-f]` and `apn service install|uninstall` manage the node-agent service (systemd on Linux, LaunchAgent on macOS) — see `docs/OPERATING.md`.
+
 ## Workflow
 
 - TDD: failing test first, including a regression test for every bug fix.

--- a/apps/node-agent/cmd/agentpod-node/help.go
+++ b/apps/node-agent/cmd/agentpod-node/help.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -155,6 +156,34 @@ func commandHelp(name string) string {
 		}
 	}
 	return ""
+}
+
+// helpRequested reports whether args' first element is a help flag. Only
+// the first argument is checked (matches the flag package's own behavior
+// of treating a later "-h" as an ordinary value, e.g. `apn logs -n -h`
+// where -h is meant as an argument to another flag) — this keeps the gate
+// from ever swallowing a command's real flags.
+//
+// Used to gate every command that doesn't already have its own
+// flag.FlagSet (which gets -h handling for free via flag.ErrHelp) behind a
+// print-help-and-exit path, checked BEFORE any side-effecting action runs
+// — so `apn stop -h` can never actually stop the service, `apn run -h` can
+// never connect and block, `apn service -h` can never install/uninstall,
+// and so on.
+func helpRequested(args []string) bool {
+	return len(args) > 0 && (args[0] == "-h" || args[0] == "--help")
+}
+
+// maybeShowHelp checks helpRequested(args) and, if true, prints name's
+// registered command help to out and returns true — the caller must stop
+// immediately (exit 0) without doing anything else. False means args
+// weren't a help request and the caller should proceed with its real work.
+func maybeShowHelp(out io.Writer, name string, args []string) bool {
+	if !helpRequested(args) {
+		return false
+	}
+	fmt.Fprintln(out, commandHelp(name))
+	return true
 }
 
 // isCommand reports whether name is a registered top-level command.

--- a/apps/node-agent/cmd/agentpod-node/help.go
+++ b/apps/node-agent/cmd/agentpod-node/help.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// command describes one top-level apn verb: its group for the top-level
+// help layout, a one-line summary for that layout, and a longer detail
+// block used both by `apn help <command>` and wired onto the command's own
+// flag.FlagSet.Usage (so `apn <command> -h` shows the same text plus flag
+// defaults). This slice is the single source of truth for all three
+// surfaces — a command missing here is a command missing from help.
+var commands = []struct {
+	name, group, oneline, detail string
+}{
+	{
+		name: "status", group: "Service",
+		oneline: "Show local service + hub connection state (--json for scripts)",
+		detail: "apn status — show local service state and hub connection state.\n\n" +
+			"Local block: whether the service is installed / enabled / running (with\n" +
+			"PID), the binary version, and the config path. Hub block: reachability\n" +
+			"and credential validity, checked against the existing\n" +
+			"GET /public/nodes/credential-check endpoint (no new endpoints).\n\n" +
+			"Exit code is 0 iff the service is running AND the stored hub credential\n" +
+			"is valid — safe to use in scripts/health checks.",
+	},
+	{
+		name: "start", group: "Service",
+		oneline: "Enable and start the background service",
+		detail: "apn start — enable and start the background service (the symmetric\n" +
+			"inverse of 'apn stop').\n\n" +
+			"macOS: `launchctl enable` + `launchctl bootstrap`. Linux: `systemctl\n" +
+			"[--user] enable --now`.\n\n" +
+			"If no service is installed yet, this prints a hint pointing at\n" +
+			"'apn service install' (or run in the foreground with 'apn run').",
+	},
+	{
+		name: "stop", group: "Service",
+		oneline: "Stop and disable the service (sticky across reboots)",
+		detail: "apn stop — stop the service AND disable it (sticky across\n" +
+			"reboots/logins — it will not come back on its own).\n\n" +
+			"macOS: `launchctl bootout` + `launchctl disable`. Linux: `systemctl\n" +
+			"[--user] stop` + `disable`.\n\n" +
+			"Undo with 'apn start' — it re-enables and starts.",
+	},
+	{
+		name: "restart", group: "Service",
+		oneline: "Restart the running service",
+		detail: "apn restart — restart the running service in place.\n\n" +
+			"macOS: `launchctl kickstart -k`. Linux: `systemctl [--user] restart`.",
+	},
+	{
+		name: "logs", group: "Service",
+		oneline: "Show service logs (-f to follow, -n N for last N lines)",
+		detail: "apn logs [-f] [-n N] — show service logs.\n\n" +
+			"macOS: reads/tails ~/Library/Logs/agentpod-node.log.\n" +
+			"Linux: execs `journalctl [--user] -u agentpod-node [-f] [-n N]`.",
+	},
+	{
+		name: "service", group: "Service",
+		oneline: "install | uninstall the platform service (launchd/systemd)",
+		detail: "apn service <install|uninstall> — manage the platform service\n" +
+			"definition.\n\n" +
+			"install: writes a plist (macOS LaunchAgent) or systemd unit from a\n" +
+			"template embedded in the binary, then enables and starts it.\n" +
+			"Idempotent — re-running replaces the file and restarts. Non-root\n" +
+			"Linux uses a --user unit; root Linux uses a system unit; macOS uses a\n" +
+			"LaunchAgent (refuses to run as root).\n\n" +
+			"uninstall: stops, disables, and removes the plist/unit. Idempotent —\n" +
+			"a no-op when nothing is installed. Leaves config/enrollment untouched.",
+	},
+	{
+		name: "enroll", group: "Node",
+		oneline: "Enroll this machine with a hub (--hub, --token, --force)",
+		detail: "apn enroll [--hub URL] [--token TOKEN] [--force] — enroll this\n" +
+			"machine with a hub.\n\n" +
+			"Falls back to the AGENTPOD_HUB_URL/AGENTPOD_ENROLL_TOKEN environment\n" +
+			"variables when the flags are omitted. Idempotent: running it again on\n" +
+			"an already-enrolled machine is a friendly no-op unless the stored\n" +
+			"credential is no longer valid, or --force is passed.",
+	},
+	{
+		name: "run", group: "Node",
+		oneline: "Run the agent in the foreground",
+		detail: "apn run — run the agent in the foreground: connects to the hub and\n" +
+			"handles terminal sessions until interrupted (Ctrl-C).\n\n" +
+			"This is what the installed service runs under the hood; run it\n" +
+			"directly for debugging.",
+	},
+	{
+		name: "detect", group: "Node",
+		oneline: "Print detected harness stations as JSON",
+		detail: "apn detect — print the harness stations detected on this host as\n" +
+			"JSON. Debug/ops smoke test for the descriptors; no hub connection\n" +
+			"required.",
+	},
+	{
+		name: "update", group: "Maintenance",
+		oneline: "Self-update from the latest release (--check, --force)",
+		detail: "apn update [--check] [--force] — self-update from the latest GitHub\n" +
+			"release.\n\n" +
+			"--check resolves and reports the current/latest version without\n" +
+			"changing anything. --force updates even when already on the latest\n" +
+			"version. On success the service is restarted automatically; if the\n" +
+			"restart fails, the binary is already swapped and this prints a\n" +
+			"manual-restart hint.",
+	},
+	{
+		name: "version", group: "Maintenance",
+		oneline: "Print version and platform",
+		detail:  "apn version — print the binary version and platform (GOOS/GOARCH).",
+	},
+}
+
+// commandGroups lists the group names in the order they render in the
+// top-level help layout.
+var commandGroups = []string{"Service", "Node", "Maintenance"}
+
+// helpText renders the full top-level `apn help` layout: tool one-liner and
+// version, usage line, commands grouped by purpose, an examples block, and
+// a closing hint. Matches the layout in the design spec's "Help & CLI UX"
+// section exactly, since that mock is also the acceptance bar.
+func helpText(version string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "agentpod-node (apn) — AgentPod fleet node agent  %s\n\n", version)
+	b.WriteString("Usage: apn <command> [flags]\n\n")
+
+	for _, group := range commandGroups {
+		fmt.Fprintf(&b, "%s:\n", group)
+		for _, c := range commands {
+			if c.group == group {
+				fmt.Fprintf(&b, "  %-12s%s\n", c.name, c.oneline)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("Examples:\n")
+	b.WriteString("  apn status\n")
+	b.WriteString("  apn logs -f\n")
+	b.WriteString("  apn enroll --hub https://hub.example.com --token <TOKEN>\n\n")
+	b.WriteString("Run 'apn help <command>' or 'apn <command> -h' for command details.")
+
+	return b.String()
+}
+
+// commandHelp returns the detail text for a registered command, or "" if
+// name is not a known command. Used by `apn help <command>` and by each
+// command's own flag.FlagSet.Usage.
+func commandHelp(name string) string {
+	for _, c := range commands {
+		if c.name == name {
+			return c.detail
+		}
+	}
+	return ""
+}
+
+// isCommand reports whether name is a registered top-level command.
+func isCommand(name string) bool {
+	for _, c := range commands {
+		if c.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// suggestCommand returns the registered command name closest to the
+// (presumably mistyped) input, or "" if nothing is within edit distance 2 —
+// close enough to be a plausible typo (like "statsu" -> "status") without
+// suggesting an unrelated command for a genuinely unknown verb.
+func suggestCommand(input string) string {
+	const maxSuggestDistance = 2
+	best, bestDist := "", maxSuggestDistance+1
+	for _, c := range commands {
+		if d := levenshtein(input, c.name); d < bestDist {
+			best, bestDist = c.name, d
+		}
+	}
+	if bestDist <= maxSuggestDistance {
+		return best
+	}
+	return ""
+}
+
+// levenshtein computes the edit distance between two strings (insert,
+// delete, substitute each cost 1) using the standard single-row
+// dynamic-programming table. Byte-based: fine for the ASCII command names
+// this is used against.
+func levenshtein(a, b string) int {
+	prevRow := make([]int, len(b)+1)
+	for j := range prevRow {
+		prevRow[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curRow := make([]int, len(b)+1)
+		curRow[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curRow[j] = min3(curRow[j-1]+1, prevRow[j]+1, prevRow[j-1]+cost)
+		}
+		prevRow = curRow
+	}
+	return prevRow[len(b)]
+}
+
+func min3(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}

--- a/apps/node-agent/cmd/agentpod-node/help_test.go
+++ b/apps/node-agent/cmd/agentpod-node/help_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -83,5 +84,71 @@ func TestCommandHelpLogsMentionsPlatformSources(t *testing.T) {
 func TestCommandHelpUnknownReturnsEmpty(t *testing.T) {
 	if got := commandHelp("bogus"); got != "" {
 		t.Errorf("commandHelp(bogus) = %q, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// -h/--help interception gate — registry-driven so every command in
+// `commands` is provably covered, not just the four with their own
+// flag.FlagSet. This is the gate main.go's non-FlagSet cases (stop, start,
+// restart, service, run, detect, version) must check BEFORE doing any real
+// work, so `apn stop -h` can never actually stop the service, `apn run -h`
+// can never connect and block, etc.
+// ---------------------------------------------------------------------------
+
+func TestHelpRequested(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"dash_h_first", []string{"-h"}, true},
+		{"dash_dash_help_first", []string{"--help"}, true},
+		{"dash_h_with_trailing_args", []string{"-h", "extra"}, true},
+		{"no_args", nil, false},
+		{"unrelated_flag", []string{"--json"}, false},
+		{"help_not_first", []string{"--json", "-h"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := helpRequested(c.args); got != c.want {
+				t.Errorf("helpRequested(%v) = %v, want %v", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+// TestMaybeShowHelpCoversEveryRegisteredCommand proves, for every command
+// registered in `commands`, that maybeShowHelp recognizes -h/--help and
+// prints that command's own detail text — and that it does NOT trigger for
+// ordinary (non-help) args, so it never swallows a command's real flags.
+func TestMaybeShowHelpCoversEveryRegisteredCommand(t *testing.T) {
+	for _, c := range commands {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if !maybeShowHelp(&buf, c.name, []string{"-h"}) {
+				t.Fatalf("maybeShowHelp(%q, [-h]) = false, want true", c.name)
+			}
+			if !strings.Contains(buf.String(), commandHelp(c.name)) {
+				t.Errorf("maybeShowHelp(%q) output missing its command help, got:\n%s", c.name, buf.String())
+			}
+		})
+
+		t.Run(c.name+"_double_dash_help", func(t *testing.T) {
+			var buf bytes.Buffer
+			if !maybeShowHelp(&buf, c.name, []string{"--help"}) {
+				t.Fatalf("maybeShowHelp(%q, [--help]) = false, want true", c.name)
+			}
+		})
+
+		t.Run(c.name+"_no_help_flag_does_not_intercept", func(t *testing.T) {
+			var buf bytes.Buffer
+			if maybeShowHelp(&buf, c.name, []string{"--json"}) {
+				t.Errorf("maybeShowHelp(%q, [--json]) = true, want false — must not swallow real flags", c.name)
+			}
+			if buf.Len() != 0 {
+				t.Errorf("maybeShowHelp(%q, [--json]) wrote output, want none:\n%s", c.name, buf.String())
+			}
+		})
 	}
 }

--- a/apps/node-agent/cmd/agentpod-node/help_test.go
+++ b/apps/node-agent/cmd/agentpod-node/help_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// top-level help
+// ---------------------------------------------------------------------------
+
+// TestHelpTextContainsEveryRegisteredCommand iterates the commands registry
+// itself (rather than a hard-coded list) so a new command that forgets to
+// add a one-liner fails this test.
+func TestHelpTextContainsEveryRegisteredCommand(t *testing.T) {
+	text := helpText("v0.1.13")
+	for _, c := range commands {
+		if !strings.Contains(text, c.name) {
+			t.Errorf("helpText missing command %q, got:\n%s", c.name, text)
+		}
+	}
+}
+
+func TestHelpTextContainsGroupsExamplesAndVersion(t *testing.T) {
+	text := helpText("v0.1.13")
+	for _, want := range []string{
+		"Service:",
+		"Node:",
+		"Maintenance:",
+		"Examples:",
+		"apn status",
+		"apn logs -f",
+		"apn enroll --hub https://hub.example.com --token <TOKEN>",
+		"v0.1.13",
+		"Usage: apn <command> [flags]",
+		"Run 'apn help <command>'",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("helpText missing %q, got:\n%s", want, text)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// did-you-mean
+// ---------------------------------------------------------------------------
+
+func TestSuggestCommand(t *testing.T) {
+	t.Run("close_typo_matches", func(t *testing.T) {
+		if got := suggestCommand("statsu"); got != "status" {
+			t.Errorf("suggestCommand(%q) = %q, want %q", "statsu", got, "status")
+		}
+	})
+
+	t.Run("no_close_match_returns_empty", func(t *testing.T) {
+		if got := suggestCommand("zzz"); got != "" {
+			t.Errorf("suggestCommand(%q) = %q, want empty", "zzz", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// per-command help
+// ---------------------------------------------------------------------------
+
+func TestCommandHelpStopMentionsStickySemantics(t *testing.T) {
+	text := commandHelp("stop")
+	if !strings.Contains(text, "sticky") || !strings.Contains(text, "disable") {
+		t.Errorf("commandHelp(stop) missing sticky/disable semantics, got:\n%s", text)
+	}
+}
+
+func TestCommandHelpLogsMentionsPlatformSources(t *testing.T) {
+	text := commandHelp("logs")
+	if !strings.Contains(text, "Library/Logs") {
+		t.Errorf("commandHelp(logs) missing macOS log source, got:\n%s", text)
+	}
+	if !strings.Contains(text, "journalctl") {
+		t.Errorf("commandHelp(logs) missing linux log source, got:\n%s", text)
+	}
+}
+
+func TestCommandHelpUnknownReturnsEmpty(t *testing.T) {
+	if got := commandHelp("bogus"); got != "" {
+		t.Errorf("commandHelp(bogus) = %q, want empty", got)
+	}
+}

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -22,10 +22,26 @@ func alreadyEnrolled(cfg config.Config, loadErr error) bool {
 }
 
 func main() {
-  if len(os.Args) < 2 { fmt.Println("usage: agentpod-node <enroll|run|detect|update|version>"); os.Exit(2) }
+  if len(os.Args) < 2 { fmt.Println(helpText(version)); os.Exit(0) }
   switch os.Args[1] {
+  case "help", "-h", "--help":
+    if os.Args[1] == "help" && len(os.Args) > 2 {
+      name := os.Args[2]
+      if !isCommand(name) {
+        fmt.Printf("unknown command: %q\n", name)
+        os.Exit(2)
+      }
+      fmt.Println(commandHelp(name))
+      os.Exit(0)
+    }
+    fmt.Println(helpText(version))
+    os.Exit(0)
   case "enroll":
     fs := flag.NewFlagSet("enroll", flag.ExitOnError)
+    fs.Usage = func() {
+      fmt.Fprintln(fs.Output(), commandHelp("enroll"))
+      fs.PrintDefaults()
+    }
     flagHub := fs.String("hub", "", "hub base URL")
     flagToken := fs.String("token", "", "enrollment token")
     flagForce := fs.Bool("force", false, "re-enroll even when a valid config exists")
@@ -64,6 +80,10 @@ func main() {
     detectCmd() // debug/ops: print detected stations as JSON
   case "update":
     fs := flag.NewFlagSet("update", flag.ExitOnError)
+    fs.Usage = func() {
+      fmt.Fprintln(fs.Output(), commandHelp("update"))
+      fs.PrintDefaults()
+    }
     check := fs.Bool("check", false, "resolve and report current/latest version, no changes")
     force := fs.Bool("force", false, "update even when already on the latest version")
     fs.Parse(os.Args[2:])
@@ -114,10 +134,12 @@ func main() {
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
     os.Exit(restartCmd(mgr, os.Stdout))
   case "status":
+    jsonOut, done, code := parseStatusFlags(os.Args[2:], os.Stdout)
+    if done { os.Exit(code) }
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
     cfg, cfgErr := config.Load(config.DefaultPath())
-    os.Exit(statusCmd(mgr, cfg, cfgErr, enroll.CheckCredential, parseStatusJSON(os.Args[2:]), os.Stdout))
+    os.Exit(statusCmd(mgr, cfg, cfgErr, enroll.CheckCredential, jsonOut, os.Stdout))
   case "logs":
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
@@ -130,6 +152,11 @@ func main() {
     if len(os.Args) > 3 { rest = os.Args[3:] }
     os.Exit(runServiceVerb(verb, rest, mgr, os.Stdout))
   default:
-    fmt.Println("unknown command:", os.Args[1]); os.Exit(2)
+    fmt.Printf("unknown command: %q\n", os.Args[1])
+    if s := suggestCommand(os.Args[1]); s != "" {
+      fmt.Printf("did you mean '%s'?\n", s)
+    }
+    fmt.Println("run 'apn help' for usage.")
+    os.Exit(2)
   }
 }

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -4,7 +4,8 @@ import ("context"; "errors"; "flag"; "fmt"; "os"; "runtime"
   "github.com/rakeshgangwar/agentpod/node-agent/internal/config"
   "github.com/rakeshgangwar/agentpod/node-agent/internal/enroll"
   "github.com/rakeshgangwar/agentpod/node-agent/internal/host"
-  "github.com/rakeshgangwar/agentpod/node-agent/internal/selfupdate")
+  "github.com/rakeshgangwar/agentpod/node-agent/internal/selfupdate"
+  "github.com/rakeshgangwar/agentpod/node-agent/internal/service")
 
 // version is the agent's build version. Overridden at link time via:
 //
@@ -100,6 +101,34 @@ func main() {
     }
   case "version":
     fmt.Printf("agentpod-node %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
+  case "stop":
+    mgr, err := service.NewManager(nil)
+    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+    os.Exit(stopCmd(mgr, os.Stdout))
+  case "start":
+    mgr, err := service.NewManager(nil)
+    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+    os.Exit(startCmd(mgr, os.Stdout))
+  case "restart":
+    mgr, err := service.NewManager(nil)
+    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+    os.Exit(restartCmd(mgr, os.Stdout))
+  case "status":
+    mgr, err := service.NewManager(nil)
+    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+    cfg, cfgErr := config.Load(config.DefaultPath())
+    os.Exit(statusCmd(mgr, cfg, cfgErr, enroll.CheckCredential, parseStatusJSON(os.Args[2:]), os.Stdout))
+  case "logs":
+    mgr, err := service.NewManager(nil)
+    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+    os.Exit(logsCmd(mgr, os.Args[2:], os.Stdout))
+  case "service":
+    mgr, err := service.NewManager(nil)
+    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+    var verb string; var rest []string
+    if len(os.Args) > 2 { verb = os.Args[2] }
+    if len(os.Args) > 3 { rest = os.Args[3:] }
+    os.Exit(runServiceVerb(verb, rest, mgr, os.Stdout))
   default:
     fmt.Println("unknown command:", os.Args[1]); os.Exit(2)
   }

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -75,8 +75,10 @@ func main() {
     }
     fmt.Println("enrolled:", id)
   case "run":
+    if maybeShowHelp(os.Stdout, "run", os.Args[2:]) { os.Exit(0) }
     runCmd() // implemented in Task 9
   case "detect":
+    if maybeShowHelp(os.Stdout, "detect", os.Args[2:]) { os.Exit(0) }
     detectCmd() // debug/ops: print detected stations as JSON
   case "update":
     fs := flag.NewFlagSet("update", flag.ExitOnError)
@@ -120,19 +122,23 @@ func main() {
       fmt.Println(res.Reason)
     }
   case "version":
+    if maybeShowHelp(os.Stdout, "version", os.Args[2:]) { os.Exit(0) }
     fmt.Printf("agentpod-node %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
   case "stop":
+    // stopEntry gates on -h/--help itself (see help.go's maybeShowHelp) —
+    // NewManager has no side effects of its own (it only inspects
+    // runtime.GOOS/uid), so it's safe to construct before that gate runs.
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(stopCmd(mgr, os.Stdout))
+    os.Exit(stopEntry(mgr, os.Args[2:], os.Stdout))
   case "start":
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(startCmd(mgr, os.Stdout))
+    os.Exit(startEntry(mgr, os.Args[2:], os.Stdout))
   case "restart":
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(restartCmd(mgr, os.Stdout))
+    os.Exit(restartEntry(mgr, os.Args[2:], os.Stdout))
   case "status":
     jsonOut, done, code := parseStatusFlags(os.Args[2:], os.Stdout)
     if done { os.Exit(code) }

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -121,7 +121,7 @@ func main() {
   case "logs":
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(logsCmd(mgr, os.Args[2:], os.Stdout))
+    os.Exit(logsCmd(mgr, os.Args[2:], os.Stdout, os.Stderr))
   case "service":
     mgr, err := service.NewManager(nil)
     if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }

--- a/apps/node-agent/cmd/agentpod-node/service_cmds.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds.go
@@ -225,17 +225,48 @@ func restartCmd(mgr service.Manager, out io.Writer) int {
 	return 0
 }
 
+// stopEntry/startEntry/restartEntry gate stopCmd/startCmd/restartCmd
+// behind maybeShowHelp: `apn stop -h` (etc.) must print command help and
+// exit 0 without ever touching mgr — these commands have no
+// flag.FlagSet of their own to catch -h via flag.ErrHelp, so main.go must
+// intercept it before calling the manager at all.
+func stopEntry(mgr service.Manager, args []string, out io.Writer) int {
+	if maybeShowHelp(out, "stop", args) {
+		return 0
+	}
+	return stopCmd(mgr, out)
+}
+
+func startEntry(mgr service.Manager, args []string, out io.Writer) int {
+	if maybeShowHelp(out, "start", args) {
+		return 0
+	}
+	return startCmd(mgr, out)
+}
+
+func restartEntry(mgr service.Manager, args []string, out io.Writer) int {
+	if maybeShowHelp(out, "restart", args) {
+		return 0
+	}
+	return restartCmd(mgr, out)
+}
+
 // ---------------------------------------------------------------------------
 // service install / uninstall
 // ---------------------------------------------------------------------------
 
-// runServiceVerb dispatches `apn service <verb>`.
+// runServiceVerb dispatches `apn service <verb>`. verb == "-h"/"--help"
+// shows apn service's own command help (never Install()/Uninstall()) —
+// a genuinely unknown subverb still gets the short usage line + exit 2.
 func runServiceVerb(verb string, args []string, mgr service.Manager, out io.Writer) int {
 	switch verb {
 	case "install":
 		return serviceInstallCmd(mgr, out)
 	case "uninstall":
 		return serviceUninstallCmd(mgr, out)
+	case "-h", "--help":
+		fmt.Fprintln(out, commandHelp("service"))
+		return 0
 	default:
 		fmt.Fprintln(out, "usage: apn service <install|uninstall>")
 		return 2

--- a/apps/node-agent/cmd/agentpod-node/service_cmds.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -25,15 +26,27 @@ const serviceUnitName = "agentpod-node"
 // status
 // ---------------------------------------------------------------------------
 
-// parseStatusJSON parses `apn status`'s flag set and reports whether --json
-// was passed. Errors are non-fatal (best-effort) so main.go's case can stay
-// a one-liner that calls this inline.
-func parseStatusJSON(args []string) bool {
+// parseStatusFlags parses `apn status`'s flag set (currently just --json)
+// and reports whether main.go should stop here. done=true means the
+// caller's job is finished — print nothing further, exit with code
+// (0 for -h/--help, having already printed command help + flag defaults to
+// out; 2 for a bad flag). done=false means parsing succeeded normally and
+// the caller should proceed to statusCmd with jsonOut.
+func parseStatusFlags(args []string, out io.Writer) (jsonOut, done bool, code int) {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	jsonOut := fs.Bool("json", false, "machine-readable JSON output")
-	_ = fs.Parse(args)
-	return *jsonOut
+	fs.SetOutput(out)
+	fs.Usage = func() {
+		fmt.Fprintln(out, commandHelp("status"))
+		fs.PrintDefaults()
+	}
+	j := fs.Bool("json", false, "machine-readable JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return false, true, 0
+		}
+		return false, true, 2
+	}
+	return *j, false, 0
 }
 
 // statusCmd assembles and prints `apn status`'s local-service and hub
@@ -390,9 +403,16 @@ func resolveUnitPathForLogs(goos string, mgr service.Manager, errOut io.Writer) 
 func prepareLogsCmd(goos string, mgr service.Manager, homeDir func() (string, error), args []string, out, errOut io.Writer, stat func(string) error) (*exec.Cmd, int) {
 	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
 	fs.SetOutput(out)
+	fs.Usage = func() {
+		fmt.Fprintln(out, commandHelp("logs"))
+		fs.PrintDefaults()
+	}
 	follow := fs.Bool("f", false, "follow log output")
 	lines := fs.Int("n", 50, "number of lines to show")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, 0
+		}
 		return nil, 2
 	}
 

--- a/apps/node-agent/cmd/agentpod-node/service_cmds.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds.go
@@ -40,9 +40,16 @@ func parseStatusJSON(args []string) bool {
 // blocks. Exit code is 0 iff the service is running AND the stored hub
 // credential is valid (scriptable); 1 otherwise.
 func statusCmd(mgr service.Manager, cfg config.Config, cfgErr error, checkCred func(hub, id, secret string) (bool, error), jsonOut bool, out io.Writer) int {
-	// Status() failing degrades to a zero-value Status (not installed, not
-	// running) rather than aborting `apn status` itself.
-	st, _ := mgr.Status()
+	// Status() failing means we genuinely don't know the service's state —
+	// rendering a zero-value block ("installed: no / running: no") would
+	// misread as "not installed" and send an operator toward `apn service
+	// install` when the real problem is e.g. a permission-denied
+	// launchctl/systemctl query. Report the error and stop instead.
+	st, err := mgr.Status()
+	if err != nil {
+		fmt.Fprintln(out, "error: reading service status:", err)
+		return 1
+	}
 
 	enrolled := cfgErr == nil && cfg.NodeID != "" && cfg.NodeSecret != ""
 
@@ -207,9 +214,16 @@ func serviceInstallCmd(mgr service.Manager, out io.Writer) int {
 		return 1
 	}
 	fmt.Fprintln(out, "installed and started.")
-	if st, err := mgr.Status(); err == nil {
-		printServiceSummary(runtime.GOOS, st.UnitPath, out)
+	// A Status() failure here is cosmetic — the install itself already
+	// succeeded — so it gets a one-line warning instead of silently
+	// dropping the operating summary (which would look like install just
+	// printed nothing further, with no explanation).
+	st, err := mgr.Status()
+	if err != nil {
+		fmt.Fprintln(out, "warning: could not read service status for the summary:", err)
+		return 0
 	}
+	printServiceSummary(runtime.GOOS, st.UnitPath, out)
 	return 0
 }
 
@@ -316,6 +330,27 @@ func statFile(path string) error {
 	return err
 }
 
+// resolveUnitPathForLogs returns the systemd unit path used by buildLogsCmd
+// for --user-unit vs -u scope selection on linux. A no-op on any other
+// platform (unitPath is unused there). If Status() itself errors, it prints
+// a one-line warning and falls back to "" (system-scope journalctl) rather
+// than failing `apn logs` outright — logs are a best-effort diagnostic, not
+// worth blocking on a status query that's separately reported by `apn
+// status`. goos is injected (not read from runtime.GOOS) so this is
+// testable on any host, matching internal/service's own goos-injection
+// pattern.
+func resolveUnitPathForLogs(goos string, mgr service.Manager, out io.Writer) string {
+	if goos != "linux" || mgr == nil {
+		return ""
+	}
+	st, err := mgr.Status()
+	if err != nil {
+		fmt.Fprintln(out, "warning: could not read service status (falling back to system-scope journalctl):", err)
+		return ""
+	}
+	return st.UnitPath
+}
+
 // logsCmd parses `apn logs` flags and runs the resulting command with stdio
 // passthrough. All platform/argv decisions delegate to resolveLogsCmd, which
 // is what's under test — this function itself is exec.Cmd.Run() plumbing.
@@ -334,12 +369,7 @@ func logsCmd(mgr service.Manager, args []string, out io.Writer) int {
 		return 1
 	}
 
-	var unitPath string
-	if runtime.GOOS == "linux" && mgr != nil {
-		if st, err := mgr.Status(); err == nil {
-			unitPath = st.UnitPath
-		}
-	}
+	unitPath := resolveUnitPathForLogs(runtime.GOOS, mgr, out)
 
 	cmd, err := resolveLogsCmd(runtime.GOOS, home, unitPath, logsOptions{Follow: *follow, Lines: *lines}, statFile)
 	if err != nil {

--- a/apps/node-agent/cmd/agentpod-node/service_cmds.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds.go
@@ -47,7 +47,11 @@ func statusCmd(mgr service.Manager, cfg config.Config, cfgErr error, checkCred f
 	// launchctl/systemctl query. Report the error and stop instead.
 	st, err := mgr.Status()
 	if err != nil {
-		fmt.Fprintln(out, "error: reading service status:", err)
+		if jsonOut {
+			writeStatusErrorJSON(out, err)
+		} else {
+			fmt.Fprintln(out, "error: reading service status:", err)
+		}
 		return 1
 	}
 
@@ -72,6 +76,23 @@ func statusCmd(mgr service.Manager, cfg config.Config, cfgErr error, checkCred f
 		return 0
 	}
 	return 1
+}
+
+// writeStatusErrorJSON emits a valid, machine-parseable JSON error object
+// when --json is set and mgr.Status() itself failed — `{"error": "..."}`
+// rather than the plain-text "error: ..." line, so a `apn status --json`
+// caller's JSON decoder never has to fall back to text sniffing.
+func writeStatusErrorJSON(out io.Writer, statusErr error) {
+	payload := struct {
+		Error string `json:"error"`
+	}{Error: fmt.Sprintf("reading service status: %v", statusErr)}
+
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return
+	}
+	fmt.Fprintln(out, string(b))
 }
 
 func writeStatusJSON(out io.Writer, st service.Status, cfg config.Config, reachable, credValid bool) {
@@ -333,48 +354,70 @@ func statFile(path string) error {
 // resolveUnitPathForLogs returns the systemd unit path used by buildLogsCmd
 // for --user-unit vs -u scope selection on linux. A no-op on any other
 // platform (unitPath is unused there). If Status() itself errors, it prints
-// a one-line warning and falls back to "" (system-scope journalctl) rather
-// than failing `apn logs` outright — logs are a best-effort diagnostic, not
-// worth blocking on a status query that's separately reported by `apn
-// status`. goos is injected (not read from runtime.GOOS) so this is
-// testable on any host, matching internal/service's own goos-injection
-// pattern.
-func resolveUnitPathForLogs(goos string, mgr service.Manager, out io.Writer) string {
+// a one-line warning to errOut and falls back to "" (system-scope
+// journalctl) rather than failing `apn logs` outright — logs are a
+// best-effort diagnostic, not worth blocking on a status query that's
+// separately reported by `apn status`. errOut is deliberately distinct from
+// the out writer logsCmd uses for its own CLI-level messages: `apn logs -f`
+// streams actual log content over the same fd as out, so a diagnostic
+// written there would corrupt a piped/redirected log stream (e.g. `apn
+// logs -f | tee file`). goos is injected (not read from runtime.GOOS) so
+// this is testable on any host, matching internal/service's own
+// goos-injection pattern.
+func resolveUnitPathForLogs(goos string, mgr service.Manager, errOut io.Writer) string {
 	if goos != "linux" || mgr == nil {
 		return ""
 	}
 	st, err := mgr.Status()
 	if err != nil {
-		fmt.Fprintln(out, "warning: could not read service status (falling back to system-scope journalctl):", err)
+		fmt.Fprintln(errOut, "warning: could not read service status (falling back to system-scope journalctl):", err)
 		return ""
 	}
 	return st.UnitPath
 }
 
-// logsCmd parses `apn logs` flags and runs the resulting command with stdio
-// passthrough. All platform/argv decisions delegate to resolveLogsCmd, which
-// is what's under test — this function itself is exec.Cmd.Run() plumbing.
-func logsCmd(mgr service.Manager, args []string, out io.Writer) int {
+// prepareLogsCmd resolves `apn logs`'s flags, platform, and scope into a
+// ready-to-run *exec.Cmd — without ever calling Run(). This is the seam
+// logsCmd's tests use: homeDir/stat are injectable and goos is a parameter,
+// so every branch (including the linux Status()-error warning landing on
+// errOut, never out) is covered without touching the real filesystem,
+// home directory, or a real tail/journalctl process.
+//
+// Return contract: cmd == nil means "stop here, do not exec" (flag parse
+// error, unresolvable home dir, or resolveLogsCmd's missing-log-file
+// error) — code is the caller's exit code in that case. cmd != nil means
+// code is always 0 and the caller should wire stdio and Run() it.
+func prepareLogsCmd(goos string, mgr service.Manager, homeDir func() (string, error), args []string, out, errOut io.Writer, stat func(string) error) (*exec.Cmd, int) {
 	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
 	fs.SetOutput(out)
 	follow := fs.Bool("f", false, "follow log output")
 	lines := fs.Int("n", 50, "number of lines to show")
 	if err := fs.Parse(args); err != nil {
-		return 2
+		return nil, 2
 	}
 
-	home, err := os.UserHomeDir()
+	home, err := homeDir()
 	if err != nil {
 		fmt.Fprintln(out, "error:", err)
-		return 1
+		return nil, 1
 	}
 
-	unitPath := resolveUnitPathForLogs(runtime.GOOS, mgr, out)
+	unitPath := resolveUnitPathForLogs(goos, mgr, errOut)
 
-	cmd, err := resolveLogsCmd(runtime.GOOS, home, unitPath, logsOptions{Follow: *follow, Lines: *lines}, statFile)
+	cmd, err := resolveLogsCmd(goos, home, unitPath, logsOptions{Follow: *follow, Lines: *lines}, stat)
 	if err != nil {
 		fmt.Fprintln(out, err)
-		return 1
+		return nil, 1
+	}
+	return cmd, 0
+}
+
+// logsCmd is prepareLogsCmd's production wrapper: real platform/home dir/
+// filesystem, then exec.Cmd.Run() with stdio passthrough.
+func logsCmd(mgr service.Manager, args []string, out, errOut io.Writer) int {
+	cmd, code := prepareLogsCmd(runtime.GOOS, mgr, os.UserHomeDir, args, out, errOut, statFile)
+	if cmd == nil {
+		return code
 	}
 	cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, os.Stdin
 	if err := cmd.Run(); err != nil {

--- a/apps/node-agent/cmd/agentpod-node/service_cmds.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/service"
+)
+
+// serviceUnitName is the systemd unit name used by the logs command
+// (journalctl -u/--user-unit). Mirrors internal/service's unexported
+// systemdUnitName constant — kept local since that one isn't exported.
+const serviceUnitName = "agentpod-node"
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+// parseStatusJSON parses `apn status`'s flag set and reports whether --json
+// was passed. Errors are non-fatal (best-effort) so main.go's case can stay
+// a one-liner that calls this inline.
+func parseStatusJSON(args []string) bool {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "machine-readable JSON output")
+	_ = fs.Parse(args)
+	return *jsonOut
+}
+
+// statusCmd assembles and prints `apn status`'s local-service and hub
+// blocks. Exit code is 0 iff the service is running AND the stored hub
+// credential is valid (scriptable); 1 otherwise.
+func statusCmd(mgr service.Manager, cfg config.Config, cfgErr error, checkCred func(hub, id, secret string) (bool, error), jsonOut bool, out io.Writer) int {
+	// Status() failing degrades to a zero-value Status (not installed, not
+	// running) rather than aborting `apn status` itself.
+	st, _ := mgr.Status()
+
+	enrolled := cfgErr == nil && cfg.NodeID != "" && cfg.NodeSecret != ""
+
+	var reachable, credValid bool
+	if enrolled {
+		ok, err := checkCred(cfg.Hub, cfg.NodeID, cfg.NodeSecret)
+		if err == nil {
+			reachable = true
+			credValid = ok
+		}
+	}
+
+	if jsonOut {
+		writeStatusJSON(out, st, cfg, reachable, credValid)
+	} else {
+		writeStatusText(out, st, cfg, enrolled, reachable, credValid)
+	}
+
+	if st.Running && credValid {
+		return 0
+	}
+	return 1
+}
+
+func writeStatusJSON(out io.Writer, st service.Status, cfg config.Config, reachable, credValid bool) {
+	payload := struct {
+		Service service.Status
+		Hub     struct {
+			URL             string
+			NodeID          string
+			Reachable       bool
+			CredentialValid bool
+		}
+	}{Service: st}
+	payload.Hub.URL = cfg.Hub
+	payload.Hub.NodeID = cfg.NodeID
+	payload.Hub.Reachable = reachable
+	payload.Hub.CredentialValid = credValid
+
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return
+	}
+	fmt.Fprintln(out, string(b))
+}
+
+// writeStatusText renders the exact text contract:
+//
+//	Service:
+//	  installed:  yes (<unitPath>)
+//	  enabled:    yes
+//	  running:    yes (pid 35547)
+//	  version:    <version>
+//	Hub:
+//	  url:        https://hub.agentpod.dev
+//	  node:       node_161e685104dc488ebd11
+//	  reachable:  yes
+//	  credential: valid
+func writeStatusText(out io.Writer, st service.Status, cfg config.Config, enrolled, reachable, credValid bool) {
+	installed := "no"
+	if st.Installed {
+		installed = fmt.Sprintf("yes (%s)", st.UnitPath)
+	}
+	running := "no"
+	if st.Running {
+		running = fmt.Sprintf("yes (pid %d)", st.PID)
+	}
+
+	fmt.Fprintln(out, "Service:")
+	statusLine(out, "installed:", installed)
+	statusLine(out, "enabled:", yesNo(st.Enabled))
+	statusLine(out, "running:", running)
+	statusLine(out, "version:", version)
+
+	fmt.Fprintln(out, "Hub:")
+	if !enrolled {
+		fmt.Fprintln(out, "  not enrolled")
+		return
+	}
+	credential := "unknown"
+	if reachable {
+		credential = "valid"
+		if !credValid {
+			credential = "INVALID"
+		}
+	}
+	statusLine(out, "url:", cfg.Hub)
+	statusLine(out, "node:", cfg.NodeID)
+	statusLine(out, "reachable:", yesNo(reachable))
+	statusLine(out, "credential:", credential)
+}
+
+// statusLine prints one "  label:      value" row, left-justifying the
+// colon-terminated label to a fixed 12-column field so every block lines up.
+func statusLine(out io.Writer, label, value string) {
+	fmt.Fprintf(out, "  %-12s%s\n", label, value)
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// ---------------------------------------------------------------------------
+// stop / start / restart
+// ---------------------------------------------------------------------------
+
+// stopCmd stops and disables (sticky) the service.
+func stopCmd(mgr service.Manager, out io.Writer) int {
+	if err := mgr.Stop(); err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return 1
+	}
+	fmt.Fprintln(out, "stopped and disabled — 'apn start' re-enables")
+	return 0
+}
+
+// startCmd enables and starts the service.
+func startCmd(mgr service.Manager, out io.Writer) int {
+	if err := mgr.Start(); err != nil {
+		fmt.Fprintln(out, "error:", err)
+		fmt.Fprintln(out, "hint: no service installed? run 'apn service install' — or start in the foreground with 'apn run'")
+		return 1
+	}
+	fmt.Fprintln(out, "started and enabled — 'apn stop' disables")
+	return 0
+}
+
+// restartCmd restarts the running service in place.
+func restartCmd(mgr service.Manager, out io.Writer) int {
+	if err := mgr.Restart(); err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return 1
+	}
+	fmt.Fprintln(out, "restarted")
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// service install / uninstall
+// ---------------------------------------------------------------------------
+
+// runServiceVerb dispatches `apn service <verb>`.
+func runServiceVerb(verb string, args []string, mgr service.Manager, out io.Writer) int {
+	switch verb {
+	case "install":
+		return serviceInstallCmd(mgr, out)
+	case "uninstall":
+		return serviceUninstallCmd(mgr, out)
+	default:
+		fmt.Fprintln(out, "usage: apn service <install|uninstall>")
+		return 2
+	}
+}
+
+func serviceInstallCmd(mgr service.Manager, out io.Writer) int {
+	if err := mgr.Install(); err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return 1
+	}
+	fmt.Fprintln(out, "installed and started.")
+	if st, err := mgr.Status(); err == nil {
+		printServiceSummary(runtime.GOOS, st.UnitPath, out)
+	}
+	return 0
+}
+
+func serviceUninstallCmd(mgr service.Manager, out io.Writer) int {
+	if err := mgr.Uninstall(); err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return 1
+	}
+	fmt.Fprintln(out, "service stopped, disabled, and removed.")
+	return 0
+}
+
+// printServiceSummary prints the "how to operate it" block that
+// install.sh's install_launch_agent() used to print for darwin — updated to
+// point at the apn verbs this slice adds instead of raw launchctl
+// invocations — plus a systemd equivalent for linux. It is a pure function
+// of (goos, unitPath) so both platform branches are testable on any host.
+func printServiceSummary(goos, unitPath string, out io.Writer) {
+	switch goos {
+	case "darwin":
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Running as a launchd LaunchAgent (survives reboot while you're logged in):")
+		fmt.Fprintln(out, "  status:     apn status")
+		fmt.Fprintln(out, "  logs:       apn logs -f")
+		fmt.Fprintln(out, "  restart:    apn restart")
+		fmt.Fprintln(out, "  uninstall:  apn service uninstall")
+		fmt.Fprintln(out, "NOTE: a LaunchAgent only runs while you are logged in; system sleep")
+		fmt.Fprintln(out, "      suspends it — the node shows offline until wake (by design).")
+	case "linux":
+		userScope := strings.Contains(unitPath, filepath.Join(".config", "systemd", "user"))
+		fmt.Fprintln(out)
+		if userScope {
+			fmt.Fprintln(out, "Running as a systemd --user service:")
+		} else {
+			fmt.Fprintln(out, "Running as a systemd service (system-wide):")
+		}
+		fmt.Fprintln(out, "  status:     apn status")
+		fmt.Fprintln(out, "  logs:       apn logs -f")
+		fmt.Fprintln(out, "  restart:    apn restart")
+		fmt.Fprintln(out, "  uninstall:  apn service uninstall")
+		if userScope {
+			fmt.Fprintln(out, "NOTE: to survive logout/reboot, an admin runs once: sudo loginctl enable-linger $USER")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// logs
+// ---------------------------------------------------------------------------
+
+// logsOptions holds `apn logs`'s parsed flags.
+type logsOptions struct {
+	Follow bool
+	Lines  int
+}
+
+func darwinLogPath(home string) string {
+	return filepath.Join(home, "Library", "Logs", "agentpod-node.log")
+}
+
+// buildLogsCmd constructs the argv for viewing service logs on the given
+// platform. Pure and exec-free — the seam tests assert argv against,
+// instead of ever running real tail/journalctl. unitPath (linux only)
+// selects --user-unit vs -u by checking whether it lives under
+// ~/.config/systemd/user (mirrors internal/service's own scope selection).
+func buildLogsCmd(goos, home, unitPath string, opts logsOptions) *exec.Cmd {
+	if goos == "darwin" {
+		args := []string{"-n", strconv.Itoa(opts.Lines)}
+		if opts.Follow {
+			args = append(args, "-f")
+		}
+		args = append(args, darwinLogPath(home))
+		return exec.Command("tail", args...)
+	}
+
+	args := []string{}
+	if opts.Follow {
+		args = append(args, "-f")
+	}
+	args = append(args, "-n", strconv.Itoa(opts.Lines))
+	if strings.Contains(unitPath, filepath.Join(".config", "systemd", "user")) {
+		args = append(args, "--user-unit", serviceUnitName)
+	} else {
+		args = append(args, "-u", serviceUnitName)
+	}
+	return exec.Command("journalctl", args...)
+}
+
+// resolveLogsCmd builds the log-viewing command, or returns a friendly error
+// when there is nothing to show yet (darwin: no log file written). stat is
+// injectable so tests never touch the real filesystem.
+func resolveLogsCmd(goos, home, unitPath string, opts logsOptions, stat func(string) error) (*exec.Cmd, error) {
+	if goos == "darwin" {
+		logPath := darwinLogPath(home)
+		if err := stat(logPath); err != nil {
+			return nil, fmt.Errorf("no log file yet at %s — has the service been started? (apn service install / apn start)", logPath)
+		}
+	}
+	return buildLogsCmd(goos, home, unitPath, opts), nil
+}
+
+func statFile(path string) error {
+	_, err := os.Stat(path)
+	return err
+}
+
+// logsCmd parses `apn logs` flags and runs the resulting command with stdio
+// passthrough. All platform/argv decisions delegate to resolveLogsCmd, which
+// is what's under test — this function itself is exec.Cmd.Run() plumbing.
+func logsCmd(mgr service.Manager, args []string, out io.Writer) int {
+	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
+	fs.SetOutput(out)
+	follow := fs.Bool("f", false, "follow log output")
+	lines := fs.Int("n", 50, "number of lines to show")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return 1
+	}
+
+	var unitPath string
+	if runtime.GOOS == "linux" && mgr != nil {
+		if st, err := mgr.Status(); err == nil {
+			unitPath = st.UnitPath
+		}
+	}
+
+	cmd, err := resolveLogsCmd(runtime.GOOS, home, unitPath, logsOptions{Follow: *follow, Lines: *lines}, statFile)
+	if err != nil {
+		fmt.Fprintln(out, err)
+		return 1
+	}
+	cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, os.Stdin
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(out, "error:", err)
+		return 1
+	}
+	return 0
+}

--- a/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
@@ -208,6 +208,53 @@ func TestStatusCmd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// status flag parsing (-h / --json / bad flags)
+// ---------------------------------------------------------------------------
+
+func TestParseStatusFlags(t *testing.T) {
+	t.Run("no_flags_defaults_to_text_output", func(t *testing.T) {
+		var buf bytes.Buffer
+		jsonOut, done, code := parseStatusFlags(nil, &buf)
+		if done {
+			t.Fatalf("expected done=false, got done=true code=%d out=%s", code, buf.String())
+		}
+		if jsonOut {
+			t.Error("jsonOut: got true want false")
+		}
+	})
+
+	t.Run("json_flag_parsed", func(t *testing.T) {
+		var buf bytes.Buffer
+		jsonOut, done, _ := parseStatusFlags([]string{"--json"}, &buf)
+		if done {
+			t.Fatalf("expected done=false, got done=true out=%s", buf.String())
+		}
+		if !jsonOut {
+			t.Error("jsonOut: got false want true")
+		}
+	})
+
+	t.Run("dash_h_prints_command_help_and_exits_0", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, done, code := parseStatusFlags([]string{"-h"}, &buf)
+		if !done || code != 0 {
+			t.Fatalf("got done=%v code=%d, want done=true code=0", done, code)
+		}
+		if !strings.Contains(buf.String(), "credential") {
+			t.Errorf("expected command help on out, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("bad_flag_exits_2", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, done, code := parseStatusFlags([]string{"--bogus"}, &buf)
+		if !done || code != 2 {
+			t.Fatalf("got done=%v code=%d, want done=true code=2", done, code)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // stop / start / restart
 // ---------------------------------------------------------------------------
 
@@ -523,6 +570,37 @@ func TestPrepareLogsCmd(t *testing.T) {
 		}
 		if !strings.Contains(outBuf.String(), "no log file yet") {
 			t.Errorf("missing friendly error on out, got:\n%s", outBuf.String())
+		}
+	})
+
+	t.Run("dash_h_prints_command_help_and_exits_0", func(t *testing.T) {
+		mgr := &fakeManager{}
+		homeDir := func() (string, error) { return "/Users/x", nil }
+		var outBuf, errBuf bytes.Buffer
+
+		cmd, code := prepareLogsCmd("darwin", mgr, homeDir, []string{"-h"}, &outBuf, &errBuf, func(string) error { return nil })
+		if cmd != nil {
+			t.Fatalf("expected no cmd for -h, got %v", cmd)
+		}
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !strings.Contains(outBuf.String(), "journalctl") {
+			t.Errorf("expected command help on out, got:\n%s", outBuf.String())
+		}
+	})
+
+	t.Run("bad_flag_still_exits_2", func(t *testing.T) {
+		mgr := &fakeManager{}
+		homeDir := func() (string, error) { return "/Users/x", nil }
+		var outBuf, errBuf bytes.Buffer
+
+		cmd, code := prepareLogsCmd("darwin", mgr, homeDir, []string{"--bogus"}, &outBuf, &errBuf, func(string) error { return nil })
+		if cmd != nil {
+			t.Fatalf("expected no cmd for a bad flag, got %v", cmd)
+		}
+		if code != 2 {
+			t.Errorf("exit code: got %d want 2", code)
 		}
 	})
 }

--- a/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
@@ -119,6 +119,26 @@ func TestStatusCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("status_error_exit_1_no_misleading_service_block", func(t *testing.T) {
+		mgr := &fakeManager{statusErr: errors.New("launchctl print: permission denied")}
+		checkCred := func(hub, id, secret string) (bool, error) {
+			t.Fatal("checkCred must not be called when Status() itself failed")
+			return false, nil
+		}
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, false, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "error:") || !strings.Contains(out, "permission denied") {
+			t.Errorf("missing actionable error output, got:\n%s", out)
+		}
+		if strings.Contains(out, "installed:") || strings.Contains(out, "running:") {
+			t.Errorf("should not render a misleading service block when Status() failed, got:\n%s", out)
+		}
+	})
+
 	t.Run("json_output_unmarshals_into_expected_shape", func(t *testing.T) {
 		mgr := &fakeManager{status: running}
 		checkCred := func(hub, id, secret string) (bool, error) { return true, nil }
@@ -265,6 +285,28 @@ func TestRunServiceVerbInstall(t *testing.T) {
 			t.Errorf("exit code: got %d want 1", code)
 		}
 	})
+
+	t.Run("status_error_after_successful_install_warns_but_still_exits_0", func(t *testing.T) {
+		mgr := &fakeManager{statusErr: errors.New("launchctl print: permission denied")}
+		var buf bytes.Buffer
+		code := runServiceVerb("install", nil, mgr, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.installCalled {
+			t.Error("Install() was not called")
+		}
+		out := buf.String()
+		if !strings.Contains(out, "installed and started.") {
+			t.Errorf("missing install confirmation, got:\n%s", out)
+		}
+		if !strings.Contains(out, "warning:") || !strings.Contains(out, "permission denied") {
+			t.Errorf("missing status warning, got:\n%s", out)
+		}
+		if strings.Contains(out, "apn status") {
+			t.Errorf("should not print the platform summary when status is unknown, got:\n%s", out)
+		}
+	})
 }
 
 func TestRunServiceVerbUninstall(t *testing.T) {
@@ -373,6 +415,44 @@ func TestBuildLogsCmd(t *testing.T) {
 		want := []string{"journalctl", "-n", "100", "-u", "agentpod-node"}
 		if !reflect.DeepEqual(cmd.Args, want) {
 			t.Errorf("argv: got %v want %v", cmd.Args, want)
+		}
+	})
+}
+
+func TestResolveUnitPathForLogs(t *testing.T) {
+	t.Run("linux_status_error_warns_and_falls_back_to_system_scope", func(t *testing.T) {
+		mgr := &fakeManager{statusErr: errors.New("systemctl show: permission denied")}
+		var buf bytes.Buffer
+		got := resolveUnitPathForLogs("linux", mgr, &buf)
+		if got != "" {
+			t.Errorf("unitPath: got %q want empty (fallback)", got)
+		}
+		if !strings.Contains(buf.String(), "warning:") || !strings.Contains(buf.String(), "permission denied") {
+			t.Errorf("missing warning, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("linux_status_ok_uses_unit_path", func(t *testing.T) {
+		mgr := &fakeManager{status: service.Status{UnitPath: "/etc/systemd/system/agentpod-node.service"}}
+		var buf bytes.Buffer
+		got := resolveUnitPathForLogs("linux", mgr, &buf)
+		if got != mgr.status.UnitPath {
+			t.Errorf("unitPath: got %q want %q", got, mgr.status.UnitPath)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("expected no warning on success, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("darwin_never_calls_status", func(t *testing.T) {
+		mgr := &fakeManager{statusErr: errors.New("should not be reached")}
+		var buf bytes.Buffer
+		got := resolveUnitPathForLogs("darwin", mgr, &buf)
+		if got != "" {
+			t.Errorf("unitPath: got %q want empty", got)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("expected no output on darwin, got:\n%s", buf.String())
 		}
 	})
 }

--- a/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
@@ -334,6 +334,96 @@ func TestRestartCmd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// stop / start / restart entry points — the -h gate that keeps `apn stop -h`
+// (etc.) from ever reaching the real manager. fakeManager proves this: if
+// the gate were missing or misordered, stopCalled/startCalled/restartCalled
+// would flip true even though only -h was passed — the exact bug a user
+// probing help would otherwise trigger against a real launchd/systemd
+// service.
+// ---------------------------------------------------------------------------
+
+func TestStopEntry(t *testing.T) {
+	t.Run("dash_h_shows_help_and_never_calls_stop", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := stopEntry(mgr, []string{"-h"}, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if mgr.stopCalled {
+			t.Error("Stop() was called for -h — this would actually stop the real service")
+		}
+		if !strings.Contains(buf.String(), commandHelp("stop")) {
+			t.Errorf("missing command help, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("no_help_flag_calls_stop_normally", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := stopEntry(mgr, nil, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.stopCalled {
+			t.Error("Stop() was not called")
+		}
+	})
+}
+
+func TestStartEntry(t *testing.T) {
+	t.Run("dash_h_shows_help_and_never_calls_start", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := startEntry(mgr, []string{"--help"}, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if mgr.startCalled {
+			t.Error("Start() was called for --help — this would actually start the real service")
+		}
+	})
+
+	t.Run("no_help_flag_calls_start_normally", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := startEntry(mgr, nil, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.startCalled {
+			t.Error("Start() was not called")
+		}
+	})
+}
+
+func TestRestartEntry(t *testing.T) {
+	t.Run("dash_h_shows_help_and_never_calls_restart", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := restartEntry(mgr, []string{"-h"}, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if mgr.restartCalled {
+			t.Error("Restart() was called for -h — this would actually restart the real service")
+		}
+	})
+
+	t.Run("no_help_flag_calls_restart_normally", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := restartEntry(mgr, nil, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.restartCalled {
+			t.Error("Restart() was not called")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // service install / uninstall
 // ---------------------------------------------------------------------------
 
@@ -414,6 +504,30 @@ func TestRunServiceVerbUnknown(t *testing.T) {
 	code := runServiceVerb("bogus", nil, mgr, &buf)
 	if code != 2 {
 		t.Errorf("exit code: got %d want 2", code)
+	}
+}
+
+// TestRunServiceVerbHelp covers `apn service -h`/`apn service --help`:
+// full "service" command help, exit 0, and neither Install() nor
+// Uninstall() gets called. The bare "usage: apn service <install|
+// uninstall>" + exit 2 stays reserved for a genuinely unknown subverb
+// (TestRunServiceVerbUnknown above).
+func TestRunServiceVerbHelp(t *testing.T) {
+	for _, verb := range []string{"-h", "--help"} {
+		t.Run(verb, func(t *testing.T) {
+			mgr := &fakeManager{}
+			var buf bytes.Buffer
+			code := runServiceVerb(verb, nil, mgr, &buf)
+			if code != 0 {
+				t.Errorf("exit code: got %d want 0", code)
+			}
+			if mgr.installCalled || mgr.uninstallCalled {
+				t.Error("Install()/Uninstall() must not be called for -h/--help")
+			}
+			if !strings.Contains(buf.String(), commandHelp("service")) {
+				t.Errorf("missing service command help, got:\n%s", buf.String())
+			}
+		})
 	}
 }
 

--- a/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
@@ -1,0 +1,414 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/service"
+)
+
+// fakeManager is a scripted service.Manager for testing service_cmds.go's
+// CLI-layer logic without ever touching launchctl/systemctl.
+type fakeManager struct {
+	status    service.Status
+	statusErr error
+
+	installErr, uninstallErr, startErr, stopErr, restartErr error
+
+	installCalled, uninstallCalled, startCalled, stopCalled, restartCalled bool
+}
+
+func (f *fakeManager) Install() error   { f.installCalled = true; return f.installErr }
+func (f *fakeManager) Uninstall() error { f.uninstallCalled = true; return f.uninstallErr }
+func (f *fakeManager) Start() error     { f.startCalled = true; return f.startErr }
+func (f *fakeManager) Stop() error      { f.stopCalled = true; return f.stopErr }
+func (f *fakeManager) Restart() error   { f.restartCalled = true; return f.restartErr }
+func (f *fakeManager) Status() (service.Status, error) {
+	return f.status, f.statusErr
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+func TestStatusCmd(t *testing.T) {
+	cfg := config.Config{Hub: "https://hub.agentpod.dev", NodeID: "node_161e685104dc488ebd11", NodeSecret: "s3cr3t"}
+	running := service.Status{Installed: true, Enabled: true, Running: true, PID: 35547, UnitPath: "/tmp/dev.agentpod.node.plist"}
+	stopped := service.Status{Installed: true, Enabled: true, Running: false, UnitPath: "/tmp/dev.agentpod.node.plist"}
+
+	t.Run("running_and_credential_valid_exit_0", func(t *testing.T) {
+		mgr := &fakeManager{status: running}
+		checkCred := func(hub, id, secret string) (bool, error) { return true, nil }
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, false, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "running:    yes (pid 35547)") {
+			t.Errorf("missing running line, got:\n%s", out)
+		}
+		if !strings.Contains(out, "credential: valid") {
+			t.Errorf("missing valid-credential line, got:\n%s", out)
+		}
+	})
+
+	t.Run("running_and_credential_rejected_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{status: running}
+		checkCred := func(hub, id, secret string) (bool, error) { return false, nil }
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, false, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		if !strings.Contains(buf.String(), "credential: INVALID") {
+			t.Errorf("missing INVALID credential line, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("hub_unreachable_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{status: running}
+		checkCred := func(hub, id, secret string) (bool, error) { return false, errors.New("dial tcp: connection refused") }
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, false, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "reachable:  no") {
+			t.Errorf("missing reachable:no line, got:\n%s", out)
+		}
+		if !strings.Contains(out, "credential: unknown") {
+			t.Errorf("missing unknown-credential line, got:\n%s", out)
+		}
+	})
+
+	t.Run("not_running_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{status: stopped}
+		checkCred := func(hub, id, secret string) (bool, error) { return true, nil }
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, false, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		if !strings.Contains(buf.String(), "running:    no") {
+			t.Errorf("missing running:no line, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("no_config_not_enrolled_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{status: stopped}
+		checkCred := func(hub, id, secret string) (bool, error) {
+			t.Fatal("checkCred must not be called when there is no config")
+			return false, nil
+		}
+		var buf bytes.Buffer
+		code := statusCmd(mgr, config.Config{}, errors.New("open config.json: no such file or directory"), checkCred, false, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		if !strings.Contains(buf.String(), "not enrolled") {
+			t.Errorf("missing not-enrolled hint, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("json_output_unmarshals_into_expected_shape", func(t *testing.T) {
+		mgr := &fakeManager{status: running}
+		checkCred := func(hub, id, secret string) (bool, error) { return true, nil }
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, true, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+
+		var got struct {
+			Service service.Status
+			Hub     struct {
+				URL             string
+				NodeID          string
+				Reachable       bool
+				CredentialValid bool
+			}
+		}
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v\noutput:\n%s", err, buf.String())
+		}
+		if got.Service.PID != 35547 {
+			t.Errorf("Service.PID: got %d want 35547", got.Service.PID)
+		}
+		if !got.Service.Running {
+			t.Error("Service.Running: got false want true")
+		}
+		if got.Hub.URL != cfg.Hub {
+			t.Errorf("Hub.URL: got %q want %q", got.Hub.URL, cfg.Hub)
+		}
+		if got.Hub.NodeID != cfg.NodeID {
+			t.Errorf("Hub.NodeID: got %q want %q", got.Hub.NodeID, cfg.NodeID)
+		}
+		if !got.Hub.Reachable {
+			t.Error("Hub.Reachable: got false want true")
+		}
+		if !got.Hub.CredentialValid {
+			t.Error("Hub.CredentialValid: got false want true")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// stop / start / restart
+// ---------------------------------------------------------------------------
+
+func TestStopCmd(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := stopCmd(mgr, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.stopCalled {
+			t.Error("Stop() was not called")
+		}
+		if !strings.Contains(buf.String(), "stopped and disabled") || !strings.Contains(buf.String(), "'apn start' re-enables") {
+			t.Errorf("missing undo hint, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("manager_error_maps_to_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{stopErr: errors.New("disable failed")}
+		var buf bytes.Buffer
+		code := stopCmd(mgr, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+	})
+}
+
+func TestStartCmd(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := startCmd(mgr, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.startCalled {
+			t.Error("Start() was not called")
+		}
+	})
+
+	t.Run("manager_error_prints_install_hint_and_exits_1", func(t *testing.T) {
+		mgr := &fakeManager{startErr: errors.New("no such job")}
+		var buf bytes.Buffer
+		code := startCmd(mgr, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		if !strings.Contains(buf.String(), "apn service install") {
+			t.Errorf("missing install hint, got:\n%s", buf.String())
+		}
+	})
+}
+
+func TestRestartCmd(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := restartCmd(mgr, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.restartCalled {
+			t.Error("Restart() was not called")
+		}
+	})
+
+	t.Run("manager_error_maps_to_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{restartErr: errors.New("boom")}
+		var buf bytes.Buffer
+		code := restartCmd(mgr, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// service install / uninstall
+// ---------------------------------------------------------------------------
+
+func TestRunServiceVerbInstall(t *testing.T) {
+	t.Run("success_prints_platform_summary", func(t *testing.T) {
+		mgr := &fakeManager{status: service.Status{UnitPath: "/Users/x/Library/LaunchAgents/dev.agentpod.node.plist"}}
+		var buf bytes.Buffer
+		code := runServiceVerb("install", nil, mgr, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.installCalled {
+			t.Error("Install() was not called")
+		}
+	})
+
+	t.Run("manager_error_maps_to_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{installErr: errors.New("bootstrap failed")}
+		var buf bytes.Buffer
+		code := runServiceVerb("install", nil, mgr, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+	})
+}
+
+func TestRunServiceVerbUninstall(t *testing.T) {
+	t.Run("success_prints_confirmation", func(t *testing.T) {
+		mgr := &fakeManager{}
+		var buf bytes.Buffer
+		code := runServiceVerb("uninstall", nil, mgr, &buf)
+		if code != 0 {
+			t.Errorf("exit code: got %d want 0", code)
+		}
+		if !mgr.uninstallCalled {
+			t.Error("Uninstall() was not called")
+		}
+		if !strings.Contains(buf.String(), "removed") {
+			t.Errorf("missing removal confirmation, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("manager_error_maps_to_exit_1", func(t *testing.T) {
+		mgr := &fakeManager{uninstallErr: errors.New("boom")}
+		var buf bytes.Buffer
+		code := runServiceVerb("uninstall", nil, mgr, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+	})
+}
+
+func TestRunServiceVerbUnknown(t *testing.T) {
+	mgr := &fakeManager{}
+	var buf bytes.Buffer
+	code := runServiceVerb("bogus", nil, mgr, &buf)
+	if code != 2 {
+		t.Errorf("exit code: got %d want 2", code)
+	}
+}
+
+func TestPrintServiceSummary(t *testing.T) {
+	t.Run("darwin", func(t *testing.T) {
+		var buf bytes.Buffer
+		printServiceSummary("darwin", "/Users/x/Library/LaunchAgents/dev.agentpod.node.plist", &buf)
+		out := buf.String()
+		for _, want := range []string{"apn status", "apn logs -f", "apn restart", "apn service uninstall", "LaunchAgent"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("missing %q in:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("linux_user_scope", func(t *testing.T) {
+		var buf bytes.Buffer
+		printServiceSummary("linux", "/home/x/.config/systemd/user/agentpod-node.service", &buf)
+		out := buf.String()
+		if !strings.Contains(out, "systemd --user") {
+			t.Errorf("missing user-scope label, got:\n%s", out)
+		}
+		if !strings.Contains(out, "loginctl enable-linger") {
+			t.Errorf("missing linger hint, got:\n%s", out)
+		}
+	})
+
+	t.Run("linux_system_scope", func(t *testing.T) {
+		var buf bytes.Buffer
+		printServiceSummary("linux", "/etc/systemd/system/agentpod-node.service", &buf)
+		out := buf.String()
+		if !strings.Contains(out, "system-wide") {
+			t.Errorf("missing system-scope label, got:\n%s", out)
+		}
+		if strings.Contains(out, "loginctl") {
+			t.Errorf("system scope should not print the linger hint, got:\n%s", out)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// logs
+// ---------------------------------------------------------------------------
+
+func TestBuildLogsCmd(t *testing.T) {
+	t.Run("darwin_default", func(t *testing.T) {
+		cmd := buildLogsCmd("darwin", "/Users/x", "", logsOptions{Lines: 50})
+		want := []string{"tail", "-n", "50", filepath.Join("/Users/x", "Library", "Logs", "agentpod-node.log")}
+		if !reflect.DeepEqual(cmd.Args, want) {
+			t.Errorf("argv: got %v want %v", cmd.Args, want)
+		}
+	})
+
+	t.Run("darwin_follow", func(t *testing.T) {
+		cmd := buildLogsCmd("darwin", "/Users/x", "", logsOptions{Lines: 20, Follow: true})
+		want := []string{"tail", "-n", "20", "-f", filepath.Join("/Users/x", "Library", "Logs", "agentpod-node.log")}
+		if !reflect.DeepEqual(cmd.Args, want) {
+			t.Errorf("argv: got %v want %v", cmd.Args, want)
+		}
+	})
+
+	t.Run("linux_user_scope_follow", func(t *testing.T) {
+		cmd := buildLogsCmd("linux", "/home/x", "/home/x/.config/systemd/user/agentpod-node.service", logsOptions{Lines: 50, Follow: true})
+		want := []string{"journalctl", "-f", "-n", "50", "--user-unit", "agentpod-node"}
+		if !reflect.DeepEqual(cmd.Args, want) {
+			t.Errorf("argv: got %v want %v", cmd.Args, want)
+		}
+	})
+
+	t.Run("linux_system_scope", func(t *testing.T) {
+		cmd := buildLogsCmd("linux", "/home/x", "/etc/systemd/system/agentpod-node.service", logsOptions{Lines: 100})
+		want := []string{"journalctl", "-n", "100", "-u", "agentpod-node"}
+		if !reflect.DeepEqual(cmd.Args, want) {
+			t.Errorf("argv: got %v want %v", cmd.Args, want)
+		}
+	})
+}
+
+func TestResolveLogsCmd(t *testing.T) {
+	t.Run("darwin_missing_log_file_friendly_error", func(t *testing.T) {
+		statFail := func(string) error { return os.ErrNotExist }
+		_, err := resolveLogsCmd("darwin", "/Users/x", "", logsOptions{Lines: 50}, statFail)
+		if err == nil {
+			t.Fatal("expected a friendly error for a missing log file")
+		}
+	})
+
+	t.Run("darwin_log_file_present", func(t *testing.T) {
+		statOK := func(string) error { return nil }
+		cmd, err := resolveLogsCmd("darwin", "/Users/x", "", logsOptions{Lines: 50}, statOK)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cmd.Args[0] != "tail" {
+			t.Errorf("expected tail, got %v", cmd.Args)
+		}
+	})
+
+	t.Run("linux_never_stats_a_log_file", func(t *testing.T) {
+		called := false
+		stat := func(string) error { called = true; return nil }
+		cmd, err := resolveLogsCmd("linux", "/home/x", "/etc/systemd/system/agentpod-node.service", logsOptions{Lines: 50}, stat)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cmd.Args[0] != "journalctl" {
+			t.Errorf("expected journalctl, got %v", cmd.Args)
+		}
+		if called {
+			t.Error("linux path should never call stat")
+		}
+	})
+}

--- a/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
+++ b/apps/node-agent/cmd/agentpod-node/service_cmds_test.go
@@ -139,6 +139,32 @@ func TestStatusCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("status_error_json_mode_emits_valid_json_error_object", func(t *testing.T) {
+		mgr := &fakeManager{statusErr: errors.New("launchctl print: permission denied")}
+		checkCred := func(hub, id, secret string) (bool, error) {
+			t.Fatal("checkCred must not be called when Status() itself failed")
+			return false, nil
+		}
+		var buf bytes.Buffer
+		code := statusCmd(mgr, cfg, nil, checkCred, true, &buf)
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+
+		var got struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("--json error output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+		}
+		if !strings.Contains(got.Error, "permission denied") {
+			t.Errorf("error field: got %q, want it to mention the underlying error", got.Error)
+		}
+		if strings.Contains(buf.String(), "\"Service\"") {
+			t.Errorf("should not include a Service block in the error JSON, got:\n%s", buf.String())
+		}
+	})
+
 	t.Run("json_output_unmarshals_into_expected_shape", func(t *testing.T) {
 		mgr := &fakeManager{status: running}
 		checkCred := func(hub, id, secret string) (bool, error) { return true, nil }
@@ -420,39 +446,83 @@ func TestBuildLogsCmd(t *testing.T) {
 }
 
 func TestResolveUnitPathForLogs(t *testing.T) {
-	t.Run("linux_status_error_warns_and_falls_back_to_system_scope", func(t *testing.T) {
+	t.Run("linux_status_error_warns_on_errOut_and_falls_back_to_system_scope", func(t *testing.T) {
 		mgr := &fakeManager{statusErr: errors.New("systemctl show: permission denied")}
-		var buf bytes.Buffer
-		got := resolveUnitPathForLogs("linux", mgr, &buf)
+		var errBuf bytes.Buffer
+		got := resolveUnitPathForLogs("linux", mgr, &errBuf)
 		if got != "" {
 			t.Errorf("unitPath: got %q want empty (fallback)", got)
 		}
-		if !strings.Contains(buf.String(), "warning:") || !strings.Contains(buf.String(), "permission denied") {
-			t.Errorf("missing warning, got:\n%s", buf.String())
+		if !strings.Contains(errBuf.String(), "warning:") || !strings.Contains(errBuf.String(), "permission denied") {
+			t.Errorf("missing warning on errOut, got:\n%s", errBuf.String())
 		}
 	})
 
 	t.Run("linux_status_ok_uses_unit_path", func(t *testing.T) {
 		mgr := &fakeManager{status: service.Status{UnitPath: "/etc/systemd/system/agentpod-node.service"}}
-		var buf bytes.Buffer
-		got := resolveUnitPathForLogs("linux", mgr, &buf)
+		var errBuf bytes.Buffer
+		got := resolveUnitPathForLogs("linux", mgr, &errBuf)
 		if got != mgr.status.UnitPath {
 			t.Errorf("unitPath: got %q want %q", got, mgr.status.UnitPath)
 		}
-		if buf.Len() != 0 {
-			t.Errorf("expected no warning on success, got:\n%s", buf.String())
+		if errBuf.Len() != 0 {
+			t.Errorf("expected no warning on success, got:\n%s", errBuf.String())
 		}
 	})
 
 	t.Run("darwin_never_calls_status", func(t *testing.T) {
 		mgr := &fakeManager{statusErr: errors.New("should not be reached")}
-		var buf bytes.Buffer
-		got := resolveUnitPathForLogs("darwin", mgr, &buf)
+		var errBuf bytes.Buffer
+		got := resolveUnitPathForLogs("darwin", mgr, &errBuf)
 		if got != "" {
 			t.Errorf("unitPath: got %q want empty", got)
 		}
-		if buf.Len() != 0 {
-			t.Errorf("expected no output on darwin, got:\n%s", buf.String())
+		if errBuf.Len() != 0 {
+			t.Errorf("expected no output on darwin, got:\n%s", errBuf.String())
+		}
+	})
+}
+
+// TestPrepareLogsCmd exercises the exec-free wiring `logsCmd` uses (flags →
+// scope resolution → argv), proving that resolveUnitPathForLogs's warning
+// reaches the dedicated errOut writer and never the out writer — the out
+// writer is also what a piped `apn logs -f | tee file` would inherit as
+// stdout, so a diagnostic landing there would corrupt the log stream.
+func TestPrepareLogsCmd(t *testing.T) {
+	t.Run("linux_status_error_warning_goes_to_errOut_never_out", func(t *testing.T) {
+		mgr := &fakeManager{statusErr: errors.New("systemctl show: permission denied")}
+		homeDir := func() (string, error) { return "/home/x", nil }
+		var outBuf, errBuf bytes.Buffer
+
+		cmd, code := prepareLogsCmd("linux", mgr, homeDir, nil, &outBuf, &errBuf, func(string) error { return nil })
+		if code != 0 || cmd == nil {
+			t.Fatalf("expected a resolved cmd with code 0, got cmd=%v code=%d", cmd, code)
+		}
+		if cmd.Args[0] != "journalctl" {
+			t.Errorf("expected journalctl argv, got %v", cmd.Args)
+		}
+		if strings.Contains(outBuf.String(), "warning:") {
+			t.Errorf("warning leaked into out — would corrupt a piped log stream, got:\n%s", outBuf.String())
+		}
+		if !strings.Contains(errBuf.String(), "warning:") || !strings.Contains(errBuf.String(), "permission denied") {
+			t.Errorf("missing warning on errOut, got:\n%s", errBuf.String())
+		}
+	})
+
+	t.Run("darwin_missing_log_file_still_reports_on_out", func(t *testing.T) {
+		mgr := &fakeManager{}
+		homeDir := func() (string, error) { return "/Users/x", nil }
+		var outBuf, errBuf bytes.Buffer
+
+		cmd, code := prepareLogsCmd("darwin", mgr, homeDir, nil, &outBuf, &errBuf, func(string) error { return os.ErrNotExist })
+		if cmd != nil {
+			t.Fatalf("expected no cmd for a missing log file, got %v", cmd)
+		}
+		if code != 1 {
+			t.Errorf("exit code: got %d want 1", code)
+		}
+		if !strings.Contains(outBuf.String(), "no log file yet") {
+			t.Errorf("missing friendly error on out, got:\n%s", outBuf.String())
 		}
 	})
 }

--- a/apps/node-agent/internal/selfupdate/selfupdate.go
+++ b/apps/node-agent/internal/selfupdate/selfupdate.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/service"
 )
 
 // ErrRestartFailed is returned when the service restart command fails.
@@ -214,29 +216,29 @@ func swapBinary(targetPath, tmpPath string) error {
 	return nil
 }
 
-// restartService restarts the agentpod-node service for the given GOOS.
+// restartService restarts the agentpod-node service for the given GOOS by
+// delegating to the internal/service package's platform managers.
 //
 // linux: probes for a user-scoped systemd unit first; if active uses --user,
 // else the system unit. darwin: the installer runs the agent as the LaunchAgent
 // gui/<uid>/dev.agentpod.node — kickstart -k kills and restarts it. Returns a
-// wrapped ErrRestartFailed when the restart command fails (the binary is
-// already swapped at that point).
+// wrapped ErrRestartFailed when manager selection or the restart command
+// fails (the binary is already swapped at that point).
 func restartService(goos string, run func(name string, args ...string) error) error {
 	if run == nil {
 		run = func(name string, args ...string) error {
 			return exec.Command(name, args...).Run()
 		}
 	}
-	var restartErr error
-	if goos == "darwin" {
-		restartErr = run("launchctl", "kickstart", "-k", fmt.Sprintf("gui/%d/dev.agentpod.node", os.Getuid()))
-	} else if run("systemctl", "--user", "is-active", "agentpod-node") == nil {
-		restartErr = run("systemctl", "--user", "restart", "agentpod-node")
-	} else {
-		restartErr = run("systemctl", "restart", "agentpod-node")
+	runner := func(name string, args ...string) (string, error) {
+		return "", run(name, args...)
 	}
-	if restartErr != nil {
-		return fmt.Errorf("%w: %v", ErrRestartFailed, restartErr)
+	mgr, err := service.NewManagerForRestart(goos, runner)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrRestartFailed, err)
+	}
+	if err := mgr.Restart(); err != nil {
+		return fmt.Errorf("%w: %v", ErrRestartFailed, err)
 	}
 	return nil
 }

--- a/apps/node-agent/internal/service/launchd.go
+++ b/apps/node-agent/internal/service/launchd.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+// launchdLabel is the launchd job label, unchanged from install.sh's
+// install_launch_agent().
+const launchdLabel = "dev.agentpod.node"
+
+//go:embed templates/dev.agentpod.node.plist
+var launchdPlistTemplate string
+
+// pidLineRE matches launchctl print's `pid = 1234` line (any indentation).
+var pidLineRE = regexp.MustCompile(`(?m)^\s*"?pid"?\s*=\s*(\d+)\s*$`)
+
+// launchdManager drives a per-user launchd LaunchAgent (gui/<uid> domain).
+// home, uid, run, and binPath are all injectable so tests never touch the
+// real ~/Library or invoke launchctl.
+type launchdManager struct {
+	home    string
+	uid     int
+	run     Runner
+	binPath func() (string, error)
+}
+
+// newLaunchdManager builds the production launchdManager: a real exec.Command
+// Runner (when run is nil) and binPath resolved via os.Executable +
+// EvalSymlinks (handles the "apn" wrapper symlink).
+func newLaunchdManager(home string, uid int, run Runner) *launchdManager {
+	if run == nil {
+		run = execRunner
+	}
+	return &launchdManager{
+		home:    home,
+		uid:     uid,
+		run:     run,
+		binPath: resolveBinPath,
+	}
+}
+
+func execRunner(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func resolveBinPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("service: resolve executable: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("service: eval symlinks: %w", err)
+	}
+	return resolved, nil
+}
+
+func (m *launchdManager) plistPath() string {
+	return filepath.Join(m.home, "Library", "LaunchAgents", launchdLabel+".plist")
+}
+
+func (m *launchdManager) logPath() string {
+	return filepath.Join(m.home, "Library", "Logs", "agentpod-node.log")
+}
+
+// domain is the launchctl gui domain for this user, e.g. "gui/501".
+func (m *launchdManager) domain() string {
+	return fmt.Sprintf("gui/%d", m.uid)
+}
+
+// serviceTarget is the fully-qualified launchctl service specifier, e.g.
+// "gui/501/dev.agentpod.node".
+func (m *launchdManager) serviceTarget() string {
+	return m.domain() + "/" + launchdLabel
+}
+
+// renderPlist executes the embedded plist template against the resolved
+// binary path and log path.
+func (m *launchdManager) renderPlist() ([]byte, error) {
+	bin, err := m.binPath()
+	if err != nil {
+		return nil, fmt.Errorf("service: resolve binary path: %w", err)
+	}
+
+	tmpl, err := template.New("dev.agentpod.node.plist").Parse(launchdPlistTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("service: parse plist template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	data := struct {
+		BinaryPath string
+		LogPath    string
+	}{BinaryPath: bin, LogPath: m.logPath()}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("service: render plist: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// Install writes the plist, enables the job, and (re)bootstraps it into the
+// gui/<uid> domain. Idempotent: a stale bootstrap is torn down first
+// (bootout errors are ignored — there may be nothing loaded yet).
+func (m *launchdManager) Install() error {
+	plist, err := m.renderPlist()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(m.plistPath()), 0o755); err != nil {
+		return fmt.Errorf("service: create LaunchAgents dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.logPath()), 0o755); err != nil {
+		return fmt.Errorf("service: create Logs dir: %w", err)
+	}
+	if err := os.WriteFile(m.plistPath(), plist, 0o644); err != nil {
+		return fmt.Errorf("service: write plist: %w", err)
+	}
+
+	if _, err := m.run("launchctl", "enable", m.serviceTarget()); err != nil {
+		return fmt.Errorf("service: enable: %w", err)
+	}
+	_, _ = m.run("launchctl", "bootout", m.serviceTarget()) // best-effort: nothing may be loaded
+	if _, err := m.run("launchctl", "bootstrap", m.domain(), m.plistPath()); err != nil {
+		return fmt.Errorf("service: bootstrap: %w", err)
+	}
+	return nil
+}
+
+// Uninstall tears down any loaded job (error ignored — it may already be
+// unloaded) and removes the plist. Idempotent: a missing plist is not an
+// error.
+func (m *launchdManager) Uninstall() error {
+	_, _ = m.run("launchctl", "bootout", m.serviceTarget())
+	if err := os.Remove(m.plistPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("service: remove plist: %w", err)
+	}
+	return nil
+}
+
+// Start enables and (re)bootstraps the job. If the job is already
+// bootstrapped, bootstrap errors and Start falls back to kickstart -k, which
+// starts an existing-but-stopped job.
+func (m *launchdManager) Start() error {
+	if _, err := m.run("launchctl", "enable", m.serviceTarget()); err != nil {
+		return fmt.Errorf("service: enable: %w", err)
+	}
+	if _, err := m.run("launchctl", "bootstrap", m.domain(), m.plistPath()); err != nil {
+		if _, err := m.run("launchctl", "kickstart", "-k", m.serviceTarget()); err != nil {
+			return fmt.Errorf("service: start: %w", err)
+		}
+	}
+	return nil
+}
+
+// Stop unloads the job (error ignored — it may already be stopped) and
+// disables it so it will not restart on next login/boot ("sticky" stop).
+func (m *launchdManager) Stop() error {
+	_, _ = m.run("launchctl", "bootout", m.serviceTarget())
+	if _, err := m.run("launchctl", "disable", m.serviceTarget()); err != nil {
+		return fmt.Errorf("service: disable: %w", err)
+	}
+	return nil
+}
+
+// Restart kills and restarts the job in place. This is also the delegate
+// selfupdate.restartService uses on darwin — the argv must stay exactly
+// "launchctl kickstart -k gui/<uid>/dev.agentpod.node".
+func (m *launchdManager) Restart() error {
+	if _, err := m.run("launchctl", "kickstart", "-k", m.serviceTarget()); err != nil {
+		return fmt.Errorf("service: restart: %w", err)
+	}
+	return nil
+}
+
+// Status reports installed/enabled/running state by combining a plist
+// existence check with two launchctl queries. Neither query failing is
+// treated as fatal: an erroring "print" simply means not running, an
+// erroring "print-disabled" is treated as "no disabled entry found".
+func (m *launchdManager) Status() (Status, error) {
+	st := Status{UnitPath: m.plistPath()}
+
+	if _, err := os.Stat(m.plistPath()); err == nil {
+		st.Installed = true
+	} else if !os.IsNotExist(err) {
+		return Status{}, fmt.Errorf("service: stat plist: %w", err)
+	}
+
+	disabledOut, _ := m.run("launchctl", "print-disabled", m.domain())
+	st.Enabled = !strings.Contains(disabledOut, fmt.Sprintf("%q => disabled", launchdLabel))
+
+	if printOut, err := m.run("launchctl", "print", m.serviceTarget()); err == nil {
+		if pid, ok := parsePID(printOut); ok {
+			st.Running = true
+			st.PID = pid
+		}
+	}
+
+	return st, nil
+}
+
+// parsePID extracts the pid from a `launchctl print` block's "pid = N" line.
+func parsePID(printOutput string) (int, bool) {
+	m := pidLineRE.FindStringSubmatch(printOutput)
+	if m == nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
+}

--- a/apps/node-agent/internal/service/launchd_test.go
+++ b/apps/node-agent/internal/service/launchd_test.go
@@ -1,0 +1,413 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scriptResult is a scripted reply for one exact argv, keyed by the joined
+// command in recordingRunner.script.
+type scriptResult struct {
+	out string
+	err error
+}
+
+// recordingRunner is the table-test seam: it records every argv it is
+// called with (in order) and returns a scripted result keyed by the exact
+// argv, defaulting to ("", nil) for anything unscripted.
+type recordingRunner struct {
+	calls  [][]string
+	script map[string]scriptResult
+}
+
+func newRecordingRunner() *recordingRunner {
+	return &recordingRunner{script: map[string]scriptResult{}}
+}
+
+func (r *recordingRunner) run(name string, args ...string) (string, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	if res, ok := r.script[strings.Join(call, " ")]; ok {
+		return res.out, res.err
+	}
+	return "", nil
+}
+
+func (r *recordingRunner) on(argv []string, out string, err error) {
+	r.script[strings.Join(argv, " ")] = scriptResult{out: out, err: err}
+}
+
+func assertCalls(t *testing.T, got [][]string, want [][]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("call count: got %d %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if !equalArgv(got[i], want[i]) {
+			t.Errorf("call[%d]: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func equalArgv(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// newTestManager builds a launchdManager over a temp home and a fake binary
+// path, so tests never touch the real ~/Library or invoke launchctl.
+func newTestManager(t *testing.T, run *recordingRunner) (*launchdManager, string) {
+	t.Helper()
+	home := t.TempDir()
+	fakeBin := filepath.Join(t.TempDir(), "agentpod-node")
+	m := &launchdManager{
+		home: home,
+		uid:  os.Getuid(),
+		run:  run.run,
+		binPath: func() (string, error) {
+			return fakeBin, nil
+		},
+	}
+	return m, fakeBin
+}
+
+func target(uid int) string {
+	return fmt.Sprintf("gui/%d/dev.agentpod.node", uid)
+}
+
+func domain(uid int) string {
+	return fmt.Sprintf("gui/%d", uid)
+}
+
+// ---------------------------------------------------------------------------
+// Stop
+// ---------------------------------------------------------------------------
+
+func TestLaunchdStop(t *testing.T) {
+	t.Run("bootout_error_ignored_disable_error_returned", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "bootout", target(m.uid)}, "", fmt.Errorf("no such process"))
+		run.on([]string{"launchctl", "disable", target(m.uid)}, "", fmt.Errorf("disable failed"))
+
+		err := m.Stop()
+		if err == nil {
+			t.Fatal("expected error from disable failure")
+		}
+		want := [][]string{
+			{"launchctl", "bootout", target(m.uid)},
+			{"launchctl", "disable", target(m.uid)},
+		}
+		assertCalls(t, run.calls, want)
+	})
+
+	t.Run("bootout_error_ignored_disable_succeeds", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "bootout", target(m.uid)}, "", fmt.Errorf("no such process"))
+
+		if err := m.Stop(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := [][]string{
+			{"launchctl", "bootout", target(m.uid)},
+			{"launchctl", "disable", target(m.uid)},
+		}
+		assertCalls(t, run.calls, want)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+func TestLaunchdStart(t *testing.T) {
+	t.Run("bootstrap_succeeds_no_fallback", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		if err := m.Install(); err != nil {
+			t.Fatalf("Install setup: %v", err)
+		}
+		run.calls = nil // reset: we only care about Start()'s own argv
+
+		if err := m.Start(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := [][]string{
+			{"launchctl", "enable", target(m.uid)},
+			{"launchctl", "bootstrap", domain(m.uid), m.plistPath()},
+		}
+		assertCalls(t, run.calls, want)
+	})
+
+	t.Run("bootstrap_fails_falls_back_to_kickstart", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "bootstrap", domain(m.uid), m.plistPath()}, "", fmt.Errorf("already bootstrapped"))
+
+		if err := m.Start(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := [][]string{
+			{"launchctl", "enable", target(m.uid)},
+			{"launchctl", "bootstrap", domain(m.uid), m.plistPath()},
+			{"launchctl", "kickstart", "-k", target(m.uid)},
+		}
+		assertCalls(t, run.calls, want)
+	})
+
+	t.Run("enable_fails_returns_error_no_bootstrap", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "enable", target(m.uid)}, "", fmt.Errorf("enable failed"))
+
+		if err := m.Start(); err == nil {
+			t.Fatal("expected error when enable fails")
+		}
+		want := [][]string{
+			{"launchctl", "enable", target(m.uid)},
+		}
+		assertCalls(t, run.calls, want)
+	})
+
+	t.Run("both_bootstrap_and_kickstart_fail_returns_error", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "bootstrap", domain(m.uid), m.plistPath()}, "", fmt.Errorf("boom"))
+		run.on([]string{"launchctl", "kickstart", "-k", target(m.uid)}, "", fmt.Errorf("boom too"))
+
+		if err := m.Start(); err == nil {
+			t.Fatal("expected error when both bootstrap and kickstart fail")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Restart
+// ---------------------------------------------------------------------------
+
+func TestLaunchdRestart(t *testing.T) {
+	t.Run("kickstart_exactly", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+
+		if err := m.Restart(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := [][]string{
+			{"launchctl", "kickstart", "-k", target(m.uid)},
+		}
+		assertCalls(t, run.calls, want)
+	})
+
+	t.Run("kickstart_error_propagates", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "kickstart", "-k", target(m.uid)}, "", fmt.Errorf("boom"))
+
+		if err := m.Restart(); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Install
+// ---------------------------------------------------------------------------
+
+func TestLaunchdInstall(t *testing.T) {
+	run := newRecordingRunner()
+	m, fakeBin := newTestManager(t, run)
+
+	if err := m.Install(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := [][]string{
+		{"launchctl", "enable", target(m.uid)},
+		{"launchctl", "bootout", target(m.uid)},
+		{"launchctl", "bootstrap", domain(m.uid), m.plistPath()},
+	}
+	assertCalls(t, run.calls, want)
+
+	data, err := os.ReadFile(m.plistPath())
+	if err != nil {
+		t.Fatalf("plist not written: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "dev.agentpod.node") {
+		t.Errorf("plist missing label: %s", content)
+	}
+	if !strings.Contains(content, fmt.Sprintf("<string>%s</string>", fakeBin)) {
+		t.Errorf("plist missing binary path %q: %s", fakeBin, content)
+	}
+	if !strings.Contains(content, "<string>run</string>") {
+		t.Errorf("plist missing run argument: %s", content)
+	}
+	wantLog := filepath.Join(m.home, "Library", "Logs", "agentpod-node.log")
+	if got := strings.Count(content, wantLog); got != 2 {
+		t.Errorf("plist should reference log path %q twice (stdout+stderr), got %d occurrences: %s", wantLog, got, content)
+	}
+}
+
+func TestLaunchdInstall_BootoutErrorIgnored(t *testing.T) {
+	run := newRecordingRunner()
+	m, _ := newTestManager(t, run)
+	run.on([]string{"launchctl", "bootout", target(m.uid)}, "", fmt.Errorf("nothing loaded"))
+
+	if err := m.Install(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLaunchdInstall_EnableErrorPropagates(t *testing.T) {
+	run := newRecordingRunner()
+	m, _ := newTestManager(t, run)
+	run.on([]string{"launchctl", "enable", target(m.uid)}, "", fmt.Errorf("enable failed"))
+
+	if err := m.Install(); err == nil {
+		t.Fatal("expected error when enable fails")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall
+// ---------------------------------------------------------------------------
+
+func TestLaunchdUninstall(t *testing.T) {
+	t.Run("removes_existing_plist", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		if err := m.Install(); err != nil {
+			t.Fatalf("Install setup: %v", err)
+		}
+		run.calls = nil
+
+		if err := m.Uninstall(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := [][]string{
+			{"launchctl", "bootout", target(m.uid)},
+		}
+		assertCalls(t, run.calls, want)
+
+		if _, err := os.Stat(m.plistPath()); !os.IsNotExist(err) {
+			t.Errorf("plist should be removed, stat err = %v", err)
+		}
+	})
+
+	t.Run("idempotent_when_already_absent", func(t *testing.T) {
+		run := newRecordingRunner()
+		m, _ := newTestManager(t, run)
+		run.on([]string{"launchctl", "bootout", target(m.uid)}, "", fmt.Errorf("nothing loaded"))
+
+		if err := m.Uninstall(); err != nil {
+			t.Fatalf("expected no error when plist already absent, got: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+func TestLaunchdStatus(t *testing.T) {
+	cases := []struct {
+		name          string
+		install       bool
+		printDisabled scriptResult
+		printUnit     scriptResult
+		wantInstalled bool
+		wantEnabled   bool
+		wantRunning   bool
+		wantPID       int
+	}{
+		{
+			name:          "running_with_pid",
+			install:       true,
+			printDisabled: scriptResult{out: "", err: nil},
+			printUnit:     scriptResult{out: "gui/501/dev.agentpod.node = {\n\tpid = 4242\n\tstate = running\n}", err: nil},
+			wantInstalled: true,
+			wantEnabled:   true,
+			wantRunning:   true,
+			wantPID:       4242,
+		},
+		{
+			name:          "stopped",
+			install:       true,
+			printDisabled: scriptResult{out: "", err: nil},
+			printUnit:     scriptResult{out: "", err: fmt.Errorf("could not find service")},
+			wantInstalled: true,
+			wantEnabled:   true,
+			wantRunning:   false,
+			wantPID:       0,
+		},
+		{
+			name:          "disabled",
+			install:       true,
+			printDisabled: scriptResult{out: "\"dev.agentpod.node\" => disabled\n", err: nil},
+			printUnit:     scriptResult{out: "", err: fmt.Errorf("could not find service")},
+			wantInstalled: true,
+			wantEnabled:   false,
+			wantRunning:   false,
+			wantPID:       0,
+		},
+		{
+			name:          "not_installed",
+			install:       false,
+			printDisabled: scriptResult{out: "", err: nil},
+			printUnit:     scriptResult{out: "", err: fmt.Errorf("could not find service")},
+			wantInstalled: false,
+			wantEnabled:   true,
+			wantRunning:   false,
+			wantPID:       0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestManager(t, run)
+			run.on([]string{"launchctl", "print-disabled", domain(m.uid)}, tc.printDisabled.out, tc.printDisabled.err)
+			run.on([]string{"launchctl", "print", target(m.uid)}, tc.printUnit.out, tc.printUnit.err)
+
+			if tc.install {
+				if err := m.Install(); err != nil {
+					t.Fatalf("Install setup: %v", err)
+				}
+				run.calls = nil
+			}
+
+			st, err := m.Status()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if st.Installed != tc.wantInstalled {
+				t.Errorf("Installed: got %v want %v", st.Installed, tc.wantInstalled)
+			}
+			if st.Enabled != tc.wantEnabled {
+				t.Errorf("Enabled: got %v want %v", st.Enabled, tc.wantEnabled)
+			}
+			if st.Running != tc.wantRunning {
+				t.Errorf("Running: got %v want %v", st.Running, tc.wantRunning)
+			}
+			if st.PID != tc.wantPID {
+				t.Errorf("PID: got %v want %v", st.PID, tc.wantPID)
+			}
+			if st.UnitPath != m.plistPath() {
+				t.Errorf("UnitPath: got %q want %q", st.UnitPath, m.plistPath())
+			}
+		})
+	}
+}

--- a/apps/node-agent/internal/service/service.go
+++ b/apps/node-agent/internal/service/service.go
@@ -43,6 +43,31 @@ func NewManager(run Runner) (Manager, error) {
 	return newManager(runtime.GOOS, os.Getuid(), run)
 }
 
+// NewManagerForRestart builds a Manager for an explicit goos (rather than
+// runtime.GOOS), mirroring selfupdate.restartService's legacy platform
+// selection exactly: darwin gets the launchd manager (no uid==0 guard —
+// the old code never had one), and — matching the old code's plain
+// if/else — anything else falls through to the systemd manager, scoped by
+// an *unconditional* `systemctl --user is-active` probe (never
+// short-circuited on uid, unlike NewManager's scope selection). It exists
+// solely so selfupdate can delegate to Manager.Restart() without
+// duplicating argv-building or platform-selection logic.
+func NewManagerForRestart(goos string, run Runner) (Manager, error) {
+	uid := os.Getuid()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("service: resolve home dir: %w", err)
+	}
+	if goos == "darwin" {
+		return newLaunchdManager(home, uid, run), nil
+	}
+	probe := run
+	if probe == nil {
+		probe = execRunner
+	}
+	return newSystemdManager(run, userUnitActive(probe), home, uid), nil
+}
+
 // newManager is the GOOS/uid-injectable core of NewManager, kept separate so
 // the platform-selection branches are unit-testable without root privileges
 // or a second OS.

--- a/apps/node-agent/internal/service/service.go
+++ b/apps/node-agent/internal/service/service.go
@@ -1,0 +1,67 @@
+// Package service manages the node-agent as a platform background service:
+// a launchd LaunchAgent on macOS, a systemd unit on Linux. It is the shared
+// implementation behind `apn service install/uninstall` and the
+// start/stop/restart/status verbs, and behind selfupdate's service restart.
+package service
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// Runner executes a command and returns its combined stdout (trimmed) — the
+// injectable seam for tests. nil means exec.Command for real.
+type Runner func(name string, args ...string) (string, error)
+
+// Status reports the current state of the installed service.
+type Status struct {
+	Installed bool   `json:"installed"`
+	Enabled   bool   `json:"enabled"`
+	Running   bool   `json:"running"`
+	PID       int    `json:"pid"`
+	UnitPath  string `json:"unitPath"` // plist/unit file location
+}
+
+// Manager controls the platform service lifecycle for the node-agent.
+type Manager interface {
+	Install() error   // write template, enable, start; idempotent
+	Uninstall() error // stop, disable, remove file; idempotent
+	Start() error     // enable + start
+	Stop() error      // stop + disable (sticky)
+	Restart() error
+	Status() (Status, error)
+}
+
+// NewManager picks the platform implementation. darwin: launchd per-user
+// (returns an error for uid 0 — macOS installs are per-user by policy).
+// linux: systemd; user scope when uid != 0 OR the user unit answers
+// `systemctl --user is-active agentpod-node` (preserves selfupdate's probe
+// behavior), else system scope.
+func NewManager(run Runner) (Manager, error) {
+	return newManager(runtime.GOOS, os.Getuid(), run)
+}
+
+// newManager is the GOOS/uid-injectable core of NewManager, kept separate so
+// the platform-selection branches are unit-testable without root privileges
+// or a second OS.
+func newManager(goos string, uid int, run Runner) (Manager, error) {
+	switch goos {
+	case "darwin":
+		if uid == 0 {
+			return nil, errors.New("macOS installs are per-user; run without sudo")
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("service: resolve home dir: %w", err)
+		}
+		return newLaunchdManager(home, uid, run), nil
+	case "linux":
+		// Task 2 adds systemdManager (user/system scope, mirroring
+		// selfupdate.restartService's --user probe).
+		return nil, errors.New("service: linux support not yet implemented")
+	default:
+		return nil, fmt.Errorf("service: unsupported platform %q", goos)
+	}
+}

--- a/apps/node-agent/internal/service/service.go
+++ b/apps/node-agent/internal/service/service.go
@@ -58,9 +58,16 @@ func newManager(goos string, uid int, run Runner) (Manager, error) {
 		}
 		return newLaunchdManager(home, uid, run), nil
 	case "linux":
-		// Task 2 adds systemdManager (user/system scope, mirroring
-		// selfupdate.restartService's --user probe).
-		return nil, errors.New("service: linux support not yet implemented")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("service: resolve home dir: %w", err)
+		}
+		probe := run
+		if probe == nil {
+			probe = execRunner
+		}
+		userScope := uid != 0 || userUnitActive(probe)
+		return newSystemdManager(run, userScope, home, uid), nil
 	default:
 		return nil, fmt.Errorf("service: unsupported platform %q", goos)
 	}

--- a/apps/node-agent/internal/service/service_test.go
+++ b/apps/node-agent/internal/service/service_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewManager_PlatformSelection(t *testing.T) {
+	t.Run("darwin_non_root_returns_launchd_manager", func(t *testing.T) {
+		mgr, err := newManager("darwin", 501, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := mgr.(*launchdManager); !ok {
+			t.Fatalf("got %T, want *launchdManager", mgr)
+		}
+	})
+
+	t.Run("darwin_root_is_refused", func(t *testing.T) {
+		_, err := newManager("darwin", 0, nil)
+		if err == nil {
+			t.Fatal("expected error for uid 0")
+		}
+		if !strings.Contains(err.Error(), "per-user") {
+			t.Errorf("error %q should mention per-user install policy", err.Error())
+		}
+	})
+
+	t.Run("linux_not_yet_implemented", func(t *testing.T) {
+		_, err := newManager("linux", 501, nil)
+		if err == nil {
+			t.Fatal("expected error on linux (Task 2)")
+		}
+	})
+
+	t.Run("unsupported_platform", func(t *testing.T) {
+		_, err := newManager("plan9", 501, nil)
+		if err == nil {
+			t.Fatal("expected error for unsupported platform")
+		}
+	})
+}
+
+func TestNewManager_UsesRealGOOSAndUID(t *testing.T) {
+	// Smoke test on whatever platform CI/dev actually runs on: NewManager
+	// must not touch the filesystem or invoke any external command, so a
+	// recording Runner that fails every call must still produce either a
+	// Manager or a well-formed error, never a panic.
+	run := func(name string, args ...string) (string, error) {
+		t.Fatalf("NewManager must not execute commands: %s %v", name, args)
+		return "", nil
+	}
+	_, _ = NewManager(run)
+}

--- a/apps/node-agent/internal/service/service_test.go
+++ b/apps/node-agent/internal/service/service_test.go
@@ -26,10 +26,14 @@ func TestNewManager_PlatformSelection(t *testing.T) {
 		}
 	})
 
-	t.Run("linux_not_yet_implemented", func(t *testing.T) {
-		_, err := newManager("linux", 501, nil)
-		if err == nil {
-			t.Fatal("expected error on linux (Task 2)")
+	t.Run("linux_non_root_returns_systemd_manager", func(t *testing.T) {
+		run := func(name string, args ...string) (string, error) { return "", nil }
+		mgr, err := newManager("linux", 501, run)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := mgr.(*systemdManager); !ok {
+			t.Fatalf("got %T, want *systemdManager", mgr)
 		}
 	})
 

--- a/apps/node-agent/internal/service/systemd.go
+++ b/apps/node-agent/internal/service/systemd.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+// systemdUnitName is the systemd unit name (both --user and system scope),
+// unchanged from install.sh's linux blocks.
+const systemdUnitName = "agentpod-node"
+
+// systemUnitDirDefault is where the system-scope unit lives in production.
+// systemdManager.systemUnitPath overrides this in tests (a temp dir), since
+// tests must never write to the real /etc.
+const systemUnitDirDefault = "/etc/systemd/system"
+
+//go:embed templates/agentpod-node-user.service
+var systemdUserUnitTemplate string
+
+//go:embed templates/agentpod-node-system.service
+var systemdSystemUnitTemplate string
+
+// systemdManager drives a systemd unit, either a per-user unit
+// (~/.config/systemd/user, `systemctl --user`) or a system-wide unit
+// (/etc/systemd/system, plain `systemctl`, requires root). run, home, uid,
+// and systemUnitPath are all injectable so tests never touch the real
+// systemd or /etc.
+type systemdManager struct {
+	run       Runner
+	userScope bool
+	home      string
+	uid       int
+	binPath   func() (string, error)
+
+	// systemUnitPath overrides the system-scope unit file location.
+	// Empty means the production default (systemUnitDirDefault). Only
+	// meaningful when userScope is false; tests set this to a temp dir.
+	systemUnitPath string
+}
+
+// newSystemdManager builds the production systemdManager: a real
+// exec.Command Runner (when run is nil) and binPath resolved via
+// os.Executable + EvalSymlinks (handles the "apn" wrapper symlink).
+func newSystemdManager(run Runner, userScope bool, home string, uid int) *systemdManager {
+	if run == nil {
+		run = execRunner
+	}
+	return &systemdManager{
+		run:       run,
+		userScope: userScope,
+		home:      home,
+		uid:       uid,
+		binPath:   resolveBinPath,
+	}
+}
+
+// userUnitActive probes whether a user-scoped systemd unit is active. This
+// is exactly selfupdate.restartService's existing linux probe argv
+// (`systemctl --user is-active agentpod-node`) — NewManager's scope
+// selection mirrors it so both stay in sync.
+func userUnitActive(run Runner) bool {
+	_, err := run("systemctl", "--user", "is-active", systemdUnitName)
+	return err == nil
+}
+
+// baseArgs is the systemctl flag prefix for this manager's scope: "--user"
+// for a per-user unit, nothing for a system unit.
+func (m *systemdManager) baseArgs() []string {
+	if m.userScope {
+		return []string{"--user"}
+	}
+	return nil
+}
+
+// systemctl runs `systemctl [--user] <args...>` through the injected
+// Runner.
+func (m *systemdManager) systemctl(args ...string) (string, error) {
+	full := append(append([]string{}, m.baseArgs()...), args...)
+	return m.run("systemctl", full...)
+}
+
+// unitPath is the unit file location: ~/.config/systemd/user/agentpod-node.service
+// for user scope, /etc/systemd/system/agentpod-node.service (or
+// systemUnitPath, when overridden) for system scope.
+func (m *systemdManager) unitPath() string {
+	if m.userScope {
+		return filepath.Join(m.home, ".config", "systemd", "user", systemdUnitName+".service")
+	}
+	if m.systemUnitPath != "" {
+		return m.systemUnitPath
+	}
+	return filepath.Join(systemUnitDirDefault, systemdUnitName+".service")
+}
+
+// renderUnit executes the embedded unit template (user or system, per
+// scope) against the resolved binary path.
+func (m *systemdManager) renderUnit() ([]byte, error) {
+	bin, err := m.binPath()
+	if err != nil {
+		return nil, fmt.Errorf("service: resolve binary path: %w", err)
+	}
+
+	raw := systemdSystemUnitTemplate
+	if m.userScope {
+		raw = systemdUserUnitTemplate
+	}
+
+	tmpl, err := template.New(systemdUnitName + ".service").Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("service: parse unit template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	data := struct{ BinaryPath string }{BinaryPath: bin}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("service: render unit: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// Install writes the unit file, reloads the daemon, and enables + starts
+// the unit. Idempotent: re-install overwrites the file and re-enables.
+func (m *systemdManager) Install() error {
+	unit, err := m.renderUnit()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(m.unitPath()), 0o755); err != nil {
+		return fmt.Errorf("service: create unit dir: %w", err)
+	}
+	if err := os.WriteFile(m.unitPath(), unit, 0o644); err != nil {
+		return fmt.Errorf("service: write unit: %w", err)
+	}
+
+	if _, err := m.systemctl("daemon-reload"); err != nil {
+		return fmt.Errorf("service: daemon-reload: %w", err)
+	}
+	if _, err := m.systemctl("enable", "--now", systemdUnitName); err != nil {
+		return fmt.Errorf("service: enable: %w", err)
+	}
+	return nil
+}
+
+// Uninstall disables + stops the unit (error ignored — it may already be
+// stopped), removes the unit file, and reloads the daemon. Idempotent: a
+// missing unit file is not an error.
+func (m *systemdManager) Uninstall() error {
+	_, _ = m.systemctl("disable", "--now", systemdUnitName)
+	if err := os.Remove(m.unitPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("service: remove unit: %w", err)
+	}
+	if _, err := m.systemctl("daemon-reload"); err != nil {
+		return fmt.Errorf("service: daemon-reload: %w", err)
+	}
+	return nil
+}
+
+// Start enables and starts the unit.
+func (m *systemdManager) Start() error {
+	if _, err := m.systemctl("enable", "--now", systemdUnitName); err != nil {
+		return fmt.Errorf("service: start: %w", err)
+	}
+	return nil
+}
+
+// Stop stops the unit (error ignored — it may already be stopped) and
+// disables it so it will not restart on next boot/login ("sticky" stop).
+func (m *systemdManager) Stop() error {
+	_, _ = m.systemctl("stop", systemdUnitName)
+	if _, err := m.systemctl("disable", systemdUnitName); err != nil {
+		return fmt.Errorf("service: disable: %w", err)
+	}
+	return nil
+}
+
+// Restart restarts the unit in place. This is also the delegate
+// selfupdate.restartService uses on linux — the argv must stay exactly
+// "systemctl [--user] restart agentpod-node" for the matching scope.
+func (m *systemdManager) Restart() error {
+	if _, err := m.systemctl("restart", systemdUnitName); err != nil {
+		return fmt.Errorf("service: restart: %w", err)
+	}
+	return nil
+}
+
+// Status reports installed/enabled/running state by combining a unit-file
+// existence check with three systemctl queries. None of the queries
+// failing is fatal: systemctl exits non-zero for "disabled"/"inactive" but
+// still prints that state to stdout, which is all Status inspects.
+func (m *systemdManager) Status() (Status, error) {
+	st := Status{UnitPath: m.unitPath()}
+
+	if _, err := os.Stat(m.unitPath()); err == nil {
+		st.Installed = true
+	} else if !os.IsNotExist(err) {
+		return Status{}, fmt.Errorf("service: stat unit: %w", err)
+	}
+
+	if out, _ := m.systemctl("is-enabled", systemdUnitName); strings.TrimSpace(out) == "enabled" {
+		st.Enabled = true
+	}
+
+	if out, _ := m.systemctl("is-active", systemdUnitName); strings.TrimSpace(out) == "active" {
+		st.Running = true
+	}
+
+	if out, _ := m.systemctl("show", "-p", "MainPID", "--value", systemdUnitName); out != "" {
+		if pid, err := strconv.Atoi(strings.TrimSpace(out)); err == nil {
+			st.PID = pid
+		}
+	}
+
+	return st, nil
+}

--- a/apps/node-agent/internal/service/systemd_test.go
+++ b/apps/node-agent/internal/service/systemd_test.go
@@ -1,0 +1,438 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestSystemdManager builds a systemdManager over a temp home (user
+// scope unit dir) and a temp system-unit-dir override (system scope), plus
+// a fake binary path, so tests never touch the real systemd or /etc.
+func newTestSystemdManager(t *testing.T, run *recordingRunner, userScope bool) (*systemdManager, string) {
+	t.Helper()
+	home := t.TempDir()
+	fakeBin := filepath.Join(t.TempDir(), "agentpod-node")
+	m := &systemdManager{
+		run:       run.run,
+		userScope: userScope,
+		home:      home,
+		uid:       os.Getuid(),
+		binPath: func() (string, error) {
+			return fakeBin, nil
+		},
+	}
+	if !userScope {
+		m.systemUnitPath = filepath.Join(t.TempDir(), "agentpod-node.service")
+	}
+	return m, fakeBin
+}
+
+// base returns the expected argv prefix for a scope: "systemctl --user" for
+// user scope, "systemctl" for system scope.
+func base(userScope bool) []string {
+	if userScope {
+		return []string{"systemctl", "--user"}
+	}
+	return []string{"systemctl"}
+}
+
+// argv concatenates a base prefix with trailing args into one expected
+// call.
+func argv(base []string, extra ...string) []string {
+	out := append([]string{}, base...)
+	return append(out, extra...)
+}
+
+// bothScopes runs fn once for user scope and once for system scope.
+func bothScopes(t *testing.T, fn func(t *testing.T, userScope bool)) {
+	t.Helper()
+	t.Run("user_scope", func(t *testing.T) { fn(t, true) })
+	t.Run("system_scope", func(t *testing.T) { fn(t, false) })
+}
+
+// ---------------------------------------------------------------------------
+// Stop
+// ---------------------------------------------------------------------------
+
+func TestSystemdStop(t *testing.T) {
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		t.Run("stop_error_ignored_disable_error_returned", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+			run.on(argv(base(userScope), "stop", systemdUnitName), "", fmt.Errorf("not running"))
+			run.on(argv(base(userScope), "disable", systemdUnitName), "", fmt.Errorf("disable failed"))
+
+			if err := m.Stop(); err == nil {
+				t.Fatal("expected error from disable failure")
+			}
+			want := [][]string{
+				argv(base(userScope), "stop", systemdUnitName),
+				argv(base(userScope), "disable", systemdUnitName),
+			}
+			assertCalls(t, run.calls, want)
+		})
+
+		t.Run("stop_error_ignored_disable_succeeds", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+			run.on(argv(base(userScope), "stop", systemdUnitName), "", fmt.Errorf("not running"))
+
+			if err := m.Stop(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			want := [][]string{
+				argv(base(userScope), "stop", systemdUnitName),
+				argv(base(userScope), "disable", systemdUnitName),
+			}
+			assertCalls(t, run.calls, want)
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+func TestSystemdStart(t *testing.T) {
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		t.Run("enable_now_exactly", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+
+			if err := m.Start(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			want := [][]string{
+				argv(base(userScope), "enable", "--now", systemdUnitName),
+			}
+			assertCalls(t, run.calls, want)
+		})
+
+		t.Run("error_propagates", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+			run.on(argv(base(userScope), "enable", "--now", systemdUnitName), "", fmt.Errorf("boom"))
+
+			if err := m.Start(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Restart
+// ---------------------------------------------------------------------------
+
+func TestSystemdRestart(t *testing.T) {
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		t.Run("restart_exactly", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+
+			if err := m.Restart(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			want := [][]string{
+				argv(base(userScope), "restart", systemdUnitName),
+			}
+			assertCalls(t, run.calls, want)
+		})
+
+		t.Run("error_propagates", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+			run.on(argv(base(userScope), "restart", systemdUnitName), "", fmt.Errorf("boom"))
+
+			if err := m.Restart(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Install
+// ---------------------------------------------------------------------------
+
+func TestSystemdInstall(t *testing.T) {
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		run := newRecordingRunner()
+		m, fakeBin := newTestSystemdManager(t, run, userScope)
+
+		if err := m.Install(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := [][]string{
+			argv(base(userScope), "daemon-reload"),
+			argv(base(userScope), "enable", "--now", systemdUnitName),
+		}
+		assertCalls(t, run.calls, want)
+
+		wantPath := m.unitPath()
+		if userScope {
+			expected := filepath.Join(m.home, ".config", "systemd", "user", "agentpod-node.service")
+			if wantPath != expected {
+				t.Fatalf("unitPath: got %q want %q", wantPath, expected)
+			}
+		} else {
+			if wantPath != m.systemUnitPath {
+				t.Fatalf("unitPath: got %q want systemUnitPath %q", wantPath, m.systemUnitPath)
+			}
+		}
+
+		data, err := os.ReadFile(wantPath)
+		if err != nil {
+			t.Fatalf("unit file not written: %v", err)
+		}
+		content := string(data)
+
+		wantExecStart := fmt.Sprintf("ExecStart=%s run", fakeBin)
+		if !strings.Contains(content, wantExecStart) {
+			t.Errorf("unit missing %q: %s", wantExecStart, content)
+		}
+
+		if userScope {
+			if !strings.Contains(content, "WantedBy=default.target") {
+				t.Errorf("user unit missing WantedBy=default.target: %s", content)
+			}
+			if strings.Contains(content, "User=root") {
+				t.Errorf("user unit should not set User=root: %s", content)
+			}
+		} else {
+			if !strings.Contains(content, "WantedBy=multi-user.target") {
+				t.Errorf("system unit missing WantedBy=multi-user.target: %s", content)
+			}
+			if !strings.Contains(content, "User=root") {
+				t.Errorf("system unit missing User=root: %s", content)
+			}
+			if !strings.Contains(content, "StandardOutput=journal") {
+				t.Errorf("system unit missing journal logging: %s", content)
+			}
+			if !strings.Contains(content, "NoNewPrivileges=true") {
+				t.Errorf("system unit missing hardening block: %s", content)
+			}
+		}
+	})
+}
+
+func TestSystemdInstall_DaemonReloadErrorPropagates(t *testing.T) {
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		run := newRecordingRunner()
+		m, _ := newTestSystemdManager(t, run, userScope)
+		run.on(argv(base(userScope), "daemon-reload"), "", fmt.Errorf("reload failed"))
+
+		if err := m.Install(); err == nil {
+			t.Fatal("expected error when daemon-reload fails")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall
+// ---------------------------------------------------------------------------
+
+func TestSystemdUninstall(t *testing.T) {
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		t.Run("removes_existing_unit", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+			if err := m.Install(); err != nil {
+				t.Fatalf("Install setup: %v", err)
+			}
+			run.calls = nil
+
+			if err := m.Uninstall(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			want := [][]string{
+				argv(base(userScope), "disable", "--now", systemdUnitName),
+				argv(base(userScope), "daemon-reload"),
+			}
+			assertCalls(t, run.calls, want)
+
+			if _, err := os.Stat(m.unitPath()); !os.IsNotExist(err) {
+				t.Errorf("unit file should be removed, stat err = %v", err)
+			}
+		})
+
+		t.Run("idempotent_when_already_absent", func(t *testing.T) {
+			run := newRecordingRunner()
+			m, _ := newTestSystemdManager(t, run, userScope)
+			run.on(argv(base(userScope), "disable", "--now", systemdUnitName), "", fmt.Errorf("not loaded"))
+
+			if err := m.Uninstall(); err != nil {
+				t.Fatalf("expected no error when unit already absent, got: %v", err)
+			}
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+func TestSystemdStatus(t *testing.T) {
+	cases := []struct {
+		name          string
+		install       bool
+		isEnabled     scriptResult
+		isActive      scriptResult
+		mainPID       scriptResult
+		wantInstalled bool
+		wantEnabled   bool
+		wantRunning   bool
+		wantPID       int
+	}{
+		{
+			name:          "running_enabled_with_pid",
+			install:       true,
+			isEnabled:     scriptResult{out: "enabled", err: nil},
+			isActive:      scriptResult{out: "active", err: nil},
+			mainPID:       scriptResult{out: "4242", err: nil},
+			wantInstalled: true,
+			wantEnabled:   true,
+			wantRunning:   true,
+			wantPID:       4242,
+		},
+		{
+			name:          "stopped_but_enabled",
+			install:       true,
+			isEnabled:     scriptResult{out: "enabled", err: nil},
+			isActive:      scriptResult{out: "inactive", err: fmt.Errorf("exit status 3")},
+			mainPID:       scriptResult{out: "0", err: nil},
+			wantInstalled: true,
+			wantEnabled:   true,
+			wantRunning:   false,
+			wantPID:       0,
+		},
+		{
+			name:          "disabled",
+			install:       true,
+			isEnabled:     scriptResult{out: "disabled", err: fmt.Errorf("exit status 1")},
+			isActive:      scriptResult{out: "inactive", err: fmt.Errorf("exit status 3")},
+			mainPID:       scriptResult{out: "0", err: nil},
+			wantInstalled: true,
+			wantEnabled:   false,
+			wantRunning:   false,
+			wantPID:       0,
+		},
+		{
+			name:          "not_installed",
+			install:       false,
+			isEnabled:     scriptResult{out: "", err: fmt.Errorf("No such file or directory")},
+			isActive:      scriptResult{out: "inactive", err: fmt.Errorf("exit status 3")},
+			mainPID:       scriptResult{out: "0", err: nil},
+			wantInstalled: false,
+			wantEnabled:   false,
+			wantRunning:   false,
+			wantPID:       0,
+		},
+	}
+
+	bothScopes(t, func(t *testing.T, userScope bool) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				run := newRecordingRunner()
+				m, _ := newTestSystemdManager(t, run, userScope)
+				run.on(argv(base(userScope), "is-enabled", systemdUnitName), tc.isEnabled.out, tc.isEnabled.err)
+				run.on(argv(base(userScope), "is-active", systemdUnitName), tc.isActive.out, tc.isActive.err)
+				run.on(argv(base(userScope), "show", "-p", "MainPID", "--value", systemdUnitName), tc.mainPID.out, tc.mainPID.err)
+
+				if tc.install {
+					if err := m.Install(); err != nil {
+						t.Fatalf("Install setup: %v", err)
+					}
+					run.calls = nil
+				}
+
+				st, err := m.Status()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if st.Installed != tc.wantInstalled {
+					t.Errorf("Installed: got %v want %v", st.Installed, tc.wantInstalled)
+				}
+				if st.Enabled != tc.wantEnabled {
+					t.Errorf("Enabled: got %v want %v", st.Enabled, tc.wantEnabled)
+				}
+				if st.Running != tc.wantRunning {
+					t.Errorf("Running: got %v want %v", st.Running, tc.wantRunning)
+				}
+				if st.PID != tc.wantPID {
+					t.Errorf("PID: got %v want %v", st.PID, tc.wantPID)
+				}
+				if st.UnitPath != m.unitPath() {
+					t.Errorf("UnitPath: got %q want %q", st.UnitPath, m.unitPath())
+				}
+			})
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NewManager linux scope selection
+// ---------------------------------------------------------------------------
+
+func TestNewManager_LinuxScopeSelection(t *testing.T) {
+	t.Run("uid_1000_is_user_scope_no_probe_needed", func(t *testing.T) {
+		run := newRecordingRunner()
+		mgr, err := newManager("linux", 1000, run.run)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sm, ok := mgr.(*systemdManager)
+		if !ok {
+			t.Fatalf("got %T, want *systemdManager", mgr)
+		}
+		if !sm.userScope {
+			t.Error("expected user scope for non-root uid")
+		}
+		// uid != 0 short-circuits the probe: no `is-active` call.
+		if len(run.calls) != 0 {
+			t.Errorf("expected no probe calls for uid != 0, got %v", run.calls)
+		}
+	})
+
+	t.Run("uid_0_probe_fails_is_system_scope", func(t *testing.T) {
+		run := newRecordingRunner()
+		run.on([]string{"systemctl", "--user", "is-active", systemdUnitName}, "", fmt.Errorf("no such unit"))
+
+		mgr, err := newManager("linux", 0, run.run)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sm, ok := mgr.(*systemdManager)
+		if !ok {
+			t.Fatalf("got %T, want *systemdManager", mgr)
+		}
+		if sm.userScope {
+			t.Error("expected system scope when uid 0 and user-unit probe fails")
+		}
+		want := [][]string{
+			{"systemctl", "--user", "is-active", systemdUnitName},
+		}
+		assertCalls(t, run.calls, want)
+	})
+
+	t.Run("uid_0_probe_succeeds_is_user_scope", func(t *testing.T) {
+		run := newRecordingRunner()
+		run.on([]string{"systemctl", "--user", "is-active", systemdUnitName}, "active", nil)
+
+		mgr, err := newManager("linux", 0, run.run)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sm, ok := mgr.(*systemdManager)
+		if !ok {
+			t.Fatalf("got %T, want *systemdManager", mgr)
+		}
+		if !sm.userScope {
+			t.Error("expected user scope when uid 0 but user-unit probe succeeds (mirrors selfupdate.restartService)")
+		}
+	})
+}

--- a/apps/node-agent/internal/service/templates/agentpod-node-system.service
+++ b/apps/node-agent/internal/service/templates/agentpod-node-system.service
@@ -1,0 +1,51 @@
+[Unit]
+Description=AgentPod node-agent — fleet management daemon
+Documentation=https://github.com/rakeshgangwar/agentpod
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# -----------------------------------------------------------------------
+# User= / Group=
+# Run as the operator account that owns the managed-agent config dirs
+# (e.g. Hermes profiles under ~/profiles/, OpenClaw configs).
+# Set this to the Linux user that runs those agents.
+# On a single-operator host "root" works; for a dedicated service account
+# create one and set User=agentpod Group=agentpod here.
+# -----------------------------------------------------------------------
+User=root
+
+# Enroll once before starting the service:
+#   agentpod-node enroll --hub <HUB_URL> --token <TOKEN>
+# That writes ~/.config/agentpod-node/config.json (or
+# /root/.config/agentpod-node/config.json when User=root).
+# The config is read automatically by `agentpod-node run`.
+ExecStart={{.BinaryPath}} run
+
+Restart=always
+RestartSec=5
+
+# --- Hardening -------------------------------------------------------
+# NOTE: the node-agent is a PRIVILEGED facilities daemon — its job is to
+# read AND write the operator's filesystem (fs.write/cleanup), spawn
+# interactive PTY shells (terminal), and manage agents under the operator's
+# home. So filesystem/namespace isolation is intentionally MINIMAL:
+# ProtectSystem/ProtectHome/PrivateTmp/PrivateDevices are deliberately NOT
+# set, or write ops, cleanup, config edits, and terminals would fail.
+# We keep only the privilege/kernel hardening that does not restrict the
+# agent's legitimate file + PTY access.
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+
+# --- Logging ---------------------------------------------------------
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=agentpod-node
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/node-agent/internal/service/templates/agentpod-node-user.service
+++ b/apps/node-agent/internal/service/templates/agentpod-node-user.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=AgentPod node-agent (user service)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart={{.BinaryPath}} run
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/apps/node-agent/internal/service/templates/dev.agentpod.node.plist
+++ b/apps/node-agent/internal/service/templates/dev.agentpod.node.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.agentpod.node</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{.BinaryPath}}</string>
+    <string>run</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>{{.LogPath}}</string>
+  <key>StandardErrorPath</key><string>{{.LogPath}}</string>
+</dict>
+</plist>

--- a/apps/node-agent/scripts/install.sh
+++ b/apps/node-agent/scripts/install.sh
@@ -203,105 +203,21 @@ path_hint() {
   esac
 }
 
-install_launch_agent() {
-  # Per-user LaunchAgent: survives reboot/terminal close, respawns on crash —
-  # and respawns after self-update's exit, which is what makes console
-  # one-click updates work on macOS (KeepAlive plays systemd Restart=always).
-  local plist_dir="$HOME/Library/LaunchAgents"
-  local plist="$plist_dir/dev.agentpod.node.plist"
-  local log="$HOME/Library/Logs/agentpod-node.log"
-  mkdir -p "$plist_dir" "$HOME/Library/Logs"
-  cat > "$plist" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>dev.agentpod.node</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>${DEST_BIN}</string>
-    <string>run</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>${log}</string>
-  <key>StandardErrorPath</key><string>${log}</string>
-</dict>
-</plist>
-EOF
-  local uid; uid="$(id -u)"
-  # Idempotent re-install: tear down any loaded copy first (ignore failures).
-  launchctl bootout "gui/${uid}/dev.agentpod.node" >/dev/null 2>&1 || true
-  if launchctl bootstrap "gui/${uid}" "$plist" 2>/dev/null || launchctl load -w "$plist" 2>/dev/null; then
-    echo ""
-    echo "Running as a launchd LaunchAgent (survives reboot while you're logged in):"
-    echo "  status:     launchctl print gui/${uid}/dev.agentpod.node | head -20"
-    echo "  logs:       tail -f ${log}"
-    echo "  restart:    launchctl kickstart -k gui/${uid}/dev.agentpod.node"
-    echo "  uninstall:  launchctl bootout gui/${uid}/dev.agentpod.node && rm ${plist}"
-    echo "NOTE: a LaunchAgent only runs while you are logged in; system sleep"
-    echo "      suspends it — the node shows offline until wake (by design)."
-    return 0
-  fi
-  echo "WARNING: could not bootstrap the LaunchAgent — start manually with: apn run" >&2
-  return 1
-}
-
 if [ "$MODE" = "user" ]; then
   echo ""
   echo "Done. agentpod-node installed to ${DEST_BIN} (rootless — no sudo used)."
   path_hint
   SVC_OK=0
-  if [ "$OS" = "linux" ] && command -v systemctl >/dev/null 2>&1 && systemctl --user daemon-reload >/dev/null 2>&1; then
-    UDIR="$HOME/.config/systemd/user"
-    mkdir -p "$UDIR"
-    cat > "$UDIR/agentpod-node.service" <<EOF
-[Unit]
-Description=AgentPod node-agent (user service)
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart=${DEST_BIN} run
-Restart=always
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-EOF
-    systemctl --user daemon-reload
-    if systemctl --user enable --now agentpod-node >/dev/null 2>&1; then SVC_OK=1; fi
-  elif [ "$OS" = "darwin" ]; then
-    if install_launch_agent; then SVC_OK=1; fi
-  fi
-  echo ""
-  if [ "$SVC_OK" = "1" ]; then
-    # install_launch_agent already printed the full darwin summary; only
-    # linux's systemd --user path needs its own summary here.
-    if [ "$OS" = "linux" ]; then
-      echo "Running as a systemd --user service:"
-      echo "  status:  systemctl --user status agentpod-node"
-      echo "  logs:    journalctl --user -u agentpod-node -f"
-      echo "  To survive logout/reboot, an admin runs once:  sudo loginctl enable-linger $USER"
-    fi
-  else
+  if "$DEST_BIN" service install; then SVC_OK=1; fi
+  if [ "$SVC_OK" != "1" ]; then
+    echo ""
     echo "To start it now:       apn run"
     echo "Persist without root:  tmux new -s apn 'apn run'   (or)   nohup apn run >~/agentpod-node.log 2>&1 &"
   fi
 
-elif [ "$OS" = "linux" ]; then
-  # ---- system + Linux: systemd service ----
-  echo "==> Installing systemd service..."
-  UNIT_URL="${DOWNLOAD_BASE}/agentpod-node.service"
-  UNIT_DEST="/etc/systemd/system/agentpod-node.service"
-  if ! curl -fSL --progress-bar -o "$UNIT_DEST" "$UNIT_URL"; then
-    echo "" >&2; echo "ERROR: failed to download unit: ${UNIT_URL}" >&2; exit 1
-  fi
-  chmod 0644 "$UNIT_DEST"
-  systemctl daemon-reload
-  systemctl enable --now agentpod-node
-  echo ""
-  echo "Done. agentpod-node is running as a systemd service."
-  echo "  status:  systemctl status agentpod-node"
-  echo "  logs:    journalctl -u agentpod-node -f"
+else
+  # ---- system (root) — Linux only; macOS system-mode re-execs as the
+  # invoking user above, so MODE is never "system" on darwin.
+  echo "==> Installing service..."
+  "$DEST_BIN" service install
 fi

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -295,18 +295,11 @@ systemctl status agentpod-hub --no-pager
 
 If the console changed: rebuild locally with `PUBLIC_HUB_URL=https://hub.<your-domain> pnpm --filter @agentpod/console build` and redeploy `apps/console/build/` to Cloudflare Pages (Wrangler or push to the connected branch).
 
-Node-agent upgrades: re-run the curl installer on each host (idempotent):
+Node-agent upgrades: re-run the curl installer on each host (idempotent — it re-installs the binary, re-enrolls, and re-runs `apn service install`):
 ```bash
 curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/install.sh \
   | sudo bash -s -- https://hub.<your-domain> <TOKEN>
 ```
 Or, from a repo checkout: `sudo bash apps/node-agent/scripts/install-node-agent.sh https://hub.<your-domain> <TOKEN>`.
 
-On macOS the same command — piped and all — always installs rootless (regardless of `sudo`, re-execing as the invoking user) and (re)installs a per-user LaunchAgent — `~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`:
-```bash
-launchctl print gui/$(id -u)/dev.agentpod.node | head -20   # status
-tail -f ~/Library/Logs/agentpod-node.log                    # logs
-launchctl kickstart -k gui/$(id -u)/dev.agentpod.node       # restart
-launchctl bootout gui/$(id -u)/dev.agentpod.node && rm ~/Library/LaunchAgents/dev.agentpod.node.plist   # uninstall
-```
-It only runs while the user is logged in; system sleep suspends it and the node shows offline until wake.
+On macOS the same command — piped and all — always installs rootless (regardless of `sudo`, re-execing as the invoking user) and (re)installs a per-user LaunchAgent via `apn service install`. Manage it with the `apn` verbs — `apn status`, `apn logs -f`, `apn restart` — it only runs while the user is logged in; system sleep suspends it and the node shows offline until wake. See [docs/OPERATING.md](./OPERATING.md#1-enroll-a-node) for the full verb list and the raw-launchctl/systemctl fallback.

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -19,7 +19,7 @@ curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/in
   | sudo bash -s -- https://hub.<your-domain> <enrollment-token-from-console>
 ```
 
-**Rootless** — for key-only hosts where the login user has no `sudo` password. Pass `--user`; it installs into `~/.local/bin`, enrolls as you, and (if a user systemd manager is available) sets up a `systemd --user` service, otherwise prints run instructions (`apn run` / `tmux`):
+**Rootless** — for key-only hosts where the login user has no `sudo` password. Pass `--user`; it installs into `~/.local/bin`, enrolls as you, then runs `apn service install` (systemd `--user` on Linux) — falling back to run instructions (`apn run` / `tmux`) if no user service manager is available:
 
 ```bash
 curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/install.sh \
@@ -27,13 +27,17 @@ curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/in
 ```
 (If not root and `sudo` is absent, the installer auto-falls back to this rootless mode. For a `systemd --user` service to survive logout/reboot, run `sudo loginctl enable-linger <user>` once.)
 
-**macOS** — the same one-liner (with or without `sudo`/`--user`) always installs rootless: binary in `~/.local/bin`, enrolled as the invoking user, service registered as a per-user LaunchAgent (`~/Library/LaunchAgents/dev.agentpod.node.plist`, label `dev.agentpod.node`). The `curl | sudo bash` form above re-execs itself as `$SUDO_USER` automatically, piped invocation included.
+**macOS** — the same one-liner (with or without `sudo`/`--user`) always installs rootless: binary in `~/.local/bin`, enrolled as the invoking user, service registered via `apn service install` as a per-user LaunchAgent (label `dev.agentpod.node`). The `curl | sudo bash` form above re-execs itself as `$SUDO_USER` automatically, piped invocation included.
+
+Manage the service with the `apn` verbs, on either platform:
 
 ```bash
-launchctl print gui/$(id -u)/dev.agentpod.node | head -20                        # status
-tail -f ~/Library/Logs/agentpod-node.log                                         # logs
-launchctl kickstart -k gui/$(id -u)/dev.agentpod.node                            # restart
-launchctl bootout gui/$(id -u)/dev.agentpod.node && rm ~/Library/LaunchAgents/dev.agentpod.node.plist   # uninstall
+apn status              # installed / running / hub reachability
+apn logs -f             # follow service logs
+apn restart             # restart in place
+apn stop                # stop and disable (sticky — survives reboot until `apn start`)
+apn start                # re-enable and start
+apn service uninstall   # stop, disable, and remove the service
 ```
 
 A LaunchAgent only runs while you're logged in — system sleep suspends it, and the node shows offline until wake (by design).
@@ -41,11 +45,13 @@ A LaunchAgent only runs while you're logged in — system sleep suspends it, and
 The installer downloads the prebuilt binary for your platform (linux/darwin × amd64/arm64) from the latest GitHub Release, then — for a **system-wide Linux install (root, no `--user`)**:
 1. Installs it to `/usr/local/bin/agentpod-node`.
 2. Runs `agentpod-node enroll --hub <HUB_URL> --token <TOKEN>` — writes config to `/root/.config/agentpod-node/config.json`.
-3. Installs and enables the systemd unit `agentpod-node.service`.
+3. Runs `apn service install`, which installs and enables the systemd unit `agentpod-node.service`.
 
 (Rootless and macOS installs use the different paths and service mechanism described above instead.)
 
-The installer is idempotent: re-running upgrades the binary and re-enrolls. Binaries are published on every `v*` tag by `.github/workflows/release-node-agent.yml`.
+The installer is idempotent: re-running upgrades the binary, re-enrolls, and re-installs the service. Binaries are published on every `v*` tag by `.github/workflows/release-node-agent.yml`.
+
+> **Under the hood:** the `apn` verbs wrap the native service manager — on Linux, `systemctl [--user] status|restart|stop|start|enable|disable agentpod-node` + `journalctl [--user-unit|-u] agentpod-node -f`; on macOS, `launchctl print/kickstart/bootout gui/$(id -u)/dev.agentpod.node` + `tail -f ~/Library/Logs/agentpod-node.log`. Reach for the raw commands only when diagnosing the service manager itself — `apn status` / `apn logs` / `apn restart` are the day-to-day path.
 
 ### Option A′ — from a repo checkout (build from source)
 
@@ -69,16 +75,15 @@ apn enroll --hub https://hub.<your-domain> --token <TOKEN>
 
 # 2. Run (reads config automatically):
 apn run
-# Or, install the systemd unit and let systemd manage it:
-#   cp apps/node-agent/deploy/agentpod-node.service /etc/systemd/system/
-#   systemctl daemon-reload && systemctl enable --now agentpod-node
+# Or, let apn manage it as a persistent service (systemd on Linux, LaunchAgent on macOS):
+#   apn service install
 ```
 
 ### Verify enrollment
 
 ```bash
-systemctl status agentpod-node
-journalctl -u agentpod-node -f
+apn status
+apn logs -f
 # Expected: "connected to hub" — the node appears online in the console, labelled "no tunnel"
 ```
 
@@ -218,13 +223,13 @@ Hermes stations that have a Matrix identity configured display the **Matrix ID**
 ## 8. Troubleshooting
 
 **Node not appearing online after enroll:**
-- Check `journalctl -u agentpod-node -f` on the host for connection errors.
+- Check `apn logs -f` on the host for connection errors.
 - Confirm `PROVISIONING_HUB_URL` or `--hub` URL is reachable from the host (not `127.0.0.1`).
 - Check the hub log: `journalctl -u agentpod-hub -n 50 --no-pager`.
 
 **Terminal disconnects and does not reconnect:**
 - The node-agent holds the PTY master; a node-agent restart will lose unattached sessions.
-- Ensure `agentpod-node` is running (`systemctl status agentpod-node`).
+- Ensure `agentpod-node` is running (`apn status`).
 
 **Provisioned container does not auto-enroll:**
 - Confirm `PROVISIONING_HUB_URL` is set to the container-reachable hub URL (not `127.0.0.1`).

--- a/docs/superpowers/plans/2026-08-08-apn-service-cli.md
+++ b/docs/superpowers/plans/2026-08-08-apn-service-cli.md
@@ -1,0 +1,181 @@
+# apn Service CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `apn stop|start|restart|status|logs` + `apn service install|uninstall` + a real help system; `install.sh` thins to download → enroll → `apn service install`. Ships v0.1.13.
+
+**Architecture:** Spec: `docs/superpowers/specs/2026-08-08-apn-service-cli-design.md`. New `internal/service` package (Manager interface, launchd + systemd implementations, embedded templates, injected runner for argv-exact table tests); `main.go` gains verbs + help; `selfupdate.restartService` delegates to the service package.
+
+**Tech Stack:** Go stdlib only (no cobra).
+
+## Global Constraints
+
+- Branch `develop`. Commits `feat(node-agent): …` etc. TDD: failing test first, every step.
+- Tests: `cd apps/node-agent && go test -race ./...` fully green; gofmt-clean on new/changed files.
+- Contracts that MUST NOT drift: launchd label `dev.agentpod.node`, domain `gui/<uid>`; systemd unit name `agentpod-node`; macOS log path `~/Library/Logs/agentpod-node.log`; macOS is per-user only (root refused); selfupdate restart argv on both platforms stays byte-identical to today's (existing tests pin it).
+- `apn stop` = stop AND disable (sticky). Self-update paths never disable.
+- No live launchctl/systemctl runs in tests — everything through the injected runner. Live verification happens only in Task 7 on this Mac.
+- File one issue at Task 1 start (`gh issue create --title "apn: service management verbs (stop/start/restart/status/logs, service install) + help system" --body "Spec: docs/superpowers/specs/2026-08-08-apn-service-cli-design.md"`); use its number in commits; controller closes it after Task 7.
+
+---
+
+### Task 1: service package core + launchd manager
+
+**Files:**
+- Create: `apps/node-agent/internal/service/service.go` (types, NewManager)
+- Create: `apps/node-agent/internal/service/launchd.go` + `launchd_test.go`
+- Create: `apps/node-agent/internal/service/templates/dev.agentpod.node.plist` (embedded)
+
+**Interfaces (produced — later tasks and the spec depend on these exactly):**
+
+```go
+package service
+
+// Runner executes a command and returns its combined stdout (trimmed) — the
+// injectable seam for tests. nil means exec.Command for real.
+type Runner func(name string, args ...string) (string, error)
+
+type Status struct {
+	Installed bool   `json:"installed"`
+	Enabled   bool   `json:"enabled"`
+	Running   bool   `json:"running"`
+	PID       int    `json:"pid"`
+	UnitPath  string `json:"unitPath"` // plist/unit file location
+}
+
+type Manager interface {
+	Install() error   // write template, enable, start; idempotent
+	Uninstall() error // stop, disable, remove file; idempotent
+	Start() error     // enable + start
+	Stop() error      // stop + disable (sticky)
+	Restart() error
+	Status() (Status, error)
+}
+
+// NewManager picks the platform implementation. darwin: launchd per-user
+// (returns an error for uid 0 — macOS installs are per-user by policy).
+// linux: systemd; user scope when uid != 0 OR the user unit answers
+// `systemctl --user is-active agentpod-node` (preserves selfupdate's probe
+// behavior), else system scope.
+func NewManager(run Runner) (Manager, error)
+```
+
+- [ ] **Step 1: RED — launchd argv table test.** Create `launchd_test.go` with a recording Runner (`calls [][]string`, scripted per-call results) and table tests asserting EXACT argv sequences (uid from `os.Getuid()`, plist path under the test's fake home — inject home via a `launchdManager{home string, uid int, run Runner}` struct so tests don't touch the real `~/Library`):
+  - `Stop()` → `launchctl bootout gui/<uid>/dev.agentpod.node` (error IGNORED) then `launchctl disable gui/<uid>/dev.agentpod.node` (error returned).
+  - `Start()` → `launchctl enable gui/<uid>/dev.agentpod.node`, then `launchctl bootstrap gui/<uid> <plistPath>`; if bootstrap errors, fall back to `launchctl kickstart -k gui/<uid>/dev.agentpod.node` (test both branches).
+  - `Restart()` → `launchctl kickstart -k gui/<uid>/dev.agentpod.node` exactly (this later becomes selfupdate's delegate — argv must match selfupdate's current darwin test).
+  - `Install()` → writes the plist file (assert content contains the label, the binary path with ` run` argument, both log paths), then `enable`, `bootout` (ignored), `bootstrap`.
+  - `Uninstall()` → `bootout` (ignored), file removed, no error when file already absent.
+  - `Status()` → Installed = plist exists; Enabled = parse `launchctl print-disabled gui/<uid>` output NOT containing `"dev.agentpod.node" => disabled`; Running/PID = parse `launchctl print gui/<uid>/dev.agentpod.node` for a `pid = <N>` line, not-running when that command errors. Table cases: running-with-pid, stopped, disabled, not-installed.
+- [ ] **Step 2: Verify RED** (`go test ./internal/service/` — package doesn't exist yet → build failure, then after scaffolding types, assertion failures).
+- [ ] **Step 3: GREEN — implement `service.go` + `launchd.go`.** Plist template in `templates/dev.agentpod.node.plist` via `//go:embed`, parameterized with `text/template` on `{{.BinaryPath}}` and `{{.LogPath}}` — content identical in effect to what `install.sh`'s `install_launch_agent()` writes today (Label, ProgramArguments [bin, run], RunAtLoad, KeepAlive, both Standard*Path to the log). Binary path resolved via `os.Executable()` + `filepath.EvalSymlinks`.
+- [ ] **Step 4: Verify GREEN + `-race` + gofmt.**
+- [ ] **Step 5: Commit** `feat(node-agent): service package with launchd manager (#<N>)`.
+
+---
+
+### Task 2: systemd manager
+
+**Files:**
+- Create: `apps/node-agent/internal/service/systemd.go` + `systemd_test.go`
+- Create: `apps/node-agent/internal/service/templates/agentpod-node-user.service`, `templates/agentpod-node-system.service`
+
+**Interfaces:** `newSystemdManager(run Runner, userScope bool, home string, uid int) *systemdManager`; `NewManager` (from Task 1) wires the linux branch: userScope = `uid != 0 || userUnitActive(run)` where `userUnitActive` = `systemctl --user is-active agentpod-node` succeeding.
+
+- [ ] **Step 1: RED — argv table tests, both scopes.** Base argv `systemctl --user` (user) vs `systemctl` (system):
+  - `Stop()` → `<base> stop agentpod-node` (error ignored) + `<base> disable agentpod-node`.
+  - `Start()` → `<base> enable --now agentpod-node`.
+  - `Restart()` → `<base> restart agentpod-node` (matches selfupdate's current restart argv per scope).
+  - `Install()` → writes unit to `~/.config/systemd/user/agentpod-node.service` (user) or `/etc/systemd/system/agentpod-node.service` (system; path field on the struct so the test uses a temp dir), then `<base> daemon-reload`, `<base> enable --now agentpod-node`.
+  - `Uninstall()` → `<base> disable --now agentpod-node` (ignored), remove file, `<base> daemon-reload`.
+  - `Status()` → Installed = unit file exists; Enabled = `<base> is-enabled agentpod-node` stdout `enabled`; Running = `<base> is-active agentpod-node` stdout `active`; PID = atoi of `<base> show -p MainPID --value agentpod-node` (0 → not running).
+  - `NewManager` linux scope selection: uid 1000 → user; uid 0 + probe fails → system; uid 0 + user-unit probe succeeds → user (mirrors `restartService` today).
+- [ ] **Step 2: Verify RED.**
+- [ ] **Step 3: GREEN.** User template = the minimal unit `install.sh` writes today (Description, After/Wants network-online, `ExecStart={{.BinaryPath}} run`, Restart=always, RestartSec=5, WantedBy=default.target). System template = `deploy/agentpod-node.service` content with `ExecStart={{.BinaryPath}} run` parameterized (keep User=root + the hardening block + journal logging + WantedBy=multi-user.target verbatim).
+- [ ] **Step 4: Verify GREEN + `-race` + gofmt.**
+- [ ] **Step 5: Commit** `feat(node-agent): systemd manager for the service package (#<N>)`.
+
+---
+
+### Task 3: CLI verbs — stop/start/restart/status/logs + service install|uninstall
+
+**Files:**
+- Create: `apps/node-agent/cmd/agentpod-node/service_cmds.go` + `service_cmds_test.go`
+- Modify: `apps/node-agent/cmd/agentpod-node/main.go` (switch cases only)
+
+**Interfaces (produced):** `runServiceVerb(verb string, args []string, mgr service.Manager, out io.Writer) int` (returns exit code) and `statusCmd(mgr service.Manager, cfg config.Config, cfgErr error, checkCred func(hub, id, secret string) (bool, error), jsonOut bool, out io.Writer) int` — main.go cases stay one-liners; all logic testable with a fake Manager.
+
+- [ ] **Step 1: RED — status assembly tests.** Fake Manager returning scripted Status; table:
+  - running + credential valid (stub checkCred true) → output contains `running:    yes (pid 35547)`, `credential: valid`, exit 0.
+  - running + credential rejected → `credential: INVALID`, exit 1.
+  - hub unreachable (checkCred error) → `reachable:  no`, `credential: unknown`, exit 1.
+  - not running → exit 1; no config file → hub block shows `not enrolled`, exit 1.
+  - `--json` → unmarshal output into `struct{ Service service.Status; Hub struct{ URL, NodeID string; Reachable, CredentialValid bool } }`, assert fields.
+  Output format (text) exactly:
+
+```
+Service:
+  installed:  yes (<unitPath>)
+  enabled:    yes
+  running:    yes (pid 35547)
+  version:    <version>
+Hub:
+  url:        https://hub.agentpod.dev
+  node:       node_161e685104dc488ebd11
+  reachable:  yes
+  credential: valid
+```
+
+- [ ] **Step 2: RED — stop/start/restart wrappers** call the right Manager method, print a confirmation + undo hint (`stopped and disabled — 'apn start' re-enables`), map Manager errors to exit 1. `service install` prints the platform summary (status/logs/restart/uninstall lines — the text `install_launch_agent()` prints today moves here for darwin; a systemd equivalent for linux). `service uninstall` prints removal confirmation.
+- [ ] **Step 3: RED — logs.** `logsCmd(scope) `: darwin → exec `tail` (`-n N`, plus `-f` when set) on `~/Library/Logs/agentpod-node.log` with stdio passthrough (test: assert the built \*exec.Cmd argv via a command-builder seam; missing log file → friendly error, exit 1). linux → exec `journalctl [-f] [-n N] --user-unit agentpod-node` (user scope) / `-u agentpod-node` (system).
+- [ ] **Step 4: Verify RED, then GREEN** — implement `service_cmds.go`; wire main.go cases `"stop","start","restart","status","logs","service"` calling `service.NewManager(nil)` + `enroll.CheckCredential`.
+- [ ] **Step 5: Verify GREEN + `-race`; build darwin+linux cross (`GOOS=linux go build ./...`).**
+- [ ] **Step 6: Commit** `feat(node-agent): stop/start/restart/status/logs + service install|uninstall (#<N>)`.
+
+---
+
+### Task 4: help system
+
+**Files:**
+- Create: `apps/node-agent/cmd/agentpod-node/help.go` + `help_test.go`
+- Modify: `apps/node-agent/cmd/agentpod-node/main.go` (no-args path, help/-h/--help cases, unknown-command path)
+
+- [ ] **Step 1: RED.** Tests: (a) `helpText(version)` contains every command name from a `commands` registry slice (test iterates the slice — a new command missing from help fails the test); (b) contains the grouped section headers `Service:`, `Node:`, `Maintenance:` and the examples block from the spec; (c) `suggestCommand("statsu")` → `"status"` (levenshtein ≤ 2), `suggestCommand("zzz")` → `""`; (d) per-command help: `commandHelp("stop")` mentions sticky/disable semantics; `commandHelp("logs")` mentions the platform log sources.
+- [ ] **Step 2: GREEN.** `commands` = `[]struct{ name, group, oneline, detail string }` — single source for top-level help, `apn help <cmd>`, and the suggestion list. Small levenshtein (≤ 20 lines, stdlib). main.go: no args OR `help|-h|--help` → print `helpText(version)`, exit 0; `help <cmd>` → `commandHelp`, exit 0 (unknown cmd in help → exit 2); unknown verb → `unknown command: %q` + optional `did you mean '<s>'?` + `run 'apn help'`, exit 2. Each existing FlagSet gets a `.Usage` that prints the command's `detail` + flag defaults.
+- [ ] **Step 3: Verify GREEN + `-race`; run `go run ./cmd/agentpod-node help` once and eyeball the layout matches the spec mock.**
+- [ ] **Step 4: Commit** `feat(node-agent): help system — grouped help, per-command help, did-you-mean (#<N>)`.
+
+---
+
+### Task 5: selfupdate delegates restart to the service package
+
+**Files:**
+- Modify: `apps/node-agent/internal/selfupdate/selfupdate.go` (restartService body only; exported behavior unchanged)
+- Modify: `apps/node-agent/internal/selfupdate/selfupdate_test.go` (only if adapter shape requires)
+
+- [ ] **Step 1: Confirm the existing restart tests still pin argv** (`TestRestartService*` — linux user/system probe sequence, darwin kickstart). These are the contract; do NOT weaken them.
+- [ ] **Step 2: Replace `restartService`'s body** with delegation: adapt `run func(name string, args ...string) error` to `service.Runner` (`return "", run(...)`), build the platform manager the same way `NewManager` does but honoring the `goos` parameter (keep the signature `restartService(goos string, run ...)`; darwin → launchd Restart; linux → the same user-probe + scoped restart via systemd manager). Wrap failures in `ErrRestartFailed` exactly as today.
+- [ ] **Step 3: Verify GREEN** — the pinned argv tests pass unmodified (if they don't, the delegation is wrong — fix the service side, not the tests). Full `-race` suite.
+- [ ] **Step 4: Commit** `refactor(node-agent): selfupdate restart delegates to internal/service (#<N>)`.
+
+---
+
+### Task 6: installer thinning + docs + changelog
+
+**Files:**
+- Modify: `apps/node-agent/scripts/install.sh`
+- Modify: `docs/DEPLOYMENT.md`, `docs/OPERATING.md`, `CLAUDE.md` (commands), `CHANGELOG.md`
+
+- [ ] **Step 1: install.sh.** After the enroll step, replace the three service sections (linux `MODE=user` systemd block, `install_launch_agent()` + its call, linux system block incl. the `agentpod-node.service` download) with a single invocation: `"$DEST_BIN" service install` (system+linux runs it as root directly; user mode runs as the current user). Delete `install_launch_agent()` entirely. Keep: `path_hint`, the SVC_OK fallback echo (now driven by the exit code of `apn service install`), the darwin/sudo/mode logic (untouched — Task 2 of the launchd slice hardened it). The `.service` release asset keeps shipping (reference for direct consumers) but the installer no longer downloads it.
+- [ ] **Step 2: Lint** — `bash -n` + `shellcheck -S warning` clean; piped-simulation smoke (`cat … | bash -s -- --user https://example.invalid tok_x`) still gets past mode logic and fails only at download/enroll.
+- [ ] **Step 3: Docs.** OPERATING.md: replace raw `launchctl`/`systemctl` guidance with the `apn` verbs (keep raw commands in one "under the hood" note); DEPLOYMENT.md: service sections point at `apn service install`; CLAUDE.md root: add the new verbs to the command list. CHANGELOG `## v0.1.13 - 2026-08-08` from the actual shipped facts only.
+- [ ] **Step 4: Commit** `feat(installer): install.sh delegates service setup to apn service install (#<N>)` + `docs: changelog for v0.1.13`.
+
+---
+
+### Task 7: release v0.1.13 + live dogfood (controller-run)
+
+- [ ] **Step 1:** Full suites (`go test -race ./...`, hub + console untouched but run hub `bun test` + console `pnpm check && pnpm test` as contract-drift guard). Push, PR → main, checks green, merge (user or controller per session convention).
+- [ ] **Step 2:** Tag `v0.1.13`; watch `release-node-agent.yml`; verify all assets incl. updated `install.sh`.
+- [ ] **Step 3:** Live dogfood on this Mac (agent currently stopped via bootout — a fresh `service install` also validates recovery from that state): `apn update` (or reinstall via the one-liner) to get v0.1.13 → `apn service install` → `apn status` (expect running + credential valid, exit 0) → `apn stop` → `launchctl print-disabled gui/501` shows the label disabled + console shows node offline → `apn start` → back online → `apn logs -n 5` → `apn help` renders. Roll superchotu + molt-bot from the console (validates Task 5's delegated restart on linux user+system scopes).
+- [ ] **Step 4:** Close the issue with live evidence; update memory; ledger complete.

--- a/docs/superpowers/specs/2026-08-08-apn-service-cli-design.md
+++ b/docs/superpowers/specs/2026-08-08-apn-service-cli-design.md
@@ -1,7 +1,7 @@
 # apn Service CLI — Design
 
 **Date:** 2026-08-08
-**Goal:** `apn` absorbs platform service management: `stop|start|restart|status|logs` top-level verbs + `apn service install|uninstall`, with `install.sh` thinning to download → enroll → `apn service install`. Ships as v0.1.13.
+**Goal:** `apn` absorbs platform service management (`stop|start|restart|status|logs` + `apn service install|uninstall`), gains a real help system, and `install.sh` thins to download → enroll → `apn service install`. Ships as v0.1.13.
 
 ## Command surface
 
@@ -27,6 +27,46 @@ New `internal/service` package:
 - Templates: `//go:embed` plist + unit text, parameterized on binary path (absolute, via `os.Executable` + `EvalSymlinks`) and log path.
 - `selfupdate.restartService` refactors to delegate to `service.Restart` — one restart implementation. Behavior contract (exact argv on both platforms) preserved by existing tests.
 - `main.go` gains the verbs; existing `enroll|run|detect|update|version` unchanged.
+
+## Help & CLI UX
+
+Today `apn` prints a bare `usage: agentpod-node <enroll|run|detect|update|version>` and nothing else. This slice gives it a real help system — stdlib only (no cobra; the binary stays dependency-light):
+
+- `apn` (no args), `apn help`, `apn -h` / `apn --help` → structured help: one-line description of the tool, usage line, commands grouped by purpose with one-line descriptions, a short examples block, and the version.
+
+```
+agentpod-node (apn) — AgentPod fleet node agent  v0.1.13
+
+Usage: apn <command> [flags]
+
+Service:
+  status      Show local service + hub connection state (--json for scripts)
+  start       Enable and start the background service
+  stop        Stop and disable the service (sticky across reboots)
+  restart     Restart the running service
+  logs        Show service logs (-f to follow, -n N for last N lines)
+  service     install | uninstall the platform service (launchd/systemd)
+
+Node:
+  enroll      Enroll this machine with a hub (--hub, --token, --force)
+  run         Run the agent in the foreground
+  detect      Print detected harness stations as JSON
+
+Maintenance:
+  update      Self-update from the latest release (--check, --force)
+  version     Print version and platform
+
+Examples:
+  apn status
+  apn logs -f
+  apn enroll --hub https://hub.example.com --token <TOKEN>
+
+Run 'apn help <command>' or 'apn <command> -h' for command details.
+```
+
+- `apn help <command>` and `apn <command> -h` → per-command help: purpose, flags (each FlagSet gets proper `Usage` text — several currently print bare flag defaults), platform notes where behavior differs (e.g. `stop` semantics, where `logs` reads from).
+- `apn <unknown>` → "unknown command" + the closest match if the edit distance is small ("did you mean 'status'?") + pointer to `apn help`. Exit 2.
+- Help text lives beside the command definitions in `main.go`/a small `help.go`, asserted by unit tests (every registered command appears in top-level help; help exits 0; unknown command exits 2).
 
 ## Installer thinning
 

--- a/docs/superpowers/specs/2026-08-08-apn-service-cli-design.md
+++ b/docs/superpowers/specs/2026-08-08-apn-service-cli-design.md
@@ -1,0 +1,47 @@
+# apn Service CLI — Design
+
+**Date:** 2026-08-08
+**Goal:** `apn` absorbs platform service management: `stop|start|restart|status|logs` top-level verbs + `apn service install|uninstall`, with `install.sh` thinning to download → enroll → `apn service install`. Ships as v0.1.13.
+
+## Command surface
+
+All verbs are platform-aware (`runtime.GOOS`); label/unit contracts are unchanged: launchd `dev.agentpod.node` (gui/<uid> domain), systemd `agentpod-node` (`--user` or system).
+
+| Verb | Semantics |
+|------|-----------|
+| `apn stop` | Stop **and disable** (sticky across reboot/login). macOS: `launchctl bootout` + `launchctl disable`; linux: `systemctl [--user] stop` + `disable`. Prints undo hint. |
+| `apn start` | Enable + start (symmetric inverse of stop). macOS: `launchctl enable` + `bootstrap`; linux: `enable --now`. No service installed → helpful error pointing at `apn service install` / foreground `apn run`. |
+| `apn restart` | `launchctl kickstart -k` / `systemctl [--user] restart`. |
+| `apn status` | Local block: service installed / enabled / running (PID), binary version, config present, hub URL, nodeId. Hub block: reachability + credential validity via existing `GET /public/nodes/credential-check`. Exit 0 iff running AND credential valid (scriptable). `--json` for machine output. |
+| `apn logs [-f] [-n N]` | macOS: read/tail `~/Library/Logs/agentpod-node.log`. linux: exec `journalctl [--user] -u agentpod-node [-f] [-n N]`. |
+| `apn service install` | Write plist/unit from a template **embedded in the binary**, enable + start. Idempotent (re-install replaces file, restarts). Non-root linux → `--user` unit; root linux → system unit; macOS → LaunchAgent (root macOS: refuse, per installer policy). |
+| `apn service uninstall` | Stop + disable + remove plist/unit. Idempotent (no-op when absent). Leaves config/enrollment untouched (that's `unenroll`, future). |
+
+## Structure
+
+New `internal/service` package:
+
+- `type Manager interface { Install() error; Uninstall() error; Start() error; Stop() error; Restart() error; Status() (Status, error) }`
+- `launchdManager` + `systemdManager` implementations selected by GOOS (+ systemd user-vs-system by uid/unit presence, mirroring `selfupdate.restartService`'s probe).
+- All exec through an injected runner (same seam as `selfupdate.Options.RunCommand`) → every branch table-testable, asserting exact argv sequences.
+- Templates: `//go:embed` plist + unit text, parameterized on binary path (absolute, via `os.Executable` + `EvalSymlinks`) and log path.
+- `selfupdate.restartService` refactors to delegate to `service.Restart` — one restart implementation. Behavior contract (exact argv on both platforms) preserved by existing tests.
+- `main.go` gains the verbs; existing `enroll|run|detect|update|version` unchanged.
+
+## Installer thinning
+
+`install.sh` keeps: OS/arch detection, sudo/re-exec handling, binary download + atomic swap, enroll. Its linux systemd block and macOS `install_launch_agent()` are replaced by one call: `apn service install` (run as the target user). The static `agentpod-node.service` release asset continues to ship for direct consumers, marked as reference — the installer no longer downloads it.
+
+## Interactions
+
+- Self-update (console-driven) never disables; KeepAlive/systemd-restart respawn semantics are untouched by the sticky-stop feature (only `apn stop` disables).
+- A stopped node reads honestly offline in the console (sweeper) with last-seen preserved.
+- `status`'s hub block reuses the node's stored credential; no new endpoints.
+
+## Testing
+
+TDD. Table tests per manager per verb (argv exactness, error paths); status hub-block against `httptest` (200/401/unreachable); `logs` argv/`tail` behavior unit-tested with a temp log file. Live dogfood on the Mac node before tagging: `service install` (over the existing agent) → `status` (running + credential valid) → `stop` → verify disabled via `launchctl print-disabled` → `start` → `logs -n 5` → console shows offline/online transitions honestly. Then release v0.1.13, roll fleet, update DEPLOYMENT/OPERATING/CLAUDE.md command references.
+
+## Out of scope
+
+`doctor`, `unenroll`, `config get/set`, `--json` beyond status, Homebrew tap, Windows, operator/fleet verbs.


### PR DESCRIPTION
Closes #199. apn absorbs platform service management: sticky stop/start (disable/enable semantics), status with live hub credential check + --json, logs, service install|uninstall with embedded launchd/systemd templates; grouped help with did-you-mean and a -h safety gate (probing -h can never execute a command); selfupdate restart delegates to the shared service package (pinned argv contract preserved); install.sh thins to download → enroll → apn service install.
Spec: docs/superpowers/specs/2026-08-08-apn-service-cli-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)