### PR TITLE
fix(hub): destroyed runtimes no longer haunt the runtimes list

### DIFF
--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -220,6 +220,28 @@ test("GET /api/runtimes → only the caller's runtimes", async () => {
   expect(otherUserRts).toHaveLength(0);
 }, 30_000);
 
+test("GET /api/runtimes → destroyed runtimes are excluded (no immortal ghost rows)", async () => {
+  // Regression: destroyed rows are kept in the DB for history, but the list
+  // endpoint must not return them — the console can take no action on a
+  // destroyed runtime, so returning it produces a permanent dead row.
+  const createRes = await createRuntime(TEST_USER, "ghost-box");
+  expect(createRes.status).toBe(201);
+  const created = (await createRes.json()) as { id: string };
+
+  const delRes = await testApp.request(`/api/runtimes/${created.id}`, {
+    method: "DELETE",
+    headers: { "X-Test-User-Id": TEST_USER },
+  });
+  expect(delRes.status).toBe(204);
+
+  const res = await testApp.request("/api/runtimes", {
+    headers: { "X-Test-User-Id": TEST_USER },
+  });
+  expect(res.status).toBe(200);
+  const list = (await res.json()) as Array<{ id: string }>;
+  expect(list.find((r) => r.id === created.id)).toBeUndefined();
+}, 30_000);
+
 test("GET /api/runtimes/providers → lists enabled providers", async () => {
   const res = await testApp.request("/api/runtimes/providers", {
     headers: { "X-Test-User-Id": TEST_USER },

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -14,7 +14,7 @@
  *   - driver provision() throw   → status set to "error"; rethrow (→ 502)
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { provisionedRuntimes, nodes } from "../db/schema/nodes";
 import { mintEnrollmentToken } from "./enrollment";
@@ -174,13 +174,22 @@ export async function createRuntime(
 }
 
 /**
- * List all provisioned runtimes for a user.
+ * List a user's live provisioned runtimes.
+ *
+ * Destroyed rows stay in the DB for history but are excluded here: no action
+ * can be taken on a destroyed runtime, so surfacing it gives the console a
+ * permanent dead row.
  */
 export async function listRuntimes(userId: string): Promise<ProvisionedRuntime[]> {
   const rows = await db
     .select()
     .from(provisionedRuntimes)
-    .where(eq(provisionedRuntimes.userId, userId));
+    .where(
+      and(
+        eq(provisionedRuntimes.userId, userId),
+        ne(provisionedRuntimes.status, "destroyed")
+      )
+    );
 
   return rows.map(toContract);
 }


### PR DESCRIPTION
Dogfood finding: destroying a runtime worked (container removed, ghost node deleted) but the DB row — kept for history — was returned by `GET /api/runtimes` forever, and the console hides every action for `status=destroyed`. Result: a permanent dead row nothing can dismiss.

The list endpoint now excludes destroyed rows (history stays in the DB). Regression test: create → destroy → list must not contain the row.

Hub tests: 309 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB