### PR TITLE
feat(console): UI audit milestone 6 — the language settles

### DIFF
--- a/apps/console/src/app.css
+++ b/apps/console/src/app.css
@@ -791,15 +791,15 @@
    for readability.
    ============================================ */
 
-/* Large surfaces that should transition smoothly */
+/* Large chrome surfaces that should transition smoothly on theme switches.
+   Content containers (section/article) are deliberately excluded — a 0.5s
+   background crossfade on them makes live data refreshes read as lag. */
 body,
 main,
 aside,
 header,
 footer,
 nav,
-section,
-article,
 [data-slot="content"],
 [data-slot="sidebar"],
 [role="dialog"],

--- a/apps/console/src/lib/components/admin/RoleDialog.svelte
+++ b/apps/console/src/lib/components/admin/RoleDialog.svelte
@@ -95,7 +95,7 @@
         </Select.Root>
         {#if newRole === "admin"}
           <p class="text-xs text-destructive">
-            Warning: Admins have full access to manage all users and system settings.
+            Admins have full access to manage all users and system settings.
           </p>
         {/if}
       </div>
@@ -105,7 +105,7 @@
           Cancel
         </Button>
         <Button onclick={handleConfirm} disabled={isUpdating || newRole === user?.role}>
-          {isUpdating ? "Updating…" : "Update role"}
+          {isUpdating ? "Changing…" : "Change role"}
         </Button>
       </Dialog.Footer>
     </Dialog.Content>

--- a/apps/console/src/lib/components/admin/RoleDialog.svelte.test.ts
+++ b/apps/console/src/lib/components/admin/RoleDialog.svelte.test.ts
@@ -71,7 +71,7 @@ test("update is disabled while the selected role matches the user's current role
   const { getByRole } = render(RoleDialog, {
     props: { open: true, user, onChanged: vi.fn() },
   });
-  const updateBtn = getByRole("button", { name: /update role/i }) as HTMLButtonElement;
+  const updateBtn = getByRole("button", { name: /change role/i }) as HTMLButtonElement;
   expect(updateBtn.disabled).toBe(true);
 });
 
@@ -102,7 +102,7 @@ test("confirming an elevation calls updateUserRole and fires onChanged on succes
   const adminOption = await waitFor(() => getByRole("option", { name: /^admin$/i }));
   await fireEvent.pointerUp(adminOption, { pointerId: 1, button: 0, pointerType: "mouse" });
 
-  const updateBtn = getByRole("button", { name: /update role/i }) as HTMLButtonElement;
+  const updateBtn = getByRole("button", { name: /change role/i }) as HTMLButtonElement;
   await waitFor(() => expect(updateBtn.disabled).toBe(false));
   await fireEvent.click(updateBtn);
 

--- a/apps/console/src/lib/components/fleet/AgentTable.svelte
+++ b/apps/console/src/lib/components/fleet/AgentTable.svelte
@@ -7,6 +7,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import * as Table from "$lib/components/ui/table";
   import { Empty } from "$lib/components/ui/empty";
+  import { Button } from "$lib/components/ui/button";
   import { cn } from "$lib/utils";
   import { toast } from "svelte-sonner";
   import StatusRibbon from "./StatusRibbon.svelte";
@@ -242,12 +243,19 @@
         // and the next fleet refresh will clear updateAvailable.
       } else {
         delete updatingNodes[nodeId];
-        toast.error("Update failed", { description: result.error ?? "Unknown error" });
+        toast.error("Couldn’t update the node", {
+          description:
+            result.error ??
+            "The node didn’t respond — it may already be restarting. Check back in a minute.",
+        });
       }
     } catch (err) {
       delete updatingNodes[nodeId];
-      toast.error("Update failed", {
-        description: err instanceof Error ? err.message : "Unknown error",
+      toast.error("Couldn’t update the node", {
+        description:
+          err instanceof Error
+            ? err.message
+            : "The node didn’t respond — it may already be restarting. Check back in a minute.",
       });
     }
   }
@@ -377,7 +385,18 @@
         {#if filteredAgents.length === 0}
           <Table.Row>
             <Table.Cell colspan={9} class="p-0">
-              <Empty title="No agents match the current filter" icon={SearchIcon} class="border-none rounded-none" />
+              <Empty title="No agents match the current filter" icon={SearchIcon} class="border-none rounded-none">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onclick={() => {
+                    searchQuery = "";
+                    filterUpdateAvailable = false;
+                  }}
+                >
+                  Clear filters
+                </Button>
+              </Empty>
             </Table.Cell>
           </Table.Row>
         {:else if groupByNode}

--- a/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte
+++ b/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte
@@ -72,8 +72,8 @@
     <Dialog.Overlay />
     <Dialog.Content showCloseButton={false}>
       <Dialog.Header>
-        <Dialog.Title class="font-mono">New Runtime</Dialog.Title>
-        <Dialog.Description>Provision a new managed node-agent runtime.</Dialog.Description>
+        <Dialog.Title>New runtime</Dialog.Title>
+        <Dialog.Description>Create a container that runs an agent for you.</Dialog.Description>
       </Dialog.Header>
 
       <div class="space-y-4 py-2">
@@ -161,7 +161,7 @@
           disabled={!name.trim() || isCreating}
           class="font-mono"
         >
-          {isCreating ? "Creating…" : "Create"}
+          {isCreating ? "Creating…" : "Create runtime"}
         </Button>
       </Dialog.Footer>
     </Dialog.Content>

--- a/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte.test.ts
@@ -71,7 +71,7 @@ test("Create button is disabled when name is empty", () => {
     },
   });
 
-  const createBtn = getByRole("button", { name: /^create$/i }) as HTMLButtonElement;
+  const createBtn = getByRole("button", { name: /^create runtime$/i }) as HTMLButtonElement;
   expect(createBtn.disabled).toBe(true);
 });
 
@@ -94,7 +94,7 @@ test("filling name and clicking Create calls provisionRuntime with correct value
   fireEvent.input(nameInput, { target: { value: "my-box" } });
 
   // Create button should be enabled now (provider defaults to "docker", tier defaults to "small")
-  const createBtn = getByRole("button", { name: /^create$/i }) as HTMLButtonElement;
+  const createBtn = getByRole("button", { name: /^create runtime$/i }) as HTMLButtonElement;
   await waitFor(() => expect(createBtn.disabled).toBe(false));
 
   fireEvent.click(createBtn);
@@ -139,7 +139,7 @@ test("provisionRuntime is called with harness field (default none) when creating
   const nameInput = getByPlaceholderText("Runtime name");
   fireEvent.input(nameInput, { target: { value: "test-box" } });
 
-  const createBtn = getByRole("button", { name: /^create$/i }) as HTMLButtonElement;
+  const createBtn = getByRole("button", { name: /^create runtime$/i }) as HTMLButtonElement;
   await waitFor(() => expect(createBtn.disabled).toBe(false));
 
   fireEvent.click(createBtn);
@@ -168,7 +168,7 @@ test("failed provisionRuntime shows inline error and does NOT call onClose", asy
   const nameInput = getByPlaceholderText("Runtime name");
   fireEvent.input(nameInput, { target: { value: "fail-box" } });
 
-  const createBtn = getByRole("button", { name: /^create$/i }) as HTMLButtonElement;
+  const createBtn = getByRole("button", { name: /^create runtime$/i }) as HTMLButtonElement;
   await waitFor(() => expect(createBtn.disabled).toBe(false));
 
   fireEvent.click(createBtn);

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte
@@ -188,12 +188,15 @@
         // version and the next nodes refresh will clear updateAvailable.
       } else {
         delete updatingNodes[id];
-        toast.error("Update failed", { description: result.error ?? "Unknown error" });
+        toast.error("Couldn’t update the node", { description: result.error ?? "The node didn’t respond — it may already be restarting. Check back in a minute." });
       }
     } catch (e) {
       delete updatingNodes[id];
-      toast.error("Update failed", {
-        description: e instanceof Error ? e.message : "Unknown error",
+      toast.error("Couldn’t update the node", {
+        description:
+          e instanceof Error
+            ? e.message
+            : "The node didn’t respond — it may already be restarting. Check back in a minute.",
       });
     }
   }

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte.test.ts
@@ -290,10 +290,11 @@ test("?action=new-runtime already in the URL at mount opens the New Runtime dial
   vi.spyOn(api, "listNodes").mockResolvedValue([]);
   setSearchParam("action", "new-runtime");
 
-  const { getByText } = render(NodesOverview);
+  const { getByRole } = render(NodesOverview);
 
   await waitFor(() => {
-    expect(getByText("New Runtime")).toBeTruthy();
+    // The dialog itself (not the header's "New runtime" button) must open.
+    expect(getByRole("dialog")).toBeTruthy();
     expect(nav.replaceState).toHaveBeenCalledWith("/nodes", {});
   });
 });
@@ -324,17 +325,17 @@ test("?action= appearing while already mounted on /nodes (same-route palette nav
   // which only ever runs once) picks it up.
   vi.spyOn(api, "listNodes").mockResolvedValue([]);
 
-  const { getByText, queryByText } = render(NodesOverview);
+  const { getByRole, queryByRole } = render(NodesOverview);
 
   await waitFor(() => {
     // No dialog on initial mount without the param.
-    expect(queryByText("New Runtime")).toBeNull();
+    expect(queryByRole("dialog")).toBeNull();
   });
 
   setSearchParam("action", "new-runtime");
 
   await waitFor(() => {
-    expect(getByText("New Runtime")).toBeTruthy();
+    expect(getByRole("dialog")).toBeTruthy();
     expect(nav.replaceState).toHaveBeenCalledWith("/nodes", {});
   });
 });

--- a/apps/console/src/lib/components/fleet/ProvisionedNodeControls.svelte
+++ b/apps/console/src/lib/components/fleet/ProvisionedNodeControls.svelte
@@ -37,7 +37,7 @@
       await goto("/");
     } catch (err) {
       destroyDialogOpen = false;
-      destroyError = err instanceof Error ? err.message : "Destroy failed";
+      destroyError = err instanceof Error ? err.message : "Couldn’t destroy the runtime.";
     } finally {
       destroyInFlight = false;
     }
@@ -51,7 +51,7 @@
       await stopRuntime(provisioned.runtimeId);
       onRefresh();
     } catch (err) {
-      actionError = err instanceof Error ? err.message : "Stop failed";
+      actionError = err instanceof Error ? err.message : "Couldn’t stop the runtime.";
     } finally {
       stopInFlight = false;
     }
@@ -65,7 +65,7 @@
       await startRuntime(provisioned.runtimeId);
       onRefresh();
     } catch (err) {
-      actionError = err instanceof Error ? err.message : "Start failed";
+      actionError = err instanceof Error ? err.message : "Couldn’t start the runtime.";
     } finally {
       startInFlight = false;
     }
@@ -130,7 +130,7 @@
   <TypeToConfirmDialog
     open={destroyDialogOpen}
     title="Destroy runtime"
-    message="This will permanently destroy the runtime and remove the node from the fleet. This action cannot be undone."
+    message="This will permanently destroy the runtime and remove the node from the fleet. This action can’t be undone."
     confirmPhrase={node.hostname}
     confirmLabel="Destroy"
     onConfirm={handleDestroy}

--- a/apps/console/src/lib/components/stations/ActivityPanel.svelte
+++ b/apps/console/src/lib/components/stations/ActivityPanel.svelte
@@ -24,7 +24,7 @@
     try {
       rows = await activity(stationId);
     } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to load activity";
+      error = err instanceof Error ? err.message : "Couldn’t load activity.";
     } finally {
       isLoading = false;
     }

--- a/apps/console/src/lib/components/stations/CleanupPanel.svelte
+++ b/apps/console/src/lib/components/stations/CleanupPanel.svelte
@@ -166,7 +166,7 @@
                   {item.path}
                 </span>
                 <span class="flex shrink-0 items-center gap-2">
-                  <span class="text-xs uppercase tracking-wide text-muted-foreground">
+                  <span class="text-xs text-muted-foreground">
                     {item.kind}
                   </span>
                   <span class="font-mono text-xs tabular-nums text-muted-foreground">
@@ -185,7 +185,7 @@
 <TypeToConfirmDialog
   open={dialogOpen}
   title="Apply cleanup"
-  message="This will permanently remove the selected {selectedPaths.length} item{selectedPaths.length === 1 ? '' : 's'}. Type the station ID below to confirm."
+  message="This will permanently remove the selected {selectedPaths.length} item{selectedPaths.length === 1 ? '' : 's'}. Type the agent ID below to confirm."
   confirmPhrase={stationId}
   confirmLabel="Delete items"
   onConfirm={handleDialogConfirm}

--- a/apps/console/src/lib/components/stations/ConfigEditor.svelte
+++ b/apps/console/src/lib/components/stations/ConfigEditor.svelte
@@ -49,7 +49,7 @@
       original = result.content;
       buffer = result.content;
     } catch (err) {
-      loadError = err instanceof Error ? err.message : "Failed to load file";
+      loadError = err instanceof Error ? err.message : "Couldn’t load this file.";
     } finally {
       isLoading = false;
     }
@@ -92,7 +92,7 @@
       backupPath = result.backupPath ?? null;
       onSaved?.(path);
     } catch (err) {
-      saveError = err instanceof Error ? err.message : "Failed to save";
+      saveError = err instanceof Error ? err.message : "Couldn’t save the file.";
     } finally {
       isSaving = false;
       showConfirm = false;
@@ -158,7 +158,7 @@
       {#if hasChanges}
         <div class="flex flex-col flex-1 overflow-auto border-t border-border bg-muted/10">
           <div class="px-3 py-1 text-xs font-sans text-muted-foreground border-b border-border/60">
-            Diff (original → buffer)
+            Changes
           </div>
           <div
             data-testid="diff-view"

--- a/apps/console/src/lib/components/stations/FileBrowser.svelte
+++ b/apps/console/src/lib/components/stations/FileBrowser.svelte
@@ -17,7 +17,7 @@
     /** Show write actions when the station advertises fs.write capability. */
     canWrite?: boolean;
     /**
-     * Called when the user clicks "Edit (diff)" on a file.
+     * Called when the user clicks "Edit" on a file.
      * The station page uses this to open the ConfigEditor modal.
      * Only invoked when canWrite is true.
      */
@@ -148,7 +148,7 @@
       next.set(path, result);
       contentCache = next;
     } catch (err) {
-      fileError = err instanceof Error ? err.message : "Failed to read file";
+      fileError = err instanceof Error ? err.message : "Couldn’t read this file.";
     } finally {
       isLoadingFile = false;
     }
@@ -293,7 +293,7 @@
                   class="h-7 px-2 text-xs font-sans"
                   onclick={() => onOpenConfigEditor!(activePath!)}
                 >
-                  Edit (diff)
+                  Edit
                 </Button>
               {/if}
             </div>

--- a/apps/console/src/lib/components/stations/FileBrowser.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/FileBrowser.svelte.test.ts
@@ -181,7 +181,7 @@ test("FileBrowser: new folder button calls mkdir", async () => {
   });
 });
 
-test("FileBrowser: 'Edit (diff)' button calls onOpenConfigEditor with the file path", async () => {
+test("FileBrowser: 'Edit' button calls onOpenConfigEditor with the file path", async () => {
   vi.spyOn(api, "listFiles").mockResolvedValue([mockFile]);
   vi.spyOn(api, "readFile").mockResolvedValue({ content: "# Hello", truncated: false });
 
@@ -196,12 +196,12 @@ test("FileBrowser: 'Edit (diff)' button calls onOpenConfigEditor with the file p
   // Click the file to open the preview
   fireEvent.click(getByText("README.md"));
 
-  // Wait for file content to load and "Edit (diff)" to appear
+  // Wait for file content to load and "Edit" to appear
   await waitFor(() => {
-    expect(getByRole("button", { name: /edit \(diff\)/i })).toBeTruthy();
+    expect(getByRole("button", { name: /^edit$/i })).toBeTruthy();
   });
 
-  fireEvent.click(getByRole("button", { name: /edit \(diff\)/i }));
+  fireEvent.click(getByRole("button", { name: /^edit$/i }));
 
   expect(onOpenConfigEditor).toHaveBeenCalledWith("README.md");
 });
@@ -292,7 +292,7 @@ test("FileBrowser: shows a metadata card instead of fetching binary files", asyn
   fireEvent.click(getByText("logo.png"));
 
   await waitFor(() => {
-    expect(getByText(/preview not available/i)).toBeTruthy();
+    expect(getByText(/can’t preview this file type/i)).toBeTruthy();
   });
   expect(readFileSpy).not.toHaveBeenCalled();
   // 2048 bytes → "2.0 KB" via the metadata card's size formatting.

--- a/apps/console/src/lib/components/stations/HealthPanel.svelte
+++ b/apps/console/src/lib/components/stations/HealthPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { stationHealth, lifecycle } from "$lib/api/client";
-  import TypeToConfirmDialog from "$lib/components/ui/TypeToConfirmDialog.svelte";
+  import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Status } from "$lib/components/ui/status";
@@ -32,7 +32,7 @@
     try {
       health = await stationHealth(stationId);
     } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to load health";
+      error = err instanceof Error ? err.message : "Couldn’t read this agent’s health — the node may be offline.";
     } finally {
       isLoading = false;
     }
@@ -115,7 +115,7 @@
 
 {#if isLoading}
   <div class="p-4 space-y-3">
-    <p class="text-sm text-muted-foreground">Loading health data…</p>
+    
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {#each Array(8) as _, i (i)}
         <Skeleton class="h-14 rounded-lg" />
@@ -240,12 +240,15 @@
   </div>
 
   {#if canLifecycle}
-    <TypeToConfirmDialog
+    <!-- Stop/restart are reversible, routine actions — a plain confirm is
+         the right escalation. Type-to-confirm stays reserved for destroy
+         and permanent deletion. -->
+    <ConfirmDialog
       open={dialogOpen}
-      title="{pendingAction === 'stop' ? 'Stop' : 'Restart'} station"
-      message="This will {pendingAction} the station process. Type the station ID below to confirm."
-      confirmPhrase={stationId}
+      title="{pendingAction === 'stop' ? 'Stop' : 'Restart'} agent"
+      message="This will {pendingAction} the agent process."
       confirmLabel={pendingAction === "stop" ? "Stop agent" : "Restart agent"}
+      destructive={pendingAction === "stop"}
       onConfirm={handleDialogConfirm}
       onCancel={handleDialogCancel}
     />

--- a/apps/console/src/lib/components/stations/HealthPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/HealthPanel.svelte.test.ts
@@ -65,12 +65,11 @@ test("HealthPanel shows loading then data", async () => {
 
   const { getByText, queryByText } = render(HealthPanel, { props: { stationId: "station_3" } });
 
-  // loading state
-  expect(getByText(/loading/i)).toBeTruthy();
+  // loading state: skeleton only, no data yet
+  expect(queryByText(/12345/)).toBeNull();
 
   resolve(healthFull);
   await waitFor(() => {
-    expect(queryByText(/loading/i)).toBeNull();
     expect(getByText(/12345/)).toBeTruthy();
   });
 });
@@ -129,7 +128,7 @@ test("HealthPanel: Start (on a stopped agent) calls lifecycle immediately withou
   expect(queryByRole("dialog")).toBeNull();
 });
 
-test("HealthPanel: Stop opens type-to-confirm dialog; confirming calls lifecycle stop", async () => {
+test("HealthPanel: Stop opens confirm dialog; confirming calls lifecycle stop", async () => {
   vi.spyOn(api, "stationHealth").mockResolvedValue(healthFull);
   vi.spyOn(api, "lifecycle").mockResolvedValue(healthFull);
 
@@ -147,26 +146,17 @@ test("HealthPanel: Stop opens type-to-confirm dialog; confirming calls lifecycle
   // lifecycle must NOT be called before confirming
   expect(api.lifecycle).not.toHaveBeenCalled();
 
-  // Type the confirm phrase (= stationId)
+  // Routine stop is a plain confirm (no type-to-confirm), labeled with the action
   const dialog = getByRole("dialog");
-  fireEvent.input(within(dialog).getByRole("textbox"), {
-    target: { value: "station_lc" },
-  });
-
-  // Confirm button unlocks — labeled with the action, never a bare "Confirm"
-  await waitFor(() => {
-    const btn = getByRole("button", { name: "Stop agent" }) as HTMLButtonElement;
-    expect(btn.disabled).toBe(false);
-  });
-
-  fireEvent.click(getByRole("button", { name: "Stop agent" }));
+  expect(within(dialog).queryByRole("textbox")).toBeNull();
+  fireEvent.click(within(dialog).getByRole("button", { name: "Stop agent" }));
 
   await waitFor(() =>
     expect(api.lifecycle).toHaveBeenCalledWith("station_lc", "stop"),
   );
 });
 
-test("HealthPanel: Restart opens type-to-confirm dialog; confirming calls lifecycle restart", async () => {
+test("HealthPanel: Restart opens confirm dialog; confirming calls lifecycle restart", async () => {
   vi.spyOn(api, "stationHealth").mockResolvedValue(healthFull);
   vi.spyOn(api, "lifecycle").mockResolvedValue(healthFull);
 
@@ -181,16 +171,8 @@ test("HealthPanel: Restart opens type-to-confirm dialog; confirming calls lifecy
   await waitFor(() => expect(getByRole("dialog")).toBeTruthy());
 
   const dialog = getByRole("dialog");
-  fireEvent.input(within(dialog).getByRole("textbox"), {
-    target: { value: "station_lc" },
-  });
-
-  await waitFor(() => {
-    const btn = getByRole("button", { name: "Restart agent" }) as HTMLButtonElement;
-    expect(btn.disabled).toBe(false);
-  });
-
-  fireEvent.click(getByRole("button", { name: "Restart agent" }));
+  expect(within(dialog).queryByRole("textbox")).toBeNull();
+  fireEvent.click(within(dialog).getByRole("button", { name: "Restart agent" }));
 
   await waitFor(() =>
     expect(api.lifecycle).toHaveBeenCalledWith("station_lc", "restart"),

--- a/apps/console/src/lib/components/stations/LogTail.svelte
+++ b/apps/console/src/lib/components/stations/LogTail.svelte
@@ -389,7 +389,7 @@
       <DownloadIcon class="size-3.5" aria-hidden="true" />
     </Button>
 
-    <span class="ml-auto shrink-0 text-muted-foreground">{lines.length} lines</span>
+    <span class="ml-auto shrink-0 text-muted-foreground">{lines.length} {lines.length === 1 ? "line" : "lines"}</span>
   </div>
 
   <!-- Log lines -->
@@ -401,11 +401,16 @@
       onscroll={handleScroll}
     >
       {#if lines.length === 0 && status === "connected"}
-        <Empty title="No log output yet" icon={TerminalIcon} class="border-none" />
+        <Empty
+          title="No log output yet"
+          description="The agent is connected but hasn’t logged anything."
+          icon={TerminalIcon}
+          class="border-none"
+        />
       {:else if lines.length === 0}
         <div class="px-3 py-1 italic text-muted-foreground">Waiting for log output…</div>
       {:else if visibleLines.length === 0}
-        <div class="px-3 py-1 italic text-muted-foreground">No lines match the current filter.</div>
+        <div class="px-3 py-1 italic text-muted-foreground">No lines match the current filter</div>
       {:else}
         {#each visibleLines as line, i (i)}
           <div
@@ -429,7 +434,7 @@
         class="absolute bottom-2 left-1/2 -translate-x-1/2 flex items-center gap-1 rounded-full border bg-background px-3 py-1 text-xs shadow-md hover:bg-muted"
         onclick={jumpToBottom}
       >
-        {newLinesCount} new lines
+        {newLinesCount} new {newLinesCount === 1 ? "line" : "lines"}
         <ArrowDownIcon class="size-3" aria-hidden="true" />
       </button>
     {/if}

--- a/apps/console/src/lib/components/stations/StationTree.svelte
+++ b/apps/console/src/lib/components/stations/StationTree.svelte
@@ -93,7 +93,7 @@
 
 <div class="flex flex-col gap-0.5 rounded-xl border bg-card p-2">
   {#if roots.length === 0}
-    <p class="text-sm text-muted-foreground p-2">No stations adopted.</p>
+    <p class="text-sm text-muted-foreground p-2">No agents added.</p>
   {:else}
     {#each roots as root (root.id)}
       {@render stationNode(root, 0)}

--- a/apps/console/src/lib/components/stations/StationTree.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/StationTree.svelte.test.ts
@@ -104,7 +104,7 @@ test("StationTree shows empty state when no stations", () => {
     },
   });
 
-  expect(getByText("No stations adopted.")).toBeTruthy();
+  expect(getByText("No agents added.")).toBeTruthy();
 });
 
 test("StationTree toggle expand/collapse on parent with children", async () => {

--- a/apps/console/src/lib/components/stations/file-preview.svelte
+++ b/apps/console/src/lib/components/stations/file-preview.svelte
@@ -60,12 +60,12 @@
         <div class="flex max-w-sm flex-col items-center gap-2 rounded-lg border border-dashed border-border p-8 text-center">
           <FileIcon filename={entry.name} size="lg" />
           <p class="text-sm font-medium text-foreground">{entry.name}</p>
-          <p class="text-xs text-muted-foreground">Binary/Image file</p>
+          <p class="text-xs text-muted-foreground">Binary file</p>
           <p class="text-xs text-muted-foreground">
             {formatBytes(entry.size)} · modified {relativeTime(entry.modified)}
           </p>
           <p class="text-xs text-muted-foreground/80">
-            Preview not available over the station API
+            Can’t preview this file type
           </p>
         </div>
       </div>
@@ -114,7 +114,7 @@
 
   {#if content !== null && !isBinary}
     <div class="shrink-0 border-t border-border/60 px-3 py-1 font-mono text-xs text-muted-foreground">
-      {(isMarkdown ? "markdown" : ext || "plaintext").toUpperCase()} · {formatBytes(entry.size)} · modified {relativeTime(entry.modified)}
+      {isMarkdown ? "Markdown" : ext || "plain text"} · {formatBytes(entry.size)} · modified {relativeTime(entry.modified)}
     </div>
   {/if}
 </div>

--- a/apps/console/src/lib/components/stations/file-tree.svelte
+++ b/apps/console/src/lib/components/stations/file-tree.svelte
@@ -79,7 +79,7 @@
       rootEntries = await listFiles(stationId, "");
       onEntriesLoaded?.("", rootEntries);
     } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to load directory";
+      error = err instanceof Error ? err.message : "Couldn’t load this folder.";
     } finally {
       isLoading = false;
     }
@@ -379,7 +379,7 @@
 <TypeToConfirmDialog
   open={deleteTarget !== null}
   title="Delete {deleteTarget?.name ?? ''}"
-  message="This will permanently delete {deleteTarget?.name ?? ''}. This action cannot be undone."
+  message="This will permanently delete {deleteTarget?.name ?? ''}. This action can’t be undone."
   confirmPhrase={deleteTarget?.name ?? ""}
   confirmLabel={deleteTarget?.type === "dir" ? "Delete folder" : "Delete file"}
   onConfirm={handleDelete}

--- a/apps/console/src/lib/components/theme-settings.svelte
+++ b/apps/console/src/lib/components/theme-settings.svelte
@@ -137,8 +137,8 @@
   <!-- Tabs for Color Scheme and Font Pairing -->
   <Tabs.Root value="colors" class="w-full">
     <Tabs.List class="grid w-full grid-cols-2">
-      <Tabs.Trigger value="colors">Color Schemes</Tabs.Trigger>
-      <Tabs.Trigger value="fonts">Font Pairings</Tabs.Trigger>
+      <Tabs.Trigger value="colors">Color schemes</Tabs.Trigger>
+      <Tabs.Trigger value="fonts">Font pairings</Tabs.Trigger>
     </Tabs.List>
 
     <!-- Color Schemes Tab -->
@@ -153,10 +153,10 @@
           }}
         >
           <Select.Trigger class="w-48">
-            {selectedColorCategory === "all" ? "All Categories" : getColorCategoryLabel(selectedColorCategory)}
+            {selectedColorCategory === "all" ? "All categories" : getColorCategoryLabel(selectedColorCategory)}
           </Select.Trigger>
           <Select.Content class="font-mono">
-            <Select.Item value="all" label="All Categories" />
+            <Select.Item value="all" label="All categories" />
             {#each colorSchemeCategories as category}
               <Select.Item value={category.id} label={category.label} />
             {/each}
@@ -225,7 +225,7 @@
             <div>
               <p class="text-sm font-mono font-medium text-primary">{themeStore.currentColorScheme.label}</p>
               <p class="text-xs text-muted-foreground font-mono capitalize">
-                {themeStore.currentColorScheme.category} · Shiki: {themeStore.shikiThemes.light}/{themeStore.shikiThemes.dark}
+                {themeStore.currentColorScheme.category}
               </p>
             </div>
             <div class="flex gap-1">
@@ -262,10 +262,10 @@
           }}
         >
           <Select.Trigger class="w-48">
-            {selectedFontCategory === "all" ? "All Categories" : getFontCategoryLabel(selectedFontCategory)}
+            {selectedFontCategory === "all" ? "All categories" : getFontCategoryLabel(selectedFontCategory)}
           </Select.Trigger>
           <Select.Content class="font-mono">
-            <Select.Item value="all" label="All Categories" />
+            <Select.Item value="all" label="All categories" />
             {#each fontPairingCategories as category}
               <Select.Item value={category.id} label={category.label} />
             {/each}

--- a/apps/console/src/lib/components/ui/status/status.svelte
+++ b/apps/console/src/lib/components/ui/status/status.svelte
@@ -54,7 +54,7 @@
   <span data-status={token} class={cn("inline-flex shrink-0", className)}>
     <span
       class={cn(
-        "size-2 rounded-full",
+        "size-2 rounded-full transition-colors duration-200",
         statusBgClass(status),
         animate && "motion-safe:animate-pulse",
       )}
@@ -67,6 +67,6 @@
     data-status={token}
     role="img"
     aria-label={display}
-    class={cn("block rounded-[2px]", statusBgClass(status), className)}
+    class={cn("block rounded-[2px] transition-colors duration-200", statusBgClass(status), className)}
   ></span>
 {/if}

--- a/apps/console/src/lib/stores/auth.svelte.ts
+++ b/apps/console/src/lib/stores/auth.svelte.ts
@@ -162,7 +162,7 @@ export async function initAuth(): Promise<void> {
     // Session fetch failed (network error, etc.) — stay unauthenticated but
     // surface the error so the UI can reflect the failed restore attempt.
     console.warn("[Auth] Failed to restore session:", err);
-    error = err instanceof Error ? err.message : "Failed to restore session";
+    error = err instanceof Error ? err.message : "Couldn’t restore your session.";
   } finally {
     isLoading = false;
     isInitialized = true;
@@ -194,7 +194,7 @@ export async function login(): Promise<boolean> {
 
     return true;
   } catch (err) {
-    error = err instanceof Error ? err.message : "Failed to start login";
+    error = err instanceof Error ? err.message : "Couldn’t start sign-in.";
     return false;
   } finally {
     isLoading = false;
@@ -240,7 +240,7 @@ export async function loginWithEmail(emailInput: string, password: string): Prom
 
     return true;
   } catch (err) {
-    error = err instanceof Error ? err.message : "Failed to sign in";
+    error = err instanceof Error ? err.message : "Couldn’t sign in.";
     return false;
   } finally {
     isLoading = false;
@@ -286,7 +286,7 @@ export async function signUp(emailInput: string, password: string, name: string)
 
     return true;
   } catch (err) {
-    error = err instanceof Error ? err.message : "Failed to sign up";
+    error = err instanceof Error ? err.message : "Couldn’t create the account.";
     return false;
   } finally {
     isLoading = false;

--- a/apps/console/src/lib/stores/connection.svelte.ts
+++ b/apps/console/src/lib/stores/connection.svelte.ts
@@ -90,7 +90,7 @@ export async function connect(apiUrl: string, _apiKey?: string): Promise<boolean
         connected: false,
         apiUrl,
         lastTested: new Date().toISOString(),
-        error: "Health check failed",
+        error: "Couldn’t reach the hub.",
       };
       return false;
     }

--- a/apps/console/src/lib/stores/stations.svelte.ts
+++ b/apps/console/src/lib/stores/stations.svelte.ts
@@ -17,7 +17,7 @@ export const stations = {
 export async function loadDetected(nodeId: string): Promise<void> {
   isLoading = true; error = null;
   try { detected = await api.listDetected(nodeId); }
-  catch (e) { error = e instanceof Error ? e.message : "failed to load detected stations"; }
+  catch (e) { error = e instanceof Error ? e.message : "Couldn’t load detected agents."; }
   finally { isLoading = false; }
 }
 
@@ -27,13 +27,13 @@ export async function adopt(nodeId: string, keys: string[]): Promise<void> {
     await api.adoptStations(nodeId, keys);
     adopted = await api.listStations(nodeId);
   }
-  catch (e) { error = e instanceof Error ? e.message : "failed to adopt stations"; }
+  catch (e) { error = e instanceof Error ? e.message : "Couldn’t add the agents."; }
   finally { isLoading = false; }
 }
 
 export async function loadAdopted(nodeId: string): Promise<void> {
   isLoading = true; error = null;
   try { adopted = await api.listStations(nodeId); }
-  catch (e) { error = e instanceof Error ? e.message : "failed to load adopted stations"; }
+  catch (e) { error = e instanceof Error ? e.message : "Couldn’t load your agents."; }
   finally { isLoading = false; }
 }

--- a/apps/console/src/lib/utils/relative-time.test.ts
+++ b/apps/console/src/lib/utils/relative-time.test.ts
@@ -2,7 +2,7 @@
  * relative-time.test.ts
  *
  * Unit tests for relativeTime(dateStr) — widened to accept `string | null`
- * so file-preview.svelte's local copy (which handled `null` → "unknown")
+ * so file-preview.svelte's local copy (which handled `null` → "—")
  * can be deleted in favor of this shared util. Existing callers
  * (RecentActivity, activity page) never pass null and keep their behavior.
  *
@@ -18,7 +18,7 @@ function isoAgo(ms: number): string {
 
 describe("relativeTime", () => {
   test("null → \"unknown\"", () => {
-    expect(relativeTime(null)).toBe("unknown");
+    expect(relativeTime(null)).toBe("—");
   });
 
   test("just now (< 1 minute ago)", () => {

--- a/apps/console/src/lib/utils/relative-time.ts
+++ b/apps/console/src/lib/utils/relative-time.ts
@@ -12,7 +12,7 @@
  */
 
 export function relativeTime(dateStr: string | null): string {
-  if (dateStr === null) return "unknown";
+  if (dateStr === null) return "—";
   try {
     const diff = Date.now() - new Date(dateStr).getTime();
     if (Number.isNaN(diff)) return "?";

--- a/apps/console/src/routes/activity/+page.svelte
+++ b/apps/console/src/routes/activity/+page.svelte
@@ -37,7 +37,7 @@
     try {
       rows = await listActivity();
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to load activity";
+      error = e instanceof Error ? e.message : "Couldn’t load activity.";
     } finally {
       isLoading = false;
     }
@@ -52,12 +52,12 @@
   const columns: ColumnDef<ActivityRow>[] = [
     {
       accessorKey: "verb",
-      header: "Verb",
+      header: "Action",
       cell: (ctx) => renderSnippet(verbCell, { value: ctx.getValue<string>() }),
     },
     {
       id: "station",
-      header: "Station",
+      header: "Agent",
       accessorFn: (row) => row.stationKey ?? "—",
     },
     {

--- a/apps/console/src/routes/admin/+layout.svelte
+++ b/apps/console/src/routes/admin/+layout.svelte
@@ -33,7 +33,7 @@
       }
     } catch (e) {
       const err = e as Error;
-      error = err.message || "Failed to verify admin status";
+      error = err.message || "Couldn’t verify admin access.";
     } finally {
       isChecking = false;
     }

--- a/apps/console/src/routes/admin/users/+page.svelte
+++ b/apps/console/src/routes/admin/users/+page.svelte
@@ -114,7 +114,7 @@
       stats = statsResponse;
       signupEnabled = signupResponse.enabled;
     } catch (e) {
-      error = (e as Error).message || "Failed to load users";
+      error = (e as Error).message || "Couldn’t load users.";
     } finally {
       isLoading = false;
     }
@@ -149,7 +149,7 @@
       toast.success(`${user.email} has been unbanned`);
       await loadData();
     } catch (e) {
-      toast.error("Failed to unban user", { description: (e as Error).message });
+      toast.error("Couldn’t unban user", { description: (e as Error).message });
     } finally {
       delete actionLoading[user.id];
     }
@@ -168,7 +168,7 @@
         toast.success("Public signup enabled");
       }
     } catch (e) {
-      toast.error("Failed to update signup settings", { description: (e as Error).message });
+      toast.error("Couldn’t update signup settings", { description: (e as Error).message });
     } finally {
       signupLoading = false;
     }

--- a/apps/console/src/routes/admin/users/[id]/+page.svelte
+++ b/apps/console/src/routes/admin/users/[id]/+page.svelte
@@ -46,7 +46,7 @@
       user = response.user;
     } catch (e) {
       const err = e as Error;
-      error = err.message || "Failed to load user";
+      error = err.message || "Couldn’t load this user.";
     } finally {
       isLoading = false;
     }
@@ -67,7 +67,7 @@
       loadUser();
     } catch (e) {
       const err = e as Error;
-      toast.error("Failed to unban user", { description: err.message });
+      toast.error("Couldn’t unban user", { description: err.message });
     } finally {
       actionLoading = false;
     }
@@ -81,9 +81,9 @@
 <main class="flex h-screen flex-col overflow-hidden">
   <!-- Header -->
   <PageHeader
-    title={user?.name || user?.email || "User Details"}
+    title={user?.name || user?.email || "User details"}
     icon={UserIcon}
-    subtitle={user?.email || "Loading..."}
+    subtitle={user?.email ?? undefined}
     status={user
       ? user.banned
         ? { label: "Banned", variant: "error" }
@@ -156,7 +156,7 @@
                 data-testid="change-role"
               >
                 <ShieldIcon class="mr-2 h-4 w-4" />
-                Change Role
+                Change role
               </Button>
               {#if user.banned}
                 <Button variant="outline" onclick={handleUnban} disabled={actionLoading}>
@@ -171,7 +171,7 @@
                   class="border-destructive/50 text-destructive hover:bg-destructive/10"
                 >
                   <BanIcon class="mr-2 h-4 w-4" />
-                  Ban User
+                  Ban user
                 </Button>
               {/if}
             </div>
@@ -200,7 +200,7 @@
               <p class="font-mono text-xs">{formatDate(user.createdAt, "long")}</p>
             </div>
             <div>
-              <p class="text-xs text-muted-foreground">Email Verified</p>
+              <p class="text-xs text-muted-foreground">Email verified</p>
               <p class="text-xs">{user.emailVerified ? "Yes" : "No"}</p>
             </div>
           </div>

--- a/apps/console/src/routes/admin/users/page.svelte.test.ts
+++ b/apps/console/src/routes/admin/users/page.svelte.test.ts
@@ -224,7 +224,7 @@ test("role badge opens the role dialog", async () => {
     totalPages: 1,
   });
 
-  const { getAllByTestId, getByText } = render(UsersPage);
+  const { getAllByTestId, getAllByText } = render(UsersPage);
 
   await waitFor(() => {
     expect(getAllByTestId("role-badge").length).toBe(1);
@@ -233,7 +233,7 @@ test("role badge opens the role dialog", async () => {
   await fireEvent.click(getAllByTestId("role-badge")[0]);
 
   await waitFor(() => {
-    expect(getByText("Change role")).toBeTruthy();
+    expect(getAllByText("Change role").length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/apps/console/src/routes/login/+page.svelte
+++ b/apps/console/src/routes/login/+page.svelte
@@ -74,7 +74,7 @@
       // one is found, otherwise the login form is shown.
       await initAuth();
     } else {
-      connectionError = connection.error || "Connection failed";
+      connectionError = connection.error || "Couldn’t reach the hub. Check the URL and that the hub is running.";
     }
 
     isConnecting = false;
@@ -149,7 +149,7 @@
     {#if step === "setup"}
       <!-- Setup Step -->
       <form onsubmit={handleSetup} class="space-y-5">
-        <Field label="API Endpoint" for="api-url" description="Enter your AgentPod Management API URL">
+        <Field label="Hub URL" for="api-url" description="Where your AgentPod hub is running.">
           <Input
             id="api-url"
             name="hub-url"
@@ -275,7 +275,7 @@
 
         <!-- Change server -->
         <Button variant="ghost" class="w-full text-muted-foreground hover:text-foreground" onclick={disconnect}>
-          ← Use different server
+          Use a different hub
         </Button>
       </div>
     {/if}

--- a/apps/console/src/routes/login/page.svelte.test.ts
+++ b/apps/console/src/routes/login/page.svelte.test.ts
@@ -5,7 +5,7 @@
  * RED → implement +page.svelte → GREEN.
  *
  * Asserts:
- *  - Disconnected → shows the connect (setup) form: API Endpoint field + Connect button
+ *  - Disconnected → shows the connect (setup) form: Hub URL field + Connect button
  *  - Connected → shows the sign-in form, and toggling switches to signup (Name field appears)
  *  - Connected + signup disabled → toggle is blocked and the disabled message is shown
  */
@@ -95,7 +95,7 @@ beforeEach(() => {
 
 test("disconnected shows the connect form", () => {
   const { getByLabelText, getByRole } = render(LoginPage);
-  expect(getByLabelText("API Endpoint")).toBeTruthy();
+  expect(getByLabelText("Hub URL")).toBeTruthy();
   expect(getByRole("button", { name: "Connect" })).toBeTruthy();
 });
 

--- a/apps/console/src/routes/nodes/[id]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/+page.svelte
@@ -56,12 +56,15 @@
         // new version; next refresh clears updateAvailable.
       } else {
         updating = false;
-        toast.error("Update failed", { description: result.error ?? "Unknown error" });
+        toast.error("Couldn’t update the node", { description: result.error ?? "The node didn’t respond — it may already be restarting. Check back in a minute." });
       }
     } catch (e) {
       updating = false;
-      toast.error("Update failed", {
-        description: e instanceof Error ? e.message : "Unknown error",
+      toast.error("Couldn’t update the node", {
+        description:
+          e instanceof Error
+            ? e.message
+            : "The node didn’t respond — it may already be restarting. Check back in a minute.",
       });
     }
   }
@@ -104,7 +107,7 @@
   {#snippet actions()}
     {#if node}
       <span class="text-xs font-mono text-muted-foreground">
-        {node.agentVersion ?? "unknown"}
+        {node.agentVersion ?? "—"}
       </span>
       {#if node.updateAvailable}
         <span class="text-xs text-status-degraded">
@@ -135,8 +138,8 @@
   <section class="space-y-3">
     <div class="flex items-center justify-between gap-4">
       <div>
-        <h2 class="t-section">Detected stations</h2>
-        <p class="text-sm text-muted-foreground">Ready to adopt</p>
+        <h2 class="t-section">Detected agents</h2>
+        <p class="text-sm text-muted-foreground">Found on this node, not yet added</p>
       </div>
       {#if stations.detected.filter((s) => !isAlreadyAdopted(s.key)).length > 0}
         <Button
@@ -146,7 +149,7 @@
           disabled={stations.isLoading}
           class="shrink-0"
         >
-          Adopt all
+          Add all agents
         </Button>
       {/if}
     </div>
@@ -158,7 +161,12 @@
         {/each}
       </div>
     {:else if stations.detected.length === 0}
-      <Empty title="No stations detected" />
+      <Empty
+        title="No agents found on this node"
+        description="AgentPod looks for hermes, openclaw, claude-code, codex, and opencode. Start one and rescan."
+      >
+        <Button variant="outline" size="sm" onclick={loadStations}>Rescan</Button>
+      </Empty>
     {:else}
       <div class="flex flex-col gap-2 md:grid md:grid-cols-2 lg:grid-cols-3">
         {#each stations.detected as s (s.key)}
@@ -181,10 +189,10 @@
                   disabled={stations.isLoading}
                   class="shrink-0"
                 >
-                  Adopt
+                  Add agent
                 </Button>
               {:else}
-                <Badge variant="secondary" class="shrink-0">Adopted</Badge>
+                <Badge variant="secondary" class="shrink-0">Added</Badge>
               {/if}
             </Card.Content>
           </Card.Root>
@@ -193,12 +201,9 @@
     {/if}
   </section>
 
-  <!-- Adopted Stations section -->
+  <!-- Your agents section -->
   <section class="space-y-3">
-    <div>
-      <h2 class="t-section">Adopted stations</h2>
-      <p class="text-sm text-muted-foreground">Active workspaces</p>
-    </div>
+    <h2 class="t-section">Your agents</h2>
 
     {#if stations.isLoading}
       <div class="flex flex-col gap-2">
@@ -207,7 +212,10 @@
         {/each}
       </div>
     {:else if stations.adopted.length === 0}
-      <Empty title="No stations adopted yet" />
+      <Empty
+        title="No agents added yet"
+        description="Add a detected agent above to start monitoring it."
+      />
     {:else}
       <StationTree stations={stations.adopted} nodeId={id} />
     {/if}

--- a/apps/console/src/routes/nodes/[id]/page.svelte.test.ts
+++ b/apps/console/src/routes/nodes/[id]/page.svelte.test.ts
@@ -7,9 +7,9 @@
  * Asserts:
  *  - renders hostname + status badge
  *  - detected station card's Adopt button calls adopt(id, [key])
- *  - "Adopt all" calls adopt(id, allUnadoptedKeys)
+ *  - "Add all agents" calls adopt(id, allUnadoptedKeys)
  *  - detected-empty state renders "No stations detected"
- *  - adopted-empty state renders "No stations adopted yet"
+ *  - adopted-empty state renders the added-empty state
  *  - StationTree renders adopted stations (presence via station name)
  */
 
@@ -128,9 +128,9 @@ test("detected station card's Adopt button calls adopt(id, [key])", async () => 
 
   await waitFor(() => {
     expect(getByText("Workspace")).toBeTruthy();
-    expect((getByText("Adopt") as HTMLButtonElement).disabled).toBe(false);
+    expect((getByText("Add agent") as HTMLButtonElement).disabled).toBe(false);
   });
-  getByText("Adopt").click();
+  getByText("Add agent").click();
 
   await waitFor(() => {
     expect(adoptSpy).toHaveBeenCalledWith("node_1", ["claude://workspace"]);
@@ -146,14 +146,14 @@ test("Adopt all calls adopt(id, allUnadoptedKeys)", async () => {
   const { getByText } = render(NodeDetailPage);
 
   // The stations store toggles a single shared `isLoading` flag across its
-  // concurrent loadDetected/loadAdopted calls, so the "Adopt all" button can
+  // concurrent loadDetected/loadAdopted calls, so the "Add all agents" button can
   // briefly render present-but-disabled before both loaders settle. Wait for
   // it to be enabled (not merely present) before clicking.
   await waitFor(() => {
-    const btn = getByText("Adopt all") as HTMLButtonElement;
+    const btn = getByText("Add all agents") as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
   });
-  getByText("Adopt all").click();
+  getByText("Add all agents").click();
 
   await waitFor(() => {
     expect(adoptSpy).toHaveBeenCalledWith("node_1", [
@@ -171,7 +171,7 @@ test("shows detected-empty state", async () => {
   const { getByText } = render(NodeDetailPage);
 
   await waitFor(() => {
-    expect(getByText("No stations detected")).toBeTruthy();
+    expect(getByText("No agents found on this node")).toBeTruthy();
   });
 });
 
@@ -183,7 +183,7 @@ test("shows adopted-empty state", async () => {
   const { getByText } = render(NodeDetailPage);
 
   await waitFor(() => {
-    expect(getByText("No stations adopted yet")).toBeTruthy();
+    expect(getByText("No agents added yet")).toBeTruthy();
   });
 });
 

--- a/apps/console/src/routes/runtimes/+page.svelte
+++ b/apps/console/src/routes/runtimes/+page.svelte
@@ -45,7 +45,7 @@
     try {
       runtimes = await listRuntimes();
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to load runtimes";
+      error = e instanceof Error ? e.message : "Couldn’t load runtimes.";
     } finally {
       isLoading = false;
     }
@@ -80,7 +80,7 @@
       isLoading = true;
       await loadRuntimes();
     } catch (e) {
-      toast.error("Destroy failed", {
+      toast.error("Couldn’t destroy the runtime", {
         description: e instanceof Error ? e.message : "Unknown error",
       });
     } finally {
@@ -94,7 +94,7 @@
       await startRuntime(rt.id);
       await loadRuntimes();
     } catch (e) {
-      toast.error("Start failed", {
+      toast.error("Couldn’t start the runtime", {
         description: e instanceof Error ? e.message : "Unknown error",
       });
     } finally {
@@ -108,7 +108,7 @@
       await stopRuntime(rt.id);
       await loadRuntimes();
     } catch (e) {
-      toast.error("Stop failed", {
+      toast.error("Couldn’t stop the runtime", {
         description: e instanceof Error ? e.message : "Unknown error",
       });
     } finally {
@@ -271,7 +271,7 @@
       >
         <Button onclick={() => (showNewRuntimeDialog = true)} data-testid="empty-new-runtime-btn">
           <PlusIcon class="h-4 w-4 mr-2" />
-          Provision runtime
+          New runtime
         </Button>
       </Empty>
     </div>
@@ -294,7 +294,7 @@
 <TypeToConfirmDialog
   open={destroyTarget !== null}
   title="Destroy runtime"
-  message="This will permanently destroy the runtime. This action cannot be undone."
+  message="This will permanently destroy the runtime. This action can’t be undone."
   confirmPhrase={destroyTarget?.name ?? ""}
   confirmLabel="Destroy"
   onConfirm={handleDestroyConfirm}

--- a/apps/console/src/routes/settings/+page.svelte
+++ b/apps/console/src/routes/settings/+page.svelte
@@ -42,7 +42,7 @@
       </p>
     </div>
     <Button variant="outline" onclick={handleDisconnect}>
-      Use different server
+      Use a different hub
     </Button>
   </div>
 


### PR DESCRIPTION
Final substantive milestone from the UI audit — the copy/vocabulary findings (P2-4) and remaining motion hygiene (P2-5).

## One noun per entity (UI strings only — no code identifiers changed)
- **agent**, never station: "Detected agents" / "Your agents", `Add agent` / `Add all agents` / `Added` replace the Adopt/Adopted internal jargon; agent-not-found and empty states rewritten with descriptions and CTAs (including a Rescan button)
- **hub**, never API Endpoint / Management API / server: the login field is now "Hub URL — Where your AgentPod hub is running."; "Use a different hub" in both login and Settings
- One name per action through its whole flow: `New runtime → Create runtime`; `Change role → Changing… → Change role`

## Escalation rightsized
Stop/Restart were the *hardest* actions in the app (type the full station ID) while being routine and reversible — they now use a plain action-labeled confirm. Type-to-confirm remains exactly where it belongs: destroy and permanent deletion.

## One error grammar
"Couldn't X." everywhere — the admin-vs-fleet "Failed to X"/"X failed" split is gone, raw "Unknown error" toasts got actionable copy ("The node didn't respond — it may already be restarting…"), stores' lowercase error strings are sentence-cased, and connection failures say what to check.

## Copy hygiene
Admin area de-Title-Cased; Activity columns are Action/Agent (was Verb/Station); "Changes" replaces "Diff (original → buffer)"; "Edit" replaces "Edit (diff)"; file preview drops transport-speak; the theme picker stops name-dropping Shiki; `1 lines` plural bug fixed; `…` everywhere; `can't` over `cannot`; missing values render `—` consistently. AgentTable's filter-empty state gains a Clear filters CTA.

## Motion
Status dots/cells crossfade color on state change (200ms) — pressing Restart now visibly rides the real request through the status row and every on-screen ribbon. The 0.5s theme-switch crossfade no longer covers `section`/`article`, so live data refreshes stop reading as lag.

Tests: 465 green (assertions updated to the new copy — including two that had pinned the old jargon); `pnpm check` clean; production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB