### PR TITLE
Dev proxy: forward the root /health connect probe

### DIFF
--- a/apps/console/vite.config.js
+++ b/apps/console/vite.config.js
@@ -33,6 +33,11 @@ export default defineConfig(async () => ({
         changeOrigin: true,
         ws: true,
       },
+      // The connect screen's reachability probe (hub mounts health at the root).
+      "/health": {
+        target: process.env.DEV_HUB_URL ?? "http://localhost:3001",
+        changeOrigin: true,
+      },
     },
   },
 


### PR DESCRIPTION
The connect screen validates a hub via GET /health, which the hub mounts at the root — outside the /api and /public proxy rules from #205, so connecting to http://localhost:5173 404'd at the probe step. Adds the /health forward; verified against hub.agentpod.dev (200 + real payload through the proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB