### PR TITLE
feat(console): UI audit milestone 2 — the live console

### DIFF
--- a/apps/console/src/lib/components/app-shell.svelte
+++ b/apps/console/src/lib/components/app-shell.svelte
@@ -4,7 +4,9 @@
   import { cn } from "$lib/utils";
   import { BottomNav, BottomNavItem } from "$lib/components/ui/bottom-nav";
   import { auth } from "$lib/stores/auth.svelte";
+  import { connection } from "$lib/stores/connection.svelte";
   import LayoutDashboard from "@lucide/svelte/icons/layout-dashboard";
+  import WifiOff from "@lucide/svelte/icons/wifi-off";
   import Boxes from "@lucide/svelte/icons/boxes";
   import Server from "@lucide/svelte/icons/server";
   import ContainerIcon from "@lucide/svelte/icons/container";
@@ -162,6 +164,20 @@
       !hideBottomNav && "pb-16 md:pb-0",
     )}
   >
+    <!-- Hub reachability banner — the shell must never claim a live view of a
+         hub that stopped answering (periodic /health probe drives this). -->
+    {#if connection.isConnected && !connection.reachable}
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="hub-unreachable-banner"
+        class="flex items-center justify-center gap-2 border-b border-status-error/30 bg-status-error/10 px-4 py-1.5 text-xs text-status-error"
+      >
+        <WifiOff class="h-3.5 w-3.5" aria-hidden="true" />
+        <span>Hub unreachable — data may be stale. Retrying…</span>
+      </div>
+    {/if}
+
     <!-- Page content -->
     <main class="flex-1 flex flex-col">
       {@render children?.()}

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { startPolling } from "$lib/utils/poll";
   import { page } from "$app/state";
   import { replaceState } from "$app/navigation";
   import { listNodes, createEnrollmentToken, listRuntimes, listRuntimeProviders, updateNode } from "$lib/api/client";
@@ -46,9 +47,11 @@
     return stored ?? import.meta.env.PUBLIC_HUB_URL ?? "http://localhost:3001";
   }
 
-  async function loadData() {
-    isLoading = true;
-    error = null;
+  async function loadData(background = false) {
+    if (!background) {
+      isLoading = true;
+      error = null;
+    }
     try {
       const [nodesResult, runtimesResult] = await Promise.allSettled([
         listNodes(),
@@ -56,30 +59,36 @@
       ]);
       if (nodesResult.status === "fulfilled") {
         nodes = nodesResult.value;
-      } else {
+        error = null;
+      } else if (!background) {
+        // Background refreshes keep the last good data on screen; the shell's
+        // hub-unreachable banner carries the staleness signal.
         error =
           nodesResult.reason instanceof Error
             ? nodesResult.reason.message
-            : "Failed to load nodes";
+            : "Couldn't load nodes.";
       }
       if (runtimesResult.status === "fulfilled") {
         runtimes = runtimesResult.value;
       }
       // runtimes failing is non-fatal — keep the previous value
     } finally {
-      isLoading = false;
+      if (!background) isLoading = false;
     }
   }
 
-  onMount(async () => {
-    // Fetch enabled providers; fall back to defaults on failure
-    try {
-      const res = await listRuntimeProviders();
-      if (res.providers.length > 0) providers = res.providers;
-    } catch {
-      // keep fallback ["docker", "cloudflare"]
-    }
-    await loadData();
+  onMount(() => {
+    void (async () => {
+      // Fetch enabled providers; fall back to defaults on failure
+      try {
+        const res = await listRuntimeProviders();
+        if (res.providers.length > 0) providers = res.providers;
+      } catch {
+        // keep fallback ["docker", "cloudflare"]
+      }
+      await loadData();
+    })();
+    return startPolling(() => void loadData(true), 30_000);
   });
 
   // ?action=<new-runtime|create-token> handling. This must be a reactive
@@ -232,7 +241,7 @@
       role="alert"
     >
       <p class="text-sm text-destructive">{error}</p>
-      <Button variant="outline" size="sm" onclick={loadData}>Retry</Button>
+      <Button variant="outline" size="sm" onclick={() => loadData()}>Retry</Button>
     </div>
 
   <!-- Empty state: no nodes and no provisioning runtimes → connect banner or in-place token -->

--- a/apps/console/src/lib/components/fleet/RecentActivity.svelte
+++ b/apps/console/src/lib/components/fleet/RecentActivity.svelte
@@ -3,19 +3,28 @@
   import { listActivity } from "$lib/api/client";
   import type { ActivityRow } from "$lib/api/client";
   import { relativeTime } from "$lib/utils/relative-time";
+  import { Button } from "$lib/components/ui/button";
 
   let rows = $state<ActivityRow[]>([]);
   let isLoading = $state(true);
+  let error = $state<string | null>(null);
 
-  onMount(async () => {
+  async function load() {
+    isLoading = true;
+    error = null;
     try {
       const all = await listActivity();
       rows = all.slice(0, 6);
-    } catch {
-      // non-fatal: show empty state
+    } catch (e) {
+      // A failed fetch must never masquerade as "No activity yet".
+      error = e instanceof Error ? e.message : "Couldn't load activity.";
     } finally {
       isLoading = false;
     }
+  }
+
+  onMount(() => {
+    void load();
   });
 </script>
 
@@ -23,12 +32,19 @@
   <div class="flex items-center justify-between">
     <p class="text-sm font-medium">Recent activity</p>
     <a href="/activity" class="text-xs text-primary hover:underline" data-testid="view-all-activity">
-      view all →
+      View all
     </a>
   </div>
 
   {#if isLoading}
     <p class="text-xs text-muted-foreground">Loading…</p>
+  {:else if error}
+    <div class="flex items-center justify-between gap-2" role="alert" data-testid="activity-error">
+      <p class="text-xs text-destructive">{error}</p>
+      <Button variant="outline" size="sm" class="h-6 px-2 text-xs" onclick={() => load()}>
+        Retry
+      </Button>
+    </div>
   {:else if rows.length === 0}
     <p class="text-xs text-muted-foreground" data-testid="no-activity">No activity yet</p>
   {:else}

--- a/apps/console/src/lib/components/fleet/RecentActivity.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/RecentActivity.svelte.test.ts
@@ -77,12 +77,26 @@ test("'view all →' link points to /activity", async () => {
   });
 });
 
-test("shows empty state gracefully when listActivity throws", async () => {
-  vi.spyOn(api, "listActivity").mockRejectedValue(new Error("network error"));
+test("fetch failure shows an error with Retry — never the 'No activity yet' empty state", async () => {
+  // Regression: a network failure used to render the same empty state as a
+  // genuinely idle fleet, hiding outages from the operator.
+  const spy = vi.spyOn(api, "listActivity").mockRejectedValue(new Error("network error"));
 
-  const { getByTestId } = render(RecentActivity);
+  const { getByTestId, queryByTestId, getByRole, getByText } = render(RecentActivity);
 
   await waitFor(() => {
-    expect(getByTestId("no-activity")).toBeTruthy();
+    expect(getByTestId("activity-error")).toBeTruthy();
+  });
+  expect(queryByTestId("no-activity")).toBeNull();
+
+  // Retry re-fetches and renders the rows on success.
+  spy.mockResolvedValue([
+    { id: "a1", verb: "fs.read", stationKey: "st", nodeId: "node-1", createdAt: new Date().toISOString() },
+  ] as never);
+  const { fireEvent } = await import("@testing-library/svelte");
+  await fireEvent.click(getByRole("button", { name: /retry/i }));
+
+  await waitFor(() => {
+    expect(getByText("fs.read")).toBeTruthy();
   });
 });

--- a/apps/console/src/lib/stores/connection.svelte.ts
+++ b/apps/console/src/lib/stores/connection.svelte.ts
@@ -7,6 +7,7 @@
 
 import { setAuthApiUrl, clearAuthSession } from "./auth.svelte";
 import { probeHealth, getStoredApiUrl, setStoredApiUrl, clearStoredApiUrl } from "$lib/api/connection-web";
+import { startPolling } from "$lib/utils/poll";
 
 // =============================================================================
 // Types
@@ -33,6 +34,15 @@ let connectionStatus = $state<ConnectionStatus>({
 let isLoading = $state(false);
 let isInitialized = $state(false);
 
+/**
+ * Whether the hub answered the most recent periodic /health probe. Starts
+ * true (optimistic until proven otherwise) and is only meaningful while
+ * connected. Distinct from `connected`, which reflects the one-time
+ * connect/boot handshake — this tracks reachability NOW, so the shell can
+ * stop claiming "Connected" after the hub goes away mid-session.
+ */
+let reachable = $state(true);
+
 // =============================================================================
 // Derived State
 // =============================================================================
@@ -44,6 +54,7 @@ export const connection = {
   get isInitialized() { return isInitialized; },
   get apiUrl() { return connectionStatus.apiUrl; },
   get error() { return connectionStatus.error; },
+  get reachable() { return reachable; },
 };
 
 // =============================================================================
@@ -72,6 +83,7 @@ export async function connect(apiUrl: string, _apiKey?: string): Promise<boolean
       };
       setStoredApiUrl(normalised);
       setAuthApiUrl(normalised);
+      reachable = true;
       return true;
     } else {
       connectionStatus = {
@@ -156,8 +168,28 @@ export async function disconnect(): Promise<void> {
   };
   isInitialized = false;
   isLoading = false;
+  reachable = true;
   // Also clear auth so a previous hub's identity doesn't persist on switch.
   clearAuthSession();
+}
+
+/**
+ * Periodically re-probe /health so `connection.reachable` reflects the hub's
+ * CURRENT reachability instead of the boot-time snapshot. Visibility-aware
+ * (skips hidden tabs, probes immediately on tab return). Returns a stop
+ * function for layout cleanup.
+ */
+export function startReachabilityProbe(intervalMs = 30_000): () => void {
+  const probe = async () => {
+    if (!connectionStatus.connected || !connectionStatus.apiUrl) return;
+    try {
+      reachable = await probeHealth(connectionStatus.apiUrl);
+    } catch {
+      reachable = false;
+    }
+    connectionStatus.lastTested = new Date().toISOString();
+  };
+  return startPolling(() => void probe(), intervalMs);
 }
 
 /**

--- a/apps/console/src/lib/utils/poll.test.ts
+++ b/apps/console/src/lib/utils/poll.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { startPolling } from "./poll";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", { value: hidden, configurable: true });
+}
+
+test("polls on the interval while visible", () => {
+  setHidden(false);
+  const fn = vi.fn();
+  const stop = startPolling(fn, 1000);
+
+  vi.advanceTimersByTime(3000);
+  expect(fn).toHaveBeenCalledTimes(3);
+  stop();
+});
+
+test("skips ticks while the tab is hidden, fires immediately on return", () => {
+  setHidden(false);
+  const fn = vi.fn();
+  const stop = startPolling(fn, 1000);
+
+  setHidden(true);
+  vi.advanceTimersByTime(5000);
+  expect(fn).not.toHaveBeenCalled();
+
+  setHidden(false);
+  document.dispatchEvent(new Event("visibilitychange"));
+  expect(fn).toHaveBeenCalledTimes(1);
+  stop();
+});
+
+test("stop() halts the interval and removes the listener", () => {
+  setHidden(false);
+  const fn = vi.fn();
+  const stop = startPolling(fn, 1000);
+  stop();
+
+  vi.advanceTimersByTime(5000);
+  document.dispatchEvent(new Event("visibilitychange"));
+  expect(fn).not.toHaveBeenCalled();
+});

--- a/apps/console/src/lib/utils/poll.ts
+++ b/apps/console/src/lib/utils/poll.ts
@@ -1,0 +1,22 @@
+/**
+ * Visibility-aware polling.
+ *
+ * Runs `fn` every `intervalMs` while the document is visible, skips ticks in
+ * hidden tabs (no wasted requests, no battery drain), and fires immediately
+ * when the tab becomes visible again so the user never looks at data older
+ * than one interval. Returns a stop function for onMount cleanup.
+ */
+export function startPolling(fn: () => void, intervalMs: number): () => void {
+  const tick = () => {
+    if (!document.hidden) fn();
+  };
+  const id = setInterval(tick, intervalMs);
+  const onVisible = () => {
+    if (!document.hidden) fn();
+  };
+  document.addEventListener("visibilitychange", onVisible);
+  return () => {
+    clearInterval(id);
+    document.removeEventListener("visibilitychange", onVisible);
+  };
+}

--- a/apps/console/src/routes/+error.svelte
+++ b/apps/console/src/routes/+error.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { Button } from "$lib/components/ui/button";
+
+  const notFound = $derived(page.status === 404);
+</script>
+
+<svelte:head>
+  <title>{notFound ? "Page not found" : "Something went wrong"} · AgentPod</title>
+</svelte:head>
+
+<div class="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-4 text-center">
+  <p class="font-mono text-sm text-muted-foreground">{page.status}</p>
+  <h1 class="text-lg font-semibold">
+    {notFound ? "Page not found" : "Something went wrong"}
+  </h1>
+  <p class="max-w-sm text-sm text-muted-foreground">
+    {notFound
+      ? "This page doesn't exist — it may have been moved or removed."
+      : (page.error?.message ?? "An unexpected error occurred.")}
+  </p>
+  <Button href="/" variant="outline">Back to Overview</Button>
+</div>

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
   import { onMount, onDestroy } from "svelte";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
-  import { initConnection } from "$lib/stores/connection.svelte";
+  import { initConnection, startReachabilityProbe } from "$lib/stores/connection.svelte";
   import { auth, initAuth } from "$lib/stores/auth.svelte";
   import { themeStore } from "$lib/themes/store.svelte";
   import { commandPalette } from "$lib/stores/command-palette.svelte";
@@ -42,6 +42,8 @@
     }
   }
 
+  let stopReachabilityProbe: (() => void) | undefined;
+
   onMount(async () => {
     themeStore.initialize();
 
@@ -49,10 +51,14 @@
     await initAuth();
     isInitializing = false;
 
+    // Keep connection.reachable honest for the whole session (shell banner).
+    stopReachabilityProbe = startReachabilityProbe();
+
     window.addEventListener("keydown", handleGlobalKeydown);
   });
 
   onDestroy(() => {
+    stopReachabilityProbe?.();
     if (typeof window !== "undefined") {
       window.removeEventListener("keydown", handleGlobalKeydown);
     }

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { getFleet, createEnrollmentToken } from "$lib/api/client";
+  import { startPolling } from "$lib/utils/poll";
   import type { FleetStats, FleetAgent } from "@agentpod/contract";
   import PageHeader from "$lib/components/page-header.svelte";
   import OverviewStats from "$lib/components/fleet/OverviewStats.svelte";
@@ -31,17 +32,22 @@
     goto("/agents?status=" + status);
   }
 
-  async function loadFleet() {
-    isLoading = true;
-    error = null;
+  async function loadFleet(background = false) {
+    if (!background) {
+      isLoading = true;
+      error = null;
+    }
     try {
       const result = await getFleet();
       stats = result.stats;
       agents = result.agents;
+      error = null;
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to load fleet";
+      // Background refreshes keep the last good data on screen — the shell's
+      // hub-unreachable banner carries the staleness signal instead.
+      if (!background) error = e instanceof Error ? e.message : "Couldn't load the fleet.";
     } finally {
-      isLoading = false;
+      if (!background) isLoading = false;
     }
   }
 
@@ -57,10 +63,15 @@
     }
   }
 
-  onMount(async () => {
-    await loadFleet();
+  onMount(() => {
+    void loadFleet();
+    return startPolling(() => void loadFleet(true), 30_000);
   });
 </script>
+
+<svelte:head>
+  <title>Overview · AgentPod</title>
+</svelte:head>
 
 <PageHeader title="Overview" subtitle="Fleet control plane" />
 
@@ -79,7 +90,7 @@
       role="alert"
     >
       <p class="text-sm text-destructive">{error}</p>
-      <Button variant="outline" size="sm" onclick={loadFleet}>Retry</Button>
+      <Button variant="outline" size="sm" onclick={() => loadFleet()}>Retry</Button>
     </div>
 
   {:else if agents.length === 0}

--- a/apps/console/src/routes/activity/+page.svelte
+++ b/apps/console/src/routes/activity/+page.svelte
@@ -79,6 +79,10 @@
   ];
 </script>
 
+<svelte:head>
+  <title>Activity · AgentPod</title>
+</svelte:head>
+
 {#snippet verbCell({ value }: { value: string })}
   <span class="font-mono text-xs font-medium">{value}</span>
 {/snippet}

--- a/apps/console/src/routes/admin/users/+page.svelte
+++ b/apps/console/src/routes/admin/users/+page.svelte
@@ -2,6 +2,8 @@
   // Orchestrator only — composes the shared admin/* components on top of
   // DataTable's manualPagination mode; server owns search/filter/paging.
   import { onMount } from "svelte";
+  import { page } from "$app/state";
+  import { goto } from "$app/navigation";
   import { toast } from "svelte-sonner";
   import {
     listUsers,
@@ -42,14 +44,42 @@
   let signupEnabled = $state(true);
   let signupLoading = $state(false);
 
+  // Filters and pagination are seeded from the URL and written back on every
+  // change, so "banned users, page 2" is bookmarkable and survives refresh.
+  const initialParams = page.url.searchParams;
+  const initialRole = initialParams?.get("role");
+  const initialStatus = initialParams?.get("status");
+
   // Server-driven pagination (0-based, matches DataTable's manual mode)
-  let pageIndex = $state(0);
+  let pageIndex = $state(Math.max(0, (Number(initialParams?.get("page")) || 1) - 1));
   let pageCount = $derived(total > 0 ? Math.ceil(total / PAGE_SIZE) : 0);
 
   // Filters (server-side — refetched on Search/refresh, not client-filtered)
-  let searchQuery = $state("");
-  let roleFilter = $state<UserRole | "all">("all");
-  let bannedFilter = $state<"all" | "banned" | "active">("all");
+  let searchQuery = $state(initialParams?.get("search") ?? "");
+  let roleFilter = $state<UserRole | "all">(
+    initialRole === "user" || initialRole === "admin" ? initialRole : "all"
+  );
+  let bannedFilter = $state<"all" | "banned" | "active">(
+    initialStatus === "banned" || initialStatus === "active" ? initialStatus : "all"
+  );
+
+  function syncFiltersToUrl() {
+    // Guarded: test/SSR environments mock page.url with a plain object.
+    try {
+      const url = new URL(page.url);
+      const setOrDelete = (key: string, value: string, defaultValue: string) => {
+        if (value === defaultValue) url.searchParams.delete(key);
+        else url.searchParams.set(key, value);
+      };
+      setOrDelete("search", searchQuery.trim(), "");
+      setOrDelete("role", roleFilter, "all");
+      setOrDelete("status", bannedFilter, "all");
+      setOrDelete("page", String(pageIndex + 1), "1");
+      void goto(url, { replaceState: true, keepFocus: true, noScroll: true });
+    } catch {
+      // URL sync is progressive enhancement — never block the actual filter.
+    }
+  }
   let hasActiveFilters = $derived(
     searchQuery.trim() !== "" || roleFilter !== "all" || bannedFilter !== "all"
   );
@@ -94,10 +124,12 @@
 
   function handleSearch() {
     pageIndex = 0;
+    syncFiltersToUrl();
     loadData();
   }
   function goToPage(index: number) {
     pageIndex = index;
+    syncFiltersToUrl();
     loadData();
   }
   function openBanDialog(user: AdminUserView) {
@@ -152,6 +184,10 @@
     { id: "actions", header: "Actions", enableSorting: false, cell: (ctx) => renderSnippet(actionsCell, { user: ctx.row.original }) },
   ];
 </script>
+
+<svelte:head>
+  <title>Users · Admin · AgentPod</title>
+</svelte:head>
 
 {#snippet userCell({ user }: { user: AdminUserView })}
   <a href="/admin/users/{user.id}" class="flex items-center gap-3 hover:text-primary transition-colors">

--- a/apps/console/src/routes/admin/users/[id]/+page.svelte
+++ b/apps/console/src/routes/admin/users/[id]/+page.svelte
@@ -74,6 +74,10 @@
   }
 </script>
 
+<svelte:head>
+  <title>{user?.email ?? "User"} · Admin · AgentPod</title>
+</svelte:head>
+
 <main class="flex h-screen flex-col overflow-hidden">
   <!-- Header -->
   <PageHeader

--- a/apps/console/src/routes/agents/+page.svelte
+++ b/apps/console/src/routes/agents/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { startPolling } from "$lib/utils/poll";
   import { page } from "$app/state";
   import { getFleet } from "$lib/api/client";
   import type { FleetAgent } from "@agentpod/contract";
@@ -36,23 +37,33 @@
     return filter;
   });
 
-  async function loadFleet() {
-    isLoading = true;
-    error = null;
+  async function loadFleet(background = false) {
+    if (!background) {
+      isLoading = true;
+      error = null;
+    }
     try {
       const result = await getFleet();
       agents = result.agents;
+      error = null;
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to load fleet";
+      // Background refreshes keep the last good data on screen; the shell's
+      // hub-unreachable banner carries the staleness signal.
+      if (!background) error = e instanceof Error ? e.message : "Couldn't load the fleet.";
     } finally {
-      isLoading = false;
+      if (!background) isLoading = false;
     }
   }
 
-  onMount(async () => {
-    await loadFleet();
+  onMount(() => {
+    void loadFleet();
+    return startPolling(() => void loadFleet(true), 30_000);
   });
 </script>
+
+<svelte:head>
+  <title>Agents · AgentPod</title>
+</svelte:head>
 
 <PageHeader title="Agents" subtitle="Every agent in the fleet" />
 
@@ -70,7 +81,7 @@
       role="alert"
     >
       <p class="text-sm text-destructive">{error}</p>
-      <Button variant="outline" size="sm" onclick={loadFleet}>Retry</Button>
+      <Button variant="outline" size="sm" onclick={() => loadFleet()}>Retry</Button>
     </div>
 
   {:else}

--- a/apps/console/src/routes/login/+page.svelte
+++ b/apps/console/src/routes/login/+page.svelte
@@ -115,6 +115,10 @@
   });
 </script>
 
+<svelte:head>
+  <title>Sign in · AgentPod</title>
+</svelte:head>
+
 {#snippet errorBanner(message: string)}
   <div class="rounded-lg border border-destructive/50 bg-destructive/5 p-3" role="alert">
     <p class="text-sm text-destructive">{message}</p>

--- a/apps/console/src/routes/nodes/+page.svelte
+++ b/apps/console/src/routes/nodes/+page.svelte
@@ -2,4 +2,8 @@
   import NodesOverview from "$lib/components/fleet/NodesOverview.svelte";
 </script>
 
+<svelte:head>
+  <title>Nodes · AgentPod</title>
+</svelte:head>
+
 <NodesOverview />

--- a/apps/console/src/routes/nodes/[id]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/+page.svelte
@@ -90,6 +90,10 @@
   );
 </script>
 
+<svelte:head>
+  <title>{node?.hostname ?? "Node"} · AgentPod</title>
+</svelte:head>
+
 <PageHeader title={node?.hostname ?? id} status={headerStatus}>
   {#snippet leading()}
     <a

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import type { Snippet } from "svelte";
   import { page } from "$app/stores";
+  import { goto } from "$app/navigation";
   import HealthPanel from "$lib/components/stations/HealthPanel.svelte";
   import LogTail from "$lib/components/stations/LogTail.svelte";
   import FileBrowser from "$lib/components/stations/FileBrowser.svelte";
@@ -27,7 +28,15 @@
   const stationId = $derived($page.params.stationId as string);
 
   type Tab = "health" | "logs" | "files" | "terminal" | "cleanup" | "activity";
-  let activeTab = $state<Tab>("health");
+  const VALID_TABS: readonly Tab[] = ["health", "logs", "files", "terminal", "cleanup", "activity"];
+
+  // The active tab lives in the URL (?tab=logs) so station views are
+  // deep-linkable, survive refresh, and participate in back/forward.
+  // An absent or unknown param falls back to "health".
+  const activeTab = $derived.by<Tab>(() => {
+    const t = $page.url.searchParams?.get("tab");
+    return VALID_TABS.includes(t as Tab) ? (t as Tab) : "health";
+  });
 
   /** Base id PageHeader builds its tab/panel ids from — kept in one place so
    *  the tablist's aria-controls and the tabpanels' ids/aria-labelledby
@@ -51,6 +60,8 @@
   });
 
   let station = $state<StationRow | null>(null);
+  let stationLoad = $state<"loading" | "loaded" | "notFound" | "error">("loading");
+  let stationLoadError = $state<string | null>(null);
 
   /** Path of the file currently open in the ConfigEditor modal, or null. */
   let configEditorPath = $state<string | null>(null);
@@ -76,13 +87,23 @@
     Array.isArray(station?.capabilities) && station!.capabilities.includes("cleanup")
   );
 
-  onMount(async () => {
+  async function loadStation() {
+    stationLoad = "loading";
+    stationLoadError = null;
     try {
       const rows = await listStations(nodeId);
       station = rows.find((r) => r.id === stationId) ?? null;
-    } catch {
-      // Capabilities will stay null — Terminal tab won't appear
+      // A resolved fetch with no matching row means the station is gone —
+      // a dead deep link must say so instead of rendering a broken shell.
+      stationLoad = station ? "loaded" : "notFound";
+    } catch (e) {
+      stationLoad = "error";
+      stationLoadError = e instanceof Error ? e.message : "Couldn't load this agent.";
     }
+  }
+
+  onMount(() => {
+    void loadStation();
   });
 
   const tabs = $derived.by(() => [
@@ -95,7 +116,13 @@
   ]);
 
   function handleTabChange(tabId: string) {
-    activeTab = tabId as Tab;
+    const url = new URL($page.url);
+    if (tabId === "health") {
+      url.searchParams.delete("tab");
+    } else {
+      url.searchParams.set("tab", tabId);
+    }
+    void goto(url, { noScroll: true, keepFocus: true });
   }
 </script>
 
@@ -120,11 +147,15 @@
   {/if}
 {/snippet}
 
+<svelte:head>
+  <title>{station?.displayName ?? "Agent"} · AgentPod</title>
+</svelte:head>
+
 <!-- Themed header: station name, harness badge, back link, and tab bar -->
 <PageHeader
-  title={station?.displayName ?? stationId}
+  title={station?.displayName ?? (stationLoad === "loaded" || stationLoad === "loading" ? stationId : "Agent")}
   subtitle={station?.workspacePath ?? undefined}
-  {tabs}
+  tabs={stationLoad === "notFound" || stationLoad === "error" ? [] : tabs}
   activeTab={activeTab}
   onTabChange={handleTabChange}
   sticky={true}
@@ -148,6 +179,31 @@
 
 <!-- Panel content -->
 <div class="container mx-auto flex max-w-7xl flex-1 flex-col px-4 py-4 sm:px-6 md:py-6 min-h-0">
+  {#if stationLoad === "notFound"}
+    <div
+      class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-16 text-center"
+      data-testid="station-not-found"
+    >
+      <p class="text-sm font-medium">Agent not found</p>
+      <p class="max-w-sm text-sm text-muted-foreground">
+        This agent is no longer on the node — it may have been removed or renamed.
+      </p>
+      <Button href="/nodes/{nodeId}" variant="outline" size="sm">Back to node</Button>
+    </div>
+  {:else if stationLoad === "error"}
+    <div
+      class="flex items-start justify-between gap-3 rounded-lg border border-destructive/50 bg-destructive/5 p-4"
+      role="alert"
+    >
+      <p class="text-sm text-destructive">{stationLoadError}</p>
+      <Button variant="outline" size="sm" onclick={() => loadStation()}>Retry</Button>
+    </div>
+  {:else}
+    {@render stationPanels()}
+  {/if}
+</div>
+
+{#snippet stationPanels()}
   {@render mountedPanel("health", healthContent)}
   {#snippet healthContent()}
     <HealthPanel {stationId} {canLifecycle} matrixId={station?.matrixId ?? null} />
@@ -196,7 +252,7 @@
       <ActivityPanel {stationId} />
     </div>
   {/snippet}
-</div>
+{/snippet}
 
 <!-- ── ConfigEditor dialog (opened via "Edit (diff)" in the FileBrowser) ── -->
 <Dialog.Root

--- a/apps/console/src/routes/runtimes/+page.svelte
+++ b/apps/console/src/routes/runtimes/+page.svelte
@@ -158,6 +158,10 @@
   ];
 </script>
 
+<svelte:head>
+  <title>Runtimes · AgentPod</title>
+</svelte:head>
+
 {#snippet nameCell({ value }: { value: string })}
   <span class="font-mono text-sm font-medium">{value}</span>
 {/snippet}

--- a/apps/console/src/routes/settings/+page.svelte
+++ b/apps/console/src/routes/settings/+page.svelte
@@ -18,6 +18,10 @@
   }
 </script>
 
+<svelte:head>
+  <title>Settings · AgentPod</title>
+</svelte:head>
+
 <PageHeader title="Settings" />
 
 <div class="container mx-auto max-w-7xl px-4 sm:px-6 py-6 space-y-6">


### PR DESCRIPTION
Second milestone from the UI audit (`docs/superpowers/audits/2026-08-08-console-ui-audit.md`): the console stops showing stale data as fresh, stops lying about failures, and puts navigational state in the URL.

## Live fleet (audit P1-1 — the top product-level finding)
- **Auto-refresh**: Overview, Nodes, and Agents background-refresh every 30s via a new visibility-aware `startPolling` util (skips hidden tabs, refreshes immediately on tab return). Background ticks never flash skeletons and never blank good data.
- **Reachability honesty**: the connection store re-probes `/health` every 30s; when the hub stops answering, a shell-level banner says "Hub unreachable — data may be stale. Retrying…" — previously Settings could show "Connected" forever after the hub died.

## Honest errors (P1-2)
- RecentActivity distinguishes "network failed" from "no activity yet" (error + Retry, with a regression test — the old test literally asserted the lying behavior)
- A deep link to a removed agent renders "Agent not found → Back to node" instead of a broken shell of silently failing tabs; failed station loads get error + Retry
- Root `+error.svelte`: 404s land on a styled page with a way back instead of SvelteKit's bare default

## URL state (P1-3)
- Per-route `<title>` on every page — browser tabs are finally tellable apart
- Station detail tabs are deep-linkable (`?tab=logs`), survive refresh, and participate in back/forward
- Admin user filters + pagination live in the URL (`?search=&role=&status=&page=`)

Tests: 452 → 455, all green; `pnpm check` clean; production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB