### PR TITLE
feat(console): UI audit milestone 3 — one status system, the ribbon signature, terminal font fix

### DIFF
--- a/apps/console/src/lib/components/fleet/AgentTable.svelte
+++ b/apps/console/src/lib/components/fleet/AgentTable.svelte
@@ -9,6 +9,7 @@
   import { Empty } from "$lib/components/ui/empty";
   import { cn } from "$lib/utils";
   import { toast } from "svelte-sonner";
+  import StatusRibbon from "./StatusRibbon.svelte";
   import SearchIcon from "@lucide/svelte/icons/search";
 
   // ── External filter (from heatmap) ───────────────────────────────────────────
@@ -392,6 +393,16 @@
                   <span class="text-[10px]">{collapsedGroups[group.nodeId] ? "▶" : "▾"}</span>
                   <span class="font-medium text-foreground">{group.nodeName}</span>
                   <span class="text-muted-foreground/60">· {group.agents.length} {group.agents.length === 1 ? "agent" : "agents"}</span>
+                  <!-- The node's whole health in one strip -->
+                  <StatusRibbon
+                    size="sm"
+                    class="ml-1"
+                    items={group.agents.map((a) => ({
+                      id: a.stationId,
+                      label: a.agentName,
+                      status: a.status,
+                    }))}
+                  />
                 </button>
               </Table.Cell>
             </Table.Row>

--- a/apps/console/src/lib/components/fleet/FleetHeatmap.svelte
+++ b/apps/console/src/lib/components/fleet/FleetHeatmap.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { FleetAgent } from "@agentpod/contract";
+  import StatusRibbon, { type RibbonItem } from "./StatusRibbon.svelte";
+  import { statusBadgeClass } from "$lib/utils/status-badge";
 
   let {
     agents,
@@ -10,19 +12,6 @@
     onSelectAgent: (stationId: string) => void;
     onFilterStatus: (status: string) => void;
   } = $props();
-
-  // ── Status → bg class ────────────────────────────────────────────────────────
-
-  const STATUS_CELL_CLASS: Record<string, string> = {
-    running: "bg-status-running",
-    stopped: "bg-status-stopped/50",
-    error: "bg-status-error",
-    unknown: "bg-status-stopped/25",
-  };
-
-  function cellBgClass(status: string): string {
-    return STATUS_CELL_CLASS[status] ?? "bg-status-stopped/25";
-  }
 
   function cellTitle(agent: FleetAgent): string {
     let title = `${agent.agentName} · ${agent.nodeName} · ${agent.status}`;
@@ -52,56 +41,57 @@
     return title;
   }
 
+  const items = $derived<RibbonItem[]>(
+    agents.map((a) => ({
+      id: a.stationId,
+      label: a.agentName,
+      status: a.status,
+      title: cellTitle(a),
+    })),
+  );
+
   // ── Legend ───────────────────────────────────────────────────────────────────
+  // One chip per RAW status present (styled via the shared token map), so
+  // degraded/starting/sleeping agents get a legend entry instead of silently
+  // falling through — the old four-value map made a degraded agent invisible.
 
-  const STATUSES = ["running", "stopped", "error", "unknown"] as const;
+  const LEGEND_ORDER = ["error", "degraded", "starting", "running", "sleeping", "stopped", "unknown"];
+  const legendRank = (status: string) => {
+    const i = LEGEND_ORDER.indexOf(status);
+    return i === -1 ? LEGEND_ORDER.length : i;
+  };
 
-  let statusCounts = $derived.by(() => {
-    const counts: Record<string, number> = { running: 0, stopped: 0, error: 0, unknown: 0 };
+  const statusCounts = $derived.by(() => {
+    const counts = new Map<string, number>();
     for (const agent of agents) {
-      counts[agent.status] = (counts[agent.status] ?? 0) + 1;
+      counts.set(agent.status, (counts.get(agent.status) ?? 0) + 1);
     }
     return counts;
   });
 
-  const LEGEND_CLASS: Record<string, string> = {
-    running: "bg-status-running/20 text-status-running border-status-running/40 hover:bg-status-running/30",
-    stopped: "bg-status-stopped/20 text-status-stopped border-status-stopped/40 hover:bg-status-stopped/30",
-    error: "bg-status-error/20 text-status-error border-status-error/40 hover:bg-status-error/30",
-    unknown: "bg-status-stopped/10 text-status-stopped/60 border-status-stopped/20 hover:bg-status-stopped/20",
-  };
+  const legendStatuses = $derived(
+    [...statusCounts.keys()].sort((a, b) => legendRank(a) - legendRank(b) || a.localeCompare(b)),
+  );
 </script>
 
 <div class="space-y-3">
   <!-- Grid of agent cells — one per agent, colored by live status -->
-  <div class="flex flex-wrap gap-1" aria-label="Fleet heatmap">
-    {#each agents as agent (agent.stationId)}
-      <button
-        type="button"
-        class="w-5 h-5 rounded-sm {cellBgClass(agent.status)} opacity-80 hover:opacity-100 transition-opacity focus:outline-none focus:ring-1 focus:ring-ring"
-        title={cellTitle(agent)}
-        aria-label="{agent.agentName} ({agent.status})"
-        data-testid="heatmap-cell"
-        data-status={agent.status}
-        onclick={() => onSelectAgent(agent.stationId)}
-      ></button>
-    {/each}
+  <div aria-label="Fleet heatmap">
+    <StatusRibbon {items} size="lg" onSelect={onSelectAgent} cellTestId="heatmap-cell" />
   </div>
 
   <!-- Legend: status chips with counts, each clickable to filter -->
   <div class="flex flex-wrap gap-2" aria-label="Heatmap legend">
-    {#each STATUSES as status}
-      {#if statusCounts[status] > 0}
-        <button
-          type="button"
-          class="font-mono text-[10px] px-2 py-0.5 rounded border transition-colors {LEGEND_CLASS[status]}"
-          data-testid="legend-chip"
-          data-status={status}
-          onclick={() => onFilterStatus(status)}
-        >
-          {status} · {statusCounts[status]}
-        </button>
-      {/if}
+    {#each legendStatuses as status (status)}
+      <button
+        type="button"
+        class="rounded-md border px-2 py-0.5 font-mono text-xs lowercase transition-opacity hover:opacity-80 {statusBadgeClass(status)}"
+        data-testid="legend-chip"
+        data-status={status}
+        onclick={() => onFilterStatus(status)}
+      >
+        {status} · {statusCounts.get(status)}
+      </button>
     {/each}
   </div>
 </div>

--- a/apps/console/src/lib/components/fleet/NeedsAttention.svelte
+++ b/apps/console/src/lib/components/fleet/NeedsAttention.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { FleetAgent } from "@agentpod/contract";
+  import { Status } from "$lib/components/ui/status";
 
   let { agents }: { agents: FleetAgent[] } = $props();
 
@@ -30,7 +31,7 @@
           >
             <span class="text-foreground">{agent.agentName}</span>
             <span class="text-muted-foreground/60">·</span>
-            <span class="text-destructive/80">{agent.status}</span>
+            <Status form="text" status={agent.status} class="text-xs" />
           </a>
         </li>
       {/each}

--- a/apps/console/src/lib/components/fleet/StatusRibbon.svelte
+++ b/apps/console/src/lib/components/fleet/StatusRibbon.svelte
@@ -1,0 +1,97 @@
+<script lang="ts" module>
+  export interface RibbonItem {
+    id: string;
+    /** Accessible name, e.g. the agent name. */
+    label: string;
+    /** Raw status string — normalized via the shared token map. */
+    status: string;
+    /** Optional rich native tooltip (metrics etc.). */
+    title?: string;
+  }
+</script>
+
+<script lang="ts">
+  /**
+   * StatusRibbon — the fleet, at a glance, in one strip of status-colored
+   * cells. One geometry at three scales:
+   *
+   *   lg — 20px interactive heatmap cells (Overview)
+   *   sm — 8px inline strip (node rows, table group headers)
+   *   xs — 3px chrome strip flush under a PageHeader
+   *
+   * Restraint rules: cells are always 100%-opacity status tokens, the ribbon
+   * never animates on load, and `error` cells carry extra visual weight
+   * independent of hue (a ring) so red/green confusion can't hide a sick
+   * agent — except at xs, where the strip is chrome, not a chart.
+   */
+  import { cn } from "$lib/utils";
+  import { tokenFor, statusBgClass } from "$lib/utils/status-badge";
+
+  interface Props {
+    items: RibbonItem[];
+    size?: "lg" | "sm" | "xs";
+    /** When provided (lg only in practice), cells become buttons. */
+    onSelect?: (id: string) => void;
+    /** data-testid for each cell (FleetHeatmap keeps its legacy "heatmap-cell"). */
+    cellTestId?: string;
+    class?: string;
+  }
+
+  let { items, size = "sm", onSelect, cellTestId = "ribbon-cell", class: className }: Props = $props();
+
+  const CELL: Record<"lg" | "sm" | "xs", string> = {
+    lg: "size-5 rounded-sm",
+    sm: "size-2 rounded-[2px]",
+    xs: "h-[3px] w-2 rounded-none",
+  };
+  const GAP: Record<"lg" | "sm" | "xs", string> = {
+    lg: "gap-1",
+    sm: "gap-[3px]",
+    xs: "gap-px",
+  };
+
+  function emphasisClass(status: string): string {
+    return tokenFor(status) === "error" && size !== "xs"
+      ? "ring-2 ring-status-error/40 ring-offset-1 ring-offset-background"
+      : "";
+  }
+</script>
+
+<div
+  class={cn(
+    "flex",
+    size === "xs" ? "flex-nowrap overflow-hidden" : "flex-wrap",
+    GAP[size],
+    className,
+  )}
+  data-testid="status-ribbon"
+  data-size={size}
+>
+  {#each items as item (item.id)}
+    {#if onSelect}
+      <button
+        type="button"
+        class={cn(
+          CELL[size],
+          statusBgClass(item.status),
+          emphasisClass(item.status),
+          "shrink-0 transition-opacity hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-ring",
+        )}
+        title={item.title}
+        aria-label="{item.label} ({item.status.toLowerCase()})"
+        data-testid={cellTestId}
+        data-status={item.status.toLowerCase()}
+        onclick={() => onSelect(item.id)}
+      ></button>
+    {:else}
+      <span
+        role="img"
+        class={cn(CELL[size], statusBgClass(item.status), emphasisClass(item.status), "shrink-0")}
+        title={item.title}
+        aria-label="{item.label} ({item.status.toLowerCase()})"
+        data-testid={cellTestId}
+        data-status={item.status.toLowerCase()}
+      ></span>
+    {/if}
+  {/each}
+</div>

--- a/apps/console/src/lib/components/fleet/StatusRibbon.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/StatusRibbon.svelte.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+import StatusRibbon from "./StatusRibbon.svelte";
+
+afterEach(cleanup);
+
+const items = [
+  { id: "a", label: "hermes-1", status: "running" },
+  { id: "b", label: "claw-2", status: "degraded" },
+  { id: "c", label: "codex-3", status: "error" },
+  { id: "d", label: "mystery", status: "unknown" },
+];
+
+test("renders one cell per item on the full six-token vocabulary", () => {
+  const { getAllByTestId } = render(StatusRibbon, { props: { items } });
+  const cells = getAllByTestId("ribbon-cell");
+
+  expect(cells).toHaveLength(4);
+  // data-status keeps the RAW status (legend/filter semantics); the color
+  // class comes from the token. Regression: degraded used to fall through to
+  // the same class as unknown.
+  expect(cells[1].dataset.status).toBe("degraded");
+  expect(cells[1].className).toContain("bg-status-degraded");
+  expect(cells[3].dataset.status).toBe("unknown");
+  expect(cells[3].className).toContain("bg-status-stopped");
+  expect(cells[1].className).not.toBe(cells[3].className);
+});
+
+test("error cells carry hue-independent emphasis (colorblind-safe ring)", () => {
+  const { getAllByTestId } = render(StatusRibbon, { props: { items, size: "lg" } });
+  const cells = getAllByTestId("ribbon-cell");
+
+  expect(cells[2].className).toContain("ring-2");
+  expect(cells[0].className).not.toContain("ring-2");
+});
+
+test("xs strip drops the emphasis ring (chrome, not chart)", () => {
+  const { getAllByTestId } = render(StatusRibbon, { props: { items, size: "xs" } });
+  expect(getAllByTestId("ribbon-cell")[2].className).not.toContain("ring-2");
+});
+
+test("interactive when onSelect is provided: buttons with accessible names", () => {
+  const onSelect = vi.fn();
+  const { getByRole } = render(StatusRibbon, { props: { items, size: "lg", onSelect } });
+
+  const cell = getByRole("button", { name: "claw-2 (degraded)" });
+  fireEvent.click(cell);
+  expect(onSelect).toHaveBeenCalledWith("b");
+});
+
+test("non-interactive cells are labeled images, not buttons", () => {
+  const { queryAllByRole, getAllByRole } = render(StatusRibbon, { props: { items } });
+
+  expect(queryAllByRole("button")).toHaveLength(0);
+  expect(getAllByRole("img")).toHaveLength(4);
+});

--- a/apps/console/src/lib/components/page-header.svelte
+++ b/apps/console/src/lib/components/page-header.svelte
@@ -2,6 +2,7 @@
   import type { Snippet, Component } from "svelte";
   import { cn } from "$lib/utils";
   import * as Tooltip from "$lib/components/ui/tooltip";
+  import { Status } from "$lib/components/ui/status";
   import LockIcon from "@lucide/svelte/icons/lock";
 
   export interface Tab {
@@ -12,19 +13,22 @@
     disabledReason?: string;
   }
 
-  type StatusVariant = "running" | "starting" | "stopped" | "error" | "sleeping" | "degraded";
+  // Any raw status string — normalized by the shared <Status> component.
 
   interface Props {
     title: string;
     icon?: Component;
     subtitle?: string;
-    status?: { label: string; variant: StatusVariant; animate?: boolean };
+    status?: { label: string; variant: string; animate?: boolean };
     tabs?: Tab[];
     activeTab?: string;
     onTabChange?: (tabId: string) => void;
     sticky?: boolean;
     actions?: Snippet;
     leading?: Snippet;
+    /** Signature status strip rendered flush under the header border
+     *  (pass a 3px `<StatusRibbon size="xs">` scoped to this page). */
+    ribbon?: Snippet;
     tabsId?: string;
   }
 
@@ -39,6 +43,7 @@
     sticky = true,
     actions = undefined,
     leading = undefined,
+    ribbon = undefined,
     tabsId = "page-tabs",
   }: Props = $props();
 
@@ -93,22 +98,6 @@
     }
   }
 
-  const statusText: Record<StatusVariant, string> = {
-    running: "text-status-running",
-    starting: "text-status-starting",
-    stopped: "text-status-stopped",
-    error: "text-status-error",
-    sleeping: "text-status-sleeping",
-    degraded: "text-status-degraded",
-  };
-  const statusBg: Record<StatusVariant, string> = {
-    running: "bg-status-running",
-    starting: "bg-status-starting",
-    stopped: "bg-status-stopped",
-    error: "bg-status-error",
-    sleeping: "bg-status-sleeping",
-    degraded: "bg-status-degraded",
-  };
 </script>
 
 <header
@@ -131,21 +120,7 @@
           <div class="flex items-center gap-2.5 overflow-hidden">
             <h1 class="truncate text-lg font-semibold tracking-tight">{title}</h1>
             {#if status}
-              <span
-                class={cn(
-                  "inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium",
-                  statusText[status.variant],
-                )}
-              >
-                <span
-                  class={cn(
-                    "size-1.5 rounded-full",
-                    statusBg[status.variant],
-                    status.animate && "animate-pulse",
-                  )}
-                ></span>
-                {status.label}
-              </span>
+              <Status form="badge" status={status.variant} label={status.label} />
             {/if}
           </div>
           {#if subtitle}
@@ -210,4 +185,8 @@
       </div>
     {/if}
   </div>
+  {#if ribbon}
+    <!-- The fleet, as chrome: a full-bleed 3px strip flush against the border -->
+    {@render ribbon()}
+  {/if}
 </header>

--- a/apps/console/src/lib/components/page-header.svelte.test.ts
+++ b/apps/console/src/lib/components/page-header.svelte.test.ts
@@ -11,8 +11,10 @@ describe("PageHeader", () => {
     });
     expect(screen.getByRole("heading", { name: "hermes-01" })).toBeTruthy();
     expect(screen.getByText("~/projects/hermes")).toBeTruthy();
-    const badge = screen.getByText("Running");
+    // Status renders through the shared <Status> component: lowercase mono.
+    const badge = screen.getByText("running");
     expect(badge.closest("[class*='text-status-running']")).toBeTruthy();
+    expect(badge.className).toContain("font-mono");
   });
 
   it("fires onTabChange when an enabled tab is clicked, not for disabled tabs", async () => {

--- a/apps/console/src/lib/components/stations/HealthPanel.svelte
+++ b/apps/console/src/lib/components/stations/HealthPanel.svelte
@@ -4,6 +4,7 @@
   import TypeToConfirmDialog from "$lib/components/ui/TypeToConfirmDialog.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Skeleton } from "$lib/components/ui/skeleton";
+  import { Status } from "$lib/components/ui/status";
   import type { StationHealth } from "@agentpod/contract";
 
   interface Props {
@@ -70,10 +71,6 @@
   // True when the health note indicates the metrics belong to the shared gateway
   // process (composite OpenClaw stations where all subagents share one process).
   let isGateway = $derived(health?.note?.includes("gateway") ?? false);
-
-  const statusColorClass = $derived(
-    health?.running ? "text-status-running" : "text-status-stopped",
-  );
 
   async function doLifecycle(action: "start" | "stop" | "restart") {
     actionInFlight = true;
@@ -142,8 +139,8 @@
       <!-- Status -->
       <div class="rounded-lg border p-3 flex flex-col gap-1">
         <dt class="text-xs text-muted-foreground">Status</dt>
-        <dd class="font-mono text-lg {statusColorClass}">
-          {health.running ? "Running" : "Stopped"}
+        <dd>
+          <Status form="text" status={health.running ? "running" : "stopped"} class="text-lg" />
         </dd>
       </div>
 

--- a/apps/console/src/lib/components/stations/LogTail.svelte
+++ b/apps/console/src/lib/components/stations/LogTail.svelte
@@ -5,6 +5,7 @@
   import { Empty } from "$lib/components/ui/empty";
   import { cn } from "$lib/utils";
   import { chipClass } from "$lib/utils/toggle-chip";
+  import { statusTextClass } from "$lib/utils/status-badge";
   import SearchIcon from "@lucide/svelte/icons/search";
   import DownloadIcon from "@lucide/svelte/icons/download";
   import TerminalIcon from "@lucide/svelte/icons/terminal";
@@ -280,11 +281,13 @@
     reconnecting: "Reconnecting…",
     closed: "Disconnected",
   };
-  const statusColor: Record<Status, string> = {
-    connecting: "text-status-starting",
-    connected: "text-status-running",
-    reconnecting: "text-status-starting",
-    closed: "text-status-error",
+  // Session lifecycle → shared status vocabulary, so log-stream state speaks
+  // the same color language as everything else in the console.
+  const statusToken: Record<Status, string> = {
+    connecting: "starting",
+    connected: "connected",
+    reconnecting: "starting",
+    closed: "error",
   };
   function levelClass(level: Level): string {
     if (level === "error") return "text-status-error";
@@ -303,7 +306,13 @@
   <!-- Toolbar -->
   <div class="flex flex-wrap items-center gap-2 border-b px-3 py-1.5 shrink-0">
     <TerminalIcon class="size-3.5 text-muted-foreground" aria-hidden="true" />
-    <span class={cn("shrink-0", statusColor[status])}>{statusLabel[status]}</span>
+    <!-- Live region: screen-reader users hear connection transitions
+         (connect/reconnect/give-up), not just sighted users. -->
+    <span
+      role="status"
+      aria-live="polite"
+      class={cn("shrink-0", statusTextClass(statusToken[status]))}>{statusLabel[status]}</span
+    >
     {#if status === "closed"}
       <Button variant="outline" size="xs" onclick={retryNow}>Retry</Button>
     {/if}

--- a/apps/console/src/lib/components/stations/Terminal.svelte
+++ b/apps/console/src/lib/components/stations/Terminal.svelte
@@ -5,6 +5,7 @@
   import { themeStore } from "$lib/themes/store.svelte";
   import { Button } from "$lib/components/ui/button";
   import { cn } from "$lib/utils";
+  import { Status as StatusIndicator } from "$lib/components/ui/status";
   import SearchIcon from "@lucide/svelte/icons/search";
   import ChevronUpIcon from "@lucide/svelte/icons/chevron-up";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
@@ -77,6 +78,21 @@
     const _scheme = themeStore.colorSchemeId;
     if (term) {
       term.options.theme = computeXtermTheme();
+    }
+  });
+
+  // Follow font-pairing switches too: re-resolve the concrete mono stack
+  // (xterm can't read CSS variables) and refit to the new cell metrics.
+  $effect(() => {
+    const _font = themeStore.fontPairingId;
+    if (term) {
+      const themeMono = getComputedStyle(document.documentElement)
+        .getPropertyValue("--font-mono")
+        .trim();
+      if (themeMono) {
+        term.options.fontFamily = `${themeMono}, ui-monospace, Menlo, monospace`;
+        fitAddon?.fit();
+      }
     }
   });
 
@@ -244,12 +260,19 @@
       });
   }
 
-  const statusDotClass = $derived(
-    status === "connected"
-      ? "bg-status-running"
-      : status === "closed"
-        ? "bg-status-error"
-        : "bg-status-starting",
+  // Session lifecycle → shared status vocabulary + a spoken label, so the
+  // connection dot is never a color-only signal.
+  const sessionStatus = $derived(
+    status === "connected" ? "connected" : status === "closed" ? "error" : "starting",
+  );
+  const sessionLabel = $derived(
+    status === "connecting"
+      ? "Connecting…"
+      : status === "connected"
+        ? "Connected"
+        : status === "reconnecting"
+          ? "Reconnecting…"
+          : closeMessage,
   );
 
   // ── Mount / teardown ───────────────────────────────────────────────────────
@@ -270,12 +293,38 @@
 
       if (!containerEl) return;
 
+      // xterm measures cell width via canvas font strings, which CANNOT
+      // resolve CSS variables — passing var(--font-mono) makes it measure a
+      // fallback font while drawing another, rendering the huge-letter-spacing
+      // "s t r e t c h e d" prompt. Resolve the theme's mono stack to concrete
+      // family names first, and wait for the webfont so metrics are real.
+      const themeMono = getComputedStyle(document.documentElement)
+        .getPropertyValue("--font-mono")
+        .trim();
+      const fontFamily = [
+        themeMono || null,
+        "ui-monospace, 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
+      ]
+        .filter(Boolean)
+        .join(", ");
+      try {
+        await Promise.race([
+          document.fonts.load(`13px ${themeMono.split(",")[0] ?? "monospace"}`),
+          new Promise((resolve) => setTimeout(resolve, 1500)),
+        ]);
+      } catch {
+        // Font loading is best-effort; fallback metrics are still consistent.
+      }
+      if (!containerEl) return;
+
       term = new Terminal({
         cursorBlink: true,
         fontSize: 13,
-        fontFamily:
-          "var(--font-mono), ui-monospace, 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
+        fontFamily,
         theme: computeXtermTheme(),
+        // Mirrors terminal output into an ARIA live buffer — without this the
+        // entire terminal is invisible to screen readers.
+        screenReaderMode: true,
       });
 
       fitAddon = new FitAddon();
@@ -361,14 +410,14 @@
 >
   <!-- Toolbar -->
   <div class="flex flex-wrap items-center gap-2 border-b px-3 py-1.5 shrink-0">
-    <span
-      class={cn(
-        "size-2 shrink-0 rounded-full",
-        statusDotClass,
-        (status === "connecting" || status === "reconnecting") && "animate-pulse",
-      )}
-      aria-hidden="true"
-    ></span>
+    <span role="status" aria-live="polite" class="inline-flex shrink-0">
+      <StatusIndicator
+        form="dot"
+        status={sessionStatus}
+        label={sessionLabel}
+        animate={status === "connecting" || status === "reconnecting"}
+      />
+    </span>
     <span class="shrink-0 truncate font-mono text-xs text-muted-foreground">{stationId}</span>
 
     {#if status === "closed"}

--- a/apps/console/src/lib/components/ui/status/index.ts
+++ b/apps/console/src/lib/components/ui/status/index.ts
@@ -1,0 +1,1 @@
+export { default as Status } from "./status.svelte";

--- a/apps/console/src/lib/components/ui/status/status.svelte
+++ b/apps/console/src/lib/components/ui/status/status.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  /**
+   * Status — the ONE way status renders in this console.
+   *
+   * Every status surface (badges, dots, inline labels, ribbon/heatmap cells)
+   * goes through this component so all six tokens are always supported, the
+   * casing rule is enforced in one place (status is agent-reported data →
+   * lowercase mono), and opacity stays at exactly two steps: 10% fills behind
+   * text, 100% for dots and cells.
+   */
+  import { cn } from "$lib/utils";
+  import {
+    tokenFor,
+    statusBadgeClass,
+    statusTextClass,
+    statusBgClass,
+  } from "$lib/utils/status-badge";
+
+  interface Props {
+    /** Raw upstream status string (any vocab) — normalized via tokenFor. */
+    status: string;
+    /**
+     * badge = outline chip with 10% fill · text = colored mono label ·
+     * dot = solid circle with sr-only label · cell = solid square for ribbons.
+     */
+    form?: "badge" | "text" | "dot" | "cell";
+    /** Visible/accessible label override; defaults to the raw status, lowercased. */
+    label?: string;
+    /** Pulse the dot while a transition is in flight (motion-safe). */
+    animate?: boolean;
+    class?: string;
+  }
+
+  let { status, form = "badge", label, animate = false, class: className }: Props = $props();
+
+  const token = $derived(tokenFor(status));
+  const display = $derived((label ?? status).toLowerCase());
+</script>
+
+{#if form === "badge"}
+  <span
+    data-status={token}
+    class={cn(
+      "inline-flex shrink-0 items-center rounded-md border px-2 py-0.5 font-mono text-xs lowercase",
+      statusBadgeClass(status),
+      className,
+    )}>{display}</span
+  >
+{:else if form === "text"}
+  <span data-status={token} class={cn("font-mono lowercase", statusTextClass(status), className)}
+    >{display}</span
+  >
+{:else if form === "dot"}
+  <span data-status={token} class={cn("inline-flex shrink-0", className)}>
+    <span
+      class={cn(
+        "size-2 rounded-full",
+        statusBgClass(status),
+        animate && "motion-safe:animate-pulse",
+      )}
+      aria-hidden="true"
+    ></span>
+    <span class="sr-only">{display}</span>
+  </span>
+{:else}
+  <span
+    data-status={token}
+    role="img"
+    aria-label={display}
+    class={cn("block rounded-[2px]", statusBgClass(status), className)}
+  ></span>
+{/if}

--- a/apps/console/src/lib/components/ui/status/status.svelte.test.ts
+++ b/apps/console/src/lib/components/ui/status/status.svelte.test.ts
@@ -1,0 +1,55 @@
+import { test, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import Status from "./status.svelte";
+
+afterEach(cleanup);
+
+test("badge form: lowercase mono chip on the status token", () => {
+  const { container } = render(Status, { props: { status: "Running" } });
+  const el = container.querySelector("[data-status]") as HTMLElement;
+
+  expect(el.dataset.status).toBe("running");
+  expect(el.textContent).toBe("running");
+  expect(el.className).toContain("font-mono");
+  expect(el.className).toContain("bg-status-running/10");
+});
+
+test("normalizes upstream vocab: online→running, banned→error, unknown→stopped", () => {
+  for (const [raw, token] of [
+    ["online", "running"],
+    ["banned", "error"],
+    ["totally-unknown", "stopped"],
+  ] as const) {
+    const { container, unmount } = render(Status, { props: { status: raw, form: "text" } });
+    expect((container.querySelector("[data-status]") as HTMLElement).dataset.status).toBe(token);
+    unmount();
+  }
+});
+
+test("degraded is a first-class token — never collapsed to stopped", () => {
+  const { container } = render(Status, { props: { status: "degraded", form: "cell" } });
+  const el = container.querySelector("[data-status]") as HTMLElement;
+
+  expect(el.dataset.status).toBe("degraded");
+  expect(el.className).toContain("bg-status-degraded");
+  expect(el.className).not.toContain("bg-status-stopped");
+});
+
+test("dot form carries a screen-reader label", () => {
+  const { container } = render(Status, {
+    props: { status: "connecting", form: "dot", label: "Connecting…" },
+  });
+
+  expect(container.querySelector(".sr-only")?.textContent).toBe("connecting…");
+  expect(container.querySelector('[aria-hidden="true"]')?.className).toContain("rounded-full");
+});
+
+test("cell form is an accessible solid square", () => {
+  const { getByRole } = render(Status, {
+    props: { status: "error", form: "cell", label: "api-agent (error)" },
+  });
+
+  const cell = getByRole("img");
+  expect(cell.getAttribute("aria-label")).toBe("api-agent (error)");
+  expect(cell.className).toContain("bg-status-error");
+});

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import PageHeader from "$lib/components/page-header.svelte";
   import OverviewStats from "$lib/components/fleet/OverviewStats.svelte";
   import FleetHeatmap from "$lib/components/fleet/FleetHeatmap.svelte";
+  import StatusRibbon from "$lib/components/fleet/StatusRibbon.svelte";
   import NeedsAttention from "$lib/components/fleet/NeedsAttention.svelte";
   import RecentActivity from "$lib/components/fleet/RecentActivity.svelte";
   import ConnectBanner from "$lib/components/fleet/connect-banner.svelte";
@@ -73,7 +74,16 @@
   <title>Overview · AgentPod</title>
 </svelte:head>
 
-<PageHeader title="Overview" subtitle="Fleet control plane" />
+<PageHeader title="Overview" subtitle="Fleet control plane">
+  {#snippet ribbon()}
+    {#if agents.length > 0}
+      <StatusRibbon
+        size="xs"
+        items={agents.map((a) => ({ id: a.stationId, label: a.agentName, status: a.status }))}
+      />
+    {/if}
+  {/snippet}
+</PageHeader>
 
 <div class="container mx-auto px-4 sm:px-6 max-w-7xl py-6 space-y-6">
   {#if isLoading}

--- a/apps/console/src/routes/agents/+page.svelte
+++ b/apps/console/src/routes/agents/+page.svelte
@@ -6,6 +6,7 @@
   import type { FleetAgent } from "@agentpod/contract";
   import PageHeader from "$lib/components/page-header.svelte";
   import AgentTable from "$lib/components/fleet/AgentTable.svelte";
+  import StatusRibbon from "$lib/components/fleet/StatusRibbon.svelte";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Button } from "$lib/components/ui/button";
 
@@ -65,7 +66,16 @@
   <title>Agents · AgentPod</title>
 </svelte:head>
 
-<PageHeader title="Agents" subtitle="Every agent in the fleet" />
+<PageHeader title="Agents" subtitle="Every agent in the fleet">
+  {#snippet ribbon()}
+    {#if agents.length > 0}
+      <StatusRibbon
+        size="xs"
+        items={agents.map((a) => ({ id: a.stationId, label: a.agentName, status: a.status }))}
+      />
+    {/if}
+  {/snippet}
+</PageHeader>
 
 <div class="container mx-auto px-4 sm:px-6 max-w-7xl py-6">
   {#if isLoading}

--- a/apps/console/src/routes/nodes/[id]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/+page.svelte
@@ -80,13 +80,10 @@
     return stations.adopted.some((s) => s.stationKey === key);
   }
 
+  // Pass the raw status through — the shared token map classifies all values
+  // (online→running, error→error, …); collapsing here hid error states.
   const headerStatus = $derived(
-    node
-      ? {
-          label: node.status,
-          variant: (node.status === "online" ? "running" : "stopped") as "running" | "stopped",
-        }
-      : undefined,
+    node ? { label: node.status, variant: node.status } : undefined,
   );
 </script>
 


### PR DESCRIPTION
Third milestone from the UI audit: the design-lens review found **six competing status renderers** with visible consequences (a `degraded` agent rendered identically to `unknown` on the heatmap; one stopped agent was grey, red, and Title-Case-mono on three adjacent screens). This PR collapses them into one system and promotes it into the product's visual signature.

## One `<Status>` component
Four forms (`badge` / `text` / `dot` / `cell`) over the canonical `status-badge.ts` token map. All six tokens supported everywhere, labels lowercase mono (status is agent-reported data), opacity restricted to exactly two steps. All seven divergent renderers converted — PageHeader's private maps deleted, NeedsAttention no longer paints `stopped` red, HealthPanel drops its Title-Case two-state map, LogTail/Terminal connection state speaks the shared vocabulary, and node detail stops collapsing `error` → `stopped`.

## The signature: `<StatusRibbon>`
The fleet, at a glance, one geometry at three scales:
- **lg** — the Overview heatmap, rebuilt on it (legend now shows *every* status present, severity-ordered)
- **sm** — 8px strips in AgentTable's node-group headers: a node's whole health in 60px
- **xs** — a 3px live strip flush under the PageHeader on Overview and Agents: the top of the console *is* the fleet

Restraint rules baked in: never animates on load, error cells carry a hue-independent ring (colorblind-safe), xs stays chrome-quiet.

## Terminal fixes (from live dogfood screenshot)
- **Stretched-prompt bug**: xterm measures cells via canvas font strings, which can't resolve CSS variables — `var(--font-mono)` made it measure one font and draw another. Now resolves the concrete font stack, waits for the webfont before first measure, and refits on font-pairing switches.
- `screenReaderMode` enabled (terminal output was invisible to screen readers); connection dot gets an sr-only label in a polite live region; LogTail status announcements too.

Tests: 455 → 465, all green; `pnpm check` clean; production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB