### PR TITLE
feat(console): UI audit milestone 5 — hierarchy: health first, state-aware controls, Nodes table

### DIFF
--- a/apps/console/src/lib/components/fleet/NeedsAttention.svelte
+++ b/apps/console/src/lib/components/fleet/NeedsAttention.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { FleetAgent } from "@agentpod/contract";
   import { Status } from "$lib/components/ui/status";
+  import CircleCheckIcon from "@lucide/svelte/icons/circle-check";
 
   let { agents }: { agents: FleetAgent[] } = $props();
 
@@ -15,12 +16,19 @@
   let updatesAvailable = $derived(agents.filter((a) => a.updateAvailable).length);
 </script>
 
-<div class="rounded-lg border p-4 space-y-2" data-testid="needs-attention">
-  <h2 class="t-section">Needs attention</h2>
-
-  {#if notRunning.length === 0 && offlineNodes === 0 && updatesAvailable === 0}
-    <p class="text-xs text-status-running" data-testid="all-healthy">all healthy ✓</p>
-  {:else}
+<!-- The panel shrinks when there's nothing wrong: a single quiet line when
+     healthy, a full bordered panel only when something needs a human. -->
+{#if notRunning.length === 0 && offlineNodes === 0 && updatesAvailable === 0}
+  <p
+    class="flex items-center gap-1.5 text-xs text-muted-foreground"
+    data-testid="all-healthy"
+  >
+    <CircleCheckIcon class="h-3.5 w-3.5 text-status-running" aria-hidden="true" />
+    All agents healthy
+  </p>
+{:else}
+  <div class="rounded-lg border border-status-error/30 p-4 space-y-2" data-testid="needs-attention">
+    <h2 class="t-section">Needs attention</h2>
     <ul class="space-y-1">
       {#each notRunning as agent (agent.stationId)}
         <li>
@@ -60,5 +68,5 @@
         </li>
       {/if}
     </ul>
-  {/if}
-</div>
+  </div>
+{/if}

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte
@@ -3,9 +3,13 @@
   import { startPolling } from "$lib/utils/poll";
   import { page } from "$app/state";
   import { replaceState } from "$app/navigation";
-  import { listNodes, createEnrollmentToken, listRuntimes, listRuntimeProviders, updateNode } from "$lib/api/client";
+  import { listNodes, createEnrollmentToken, listRuntimes, listRuntimeProviders, updateNode, getFleet } from "$lib/api/client";
   import { toast } from "svelte-sonner";
-  import type { NodeSummary, ProvisionedRuntime } from "@agentpod/contract";
+  import type { NodeSummary, ProvisionedRuntime, FleetAgent } from "@agentpod/contract";
+  import * as Table from "$lib/components/ui/table";
+  import { Status } from "$lib/components/ui/status";
+  import StatusRibbon from "./StatusRibbon.svelte";
+  import { tokenFor } from "$lib/utils/status-badge";
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import { Skeleton } from "$lib/components/ui/skeleton";
@@ -16,7 +20,7 @@
   import Loader2Icon from "@lucide/svelte/icons/loader-2";
   import NewRuntimeDialog from "./NewRuntimeDialog.svelte";
   import ConnectBanner from "./connect-banner.svelte";
-  import { statusBadgeClass } from "$lib/utils/status-badge";
+
   import { chipClass } from "$lib/utils/toggle-chip";
   import { enrollmentCommand } from "$lib/utils/enrollment-command";
   import { cn } from "$lib/utils";
@@ -27,6 +31,19 @@
   let lastToken = $state<string | null>(null);
   let isMinting = $state(false);
   let mintError = $state<string | null>(null);
+
+  // Fleet agents, grouped per node, drive the Agents column (count + ribbon).
+  let fleetAgents = $state<FleetAgent[]>([]);
+
+  const agentsByNode = $derived.by(() => {
+    const m = new Map<string, FleetAgent[]>();
+    for (const a of fleetAgents) {
+      const list = m.get(a.nodeId) ?? [];
+      list.push(a);
+      m.set(a.nodeId, list);
+    }
+    return m;
+  });
 
   // Runtime provisioning state
   let runtimes = $state<ProvisionedRuntime[]>([]);
@@ -54,10 +71,15 @@
       error = null;
     }
     try {
-      const [nodesResult, runtimesResult] = await Promise.allSettled([
+      const [nodesResult, runtimesResult, fleetResult] = await Promise.allSettled([
         listNodes(),
         listRuntimes(),
+        getFleet(),
       ]);
+      if (fleetResult.status === "fulfilled") {
+        fleetAgents = fleetResult.value.agents;
+      }
+      // fleet agents failing is non-fatal — the Agents column shows "—"
       if (nodesResult.status === "fulfilled") {
         nodes = nodesResult.value;
         error = null;
@@ -263,82 +285,123 @@
       </div>
     </div>
 
-  <!-- Node cards + provisioning cards grid -->
+  <!-- Provisioning cards + nodes table -->
   {:else}
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      <!-- Provisioning cards (runtimes that are still spinning up) -->
-      {#each provisioningRuntimes as rt (rt.id)}
-        <div class="h-full rounded-lg border border-primary/30 bg-primary/5 p-4 space-y-1">
-          <div class="flex items-start justify-between gap-2">
-            <p class="text-sm font-medium leading-tight truncate">
-              {rt.name}
-            </p>
-            <Badge variant="secondary" class="shrink-0 gap-1.5">
-              <Loader2Icon class="h-3 w-3 animate-spin" />
-              provisioning
-            </Badge>
-          </div>
-          <p class="text-sm text-muted-foreground">
-            {rt.provider} · {rt.resourceTier}
-          </p>
-          {#if rt.harness && rt.harness !== "none"}
-            <Badge variant="outline" class="text-xs border-primary/40 text-primary">
-              {rt.harness}
-            </Badge>
-          {/if}
-        </div>
-      {/each}
-
-      <!-- Online / offline node cards -->
-      {#each nodes as node (node.id)}
-        <a
-          href="/nodes/{node.id}"
-          class="block group focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-lg"
-        >
-          <div class="h-full rounded-lg border bg-card p-4 space-y-1 transition-colors group-hover:border-primary/50">
-            <div class="flex items-start justify-between gap-2">
-              <p class="text-sm font-medium leading-tight truncate">
-                {node.hostname}
-              </p>
-              <Badge variant="outline" class="shrink-0 {statusBadgeClass(node.status)}">
-                {node.status}
-              </Badge>
-            </div>
-            <p class="text-sm text-muted-foreground">
-              <Metric>{node.arch}</Metric> · <Metric>{node.cpuCount}</Metric> CPU
-            </p>
-            <p class="text-xs text-muted-foreground/70">
-              {node.os}
-            </p>
-            <p class="text-xs text-muted-foreground/60">
-              <Metric>{node.agentVersion ?? "—"}</Metric>
-            </p>
-            {#if node.updateAvailable}
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-xs text-status-degraded">
-                  Update available · <Metric>{node.agentVersion} → {node.latestVersion}</Metric>
-                </span>
-                <button
-                  type="button"
-                  disabled={!!updatingNodes[node.id]}
-                  onclick={(e) => { e.stopPropagation(); e.preventDefault(); handleUpdate(node.id); }}
-                  class={cn(
-                    chipClass(false),
-                    "text-xs hover:border-primary hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed",
-                  )}
-                >
-                  {updatingNodes[node.id] ? "Updating…" : "Update"}
-                </button>
+    <div class="space-y-4">
+      <!-- Provisioning cards (runtimes still spinning up) — cards stay here
+           because provisioning is a status story, not a row of facts -->
+      {#if provisioningRuntimes.length > 0}
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {#each provisioningRuntimes as rt (rt.id)}
+            <div class="h-full rounded-lg border border-primary/30 bg-primary/5 p-4 space-y-1">
+              <div class="flex items-start justify-between gap-2">
+                <p class="text-sm font-medium leading-tight truncate">
+                  {rt.name}
+                </p>
+                <Badge variant="secondary" class="shrink-0 gap-1.5">
+                  <Loader2Icon class="h-3 w-3 animate-spin" />
+                  provisioning
+                </Badge>
               </div>
-            {/if}
-            {#if node.provisioned}
-              <Badge variant="outline" class="text-xs border-primary/40 text-primary">
-                provisioned · {node.provisioned.provider}
-              </Badge>
-            {/if}
-          </div>
-        </a>
-      {/each}
+              <p class="text-sm text-muted-foreground">
+                {rt.provider} · {rt.resourceTier}
+              </p>
+              {#if rt.harness && rt.harness !== "none"}
+                <Badge variant="outline" class="text-xs border-primary/40 text-primary">
+                  {rt.harness}
+                </Badge>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <!-- Nodes as an ops table: host · status · agents · facts · update -->
+      <div class="overflow-x-auto rounded-lg border">
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head>Host</Table.Head>
+              <Table.Head>Status</Table.Head>
+              <Table.Head>Agents</Table.Head>
+              <Table.Head class="hidden sm:table-cell">CPUs</Table.Head>
+              <Table.Head class="hidden md:table-cell">OS</Table.Head>
+              <Table.Head class="hidden sm:table-cell">Version</Table.Head>
+              <Table.Head><span class="sr-only">Update</span></Table.Head>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {#each nodes as node (node.id)}
+              {@const nodeAgents = agentsByNode.get(node.id) ?? []}
+              {@const runningCount = nodeAgents.filter((a) => tokenFor(a.status) === "running").length}
+              <Table.Row data-testid="node-row">
+                <Table.Cell>
+                  <a
+                    href="/nodes/{node.id}"
+                    class="text-sm font-medium hover:text-primary transition-colors"
+                  >
+                    {node.hostname}
+                  </a>
+                  {#if node.provisioned}
+                    <Badge variant="outline" class="ml-2 text-xs border-primary/40 text-primary">
+                      provisioned · {node.provisioned.provider}
+                    </Badge>
+                  {/if}
+                </Table.Cell>
+                <Table.Cell>
+                  <Status form="badge" status={node.status} />
+                </Table.Cell>
+                <Table.Cell>
+                  {#if nodeAgents.length > 0}
+                    <div class="flex items-center gap-2">
+                      <StatusRibbon
+                        size="sm"
+                        items={nodeAgents.map((a) => ({
+                          id: a.stationId,
+                          label: a.agentName,
+                          status: a.status,
+                        }))}
+                      />
+                      <Metric class="text-xs text-muted-foreground">{runningCount}/{nodeAgents.length}</Metric>
+                    </div>
+                  {:else}
+                    <span class="text-xs text-muted-foreground">—</span>
+                  {/if}
+                </Table.Cell>
+                <Table.Cell class="hidden sm:table-cell">
+                  <Metric class="text-xs text-muted-foreground">{node.cpuCount}</Metric>
+                </Table.Cell>
+                <Table.Cell class="hidden md:table-cell text-xs text-muted-foreground">
+                  {node.os} · <Metric>{node.arch}</Metric>
+                </Table.Cell>
+                <Table.Cell class="hidden sm:table-cell">
+                  <Metric class="text-xs text-muted-foreground">{node.agentVersion ?? "—"}</Metric>
+                </Table.Cell>
+                <Table.Cell class="text-right">
+                  {#if node.updateAvailable}
+                    <div class="flex items-center justify-end gap-2 whitespace-nowrap">
+                      <span class="text-xs text-status-degraded">
+                        <Metric>{node.agentVersion} → {node.latestVersion}</Metric>
+                      </span>
+                      <button
+                        type="button"
+                        disabled={!!updatingNodes[node.id]}
+                        onclick={() => handleUpdate(node.id)}
+                        class={cn(
+                          chipClass(false),
+                          "text-xs hover:border-primary hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed",
+                        )}
+                      >
+                        {updatingNodes[node.id] ? "Updating…" : "Update"}
+                      </button>
+                    </div>
+                  {/if}
+                </Table.Cell>
+              </Table.Row>
+            {/each}
+          </Table.Body>
+        </Table.Root>
+      </div>
     </div>
   {/if}
 </div>

--- a/apps/console/src/lib/components/fleet/OverviewStats.svelte
+++ b/apps/console/src/lib/components/fleet/OverviewStats.svelte
@@ -1,36 +1,55 @@
 <script lang="ts">
-  import type { FleetStats } from "@agentpod/contract";
+  /**
+   * The Overview stat band, health first: the number an operator opens this
+   * page for is "how many agents are not running", so status counts lead in
+   * status colors and machine inventory follows as one quiet line.
+   */
+  import type { FleetStats, FleetAgent } from "@agentpod/contract";
+  import { tokenFor, statusTextClass, type StatusToken } from "$lib/utils/status-badge";
 
-  let { stats }: { stats: FleetStats } = $props();
+  let { stats, agents }: { stats: FleetStats; agents: FleetAgent[] } = $props();
+
+  // running leads; problem states follow in severity order; zero-count
+  // problem states are omitted (the band shrinks when all is well).
+  const ORDER: StatusToken[] = ["running", "error", "degraded", "starting", "sleeping", "stopped"];
+
+  const counts = $derived.by(() => {
+    const c = new Map<StatusToken, number>();
+    for (const a of agents) {
+      const t = tokenFor(a.status);
+      c.set(t, (c.get(t) ?? 0) + 1);
+    }
+    return c;
+  });
+
+  const bands = $derived(ORDER.filter((t) => t === "running" || (counts.get(t) ?? 0) > 0));
 </script>
 
-<div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-  <!-- Nodes stat -->
-  <div class="rounded-lg border p-4 space-y-1">
-    <div class="text-xs text-muted-foreground">Nodes online</div>
-    <div class="t-metric text-foreground" data-testid="stat-nodes">
-      {stats.nodes.online}<span class="text-muted-foreground text-lg">/{stats.nodes.total}</span>
-    </div>
+<div class="rounded-lg border p-4 space-y-3">
+  <!-- Health: the numbers this page exists for -->
+  <div class="flex flex-wrap items-baseline gap-x-6 gap-y-2" data-testid="health-band">
+    {#each bands as token (token)}
+      <div class="flex items-baseline gap-1.5">
+        <span class="t-metric {statusTextClass(token)}" data-testid="stat-{token}"
+          >{counts.get(token) ?? 0}</span
+        >
+        <span class="t-label">{token}</span>
+      </div>
+    {/each}
   </div>
 
-  <!-- Agents stat -->
-  <div class="rounded-lg border p-4 space-y-1">
-    <div class="text-xs text-muted-foreground">Agents</div>
-    <div class="t-metric text-foreground" data-testid="stat-agents">
-      {stats.agents.total}
-    </div>
-  </div>
-
-  <!-- Updates available stat — accent when >0 -->
-  <div
-    class="rounded-lg border p-4 space-y-1 {stats.updatesAvailable > 0 ? 'border-status-degraded/50' : ''}"
-  >
-    <div class="text-xs text-muted-foreground">Updates available</div>
-    <div
-      class="t-metric {stats.updatesAvailable > 0 ? 'text-status-degraded' : 'text-foreground'}"
-      data-testid="stat-updates"
+  <!-- Inventory: quiet, mono values -->
+  <p class="text-xs text-muted-foreground" data-testid="inventory-line">
+    <span class="font-mono tabular-nums" data-testid="stat-nodes"
+      >{stats.nodes.online}/{stats.nodes.total}</span
     >
-      {stats.updatesAvailable}
-    </div>
-  </div>
+    nodes online ·
+    <span class="font-mono tabular-nums" data-testid="stat-agents">{stats.agents.total}</span>
+    agents ·
+    <span
+      class="font-mono tabular-nums {stats.updatesAvailable > 0 ? 'text-status-degraded' : ''}"
+      data-testid="stat-updates">{stats.updatesAvailable}</span
+    >
+    updates available
+  </p>
 </div>

--- a/apps/console/src/lib/components/fleet/OverviewStats.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/OverviewStats.svelte.test.ts
@@ -1,19 +1,15 @@
 /**
  * OverviewStats.svelte.test.ts
  *
- * TDD tests for the Overview stat-band component.
- * Asserts:
- *   - renders nodes online/total
- *   - renders agents total
- *   - renders updatesAvailable value
- *   - updatesAvailable > 0 → accent class applied
- *   - updatesAvailable === 0 → no accent
+ * The stat band reports HEALTH first (how many agents are running / broken,
+ * in status colors) and inventory second (nodes/agents/updates as one quiet
+ * line). Inventory numbers must never out-shout the health numbers.
  */
 
 import { test, expect, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/svelte";
 import OverviewStats from "./OverviewStats.svelte";
-import type { FleetStats } from "@agentpod/contract";
+import type { FleetStats, FleetAgent } from "@agentpod/contract";
 
 afterEach(cleanup);
 
@@ -24,35 +20,78 @@ const baseStats: FleetStats = {
   running: 0,
 };
 
-test("renders nodes online and total", () => {
-  const { getByTestId } = render(OverviewStats, { props: { stats: baseStats } });
-  const nodesEl = getByTestId("stat-nodes");
-  expect(nodesEl.textContent).toContain("2");
-  expect(nodesEl.textContent).toContain("3");
+const agent = (stationId: string, status: string): FleetAgent =>
+  ({
+    stationId,
+    nodeId: "n1",
+    nodeName: "node",
+    agentName: stationId,
+    harness: "openclaw",
+    kind: "agent",
+    nodeStatus: "online",
+    agentVersion: "v1",
+    latestVersion: "v1",
+    updateAvailable: false,
+    capabilities: [],
+    workspacePath: null,
+    status,
+    cpuPct: null,
+    memBytes: null,
+    uptimeSec: null,
+  }) as FleetAgent;
+
+const mixedAgents = [
+  agent("a1", "running"),
+  agent("a2", "running"),
+  agent("a3", "stopped"),
+  agent("a4", "error"),
+];
+
+test("health band: running count leads, colored by status token", () => {
+  const { getByTestId } = render(OverviewStats, {
+    props: { stats: baseStats, agents: mixedAgents },
+  });
+  const running = getByTestId("stat-running");
+  expect(running.textContent?.trim()).toBe("2");
+  expect(running.className).toContain("text-status-running");
 });
 
-test("renders agents total", () => {
-  const { getByTestId } = render(OverviewStats, { props: { stats: baseStats } });
-  const agentsEl = getByTestId("stat-agents");
-  expect(agentsEl.textContent?.trim()).toBe("13");
+test("health band: problem states appear with their own colored counts", () => {
+  const { getByTestId } = render(OverviewStats, {
+    props: { stats: baseStats, agents: mixedAgents },
+  });
+  expect(getByTestId("stat-error").textContent?.trim()).toBe("1");
+  expect(getByTestId("stat-error").className).toContain("text-status-error");
+  expect(getByTestId("stat-stopped").textContent?.trim()).toBe("1");
 });
 
-test("renders updatesAvailable count", () => {
-  const stats: FleetStats = { ...baseStats, updatesAvailable: 5 };
-  const { getByTestId } = render(OverviewStats, { props: { stats } });
-  const updatesEl = getByTestId("stat-updates");
-  expect(updatesEl.textContent?.trim()).toBe("5");
+test("health band: zero-count problem states are omitted; running always shows", () => {
+  const { getByTestId, queryByTestId } = render(OverviewStats, {
+    props: { stats: baseStats, agents: [agent("a1", "running")] },
+  });
+  expect(getByTestId("stat-running").textContent?.trim()).toBe("1");
+  expect(queryByTestId("stat-error")).toBeNull();
+  expect(queryByTestId("stat-stopped")).toBeNull();
 });
 
-test("updatesAvailable > 0 applies accent class (text-status-degraded)", () => {
-  const stats: FleetStats = { ...baseStats, updatesAvailable: 2 };
-  const { getByTestId } = render(OverviewStats, { props: { stats } });
-  const updatesEl = getByTestId("stat-updates");
-  expect(updatesEl.className).toContain("text-status-degraded");
+test("inventory line: nodes online/total, agent total, updates", () => {
+  const { getByTestId } = render(OverviewStats, {
+    props: { stats: { ...baseStats, updatesAvailable: 5 }, agents: mixedAgents },
+  });
+  expect(getByTestId("stat-nodes").textContent).toContain("2/3");
+  expect(getByTestId("stat-agents").textContent?.trim()).toBe("13");
+  expect(getByTestId("stat-updates").textContent?.trim()).toBe("5");
 });
 
-test("updatesAvailable === 0 does not apply text-status-degraded to updates stat", () => {
-  const { getByTestId } = render(OverviewStats, { props: { stats: baseStats } });
-  const updatesEl = getByTestId("stat-updates");
-  expect(updatesEl.className).not.toContain("text-status-degraded");
+test("updates accent only when > 0", () => {
+  const withUpdates = render(OverviewStats, {
+    props: { stats: { ...baseStats, updatesAvailable: 2 }, agents: mixedAgents },
+  });
+  expect(withUpdates.getByTestId("stat-updates").className).toContain("text-status-degraded");
+  withUpdates.unmount();
+
+  const without = render(OverviewStats, {
+    props: { stats: baseStats, agents: mixedAgents },
+  });
+  expect(without.getByTestId("stat-updates").className).not.toContain("text-status-degraded");
 });

--- a/apps/console/src/lib/components/stations/HealthPanel.svelte
+++ b/apps/console/src/lib/components/stations/HealthPanel.svelte
@@ -134,114 +134,109 @@
   </div>
 {:else if health}
   <div class="p-4 space-y-4">
-    <!-- Responsive stat-tile grid: 1 col mobile → 2 cols sm -->
-    <dl class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-      <!-- Status -->
-      <div class="rounded-lg border p-3 flex flex-col gap-1">
-        <dt class="text-xs text-muted-foreground">Status</dt>
-        <dd>
-          <Status form="text" status={health.running ? "running" : "stopped"} class="text-lg" />
-        </dd>
-      </div>
+    <!-- Status row: the one fact this panel exists for, full width, with the
+         contextual action beside it — Start/Stop/Restart are state-aware
+         instead of three always-on buttons. -->
+    <div class="flex flex-wrap items-center gap-3 rounded-lg border p-3" data-testid="status-row">
+      <Status
+        form="dot"
+        status={health.running ? "running" : "stopped"}
+        animate={actionInFlight}
+      />
+      <Status form="text" status={health.running ? "running" : "stopped"} class="text-sm" />
+      {#if health.running && health.uptimeSec !== null}
+        <span class="text-xs text-muted-foreground">
+          up <span class="font-mono tabular-nums">{fmtUptime(health.uptimeSec)}</span
+          >{#if isGateway}<span class="ml-1">(gateway)</span>{/if}
+        </span>
+      {/if}
+      {#if canLifecycle}
+        <div class="ml-auto flex flex-wrap gap-2">
+          {#if health.running}
+            <Button variant="outline" size="sm" disabled={actionInFlight} onclick={handleStop}>
+              {inFlightAction === "stop" ? "Stopping…" : "Stop"}
+            </Button>
+            <Button variant="outline" size="sm" disabled={actionInFlight} onclick={handleRestart}>
+              {inFlightAction === "restart" ? "Restarting…" : "Restart"}
+            </Button>
+          {:else}
+            <Button variant="default" size="sm" disabled={actionInFlight} onclick={handleStart}>
+              {inFlightAction === "start" ? "Starting…" : "Start"}
+            </Button>
+          {/if}
+        </div>
+      {/if}
+    </div>
+    {#if actionError}
+      <p class="text-sm text-destructive" role="alert">{actionError}</p>
+    {/if}
 
-      <!-- PID -->
-      <div class="rounded-lg border p-3 flex flex-col gap-1">
-        <dt class="text-xs text-muted-foreground">PID</dt>
-        <dd class="font-mono text-lg text-foreground">
-          {fmt(health.pid)}{#if isGateway && health.pid !== null}<span class="text-muted-foreground text-xs ml-1">(gateway)</span>{/if}
-        </dd>
-      </div>
-
-      <!-- CPU -->
+    <!-- Live metrics -->
+    <dl class="grid grid-cols-2 gap-3 sm:grid-cols-4">
       <div class="rounded-lg border p-3 flex flex-col gap-1">
         <dt class="text-xs text-muted-foreground">CPU</dt>
-        <dd class="font-mono text-lg text-foreground">
+        <dd class="font-mono tabular-nums text-lg text-foreground">
           {health.cpuPct !== null ? `${health.cpuPct}%` : "—"}{#if isGateway && health.cpuPct !== null}<span class="text-muted-foreground text-xs ml-1">(gateway)</span>{/if}
         </dd>
       </div>
 
-      <!-- Memory -->
       <div class="rounded-lg border p-3 flex flex-col gap-1">
         <dt class="text-xs text-muted-foreground">Memory</dt>
-        <dd class="font-mono text-lg text-foreground">
+        <dd class="font-mono tabular-nums text-lg text-foreground">
           {fmtBytes(health.memBytes)}{#if isGateway && health.memBytes !== null}<span class="text-muted-foreground text-xs ml-1">(gateway)</span>{/if}
         </dd>
       </div>
 
-      <!-- Disk -->
       <div class="rounded-lg border p-3 flex flex-col gap-1">
         <dt class="text-xs text-muted-foreground">Disk</dt>
-        <dd class="font-mono text-lg text-foreground">{fmtBytes(health.diskBytes)}</dd>
+        <dd class="font-mono tabular-nums text-lg text-foreground">{fmtBytes(health.diskBytes)}</dd>
       </div>
 
-      <!-- Uptime -->
       <div class="rounded-lg border p-3 flex flex-col gap-1">
-        <dt class="text-xs text-muted-foreground">Uptime</dt>
-        <dd class="font-mono text-lg text-foreground">
-          {fmtUptime(health.uptimeSec)}{#if isGateway && health.uptimeSec !== null}<span class="text-muted-foreground text-xs ml-1">(gateway)</span>{/if}
-        </dd>
-      </div>
-
-      <!-- Last Activity -->
-      <div class="rounded-lg border p-3 flex flex-col gap-1">
-        <dt class="text-xs text-muted-foreground">Last Activity</dt>
+        <dt class="text-xs text-muted-foreground">Last activity</dt>
         <dd class="font-mono text-sm text-foreground">{fmtStr(health.lastActivity)}</dd>
       </div>
-
-      <!-- Note -->
-      <div class="rounded-lg border p-3 flex flex-col gap-1">
-        <dt class="text-xs text-muted-foreground">Note</dt>
-        <dd class="font-mono text-sm text-foreground">{fmtStr(health.note)}</dd>
-      </div>
-
-      <!-- Matrix ID (conditional) -->
-      {#if matrixId}
-        <div class="rounded-lg border p-3 flex flex-col gap-1 sm:col-span-2">
-          <dt class="text-xs text-muted-foreground">Matrix</dt>
-          <dd class="font-mono text-sm">
-            <a
-              href="https://matrix.to/#/{matrixId}"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-primary hover:underline break-all"
-            >{matrixId}</a>
-          </dd>
-        </div>
-      {/if}
     </dl>
 
-    <!-- Lifecycle controls -->
-    {#if canLifecycle}
-      <div class="pt-2 border-t flex flex-wrap gap-2">
-        <Button
-          variant="default"
-          size="sm"
-          disabled={actionInFlight}
-          onclick={handleStart}
-        >
-          {inFlightAction === "start" ? "Starting…" : "Start"}
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={actionInFlight}
-          onclick={handleStop}
-        >
-          {inFlightAction === "stop" ? "Stopping…" : "Stop"}
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={actionInFlight}
-          onclick={handleRestart}
-        >
-          {inFlightAction === "restart" ? "Restarting…" : "Restart"}
-        </Button>
-      </div>
-      {#if actionError}
-        <p class="text-sm text-destructive">{actionError}</p>
-      {/if}
-    {/if}
+    <!-- Process plumbing, out of the way but one click deep -->
+    <details class="rounded-lg border">
+      <summary class="cursor-pointer select-none px-3 py-2 text-xs text-muted-foreground">
+        Process details
+      </summary>
+      <dl class="grid grid-cols-1 gap-3 p-3 pt-1 sm:grid-cols-2">
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs text-muted-foreground">PID</dt>
+          <dd class="font-mono tabular-nums text-sm text-foreground">
+            {fmt(health.pid)}{#if isGateway && health.pid !== null}<span class="text-muted-foreground text-xs ml-1">(gateway)</span>{/if}
+          </dd>
+        </div>
+        {#if !health.running || health.uptimeSec === null}
+          <div class="flex flex-col gap-1">
+            <dt class="text-xs text-muted-foreground">Uptime</dt>
+            <dd class="font-mono tabular-nums text-sm text-foreground">{fmtUptime(health.uptimeSec)}</dd>
+          </div>
+        {/if}
+        {#if health.note}
+          <div class="flex flex-col gap-1 sm:col-span-2">
+            <dt class="text-xs text-muted-foreground">Note</dt>
+            <dd class="font-mono text-sm text-foreground">{fmtStr(health.note)}</dd>
+          </div>
+        {/if}
+        {#if matrixId}
+          <div class="flex flex-col gap-1 sm:col-span-2">
+            <dt class="text-xs text-muted-foreground">Matrix</dt>
+            <dd class="font-mono text-sm">
+              <a
+                href="https://matrix.to/#/{matrixId}"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-primary hover:underline break-all"
+              >{matrixId}</a>
+            </dd>
+          </div>
+        {/if}
+      </dl>
+    </details>
   </div>
 
   {#if canLifecycle}

--- a/apps/console/src/lib/components/stations/HealthPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/HealthPanel.svelte.test.ts
@@ -34,11 +34,11 @@ const healthNulls: StationHealth = {
 test("HealthPanel renders running state and numeric pid", async () => {
   vi.spyOn(api, "stationHealth").mockResolvedValue(healthFull);
 
-  const { getByText } = render(HealthPanel, { props: { stationId: "station_1" } });
+  const { getByText, getAllByText } = render(HealthPanel, { props: { stationId: "station_1" } });
 
   await waitFor(() => {
-    // running should appear (e.g. "Running" badge text)
-    expect(getByText(/running/i)).toBeTruthy();
+    // running appears (status dot sr-only label + visible text label)
+    expect(getAllByText(/running/i).length).toBeGreaterThanOrEqual(1);
     // pid should appear
     expect(getByText(/12345/)).toBeTruthy();
   });
@@ -92,22 +92,23 @@ test("HealthPanel: no lifecycle buttons rendered when canLifecycle is false (def
   expect(queryByRole("button", { name: /^restart$/i })).toBeNull();
 });
 
-test("HealthPanel: lifecycle buttons visible when canLifecycle is true", async () => {
+test("HealthPanel: controls are state-aware — running shows Stop/Restart, never Start", async () => {
   vi.spyOn(api, "stationHealth").mockResolvedValue(healthFull);
 
-  const { getByRole } = render(HealthPanel, {
+  const { getByRole, queryByRole } = render(HealthPanel, {
     props: { stationId: "station_lc", canLifecycle: true },
   });
 
   await waitFor(() => {
-    expect(getByRole("button", { name: /^start$/i })).toBeTruthy();
     expect(getByRole("button", { name: /^stop$/i })).toBeTruthy();
     expect(getByRole("button", { name: /^restart$/i })).toBeTruthy();
   });
+  // A running agent must not offer the one action that does nothing.
+  expect(queryByRole("button", { name: /^start$/i })).toBeNull();
 });
 
-test("HealthPanel: Start calls lifecycle immediately without a dialog", async () => {
-  vi.spyOn(api, "stationHealth").mockResolvedValue(healthFull);
+test("HealthPanel: Start (on a stopped agent) calls lifecycle immediately without a dialog", async () => {
+  vi.spyOn(api, "stationHealth").mockResolvedValue(healthNulls);
   vi.spyOn(api, "lifecycle").mockResolvedValue(healthFull);
 
   const { getByRole, queryByRole } = render(HealthPanel, {
@@ -115,6 +116,9 @@ test("HealthPanel: Start calls lifecycle immediately without a dialog", async ()
   });
 
   await waitFor(() => expect(getByRole("button", { name: /^start$/i })).toBeTruthy());
+  // A stopped agent shows only Start.
+  expect(queryByRole("button", { name: /^stop$/i })).toBeNull();
+  expect(queryByRole("button", { name: /^restart$/i })).toBeNull();
 
   fireEvent.click(getByRole("button", { name: /^start$/i }));
 

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -122,10 +122,15 @@
     </div>
 
   {:else}
-    <!-- Stat band -->
+    <!-- Stat band: health first, inventory second -->
     {#if stats}
-      <OverviewStats {stats} />
+      <OverviewStats {stats} {agents} />
     {/if}
+
+    <!-- Needs attention: full width when something's wrong, one quiet line
+         when healthy — the panel earns its size, it doesn't sit at equal
+         weight with a log of things that happened. -->
+    <NeedsAttention {agents} />
 
     <!-- Fleet heatmap — clicking a cell navigates to /agents filtered by that station -->
     <div class="rounded-lg border p-4 space-y-2">
@@ -137,10 +142,6 @@
       />
     </div>
 
-    <!-- Dashboard panels: Needs Attention + Recent Activity -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <NeedsAttention {agents} />
-      <RecentActivity />
-    </div>
+    <RecentActivity />
   {/if}
 </div>


### PR DESCRIPTION
Fifth milestone from the UI audit — the information-hierarchy findings (P2-3). The design lens's sharpest observation: "the biggest type on the fleet dashboard is a count of machines, and the smallest type is the count of broken agents." This PR inverts that.

## Overview: health first
- The stat band now leads with colored per-token agent counts (`2 running · 1 error · 1 stopped`) — problem states appear only when non-zero, so the band shrinks when all is well. Machine inventory (`2/3 nodes online · 13 agents · 0 updates available`) demotes to one quiet mono line.
- **NeedsAttention earns its size**: a full-width, error-bordered panel above the heatmap when something needs a human; a single quiet "All agents healthy" line when nothing does. (Previously it sat at equal weight with the activity log forever, saying `all healthy ✓` in lowercase with a text glyph.)

## HealthPanel: status is not a tile
- Status promoted out of the eight-equal-tiles grid into a full-width row: dot + label + uptime + the contextual action. **Controls are state-aware** — Stop/Restart on a running agent, Start on a stopped one; the loudest button is never the one that does nothing.
- PID / Note / Matrix demote behind a "Process details" disclosure; the live metrics (CPU/Memory/Disk/Last activity) read as one row of four.

## Nodes: a table, not cards of constants
- The 3-column card grid (five lines of near-static inventory per node) becomes an ops table: host · status · **agents** · CPUs · OS · version · update. The Agents column shows a per-node status ribbon plus a running/total count from live fleet data — the thing the old cards never told you.
- Cards remain only for provisioning runtimes, where the content genuinely is a status story.

Tests: 465 green (HealthPanel tests updated for the intended state-aware behavior; OverviewStats suite rewritten for the health-first contract); `pnpm check` clean; production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB