### PR TITLE
Console dev proxy: iterate on UI against a real hub

### DIFF
--- a/apps/console/vite.config.js
+++ b/apps/console/vite.config.js
@@ -9,6 +9,33 @@ export default defineConfig(async () => ({
   // Required for import.meta.env.PUBLIC_HUB_URL used in src/lib/api/client.ts.
   envPrefix: ["VITE_", "PUBLIC_"],
 
+  // Dev-only: proxy the hub API so a local console can iterate against a real
+  // hub with working cookie auth. The hub's session cookie is SameSite=Lax, so
+  // the browser only sends it in a same-site context — proxying makes every
+  // request same-origin from the browser's point of view (cookies scope to
+  // localhost), and the SSE log stream + terminal WebSocket ride along.
+  //
+  // Usage: DEV_HUB_URL=https://hub.agentpod.dev pnpm dev
+  // then connect to http://localhost:5173 in the login screen.
+  // Without DEV_HUB_URL the proxy targets the local hub on :3001, which is a
+  // no-op for the normal local workflow (you can still connect to :3001
+  // directly). NOTE: against a production hub this operates the REAL fleet.
+  server: {
+    proxy: {
+      "/api": {
+        target: process.env.DEV_HUB_URL ?? "http://localhost:3001",
+        changeOrigin: true,
+        ws: true,
+        cookieDomainRewrite: "",
+      },
+      "/public": {
+        target: process.env.DEV_HUB_URL ?? "http://localhost:3001",
+        changeOrigin: true,
+        ws: true,
+      },
+    },
+  },
+
   // Mark dev-only packages as external for SSR builds (they're dynamically imported only in dev mode)
   ssr: {
     external: [],


### PR DESCRIPTION
## Summary

Adds a dev-only Vite proxy so a local console (`pnpm dev`) can work against a real hub with functioning cookie auth — the hub session cookie is SameSite=Lax, so direct cross-site calls from localhost never carry it; proxying makes everything same-origin from the browser's view (SSE log stream and terminal WebSocket included).

## Usage

```bash
DEV_HUB_URL=https://hub.agentpod.dev pnpm dev
# then connect to http://localhost:5173 in the login screen
```

Without `DEV_HUB_URL` the proxy targets the local hub on :3001 (no-op for the existing workflow). `server.proxy` only affects the dev server — production builds are untouched, so no deploy needed.

Verified: dev server boots with the proxy and `hub.agentpod.dev` answers through it (its auth envelope on a session-less request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB