### PR TITLE
feat: ACP slice 1 — rails (contract verbs, node-agent acp piping, runtime lifecycle, log-follow fix)

### DIFF
--- a/apps/node-agent/cmd/agentpod-node/run.go
+++ b/apps/node-agent/cmd/agentpod-node/run.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/acp"
 	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
 	"github.com/rakeshgangwar/agentpod/node-agent/internal/descriptor"
 	"github.com/rakeshgangwar/agentpod/node-agent/internal/gateway"
@@ -26,6 +27,8 @@ func runCmd() {
 	reg := buildRegistry(cfg.HermesStartCmd, cfg.OpenClawStartCmd)
 	mgr := terminal.NewManager()
 	defer mgr.Shutdown()
+	acpMgr := acp.NewManager()
+	defer acpMgr.Shutdown()
 
 	resolver := gateway.WorkspaceFunc(func(key string) (string, error) {
 		d, err := reg.For(key)
@@ -100,6 +103,7 @@ func runCmd() {
 	}
 
 	h := gateway.NewTerminalHandler(descriptor.NewHandler(reg), resolver, mgr, lifecycleFn)
+	h = gateway.NewACPHandler(h, acpMgr, descriptor.NewCapabilityHandler(reg).ACPCommand)
 	h = gateway.NewUpdateHandler(h, version)
 	gateway.Run(ctx, cfg, h, version, gatherHealth)
 }

--- a/apps/node-agent/deploy/Dockerfile.opencode
+++ b/apps/node-agent/deploy/Dockerfile.opencode
@@ -14,8 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # procps provides `pgrep`, used by the OpenCode descriptor's running-process
 # health check; without it the station Health panel shows "process check unavailable".
 
-# Install the opencode CLI (pinned to fleet version 0.5.5)
-RUN bun add -g opencode-ai@0.5.5
+# Install the opencode CLI (pinned to fleet version 1.18.15 — the newest
+# published version as of 2026-08-09, confirmed to ship the `acp` subcommand
+# the node-agent's ACPCommand uses to spawn `opencode acp` sessions).
+RUN bun add -g opencode-ai@1.18.15
 
 COPY --from=builder /agentpod-node /agentpod-node
 COPY deploy/node-opencode-entrypoint.sh /node-opencode-entrypoint.sh

--- a/apps/node-agent/deploy/Dockerfile.opencode
+++ b/apps/node-agent/deploy/Dockerfile.opencode
@@ -6,13 +6,22 @@ WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /agentpod-node ./cmd/agentpod-node
 
-# Stage 2: Runtime — bun base (Debian) for opencode + sqlite3 for DB seeding
+# Stage 2: Runtime — bun base (Debian) for opencode
 FROM oven/bun:1-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates git sqlite3 procps \
+    ca-certificates git procps \
     && rm -rf /var/lib/apt/lists/*
 # procps provides `pgrep`, used by the OpenCode descriptor's running-process
-# health check; without it the station Health panel shows "process check unavailable".
+# health check and its supervised-serve Stop/Start; without it the station
+# Health panel shows "process check unavailable".
+#
+# `sqlite3` is deliberately NOT installed. The entrypoint used to hand-seed
+# opencode.db (the descriptor's PRIMARY project-discovery path) with a schema
+# snapshot that broke across opencode-ai version bumps (see
+# node-opencode-entrypoint.sh's comment). Omitting sqlite3 makes that PRIMARY
+# path unavailable to the descriptor in-container, so it always falls back to
+# the directory-enumeration path instead — opencode's self-managed
+# opencode.db (whatever its current schema) is then irrelevant to detection.
 
 # Install the opencode CLI (pinned to fleet version 1.18.15 — the newest
 # published version as of 2026-08-09, confirmed to ship the `acp` subcommand

--- a/apps/node-agent/deploy/node-opencode-entrypoint.sh
+++ b/apps/node-agent/deploy/node-opencode-entrypoint.sh
@@ -57,13 +57,22 @@ SQL
 # immediately resurrect `opencode serve` after the node-agent's opencode
 # descriptor (internal/descriptor/opencode.go) runs a lifecycle Stop on it,
 # making Stop a no-op. The descriptor's Stop kills the process THEN touches
-# /var/run/opencode-serve.stop; the loop checks that sentinel before every
-# (re)spawn and exits when it is present. The descriptor's Start removes the
-# sentinel and re-spawns `opencode serve` itself — this loop has already
-# exited by then, so the two never race.
+# /var/run/opencode-serve.stop (kill-before-touch is intentional and safe:
+# the loop's `sleep 2` after every exit means it can't re-check the sentinel
+# and respawn faster than Stop can touch it); the loop checks that sentinel
+# before every (re)spawn and exits when it is present. The descriptor's Start
+# removes the sentinel and re-spawns `opencode serve` itself — this loop has
+# already exited by then, so the two never race.
 mkdir -p /var/run
 rm -f /var/run/opencode-serve.stop
 (
+  # `set +e`: the top-level `set -e` (line 2) is inherited into this subshell.
+  # Without disabling it here, any non-zero exit from `opencode serve` (a
+  # crash, or exit 143 from the lifecycle Stop's SIGTERM) would terminate the
+  # subshell at that line — the echo/sleep/loop-back below would never run,
+  # making supervision single-shot instead of restart-on-crash. Scoped to this
+  # subshell only; the outer script keeps `set -e`.
+  set +e
   cd /workspace
   while :; do
     if [ -f /var/run/opencode-serve.stop ]; then

--- a/apps/node-agent/deploy/node-opencode-entrypoint.sh
+++ b/apps/node-agent/deploy/node-opencode-entrypoint.sh
@@ -50,5 +50,34 @@ SQL
 # Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
 /agentpod-node enroll
 
-# Hand off to the run loop.
+# Supervised opencode server: the station's long-running process. Restarts on
+# crash with 2s backoff; killed cleanly when the container stops.
+#
+# Lifecycle coordination: without the sentinel check below, this loop would
+# immediately resurrect `opencode serve` after the node-agent's opencode
+# descriptor (internal/descriptor/opencode.go) runs a lifecycle Stop on it,
+# making Stop a no-op. The descriptor's Stop kills the process THEN touches
+# /var/run/opencode-serve.stop; the loop checks that sentinel before every
+# (re)spawn and exits when it is present. The descriptor's Start removes the
+# sentinel and re-spawns `opencode serve` itself — this loop has already
+# exited by then, so the two never race.
+mkdir -p /var/run
+rm -f /var/run/opencode-serve.stop
+(
+  cd /workspace
+  while :; do
+    if [ -f /var/run/opencode-serve.stop ]; then
+      echo "[entrypoint] opencode-serve.stop present, halting supervision loop" >>/var/log/opencode-serve.log
+      break
+    fi
+    opencode serve >>/var/log/opencode-serve.log 2>&1
+    echo "[entrypoint] opencode serve exited ($?), restarting in 2s" >>/var/log/opencode-serve.log
+    sleep 2
+  done
+) &
+export AGENTPOD_OPENCODE_SUPERVISED=1
+
+# Hand off to the run loop. AGENTPOD_OPENCODE_SUPERVISED, exported above,
+# flows into this process so the opencode descriptor gates its "lifecycle"
+# capability and Stop/Start methods on it.
 exec /agentpod-node run

--- a/apps/node-agent/deploy/node-opencode-entrypoint.sh
+++ b/apps/node-agent/deploy/node-opencode-entrypoint.sh
@@ -16,36 +16,19 @@ mkdir -p /workspace
 #             name is a sanitised workspace path (leading '/' stripped, '/' → '-'),
 #             e.g. /workspace → "workspace".
 #
-# We seed BOTH so detection works regardless of whether sqlite3 is available.
-
+# We deliberately only seed the FALLBACK directory here. An earlier version of
+# this script also hand-seeded opencode.db (the PRIMARY path) with a sqlite3
+# heredoc matching a specific schema snapshot; that broke when opencode-ai was
+# bumped past the version that schema was captured from (`opencode serve`
+# refused to start against the pre-seeded db: "Database is not empty and has
+# no session table"). Chasing opencode's internal schema across every future
+# version bump is brittle, so instead: opencode creates and owns its own
+# opencode.db on first run, and this image does not install `sqlite3` (see
+# Dockerfile.opencode), which makes the PRIMARY path unavailable in-container
+# and forces Detect() onto this directory fallback unconditionally — the
+# schema of opencode's self-created db becomes irrelevant to detection.
 OPENCODE_DATA="${HOME:-/root}/.local/share/opencode"
-OPENCODE_DB="${OPENCODE_DATA}/opencode.db"
-
-# Create the data-dir structure opencode.go's Detect() requires.
 mkdir -p "${OPENCODE_DATA}/project/workspace"
-
-# PRIMARY: seed opencode.db with a project row for /workspace.
-# Schema matches the real opencode.db (id text PK, worktree text NOT NULL,
-# sandboxes text NOT NULL, time_created/time_updated integer NOT NULL).
-sqlite3 "${OPENCODE_DB}" <<'SQL'
-CREATE TABLE IF NOT EXISTS project (
-  id            text    PRIMARY KEY,
-  worktree      text    NOT NULL,
-  vcs           text,
-  name          text,
-  icon_url      text,
-  icon_color    text,
-  time_created  integer NOT NULL,
-  time_updated  integer NOT NULL,
-  time_initialized integer,
-  sandboxes     text    NOT NULL,
-  commands      text
-);
-INSERT OR IGNORE INTO project
-  (id, worktree, time_created, time_updated, sandboxes)
-VALUES
-  ('agentpod-workspace', '/workspace', unixepoch() * 1000, unixepoch() * 1000, '[]');
-SQL
 
 # Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
 /agentpod-node enroll

--- a/apps/node-agent/internal/acp/manager.go
+++ b/apps/node-agent/internal/acp/manager.go
@@ -1,0 +1,125 @@
+package acp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+)
+
+// Manager owns the set of live ACP sessions keyed both by session ID and by
+// station key. All public methods are safe for concurrent use.
+type Manager struct {
+	mu    sync.Mutex
+	byID  map[string]*Session
+	byKey map[string]string // station key → session ID
+}
+
+// NewManager allocates an empty Manager.
+func NewManager() *Manager {
+	return &Manager{
+		byID:  make(map[string]*Session),
+		byKey: make(map[string]string),
+	}
+}
+
+// newSessionID returns a fresh identifier of the form "acp_" + 8 random hex
+// characters.
+func newSessionID() string {
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	return "acp_" + hex.EncodeToString(b[:])
+}
+
+// Open returns the live session for key if one already exists (idempotent),
+// or spawns argv[0] with argv[1:] in dir with env appended to os.Environ().
+// stdout is streamed to subscribers in chunks; stderr is discarded to a
+// bounded ring (last 4 KiB) exposed via s.StderrTail() for exit reasons.
+func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Session, error) {
+	m.mu.Lock()
+	// Fast path: session already alive for this key.
+	if id, ok := m.byKey[key]; ok {
+		if s, ok := m.byID[id]; ok {
+			m.mu.Unlock()
+			return s, nil
+		}
+	}
+	m.mu.Unlock()
+
+	// Spawn the session outside the lock (process creation may be slow).
+	id := newSessionID()
+	s, err := newSession(id, argv, dir, env)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	// Double-check: another goroutine may have won the race for this key.
+	if existingID, ok := m.byKey[key]; ok {
+		if existing, ok := m.byID[existingID]; ok {
+			m.mu.Unlock()
+			// We lost the race — discard our session.
+			_ = s.Close()
+			return existing, nil
+		}
+	}
+	m.byID[id] = s
+	m.byKey[key] = id
+	m.mu.Unlock()
+
+	// Drop the session from the registry once the child exits so a later
+	// Open for the same key spawns a fresh process instead of returning a
+	// dead session.
+	s.OnExit(func(string) { m.remove(id) })
+	return s, nil
+}
+
+// Get looks up a session by its ID.
+func (m *Manager) Get(id string) (*Session, bool) {
+	m.mu.Lock()
+	s, ok := m.byID[id]
+	m.mu.Unlock()
+	return s, ok
+}
+
+// remove deletes id from both indexes (no-op if already gone).
+func (m *Manager) remove(id string) {
+	m.mu.Lock()
+	delete(m.byID, id)
+	for k, v := range m.byKey {
+		if v == id {
+			delete(m.byKey, k)
+			break
+		}
+	}
+	m.mu.Unlock()
+}
+
+// Close removes the session from both indexes and shuts down its process
+// (SIGTERM → 3s grace → SIGKILL). Returns nil if no session with that ID
+// exists.
+func (m *Manager) Close(id string) error {
+	m.mu.Lock()
+	s, ok := m.byID[id]
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	m.remove(id)
+	return s.Close()
+}
+
+// Shutdown closes every session.
+func (m *Manager) Shutdown() {
+	m.mu.Lock()
+	sessions := make([]*Session, 0, len(m.byID))
+	for _, s := range m.byID {
+		sessions = append(sessions, s)
+	}
+	m.byID = make(map[string]*Session)
+	m.byKey = make(map[string]string)
+	m.mu.Unlock()
+
+	for _, s := range sessions {
+		_ = s.Close()
+	}
+}

--- a/apps/node-agent/internal/acp/manager.go
+++ b/apps/node-agent/internal/acp/manager.go
@@ -3,8 +3,12 @@ package acp
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"sync"
 )
+
+// ErrEmptyArgv is returned by Open when argv has no command to run.
+var ErrEmptyArgv = errors.New("acp: empty argv")
 
 // Manager owns the set of live ACP sessions keyed both by session ID and by
 // station key. All public methods are safe for concurrent use.
@@ -35,6 +39,10 @@ func newSessionID() string {
 // stdout is streamed to subscribers in chunks; stderr is discarded to a
 // bounded ring (last 4 KiB) exposed via s.StderrTail() for exit reasons.
 func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Session, error) {
+	if len(argv) == 0 {
+		return nil, ErrEmptyArgv
+	}
+
 	m.mu.Lock()
 	// Fast path: session already alive for this key.
 	if id, ok := m.byKey[key]; ok {
@@ -43,10 +51,18 @@ func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Se
 			return s, nil
 		}
 	}
+	// Pick an ID that is not in use, retrying on (astronomically unlikely)
+	// random collision.
+	id := newSessionID()
+	for {
+		if _, taken := m.byID[id]; !taken {
+			break
+		}
+		id = newSessionID()
+	}
 	m.mu.Unlock()
 
 	// Spawn the session outside the lock (process creation may be slow).
-	id := newSessionID()
 	s, err := newSession(id, argv, dir, env)
 	if err != nil {
 		return nil, err

--- a/apps/node-agent/internal/acp/session.go
+++ b/apps/node-agent/internal/acp/session.go
@@ -5,6 +5,7 @@ package acp
 
 import (
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"sync"
@@ -15,6 +16,11 @@ import (
 // stdoutChunkBytes is the read-buffer size for the stdout streaming loop.
 const stdoutChunkBytes = 32 * 1024
 
+// subChanBuffer is the per-subscriber chunk buffer. A subscriber whose
+// callback falls more than subChanBuffer chunks behind is dropped
+// (unsubscribed) rather than allowed to stall the stdout read loop.
+const subChanBuffer = 64
+
 // stderrRingBytes is the maximum number of stderr bytes retained for exit
 // reasons (last 4 KiB).
 const stderrRingBytes = 4 * 1024
@@ -23,6 +29,19 @@ const stderrRingBytes = 4 * 1024
 // SIGKILL.
 const closeGrace = 3 * time.Second
 
+// subscriber is one registered stdout consumer: a buffered chunk queue fed by
+// the read loop and drained by a dedicated dispatcher goroutine.
+type subscriber struct {
+	ch   chan []byte
+	quit chan struct{}
+	stop sync.Once
+}
+
+// shutdown detaches the subscriber's dispatcher (idempotent).
+func (sub *subscriber) shutdown() {
+	sub.stop.Do(func() { close(sub.quit) })
+}
+
 // Session wraps a single ACP child process wired over plain stdio pipes.
 // It is safe for concurrent use.
 type Session struct {
@@ -30,8 +49,10 @@ type Session struct {
 	cmd   *exec.Cmd
 	stdin io.WriteCloser
 
+	writeMu sync.Mutex // serializes Write so JSON-RPC frames never interleave
+
 	mu         sync.Mutex
-	subs       map[int]func(chunk []byte)
+	subs       map[int]*subscriber
 	subSeq     int
 	stderrRing []byte
 	exitFns    []func(reason string)
@@ -74,7 +95,7 @@ func newSession(id string, argv []string, dir string, env []string) (*Session, e
 		id:    id,
 		cmd:   cmd,
 		stdin: stdin,
-		subs:  make(map[int]func(chunk []byte)),
+		subs:  make(map[int]*subscriber),
 		done:  make(chan struct{}),
 	}
 
@@ -88,7 +109,10 @@ func newSession(id string, argv []string, dir string, env []string) (*Session, e
 	return s, nil
 }
 
-// stdoutLoop streams child stdout to subscribers in chunks.
+// stdoutLoop streams child stdout to subscriber queues in chunks. Delivery is
+// a non-blocking send to each subscriber's buffered channel — the read loop
+// never blocks on a consumer. A subscriber whose queue overflows is dropped
+// (unsubscribed) so a stalled consumer cannot wedge the session.
 func (s *Session) stdoutLoop(r io.Reader, wg *sync.WaitGroup) {
 	defer wg.Done()
 
@@ -99,20 +123,52 @@ func (s *Session) stdoutLoop(r io.Reader, wg *sync.WaitGroup) {
 			chunk := make([]byte, n)
 			copy(chunk, buf[:n])
 
-			// Snapshot subscribers under the lock, invoke outside it so a
-			// callback may safely call back into the session.
 			s.mu.Lock()
-			fns := make([]func([]byte), 0, len(s.subs))
-			for _, fn := range s.subs {
-				fns = append(fns, fn)
+			for id, sub := range s.subs {
+				select {
+				case sub.ch <- chunk:
+				default:
+					// Slow consumer: drop the subscriber, not the stream.
+					delete(s.subs, id)
+					sub.shutdown()
+					log.Printf("acp: session %s dropped slow subscriber (queue overflow)", s.id)
+				}
 			}
 			s.mu.Unlock()
-			for _, fn := range fns {
-				fn(chunk)
-			}
 		}
 		if err != nil {
-			return
+			break
+		}
+	}
+
+	// Session output is over: detach all subscribers so their dispatcher
+	// goroutines drain any buffered chunks and exit.
+	s.mu.Lock()
+	subs := s.subs
+	s.subs = make(map[int]*subscriber)
+	s.mu.Unlock()
+	for _, sub := range subs {
+		sub.shutdown()
+	}
+}
+
+// dispatch delivers queued chunks to one subscriber's callback in order. On
+// shutdown it drains whatever is already buffered, then exits. A callback
+// that blocks forever pins only this goroutine — never the read loop.
+func (s *Session) dispatch(sub *subscriber, fn func(chunk []byte)) {
+	for {
+		select {
+		case c := <-sub.ch:
+			fn(c)
+		case <-sub.quit:
+			for {
+				select {
+				case c := <-sub.ch:
+					fn(c)
+				default:
+					return
+				}
+			}
 		}
 	}
 }
@@ -159,10 +215,12 @@ func (s *Session) reap(readers *sync.WaitGroup) {
 	s.exitFns = nil
 	s.mu.Unlock()
 
+	// Close done BEFORE firing callbacks: a callback may call s.Close(),
+	// which blocks on done — firing first would deadlock forever.
+	close(s.done)
 	for _, fn := range fns {
 		fn(reason)
 	}
-	close(s.done)
 }
 
 // ID returns the unique session identifier (e.g. "acp_1a2b3c4d").
@@ -170,27 +228,46 @@ func (s *Session) ID() string {
 	return s.id
 }
 
-// Write sends p to the child's stdin.
+// Write sends p to the child's stdin. Concurrent calls are serialized, so
+// each call's bytes reach the child contiguously — a JSON-RPC frame written
+// in one call is never interleaved with another writer's frame.
 func (s *Session) Write(p []byte) error {
+	s.writeMu.Lock()
 	_, err := s.stdin.Write(p)
+	s.writeMu.Unlock()
 	return err
 }
 
 // Subscribe registers fn to receive child stdout chunks and returns an
-// unsubscribe function. Callbacks are invoked sequentially from the stdout
-// read loop; a slow callback backpressures the child rather than dropping
-// data (ACP frames must not be lost).
+// unsubscribe function.
+//
+// Delivery contract (Task 4 relies on this): chunks are delivered in order by
+// a dedicated per-subscriber goroutine feeding from a buffered queue of
+// subChanBuffer chunks. The stdout read loop never blocks on a subscriber —
+// if fn falls more than subChanBuffer chunks behind, the subscriber is
+// DROPPED (auto-unsubscribed, logged) rather than allowed to stall the
+// session or lose stream position for other subscribers. A dropped or
+// unsubscribed consumer receives no further chunks after its buffered
+// backlog drains.
 func (s *Session) Subscribe(fn func(chunk []byte)) (unsub func()) {
+	sub := &subscriber{
+		ch:   make(chan []byte, subChanBuffer),
+		quit: make(chan struct{}),
+	}
+
 	s.mu.Lock()
 	id := s.subSeq
 	s.subSeq++
-	s.subs[id] = fn
+	s.subs[id] = sub
 	s.mu.Unlock()
+
+	go s.dispatch(sub, fn)
 
 	return func() {
 		s.mu.Lock()
 		delete(s.subs, id)
 		s.mu.Unlock()
+		sub.shutdown()
 	}
 }
 
@@ -253,8 +330,14 @@ func (s *Session) closeStdin() {
 }
 
 // signal delivers sig to the child's process group, falling back to the
-// process itself if the group lookup fails.
+// process itself if the group lookup fails. It is a no-op once the child has
+// been reaped (guards against signaling a reused pid).
 func (s *Session) signal(sig syscall.Signal) {
+	select {
+	case <-s.done:
+		return // child already reaped; pid may have been reused
+	default:
+	}
 	if s.cmd.Process == nil {
 		return
 	}

--- a/apps/node-agent/internal/acp/session.go
+++ b/apps/node-agent/internal/acp/session.go
@@ -30,11 +30,14 @@ const stderrRingBytes = 4 * 1024
 const closeGrace = 3 * time.Second
 
 // subscriber is one registered stdout consumer: a buffered chunk queue fed by
-// the read loop and drained by a dedicated dispatcher goroutine.
+// the read loop and drained by a dedicated dispatcher goroutine. finished is
+// closed once the dispatcher has delivered every queued chunk and returned —
+// unsubscribe blocks on it so callers get a drain guarantee.
 type subscriber struct {
-	ch   chan []byte
-	quit chan struct{}
-	stop sync.Once
+	ch       chan []byte
+	quit     chan struct{}
+	stop     sync.Once
+	finished chan struct{}
 }
 
 // shutdown detaches the subscriber's dispatcher (idempotent).
@@ -55,7 +58,8 @@ type Session struct {
 	subs       map[int]*subscriber
 	subSeq     int
 	stderrRing []byte
-	exitFns    []func(reason string)
+	exitFns    map[int]func(reason string)
+	exitSeq    int
 	exited     bool
 	exitReason string
 	stdinDone  bool
@@ -153,9 +157,11 @@ func (s *Session) stdoutLoop(r io.Reader, wg *sync.WaitGroup) {
 }
 
 // dispatch delivers queued chunks to one subscriber's callback in order. On
-// shutdown it drains whatever is already buffered, then exits. A callback
-// that blocks forever pins only this goroutine — never the read loop.
+// shutdown it drains whatever is already buffered, then exits and closes
+// sub.finished. A callback that blocks forever pins only this goroutine (and
+// any unsubscribe waiting on the drain) — never the read loop.
 func (s *Session) dispatch(sub *subscriber, fn func(chunk []byte)) {
+	defer close(sub.finished)
 	for {
 		select {
 		case c := <-sub.ch:
@@ -249,10 +255,18 @@ func (s *Session) Write(p []byte) error {
 // session or lose stream position for other subscribers. A dropped or
 // unsubscribed consumer receives no further chunks after its buffered
 // backlog drains.
+//
+// Drain guarantee: unsub BLOCKS until every chunk already queued for this
+// subscriber has been delivered to fn and the dispatcher goroutine has
+// returned — a caller that unsubscribes after child exit is certain fn saw
+// the child's complete output first. Consequently unsub must NEVER be called
+// from within fn itself (self-deadlock); spawn a goroutine for that
+// (`go unsub()`). unsub is idempotent and safe for concurrent use.
 func (s *Session) Subscribe(fn func(chunk []byte)) (unsub func()) {
 	sub := &subscriber{
-		ch:   make(chan []byte, subChanBuffer),
-		quit: make(chan struct{}),
+		ch:       make(chan []byte, subChanBuffer),
+		quit:     make(chan struct{}),
+		finished: make(chan struct{}),
 	}
 
 	s.mu.Lock()
@@ -268,6 +282,7 @@ func (s *Session) Subscribe(fn func(chunk []byte)) (unsub func()) {
 		delete(s.subs, id)
 		s.mu.Unlock()
 		sub.shutdown()
+		<-sub.finished
 	}
 }
 
@@ -275,16 +290,40 @@ func (s *Session) Subscribe(fn func(chunk []byte)) (unsub func()) {
 // reason is "exit" for a clean exit, otherwise the error string (with the
 // stderr tail appended when present). If the child has already exited, fn is
 // invoked immediately with the recorded reason.
-func (s *Session) OnExit(fn func(reason string)) {
+//
+// The returned unregister func removes the callback so long-lived sessions do
+// not accumulate one closure per attach/detach cycle; it is idempotent, safe
+// after exit, and a no-op once fn has fired (or is firing).
+func (s *Session) OnExit(fn func(reason string)) (unregister func()) {
 	s.mu.Lock()
 	if s.exited {
 		reason := s.exitReason
 		s.mu.Unlock()
 		fn(reason)
-		return
+		return func() {}
 	}
-	s.exitFns = append(s.exitFns, fn)
+	if s.exitFns == nil {
+		s.exitFns = make(map[int]func(reason string))
+	}
+	id := s.exitSeq
+	s.exitSeq++
+	s.exitFns[id] = fn
 	s.mu.Unlock()
+	return func() {
+		s.mu.Lock()
+		delete(s.exitFns, id)
+		s.mu.Unlock()
+	}
+}
+
+// OnExitCount reports the number of currently registered exit callbacks
+// (diagnostic/test helper — pins that attach/detach cycles unregister their
+// hooks instead of leaking).
+func (s *Session) OnExitCount() int {
+	s.mu.Lock()
+	n := len(s.exitFns)
+	s.mu.Unlock()
+	return n
 }
 
 // StderrTail returns the last 4 KiB of the child's stderr output.

--- a/apps/node-agent/internal/acp/session.go
+++ b/apps/node-agent/internal/acp/session.go
@@ -1,0 +1,267 @@
+// Package acp provides a non-PTY stdio session manager for spawning harness
+// ACP (Agent Client Protocol) processes. ACP speaks JSON-RPC over stdio, so
+// the child is wired with plain pipes — a PTY would corrupt the framing.
+package acp
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// stdoutChunkBytes is the read-buffer size for the stdout streaming loop.
+const stdoutChunkBytes = 32 * 1024
+
+// stderrRingBytes is the maximum number of stderr bytes retained for exit
+// reasons (last 4 KiB).
+const stderrRingBytes = 4 * 1024
+
+// closeGrace is how long Close waits after SIGTERM before escalating to
+// SIGKILL.
+const closeGrace = 3 * time.Second
+
+// Session wraps a single ACP child process wired over plain stdio pipes.
+// It is safe for concurrent use.
+type Session struct {
+	id    string
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+
+	mu         sync.Mutex
+	subs       map[int]func(chunk []byte)
+	subSeq     int
+	stderrRing []byte
+	exitFns    []func(reason string)
+	exited     bool
+	exitReason string
+	stdinDone  bool
+
+	closeOnce sync.Once
+	done      chan struct{} // closed once the child has been reaped
+}
+
+// newSession spawns argv[0] with argv[1:] in dir with env appended to
+// os.Environ(), and starts the stdout/stderr pump and reaper goroutines.
+func newSession(id string, argv []string, dir string, env []string) (*Session, error) {
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	// Put the child in its own process group so Close can signal the whole
+	// group (reaps grandchildren too). No PTY here, so Setpgid is safe.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	s := &Session{
+		id:    id,
+		cmd:   cmd,
+		stdin: stdin,
+		subs:  make(map[int]func(chunk []byte)),
+		done:  make(chan struct{}),
+	}
+
+	// The pipe readers must drain before cmd.Wait() is called (Wait closes
+	// the parent ends of the pipes).
+	var readers sync.WaitGroup
+	readers.Add(2)
+	go s.stdoutLoop(stdout, &readers)
+	go s.stderrLoop(stderr, &readers)
+	go s.reap(&readers)
+	return s, nil
+}
+
+// stdoutLoop streams child stdout to subscribers in chunks.
+func (s *Session) stdoutLoop(r io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	buf := make([]byte, stdoutChunkBytes)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+
+			// Snapshot subscribers under the lock, invoke outside it so a
+			// callback may safely call back into the session.
+			s.mu.Lock()
+			fns := make([]func([]byte), 0, len(s.subs))
+			for _, fn := range s.subs {
+				fns = append(fns, fn)
+			}
+			s.mu.Unlock()
+			for _, fn := range fns {
+				fn(chunk)
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// stderrLoop drains child stderr into a bounded ring (last stderrRingBytes).
+func (s *Session) stderrLoop(r io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			s.mu.Lock()
+			s.stderrRing = append(s.stderrRing, buf[:n]...)
+			if len(s.stderrRing) > stderrRingBytes {
+				s.stderrRing = s.stderrRing[len(s.stderrRing)-stderrRingBytes:]
+			}
+			s.mu.Unlock()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// reap waits for the pipe readers to drain, reaps the child, and fires the
+// OnExit callbacks exactly once.
+func (s *Session) reap(readers *sync.WaitGroup) {
+	readers.Wait()
+	err := s.cmd.Wait()
+
+	reason := "exit"
+	if err != nil {
+		reason = err.Error()
+		if tail := s.StderrTail(); tail != "" {
+			reason += ": " + tail
+		}
+	}
+
+	s.mu.Lock()
+	s.exited = true
+	s.exitReason = reason
+	fns := s.exitFns
+	s.exitFns = nil
+	s.mu.Unlock()
+
+	for _, fn := range fns {
+		fn(reason)
+	}
+	close(s.done)
+}
+
+// ID returns the unique session identifier (e.g. "acp_1a2b3c4d").
+func (s *Session) ID() string {
+	return s.id
+}
+
+// Write sends p to the child's stdin.
+func (s *Session) Write(p []byte) error {
+	_, err := s.stdin.Write(p)
+	return err
+}
+
+// Subscribe registers fn to receive child stdout chunks and returns an
+// unsubscribe function. Callbacks are invoked sequentially from the stdout
+// read loop; a slow callback backpressures the child rather than dropping
+// data (ACP frames must not be lost).
+func (s *Session) Subscribe(fn func(chunk []byte)) (unsub func()) {
+	s.mu.Lock()
+	id := s.subSeq
+	s.subSeq++
+	s.subs[id] = fn
+	s.mu.Unlock()
+
+	return func() {
+		s.mu.Lock()
+		delete(s.subs, id)
+		s.mu.Unlock()
+	}
+}
+
+// OnExit registers a callback invoked exactly once when the child exits;
+// reason is "exit" for a clean exit, otherwise the error string (with the
+// stderr tail appended when present). If the child has already exited, fn is
+// invoked immediately with the recorded reason.
+func (s *Session) OnExit(fn func(reason string)) {
+	s.mu.Lock()
+	if s.exited {
+		reason := s.exitReason
+		s.mu.Unlock()
+		fn(reason)
+		return
+	}
+	s.exitFns = append(s.exitFns, fn)
+	s.mu.Unlock()
+}
+
+// StderrTail returns the last 4 KiB of the child's stderr output.
+func (s *Session) StderrTail() string {
+	s.mu.Lock()
+	tail := string(s.stderrRing)
+	s.mu.Unlock()
+	return tail
+}
+
+// Close shuts the session down: closes stdin, sends SIGTERM to the child's
+// process group, waits up to 3s for it to exit, then escalates to SIGKILL.
+// It blocks until the child has been reaped and is idempotent.
+func (s *Session) Close() error {
+	s.closeOnce.Do(func() {
+		s.closeStdin()
+		s.signal(syscall.SIGTERM)
+
+		select {
+		case <-s.done:
+			return
+		case <-time.After(closeGrace):
+		}
+		s.signal(syscall.SIGKILL)
+	})
+
+	// Every caller (including repeat calls) blocks until the reaper is done —
+	// no zombies, no goroutine leaks.
+	<-s.done
+	return nil
+}
+
+// closeStdin closes the child's stdin exactly once (EOF lets well-behaved
+// children exit on their own).
+func (s *Session) closeStdin() {
+	s.mu.Lock()
+	already := s.stdinDone
+	s.stdinDone = true
+	s.mu.Unlock()
+	if !already {
+		_ = s.stdin.Close()
+	}
+}
+
+// signal delivers sig to the child's process group, falling back to the
+// process itself if the group lookup fails.
+func (s *Session) signal(sig syscall.Signal) {
+	if s.cmd.Process == nil {
+		return
+	}
+	pid := s.cmd.Process.Pid
+	if pgid, err := syscall.Getpgid(pid); err == nil {
+		_ = syscall.Kill(-pgid, sig)
+	} else {
+		_ = s.cmd.Process.Signal(sig)
+	}
+}

--- a/apps/node-agent/internal/acp/session_test.go
+++ b/apps/node-agent/internal/acp/session_test.go
@@ -1,0 +1,69 @@
+package acp
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSession_EchoRoundTrip(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(chan []byte, 4)
+	unsub := s.Subscribe(func(c []byte) { got <- append([]byte(nil), c...) })
+	defer unsub()
+	if err := s.Write([]byte("{\"jsonrpc\":\"2.0\"}\n")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case c := <-got:
+		if !strings.Contains(string(c), "jsonrpc") {
+			t.Fatalf("chunk = %q", c)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no echo received")
+	}
+}
+
+func TestSession_ExitFiresOnceWithReason(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	s, _ := m.Open("k", []string{"/bin/sh", "-c", "echo err >&2; exit 3"}, t.TempDir(), nil)
+	reasons := make(chan string, 2)
+	s.OnExit(func(r string) { reasons <- r })
+	select {
+	case r := <-reasons:
+		if !strings.Contains(r, "exit status 3") || !strings.Contains(r, "err") {
+			t.Fatalf("reason = %q", r)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no exit callback")
+	}
+	select {
+	case r := <-reasons:
+		t.Fatalf("second callback: %q", r)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestManager_CloseKillsProcess(t *testing.T) {
+	m := NewManager()
+	s, _ := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	done := make(chan string, 1)
+	s.OnExit(func(r string) { done <- r })
+	if err := m.Close(s.ID()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process not reaped")
+	}
+	if _, ok := m.Get(s.ID()); ok {
+		t.Fatal("session still registered after Close")
+	}
+}

--- a/apps/node-agent/internal/acp/session_test.go
+++ b/apps/node-agent/internal/acp/session_test.go
@@ -1,6 +1,7 @@
 package acp
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -117,6 +118,101 @@ func TestManager_CloseWithBlockedSubscriber(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("process not reaped")
 	}
+}
+
+// TestSession_UnsubscribeWaitsForBacklog pins the drain guarantee consumers
+// (gateway acp.attach) rely on for exit ordering: unsub must not return until
+// every chunk already queued for this subscriber has been delivered to fn —
+// otherwise the child's final output (e.g. its last JSON-RPC response) is
+// silently truncated when an exit event is emitted right after unsub.
+func TestSession_UnsubscribeWaitsForBacklog(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+
+	// Child paces its writes so the fast read loop queues ~20 distinct chunks,
+	// then exits immediately after the burst.
+	s, err := m.Open("k",
+		[]string{"/bin/sh", "-c", "i=1; while [ $i -le 20 ]; do echo line$i; sleep 0.01; i=$((i+1)); done"},
+		t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var got []byte
+	unsub := s.Subscribe(func(c []byte) {
+		time.Sleep(30 * time.Millisecond) // slow consumer: backlog builds
+		mu.Lock()
+		got = append(got, c...)
+		mu.Unlock()
+	})
+
+	exited := make(chan struct{})
+	s.OnExit(func(string) { close(exited) })
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("child did not exit")
+	}
+
+	// At child exit the slow subscriber is still draining its queue. unsub
+	// must block until that backlog has been delivered.
+	unsub()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 1; i <= 20; i++ {
+		if !strings.Contains(string(got), fmt.Sprintf("line%d", i)) {
+			t.Fatalf("line%d missing after unsub returned; got %d bytes: %q", i, len(got), got)
+		}
+	}
+}
+
+// TestSession_OnExitUnregister pins that OnExit returns an unregister func so
+// long-lived sessions don't accumulate one dead closure per attach/detach
+// cycle, and that unregistered callbacks never fire.
+func TestSession_OnExitUnregister(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	base := s.OnExitCount() // manager registers its own removal hook
+
+	fired := make(chan int, 4)
+	unreg1 := s.OnExit(func(string) { fired <- 1 })
+	unreg2 := s.OnExit(func(string) { fired <- 2 })
+	if got := s.OnExitCount(); got != base+2 {
+		t.Fatalf("OnExitCount = %d, want %d", got, base+2)
+	}
+
+	unreg1()
+	unreg1() // idempotent
+	if got := s.OnExitCount(); got != base+1 {
+		t.Fatalf("OnExitCount after unregister = %d, want %d", got, base+1)
+	}
+
+	if err := m.Close(s.ID()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case n := <-fired:
+		if n != 2 {
+			t.Fatalf("unregistered callback %d fired", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("remaining callback did not fire")
+	}
+	select {
+	case n := <-fired:
+		t.Fatalf("unexpected extra callback: %d", n)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	unreg2() // after exit: must be a harmless no-op
 }
 
 func TestManager_OpenEmptyArgv(t *testing.T) {

--- a/apps/node-agent/internal/acp/session_test.go
+++ b/apps/node-agent/internal/acp/session_test.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -47,6 +48,82 @@ func TestSession_ExitFiresOnceWithReason(t *testing.T) {
 	case r := <-reasons:
 		t.Fatalf("second callback: %q", r)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestSession_CloseFromOnExitDoesNotDeadlock(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	s, err := m.Open("k", []string{"/bin/sh", "-c", "exit 0"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	s.OnExit(func(string) {
+		_ = s.Close() // must not deadlock on the session's own exit path
+		close(done)
+	})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close called from OnExit deadlocked")
+	}
+}
+
+func TestManager_CloseWithBlockedSubscriber(t *testing.T) {
+	m := NewManager()
+	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	defer close(release) // let the blocked dispatcher goroutine exit at test end
+	first := make(chan struct{})
+	var once sync.Once
+	s.Subscribe(func([]byte) {
+		once.Do(func() { close(first) })
+		<-release
+	})
+	// Prime one chunk and wait until the callback is provably blocked in it.
+	if err := s.Write([]byte("prime\n")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-first:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no first chunk delivered")
+	}
+	// Push chunks past the per-subscriber buffer while the callback is
+	// blocked; the read loop must never wedge on a stalled consumer.
+	for i := 0; i < subChanBuffer+8; i++ {
+		if err := s.Write([]byte("chunk\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exited := make(chan string, 1)
+	s.OnExit(func(r string) { exited <- r })
+	closed := make(chan error, 1)
+	go func() { closed <- m.Close(s.ID()) }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Manager.Close hung with a blocked subscriber")
+	}
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process not reaped")
+	}
+}
+
+func TestManager_OpenEmptyArgv(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	if _, err := m.Open("k", nil, t.TempDir(), nil); err == nil {
+		t.Fatal("Open with empty argv should error, not panic")
 	}
 }
 

--- a/apps/node-agent/internal/descriptor/acp_command_test.go
+++ b/apps/node-agent/internal/descriptor/acp_command_test.go
@@ -1,0 +1,189 @@
+package descriptor
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// --- OpenCode ---
+
+func TestOpenCodeACPCommand(t *testing.T) {
+	dataDir, projPath := buildOpenCodeFixture(t)
+	d := NewOpenCode(dataDir)
+
+	c, ok := d.(ACPCommander)
+	if !ok {
+		t.Fatal("opencode descriptor must implement ACPCommander")
+	}
+
+	argv, dir, env, err := c.ACPCommand(expectedOpenCodeKey(projPath))
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{"opencode", "acp"}; !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if dir != projPath {
+		t.Errorf("dir = %q, want station workspace %q", dir, projPath)
+	}
+	if env != nil {
+		t.Errorf("env = %v, want nil", env)
+	}
+}
+
+func TestOpenCodeACPCommand_UnknownKey(t *testing.T) {
+	dataDir, _ := buildOpenCodeFixture(t)
+	d := NewOpenCode(dataDir)
+
+	c, ok := d.(ACPCommander)
+	if !ok {
+		t.Fatal("opencode descriptor must implement ACPCommander")
+	}
+
+	if _, _, _, err := c.ACPCommand("opencode:deadbeef"); err == nil {
+		t.Fatal("expected error for unknown station key")
+	}
+}
+
+// --- Hermes ---
+
+func TestHermesACPCommand_UsesProfileFlag(t *testing.T) {
+	home := testdataHermesHome(t)
+	d := NewHermes(home)
+
+	c, ok := d.(ACPCommander)
+	if !ok {
+		t.Fatal("hermes descriptor must implement ACPCommander")
+	}
+
+	argv, dir, env, err := c.ACPCommand("hermes:coder-kai")
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	want := []string{"hermes", "-p", "coder-kai", "acp", "--accept-hooks"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if wantDir := filepath.Join(home, "profiles", "coder-kai"); dir != wantDir {
+		t.Errorf("dir = %q, want profile workspace %q", dir, wantDir)
+	}
+	if env != nil {
+		t.Errorf("env = %v, want nil", env)
+	}
+}
+
+func TestHermesACPCommand_RootKeyOmitsProfileFlag(t *testing.T) {
+	home := testdataHermesHome(t)
+	d := NewHermes(home)
+
+	c, ok := d.(ACPCommander)
+	if !ok {
+		t.Fatal("hermes descriptor must implement ACPCommander")
+	}
+
+	argv, dir, _, err := c.ACPCommand("hermes")
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	want := []string{"hermes", "acp", "--accept-hooks"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if dir != home {
+		t.Errorf("dir = %q, want hermes home %q", dir, home)
+	}
+}
+
+func TestHermesACPCommand_BadKey(t *testing.T) {
+	home := testdataHermesHome(t)
+	d := NewHermes(home)
+
+	c, ok := d.(ACPCommander)
+	if !ok {
+		t.Fatal("hermes descriptor must implement ACPCommander")
+	}
+
+	if _, _, _, err := c.ACPCommand("openclaw:main"); err == nil {
+		t.Fatal("expected error for unrecognized key")
+	}
+}
+
+// --- capability advertising ---
+
+func TestCapabilitiesIncludeACP(t *testing.T) {
+	t.Run("opencode", func(t *testing.T) {
+		dataDir, _ := buildOpenCodeFixture(t)
+		assertAllStationsHaveACP(t, NewOpenCode(dataDir))
+	})
+	t.Run("hermes", func(t *testing.T) {
+		assertAllStationsHaveACP(t, NewHermes(testdataHermesHome(t)))
+	})
+}
+
+func assertAllStationsHaveACP(t *testing.T, d Descriptor) {
+	t.Helper()
+	stations, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(stations) == 0 {
+		t.Fatal("fixture produced no stations")
+	}
+	for _, s := range stations {
+		var found bool
+		for _, c := range s.Capabilities {
+			if c == "acp" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("station %q missing %q capability: %v", s.Key, "acp", s.Capabilities)
+		}
+	}
+}
+
+// --- Handler resolution ---
+
+func TestHandlerACPCommand_ResolvesOpenCode(t *testing.T) {
+	dataDir, projPath := buildOpenCodeFixture(t)
+	reg := NewRegistry()
+	reg.Register(NewOpenCode(dataDir))
+	h := NewCapabilityHandler(reg)
+
+	argv, dir, env, err := h.ACPCommand(expectedOpenCodeKey(projPath))
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{"opencode", "acp"}; !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if dir != projPath {
+		t.Errorf("dir = %q, want %q", dir, projPath)
+	}
+	if env != nil {
+		t.Errorf("env = %v, want nil", env)
+	}
+}
+
+func TestHandlerACPCommand_UnsupportedHarness(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(NewClaudeCode("/nonexistent/claude/home"))
+	h := NewCapabilityHandler(reg)
+
+	_, _, _, err := h.ACPCommand("claude-code:abcd1234")
+	if err == nil {
+		t.Fatal("expected error for harness without ACP support")
+	}
+	if !strings.Contains(err.Error(), "acp not supported") {
+		t.Errorf("error should contain %q, got: %v", "acp not supported", err)
+	}
+}
+
+func TestHandlerACPCommand_UnknownHarness(t *testing.T) {
+	h := NewCapabilityHandler(NewRegistry())
+	if _, _, _, err := h.ACPCommand("hermes:coder-kai"); err == nil {
+		t.Fatal("expected error for unregistered harness")
+	}
+}

--- a/apps/node-agent/internal/descriptor/claudecode.go
+++ b/apps/node-agent/internal/descriptor/claudecode.go
@@ -412,14 +412,18 @@ func (c *claudeCodeDescriptor) TailLogs(ctx context.Context, key string, follow 
 	}
 
 	sessDir := c.sessionDirFor(projPath)
-	logFiles := collectJsonlFiles(sessDir)
+	collect := func() []string { return collectJsonlFiles(sessDir) }
+	logFiles := collect()
 
 	if !follow {
 		// One-shot: emit the last N lines of existing content.
 		return emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit)
 	}
 
-	// Follow mode: emit the last N lines first, then poll for appends.
+	// Follow mode: wait for a log file to exist (a harness that hasn't
+	// written logs yet must not close the stream immediately), then emit the
+	// last N lines and poll for appends.
+	logFiles = waitForLogFiles(ctx, collect)
 	if err := emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit); err != nil {
 		return err
 	}

--- a/apps/node-agent/internal/descriptor/codex.go
+++ b/apps/node-agent/internal/descriptor/codex.go
@@ -108,12 +108,17 @@ func (c *codexDescriptor) ReadFile(key, rel string, maxBytes int64) ([]byte, str
 // home directory is available. Falls back gracefully if absent.
 func (c *codexDescriptor) TailLogs(ctx context.Context, key string, follow bool, emit func([]byte) error) error {
 	sessDir := filepath.Join(c.home, "sessions")
-	logFiles := collectCodexLogFiles(sessDir)
+	collect := func() []string { return collectCodexLogFiles(sessDir) }
+	logFiles := collect()
 
 	if !follow {
 		return emitLogFiles(logFiles, emit)
 	}
 
+	// Follow mode: wait for a log file to exist (a harness that hasn't
+	// written logs yet must not close the stream immediately), then emit its
+	// content and poll for appends.
+	logFiles = waitForLogFiles(ctx, collect)
 	if err := emitLogFiles(logFiles, emit); err != nil {
 		return err
 	}

--- a/apps/node-agent/internal/descriptor/descriptor.go
+++ b/apps/node-agent/internal/descriptor/descriptor.go
@@ -166,3 +166,15 @@ type Descriptor interface {
 	// If follow is true the stream continues until ctx is cancelled.
 	TailLogs(ctx context.Context, key string, follow bool, emit func([]byte) error) error
 }
+
+// ACPCommander is an OPTIONAL interface implemented by descriptors whose
+// harness can serve an ACP (Agent Client Protocol) session over stdio. The
+// "acp" capability is advertised in Detect output ONLY when the descriptor
+// implements this interface.
+//
+// ACPCommand returns the command to spawn for a station key: argv is the full
+// command line (argv[0] is the binary); dir is the working directory; env is
+// extra environment appended to the inherited one (may be nil).
+type ACPCommander interface {
+	ACPCommand(key string) (argv []string, dir string, env []string, err error)
+}

--- a/apps/node-agent/internal/descriptor/handler.go
+++ b/apps/node-agent/internal/descriptor/handler.go
@@ -56,6 +56,34 @@ func NewHandler(reg *Registry) gateway.Handler {
 	})
 }
 
+// Handler exposes typed per-station capability resolution over a Registry for
+// the gateway wiring in cmd/agentpod-node. The verb-routing gateway.Handler is
+// built separately by NewHandler; methods here are injected into the gateway
+// as plain funcs, mirroring how lifecycleFn resolves the Lifecycle interface.
+type Handler struct {
+	reg *Registry
+}
+
+// NewCapabilityHandler returns a Handler resolving capabilities against reg.
+func NewCapabilityHandler(reg *Registry) *Handler {
+	return &Handler{reg: reg}
+}
+
+// ACPCommand resolves the descriptor for key and, when it implements
+// ACPCommander, returns the ACP spawn command for the station. Descriptors
+// that do not implement the interface yield an "acp not supported" error.
+func (h *Handler) ACPCommand(key string) (argv []string, dir string, env []string, err error) {
+	d, err := h.reg.For(key)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	c, ok := d.(ACPCommander)
+	if !ok {
+		return nil, "", nil, fmt.Errorf("acp not supported for harness %q", d.Harness())
+	}
+	return c.ACPCommand(key)
+}
+
 // --- verb handlers ---
 
 func handleDetect(reg *Registry) (any, bool, error) {

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -61,7 +61,7 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 		return []Station{}, nil
 	}
 
-	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "lifecycle", "cleanup"}
+	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "lifecycle", "cleanup", "acp"}
 	homeCopy := h.home
 
 	stations := []Station{
@@ -120,6 +120,23 @@ func (h *hermesDescriptor) workspaceFor(key string) (string, error) {
 		return filepath.Join(h.home, "profiles", name), nil
 	}
 	return "", fmt.Errorf("hermes: unrecognized key %q", key)
+}
+
+// ACPCommand implements ACPCommander. Hermes serves an ACP session via
+// `hermes -p <profile> acp --accept-hooks`, run from the profile's workspace.
+// The profile is derived from the station key the same way workspaceFor and
+// hermesNativeStartArgs parse it; for the root "hermes" key the profile
+// selector is omitted (mirroring hermesNativeStartArgs) and dir is the home.
+func (h *hermesDescriptor) ACPCommand(key string) (argv []string, dir string, env []string, err error) {
+	dir, err = h.workspaceFor(key)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	if key == "hermes" {
+		return []string{"hermes", "acp", "--accept-hooks"}, dir, nil, nil
+	}
+	name := strings.TrimPrefix(key, "hermes:")
+	return []string{"hermes", "-p", name, "acp", "--accept-hooks"}, dir, nil, nil
 }
 
 // Health returns a best-effort liveness/resource snapshot for a station.

--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -436,14 +436,18 @@ func (h *hermesDescriptor) TailLogs(ctx context.Context, key string, follow bool
 	}
 
 	// Collect all log file paths from the log directories.
-	logFiles := collectLogFiles(logDirs)
+	collect := func() []string { return collectLogFiles(logDirs) }
+	logFiles := collect()
 
 	if !follow {
 		// One-shot: emit the last N lines of existing content.
 		return emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit)
 	}
 
-	// Follow mode: emit the last N lines first, then poll for appends.
+	// Follow mode: wait for a log file to exist (a harness that hasn't
+	// written logs yet must not close the stream immediately), then emit the
+	// last N lines and poll for appends.
+	logFiles = waitForLogFiles(ctx, collect)
 	if err := emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit); err != nil {
 		return err
 	}

--- a/apps/node-agent/internal/descriptor/openclaw.go
+++ b/apps/node-agent/internal/descriptor/openclaw.go
@@ -427,14 +427,18 @@ func (o *openclawDescriptor) ReadFile(key, rel string, maxBytes int64) ([]byte, 
 // (e.g. binary or config files that may appear in the logs dir) are skipped.
 func (o *openclawDescriptor) TailLogs(ctx context.Context, key string, follow bool, emit func([]byte) error) error {
 	logsDir := filepath.Join(o.home, "logs")
-	logFiles := collectOpenClawLogFiles(logsDir)
+	collect := func() []string { return collectOpenClawLogFiles(logsDir) }
+	logFiles := collect()
 
 	if !follow {
 		// One-shot: emit the last N lines of existing content.
 		return emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit)
 	}
 
-	// Follow mode: emit the last N lines first, then poll for appends.
+	// Follow mode: wait for a log file to exist (a harness that hasn't
+	// written logs yet must not close the stream immediately), then emit the
+	// last N lines and poll for appends.
+	logFiles = waitForLogFiles(ctx, collect)
 	if err := emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit); err != nil {
 		return err
 	}

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -391,14 +391,18 @@ func (o *openCodeDescriptor) TailLogs(ctx context.Context, key string, follow bo
 	}
 
 	logDir := filepath.Join(o.dataDir, "log")
-	logFiles := collectOpenCodeLogFiles(logDir)
+	collect := func() []string { return collectOpenCodeLogFiles(logDir) }
+	logFiles := collect()
 
 	if !follow {
 		// One-shot: emit the last N lines of existing content.
 		return emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit)
 	}
 
-	// Follow mode: emit the last N lines first, then poll for appends.
+	// Follow mode: wait for a log file to exist (a harness that hasn't
+	// written logs yet must not close the stream immediately), then emit the
+	// last N lines and poll for appends.
+	logFiles = waitForLogFiles(ctx, collect)
 	if err := emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit); err != nil {
 		return err
 	}

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -424,7 +424,17 @@ func startOpenCodeServeDetached() error {
 // process (TERM → grace → KILL via stopProcess) and then touches the stop
 // sentinel so the entrypoint's supervision loop does not immediately
 // resurrect it. See the package comment above for the coordination mechanism.
+//
+// Guarded by openCodeSupervised(): Detect() only advertises "lifecycle" when
+// AGENTPOD_OPENCODE_SUPERVISED=1, but Go's structural typing means Stop/Start
+// are still callable if a lifecycle verb ever reached this descriptor another
+// way (a hub bug, a future direct WS caller). Without this guard, Stop on a
+// real host would hunt for (and possibly kill) any process whose command line
+// happens to match "opencode.*serve".
 func (o *openCodeDescriptor) Stop(key string) error {
+	if !openCodeSupervised() {
+		return fmt.Errorf("opencode: stop %q: lifecycle requires supervised mode (%s=1)", key, openCodeSupervisedEnvVar)
+	}
 	pid, err := openCodeServePID()
 	if err != nil {
 		return fmt.Errorf("opencode: stop %q: %w", key, err)
@@ -440,7 +450,15 @@ func (o *openCodeDescriptor) Stop(key string) error {
 
 // Start implements Lifecycle. It removes the stop sentinel and re-spawns
 // `opencode serve` detached in /workspace, appending to the shared log.
+//
+// Guarded by openCodeSupervised() for the same reason as Stop: without it,
+// Start would spawn an unsupervised `opencode serve` on a bare-metal host
+// that has no supervision loop to restart it on crash and no sentinel
+// convention for a later Stop to coordinate with.
 func (o *openCodeDescriptor) Start(key string) error {
+	if !openCodeSupervised() {
+		return fmt.Errorf("opencode: start %q: lifecycle requires supervised mode (%s=1)", key, openCodeSupervisedEnvVar)
+	}
 	if err := os.Remove(openCodeServeSentinelPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("opencode: start %q: clear sentinel: %w", key, err)
 	}

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -110,6 +112,14 @@ func (o *openCodeDescriptor) Detect() ([]Station, error) {
 	}
 
 	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup", "acp"}
+	if openCodeSupervised() {
+		// Only a provisioned opencode container (deploy/node-opencode-entrypoint.sh)
+		// runs a supervised `opencode serve` process for Stop/Start to control.
+		// On a real host, opencode has no persistent process to manage — the
+		// capability, and therefore the descriptor's Lifecycle methods, must
+		// stay unadvertised there.
+		caps = append(caps, "lifecycle")
+	}
 	seen := make(map[string]bool)
 	var stations []Station
 
@@ -300,6 +310,144 @@ func openCodeProcessRunning() (running bool, note string) {
 		return false, "process check unavailable (pgrep not found or failed)"
 	}
 	return strings.TrimSpace(string(out)) != "", ""
+}
+
+// --- Lifecycle (gated: AGENTPOD_OPENCODE_SUPERVISED=1) ---
+//
+// A provisioned opencode container (deploy/node-opencode-entrypoint.sh) runs
+// `opencode serve` under a supervision loop: a shell while-loop that restarts
+// the process on crash with a 2s backoff. That loop is what makes the
+// container a living, dispatchable station — but it also means a bare SIGTERM
+// from Stop would be undone within 2s. The two sides coordinate via a
+// sentinel file, /var/run/opencode-serve.stop:
+//
+//   - Stop terminates the running `opencode serve` process, THEN touches the
+//     sentinel. The entrypoint loop checks the sentinel before every respawn
+//     and exits the loop when it is present, so the process actually stays
+//     down.
+//   - Start removes the sentinel and re-spawns `opencode serve` itself
+//     (the entrypoint loop already exited, so it will not race the respawn).
+//
+// On a real host (env var unset) these methods are unreachable in practice:
+// Detect() omits "lifecycle" from capabilities, so neither the console nor
+// the lifecycle dispatcher (cmd/agentpod-node/run.go) ever calls them for an
+// opencode key.
+
+const (
+	// openCodeSupervisedEnvVar gates the "lifecycle" capability and the
+	// interpretation of Stop/Start below. Set by
+	// deploy/node-opencode-entrypoint.sh in provisioned opencode containers.
+	openCodeSupervisedEnvVar = "AGENTPOD_OPENCODE_SUPERVISED"
+
+	// openCodeServePattern is the pgrep -f pattern matching the supervised
+	// `opencode serve` process, mirroring the entrypoint's invocation.
+	openCodeServePattern = "opencode.*serve"
+)
+
+// These are `var`, not `const`, purely so tests can point them at a temp
+// directory instead of the real container paths below. Production code never
+// reassigns them.
+var (
+	// openCodeServeLogPath is the log file the entrypoint's supervision loop
+	// appends to; Start appends to the same file so log output survives a
+	// lifecycle-triggered restart.
+	openCodeServeLogPath = "/var/log/opencode-serve.log"
+
+	// openCodeServeSentinelPath is the file Stop touches (and Start removes)
+	// to signal the entrypoint's supervision loop to halt/resume.
+	openCodeServeSentinelPath = "/var/run/opencode-serve.stop"
+
+	// openCodeWorkspaceDir is the fixed workspace root for a provisioned
+	// opencode container (see node-opencode-entrypoint.sh).
+	openCodeWorkspaceDir = "/workspace"
+)
+
+// openCodeSupervised reports whether this runtime is a provisioned opencode
+// container running the supervised `opencode serve` loop, as opposed to a
+// bare-metal fleet host where opencode has no persistent process.
+func openCodeSupervised() bool {
+	return os.Getenv(openCodeSupervisedEnvVar) == "1"
+}
+
+// openCodeServePID returns the PID of the running `opencode serve` process
+// (matched via openCodeServePattern), or an error if none is found.
+func openCodeServePID() (int, error) {
+	out, err := exec.Command("pgrep", "-f", openCodeServePattern).Output()
+	if err != nil {
+		return 0, fmt.Errorf("no running 'opencode serve' process found")
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("no running 'opencode serve' process found")
+	}
+	return strconv.Atoi(fields[0])
+}
+
+// touchOpenCodeStopSentinel creates (or refreshes) the sentinel file that
+// tells the entrypoint's supervision loop to stop respawning `opencode serve`.
+func touchOpenCodeStopSentinel() error {
+	if err := os.MkdirAll(filepath.Dir(openCodeServeSentinelPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir sentinel dir: %w", err)
+	}
+	f, err := os.OpenFile(openCodeServeSentinelPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("touch sentinel %q: %w", openCodeServeSentinelPath, err)
+	}
+	return f.Close()
+}
+
+// startOpenCodeServeDetached spawns `opencode serve` rooted at the workspace,
+// detached from the node-agent process, appending stdout/stderr to the same
+// log file the entrypoint's supervision loop writes to.
+func startOpenCodeServeDetached() error {
+	logFile, err := os.OpenFile(openCodeServeLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open log %q: %w", openCodeServeLogPath, err)
+	}
+	defer logFile.Close()
+
+	cmd := exec.Command("opencode", "serve")
+	cmd.Dir = openCodeWorkspaceDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start opencode serve: %w", err)
+	}
+	// Reap in the background so an unexpectedly short-lived process does not
+	// linger as a zombie under the node-agent.
+	go func() { _ = cmd.Wait() }()
+	return nil
+}
+
+// Stop implements Lifecycle. It terminates the supervised `opencode serve`
+// process (TERM → grace → KILL via stopProcess) and then touches the stop
+// sentinel so the entrypoint's supervision loop does not immediately
+// resurrect it. See the package comment above for the coordination mechanism.
+func (o *openCodeDescriptor) Stop(key string) error {
+	pid, err := openCodeServePID()
+	if err != nil {
+		return fmt.Errorf("opencode: stop %q: %w", key, err)
+	}
+	if err := stopProcess(pid, LifecycleGracePeriod); err != nil {
+		return fmt.Errorf("opencode: stop %q: %w", key, err)
+	}
+	if err := touchOpenCodeStopSentinel(); err != nil {
+		return fmt.Errorf("opencode: stop %q: %w", key, err)
+	}
+	return nil
+}
+
+// Start implements Lifecycle. It removes the stop sentinel and re-spawns
+// `opencode serve` detached in /workspace, appending to the shared log.
+func (o *openCodeDescriptor) Start(key string) error {
+	if err := os.Remove(openCodeServeSentinelPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("opencode: start %q: clear sentinel: %w", key, err)
+	}
+	if err := startOpenCodeServeDetached(); err != nil {
+		return fmt.Errorf("opencode: start %q: %w", key, err)
+	}
+	return nil
 }
 
 // ListDir lists the directory at rel within the project workspace.

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -109,7 +109,7 @@ func (o *openCodeDescriptor) Detect() ([]Station, error) {
 		return nil, err
 	}
 
-	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup"}
+	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup", "acp"}
 	seen := make(map[string]bool)
 	var stations []Station
 
@@ -241,6 +241,17 @@ func (o *openCodeDescriptor) projectPathForKey(key string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("opencode: station not found: %q", key)
+}
+
+// ACPCommand implements ACPCommander. OpenCode serves an ACP session via
+// `opencode acp`, run from the station's project workspace (the same path
+// term.open resolves through the workspace resolver).
+func (o *openCodeDescriptor) ACPCommand(key string) (argv []string, dir string, env []string, err error) {
+	projPath, err := o.projectPathForKey(key)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return []string{"opencode", "acp"}, projPath, nil, nil
 }
 
 // Health returns a best-effort liveness/resource snapshot for a leaf station.

--- a/apps/node-agent/internal/descriptor/opencode_test.go
+++ b/apps/node-agent/internal/descriptor/opencode_test.go
@@ -531,6 +531,7 @@ exit 0
 // an error when no `opencode serve` process can be found (pgrep exits 1, as
 // on a fresh runtime with nothing running yet).
 func TestOpenCodeLifecycle_Stop_NoProcess_ReturnsError(t *testing.T) {
+	t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")
 	tmpDir := t.TempDir()
 	writeFakePgrep(t, tmpDir) // from hermes_lifecycle_systemd_test.go: always exits 1
 	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
@@ -545,6 +546,7 @@ func TestOpenCodeLifecycle_Stop_NoProcess_ReturnsError(t *testing.T) {
 // queries pgrep with the exact "-f opencode.*serve" pattern the entrypoint's
 // supervised process matches.
 func TestOpenCodeLifecycle_Stop_UsesExpectedPgrepPattern(t *testing.T) {
+	t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")
 	tmpDir := t.TempDir()
 	argsFile := filepath.Join(tmpDir, "pgrep.args")
 
@@ -576,6 +578,7 @@ func TestOpenCodeLifecycle_Stop_UsesExpectedPgrepPattern(t *testing.T) {
 // AND leave the stop sentinel behind so the entrypoint's supervision loop
 // halts instead of resurrecting it within 2s (which would make Stop a no-op).
 func TestOpenCodeLifecycle_Stop_KillsProcessAndTouchesSentinel(t *testing.T) {
+	t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")
 	tmpDir := t.TempDir()
 	argsFile := filepath.Join(tmpDir, "pgrep.args")
 
@@ -642,6 +645,7 @@ func withTempWorkspaceDir(t *testing.T, dir string) {
 // action isn't confused by a stale one) and re-spawns `opencode serve` cd'd
 // into the workspace, appending output to the shared serve log.
 func TestOpenCodeLifecycle_Start_RemovesSentinelAndSpawnsServeInWorkspace(t *testing.T) {
+	t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")
 	stubDir := t.TempDir()
 	argsFile := filepath.Join(stubDir, "opencode.args")
 	cwdFile := filepath.Join(stubDir, "opencode.cwd")
@@ -707,6 +711,7 @@ pwd > %s
 // does not error when the sentinel file does not already exist (the common
 // case: Start after a normal boot, not after a prior Stop).
 func TestOpenCodeLifecycle_Start_NoSentinel_StillSucceeds(t *testing.T) {
+	t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")
 	stubDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stubDir, "opencode"), []byte("#!/bin/sh\ntrue\n"), 0o755); err != nil {
 		t.Fatalf("write opencode stub: %v", err)
@@ -720,5 +725,66 @@ func TestOpenCodeLifecycle_Start_NoSentinel_StillSucceeds(t *testing.T) {
 	o := &openCodeDescriptor{}
 	if err := o.Start("opencode:abc"); err != nil {
 		t.Fatalf("Start with no pre-existing sentinel: unexpected error: %v", err)
+	}
+}
+
+// --- Lifecycle guard: Stop/Start must refuse to act on an unsupervised host ---
+//
+// Detect() only advertises "lifecycle" when AGENTPOD_OPENCODE_SUPERVISED=1,
+// but openCodeDescriptor structurally satisfies the Lifecycle interface
+// either way (Go can't gate a method set by an env var). These tests cover
+// the in-method guard that makes Stop/Start themselves refuse to run without
+// the env var — so a lifecycle verb reaching this descriptor by some other
+// path (a hub bug, a future direct WS caller) can't kill or spawn an
+// unsupervised `opencode serve` on a bare-metal host.
+
+// TestOpenCodeLifecycle_Stop_UnsupervisedHost_ReturnsError asserts that Stop
+// refuses to run (and never touches pgrep or the sentinel) when
+// AGENTPOD_OPENCODE_SUPERVISED is unset.
+func TestOpenCodeLifecycle_Stop_UnsupervisedHost_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "pgrep.args")
+	writeFakePgrepPID(t, tmpDir, 99999, argsFile) // would "succeed" if ever invoked
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	withTempSentinel(t)
+
+	o := &openCodeDescriptor{}
+	if err := o.Stop("opencode:abc"); err == nil {
+		t.Fatal("expected error from Stop when AGENTPOD_OPENCODE_SUPERVISED is unset")
+	}
+	if readLog(t, argsFile) != "" {
+		t.Error("Stop must not invoke pgrep when unsupervised")
+	}
+}
+
+// TestOpenCodeLifecycle_Start_UnsupervisedHost_ReturnsError asserts that
+// Start refuses to run (and never spawns opencode or removes the sentinel)
+// when AGENTPOD_OPENCODE_SUPERVISED is unset.
+func TestOpenCodeLifecycle_Start_UnsupervisedHost_ReturnsError(t *testing.T) {
+	stubDir := t.TempDir()
+	argsFile := filepath.Join(stubDir, "opencode.args")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s' "$*" > %s
+`, argsFile)
+	if err := os.WriteFile(filepath.Join(stubDir, "opencode"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write opencode stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+	withTempWorkspaceDir(t, t.TempDir())
+	withTempServeLog(t)
+	sentinel := withTempSentinel(t)
+	if err := os.WriteFile(sentinel, []byte(""), 0o644); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+
+	o := &openCodeDescriptor{}
+	if err := o.Start("opencode:abc"); err == nil {
+		t.Fatal("expected error from Start when AGENTPOD_OPENCODE_SUPERVISED is unset")
+	}
+	if readLog(t, argsFile) != "" {
+		t.Error("Start must not invoke opencode when unsupervised")
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("Start must not remove the sentinel when unsupervised, stat err = %v", err)
 	}
 }

--- a/apps/node-agent/internal/descriptor/opencode_test.go
+++ b/apps/node-agent/internal/descriptor/opencode_test.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // buildOpenCodeFixture creates a temporary OpenCode data directory suitable for
@@ -444,5 +446,279 @@ func TestOpenCodeDetect_DBPrimary(t *testing.T) {
 	}
 	if s.Kind != "leaf" {
 		t.Errorf("kind: want leaf, got %q", s.Kind)
+	}
+}
+
+// --- Lifecycle capability gating ---
+
+// TestOpenCodeDetect_LifecycleCapability_UngatedByDefault asserts that a
+// bare-metal opencode host (no AGENTPOD_OPENCODE_SUPERVISED env var) never
+// advertises "lifecycle" — it has no supervised process for Stop/Start to
+// control.
+func TestOpenCodeDetect_LifecycleCapability_UngatedByDefault(t *testing.T) {
+	dataDir, projPath := buildOpenCodeFixture(t)
+	d := NewOpenCode(dataDir)
+
+	stations, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	key := expectedOpenCodeKey(projPath)
+	s := findOpenCodeStation(t, stations, key)
+	if hasCapability(s.Capabilities, "lifecycle") {
+		t.Errorf("capabilities should NOT include 'lifecycle' without AGENTPOD_OPENCODE_SUPERVISED, got %v", s.Capabilities)
+	}
+}
+
+// TestOpenCodeDetect_LifecycleCapability_WhenSupervised asserts that setting
+// AGENTPOD_OPENCODE_SUPERVISED=1 (as the provisioned-opencode entrypoint
+// does) adds "lifecycle" to the station's capabilities.
+func TestOpenCodeDetect_LifecycleCapability_WhenSupervised(t *testing.T) {
+	t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")
+	dataDir, projPath := buildOpenCodeFixture(t)
+	d := NewOpenCode(dataDir)
+
+	stations, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	key := expectedOpenCodeKey(projPath)
+	s := findOpenCodeStation(t, stations, key)
+	if !hasCapability(s.Capabilities, "lifecycle") {
+		t.Errorf("capabilities should include 'lifecycle' when AGENTPOD_OPENCODE_SUPERVISED=1, got %v", s.Capabilities)
+	}
+}
+
+func findOpenCodeStation(t *testing.T, stations []Station, key string) Station {
+	t.Helper()
+	for _, s := range stations {
+		if s.Key == key {
+			return s
+		}
+	}
+	t.Fatalf("station %q not found in %+v", key, stations)
+	return Station{}
+}
+
+func hasCapability(caps []string, want string) bool {
+	for _, c := range caps {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Lifecycle Stop/Start ---
+
+// writeFakePgrepPID writes an executable "pgrep" stub in tmpDir. It logs its
+// invocation args (space-joined) to argsFile, then prints pid and exits 0 —
+// simulating a matching `opencode serve` process without depending on the
+// real opencode binary or a real pgrep -f substring match.
+func writeFakePgrepPID(t *testing.T, tmpDir string, pid int, argsFile string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %s
+echo %d
+exit 0
+`, argsFile, pid)
+	if err := os.WriteFile(filepath.Join(tmpDir, "pgrep"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writeFakePgrepPID: %v", err)
+	}
+}
+
+// TestOpenCodeLifecycle_Stop_NoProcess_ReturnsError asserts that Stop returns
+// an error when no `opencode serve` process can be found (pgrep exits 1, as
+// on a fresh runtime with nothing running yet).
+func TestOpenCodeLifecycle_Stop_NoProcess_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeFakePgrep(t, tmpDir) // from hermes_lifecycle_systemd_test.go: always exits 1
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	o := &openCodeDescriptor{}
+	if err := o.Stop("opencode:abc"); err == nil {
+		t.Fatal("expected error when no opencode serve process is running")
+	}
+}
+
+// TestOpenCodeLifecycle_Stop_UsesExpectedPgrepPattern asserts that Stop
+// queries pgrep with the exact "-f opencode.*serve" pattern the entrypoint's
+// supervised process matches.
+func TestOpenCodeLifecycle_Stop_UsesExpectedPgrepPattern(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "pgrep.args")
+
+	// A real process for the fake pgrep to "find" and for stopProcess to kill.
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	writeFakePgrepPID(t, tmpDir, cmd.Process.Pid, argsFile)
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	withTempSentinel(t)
+
+	o := &openCodeDescriptor{}
+	if err := o.Stop("opencode:abc"); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Stop: %v", err)
+	}
+
+	got := readLog(t, argsFile)
+	if !strings.Contains(got, "-f opencode.*serve") {
+		t.Errorf("expected pgrep invoked with '-f opencode.*serve', got %q", got)
+	}
+}
+
+// TestOpenCodeLifecycle_Stop_KillsProcessAndTouchesSentinel is the core
+// regression: Stop must both terminate the running `opencode serve` process
+// AND leave the stop sentinel behind so the entrypoint's supervision loop
+// halts instead of resurrecting it within 2s (which would make Stop a no-op).
+func TestOpenCodeLifecycle_Stop_KillsProcessAndTouchesSentinel(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "pgrep.args")
+
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+	pid := cmd.Process.Pid
+
+	writeFakePgrepPID(t, tmpDir, pid, argsFile)
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	sentinel := withTempSentinel(t)
+
+	o := &openCodeDescriptor{}
+	if err := o.Stop("opencode:abc"); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if err := cmd.Process.Signal(syscall.Signal(0)); err == nil {
+		_ = cmd.Process.Kill()
+		t.Fatal("process still alive after Stop")
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("expected stop sentinel %q to exist after Stop: %v", sentinel, err)
+	}
+}
+
+// withTempSentinel points openCodeServeSentinelPath at a path inside a fresh
+// t.TempDir() for the duration of the test and restores it afterward — Stop
+// and Start must never touch the real /var/run path in tests.
+func withTempSentinel(t *testing.T) string {
+	t.Helper()
+	sentinel := filepath.Join(t.TempDir(), "opencode-serve.stop")
+	orig := openCodeServeSentinelPath
+	openCodeServeSentinelPath = sentinel
+	t.Cleanup(func() { openCodeServeSentinelPath = orig })
+	return sentinel
+}
+
+// withTempServeLog points openCodeServeLogPath at a path inside a fresh
+// t.TempDir() for the duration of the test.
+func withTempServeLog(t *testing.T) string {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "opencode-serve.log")
+	orig := openCodeServeLogPath
+	openCodeServeLogPath = logPath
+	t.Cleanup(func() { openCodeServeLogPath = orig })
+	return logPath
+}
+
+// withTempWorkspaceDir points openCodeWorkspaceDir at dir for the duration of
+// the test.
+func withTempWorkspaceDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := openCodeWorkspaceDir
+	openCodeWorkspaceDir = dir
+	t.Cleanup(func() { openCodeWorkspaceDir = orig })
+}
+
+// TestOpenCodeLifecycle_Start_RemovesSentinelAndSpawnsServeInWorkspace
+// asserts that Start clears the stop sentinel (so a subsequent lifecycle
+// action isn't confused by a stale one) and re-spawns `opencode serve` cd'd
+// into the workspace, appending output to the shared serve log.
+func TestOpenCodeLifecycle_Start_RemovesSentinelAndSpawnsServeInWorkspace(t *testing.T) {
+	stubDir := t.TempDir()
+	argsFile := filepath.Join(stubDir, "opencode.args")
+	cwdFile := filepath.Join(stubDir, "opencode.cwd")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s' "$*" > %s
+pwd > %s
+`, argsFile, cwdFile)
+	if err := os.WriteFile(filepath.Join(stubDir, "opencode"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write opencode stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	workspace := t.TempDir()
+	withTempWorkspaceDir(t, workspace)
+	logPath := withTempServeLog(t)
+	sentinel := withTempSentinel(t)
+	if err := os.WriteFile(sentinel, []byte(""), 0o644); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+
+	o := &openCodeDescriptor{}
+	if err := o.Start("opencode:abc"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Errorf("expected sentinel removed after Start, stat err = %v", err)
+	}
+
+	var args string
+	for i := 0; i < 100; i++ {
+		if b, err := os.ReadFile(argsFile); err == nil && len(b) > 0 {
+			args = string(b)
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if args != "serve" {
+		t.Errorf("expected stub invoked with 'serve', got %q", args)
+	}
+
+	var cwdOut string
+	for i := 0; i < 100; i++ {
+		if b, err := os.ReadFile(cwdFile); err == nil && len(b) > 0 {
+			cwdOut = strings.TrimSpace(string(b))
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	wantWorkspace, _ := filepath.EvalSymlinks(workspace)
+	gotWorkspace, _ := filepath.EvalSymlinks(cwdOut)
+	if gotWorkspace != wantWorkspace {
+		t.Errorf("expected opencode serve to run in %q, ran in %q", wantWorkspace, cwdOut)
+	}
+
+	// The log file must exist (opened for append before the stub ran).
+	if _, err := os.Stat(logPath); err != nil {
+		t.Errorf("expected serve log %q to exist: %v", logPath, err)
+	}
+}
+
+// TestOpenCodeLifecycle_Start_NoSentinel_StillSucceeds asserts that Start
+// does not error when the sentinel file does not already exist (the common
+// case: Start after a normal boot, not after a prior Stop).
+func TestOpenCodeLifecycle_Start_NoSentinel_StillSucceeds(t *testing.T) {
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "opencode"), []byte("#!/bin/sh\ntrue\n"), 0o755); err != nil {
+		t.Fatalf("write opencode stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	withTempWorkspaceDir(t, t.TempDir())
+	withTempServeLog(t)
+	withTempSentinel(t) // path set but file not created
+
+	o := &openCodeDescriptor{}
+	if err := o.Start("opencode:abc"); err != nil {
+		t.Fatalf("Start with no pre-existing sentinel: unexpected error: %v", err)
 	}
 }

--- a/apps/node-agent/internal/descriptor/tail.go
+++ b/apps/node-agent/internal/descriptor/tail.go
@@ -2,12 +2,51 @@ package descriptor
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
+	"time"
 )
 
 // tailDefaultN is the default number of lines returned by the initial log emit.
 const tailDefaultN = 500
+
+// tailWaitInterval is how often follow-mode TailLogs implementations poll
+// for the first log file to appear when none exist yet. See
+// waitForLogFiles.
+const tailWaitInterval = 1 * time.Second
+
+// waitForLogFiles blocks until collect() returns at least one file or ctx is
+// cancelled, polling every tailWaitInterval. If collect() already has
+// results on the first call, it returns immediately without waiting for a
+// tick. Returns nil if ctx is cancelled before any file appears.
+//
+// Follow-mode TailLogs implementations call this before starting their
+// append-polling loop so that a harness which hasn't written any log files
+// yet doesn't cause the stream to close immediately — see the dogfooding bug
+// (2026-08-09): follow-mode with zero matching log files returned right
+// away, the hub then closed the SSE instantly, and the console's Logs tab
+// retry-looped into "Disconnected" for any harness that hadn't written logs
+// yet.
+func waitForLogFiles(ctx context.Context, collect func() []string) []string {
+	if files := collect(); len(files) > 0 {
+		return files
+	}
+
+	ticker := time.NewTicker(tailWaitInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if files := collect(); len(files) > 0 {
+				return files
+			}
+		}
+	}
+}
 
 // tailMaxBytes is the maximum number of bytes read from the end of a log file
 // for the initial emit. Files larger than this are seeked so only the tail

--- a/apps/node-agent/internal/descriptor/tail_test.go
+++ b/apps/node-agent/internal/descriptor/tail_test.go
@@ -1,10 +1,13 @@
 package descriptor
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestLastNLines_LargeFile verifies that a file with 5000 lines returns only
@@ -132,5 +135,120 @@ func TestLastNLines_ByteCapKeepsWholeLines(t *testing.T) {
 	// Must have at least some lines.
 	if len(lines) == 0 {
 		t.Error("expected at least one line with maxBytes=1000")
+	}
+}
+
+// --- follow-mode wait-for-first-file ---
+//
+// tailGlob exercises waitForLogFiles the same way production TailLogs
+// implementations do: collect files matching a glob, and in follow mode wait
+// for the first one to appear before emitting. It is a thin test harness
+// over the real shared helper (waitForLogFiles in tail.go), not a
+// reimplementation of it.
+func tailGlob(ctx context.Context, pattern string, follow bool, emit func([]byte) error) error {
+	collect := func() []string {
+		matches, _ := filepath.Glob(pattern)
+		return matches
+	}
+	files := collect()
+	if follow {
+		files = waitForLogFiles(ctx, collect)
+	}
+	return emitLastNLines(files, tailDefaultN, tailMaxBytes, emit)
+}
+
+// TestTailFollow_WaitsForFirstLogFile verifies that follow-mode does not
+// return when the glob initially matches nothing — it must keep polling
+// until a matching file appears, then emit its content. Regression test for
+// the dogfooding bug (2026-08-09) where follow-mode with zero matching log
+// files returned immediately, the hub closed the SSE instantly, and the
+// console's Logs tab retry-looped into "Disconnected" for any harness that
+// hadn't written logs yet.
+func TestTailFollow_WaitsForFirstLogFile(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got := make(chan []byte, 8)
+	go func() {
+		_ = tailGlob(ctx, filepath.Join(dir, "*.log"), true, func(b []byte) error {
+			got <- append([]byte(nil), b...)
+			return nil
+		})
+	}()
+	time.Sleep(300 * time.Millisecond) // helper is now waiting, not returned
+	if err := os.WriteFile(filepath.Join(dir, "a.log"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case b := <-got:
+		if !strings.Contains(string(b), "hello") {
+			t.Fatalf("chunk = %q", b)
+		}
+	case <-ctx.Done():
+		t.Fatal("no output after log file appeared — follow returned early or never polled")
+	}
+}
+
+// TestTailNoFollow_EmptyDirReturnsImmediately verifies that follow==false is
+// unchanged: an empty glob returns right away with no polling.
+func TestTailNoFollow_EmptyDirReturnsImmediately(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	if err := tailGlob(context.Background(), filepath.Join(dir, "*.log"), false, func([]byte) error { return nil }); err != nil {
+		t.Fatalf("tailGlob: %v", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("no-follow should return immediately")
+	}
+}
+
+// TestWaitForLogFiles_ReturnsImmediatelyWhenFilesAlreadyExist verifies that
+// waitForLogFiles does not wait for a poll tick when collect already has
+// results — it must return on the first call.
+func TestWaitForLogFiles_ReturnsImmediatelyWhenFilesAlreadyExist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.log")
+	if err := os.WriteFile(path, []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	files := waitForLogFiles(context.Background(), func() []string {
+		matches, _ := filepath.Glob(filepath.Join(dir, "*.log"))
+		return matches
+	})
+	if time.Since(start) > time.Second {
+		t.Fatal("waitForLogFiles should not wait when files already exist")
+	}
+	if len(files) != 1 || files[0] != path {
+		t.Fatalf("files = %v, want [%s]", files, path)
+	}
+}
+
+// TestWaitForLogFiles_StopsOnContextCancel verifies that waitForLogFiles
+// gives up and returns nil once ctx is cancelled, rather than polling
+// forever.
+func TestWaitForLogFiles_StopsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- waitForLogFiles(ctx, func() []string {
+			matches, _ := filepath.Glob(filepath.Join(dir, "*.log"))
+			return matches
+		})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case files := <-done:
+		if files != nil {
+			t.Fatalf("files = %v, want nil after cancel", files)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForLogFiles did not return after ctx cancel")
 	}
 }

--- a/apps/node-agent/internal/gateway/acp.go
+++ b/apps/node-agent/internal/gateway/acp.go
@@ -22,30 +22,38 @@ type ACPCommandFunc func(key string) (argv []string, dir string, env []string, e
 // event from the session's reaper — so mu serializes them, keeping stream seq
 // numbers monotonic and guaranteeing nothing is emitted after the exit event.
 type acpAttachState struct {
-	sessionID string
-	unsub     func()
+	unsub func()
 
-	mu   sync.Mutex
-	seq  int
-	done bool // set once the exit event has been emitted
-	emit func(seq int, chunk string, eof bool, enc string) error
+	mu     sync.Mutex
+	seq    int
+	done   bool // set once the exit event has been emitted
+	failed bool // set once emit errored; suppresses further chunk frames
+	emit   func(seq int, chunk string, eof bool, enc string) error
 
 	exited chan struct{} // closed after the exit event; unblocks the attach handler
 }
 
 // emitChunk sends one base64 stream frame unless the exit event has already
-// been emitted.
+// been emitted or a previous emit failed. On emit failure the subscriber is
+// detached (mirroring term.attach's unsub-on-emit-error); the unsubscribe must
+// run async because it blocks until the session dispatcher — the goroutine
+// calling this very function — has drained and returned.
 func (st *acpAttachState) emitChunk(chunk []byte) {
 	encoded := base64.StdEncoding.EncodeToString(chunk)
 	st.mu.Lock()
-	defer st.mu.Unlock()
-	if st.done {
+	if st.done || st.failed {
+		st.mu.Unlock()
 		return
 	}
 	if err := st.emit(st.seq, encoded, false, "base64"); err != nil {
-		return // hub disconnected or attach cancelled — frames stop here
+		// Hub disconnected or attach cancelled — detach this subscriber.
+		st.failed = true
+		st.mu.Unlock()
+		go st.unsub()
+		return
 	}
 	st.seq++
+	st.mu.Unlock()
 }
 
 // emitExit sends the final stream frame whose decoded payload is the JSON
@@ -53,8 +61,8 @@ func (st *acpAttachState) emitChunk(chunk []byte) {
 // handler. Idempotent.
 func (st *acpAttachState) emitExit(reason string) {
 	st.mu.Lock()
-	defer st.mu.Unlock()
 	if st.done {
+		st.mu.Unlock()
 		return
 	}
 	st.done = true
@@ -62,6 +70,7 @@ func (st *acpAttachState) emitExit(reason string) {
 		_ = st.emit(st.seq, base64.StdEncoding.EncodeToString(payload), false, "base64")
 		st.seq++
 	}
+	st.mu.Unlock()
 	close(st.exited)
 }
 
@@ -69,13 +78,13 @@ func (st *acpAttachState) emitExit(reason string) {
 // (acp.open, acp.attach, acp.close) plus inbound input frame handling via the
 // FrameHandler interface. Input frames whose id is not a live ACP session ID
 // pass through to the inner handler (terminal), preserving the frame chain.
+// All per-attach state lives on the attach request's own stack — input frames
+// are correlated by session ID against the manager, so no attach registry is
+// needed.
 type acpHandler struct {
 	inner Handler
 	mgr   *acp.Manager
 	cmdFn ACPCommandFunc
-
-	attachMu sync.Mutex
-	attaches map[string]*acpAttachState // keyed by attach request ID
 }
 
 // NewACPHandler wraps inner with ACP verb and input frame support.
@@ -85,10 +94,9 @@ type acpHandler struct {
 // The returned handler implements both Handler and FrameHandler.
 func NewACPHandler(inner Handler, mgr *acp.Manager, cmdFn ACPCommandFunc) Handler {
 	return &acpHandler{
-		inner:    inner,
-		mgr:      mgr,
-		cmdFn:    cmdFn,
-		attaches: make(map[string]*acpAttachState),
+		inner: inner,
+		mgr:   mgr,
+		cmdFn: cmdFn,
 	}
 }
 
@@ -140,15 +148,18 @@ func (h *acpHandler) handleOpen(params json.RawMessage) (any, bool, error) {
 
 // handleAttach subscribes to the session's stdout stream and forwards each
 // chunk as a base64-encoded stream frame. It blocks until the context is
-// cancelled (detach via cancel frame) or the child exits — on exit a final
-// frame carrying {"event":"exit","reason":...} is emitted before the handler
-// returns and cleans up. On context cancellation the subscriber is removed
-// WITHOUT closing the session.
+// cancelled (detach via cancel frame) or the child exits — on exit every
+// chunk already queued for this subscriber is delivered first (Session unsub
+// blocks until the backlog has drained), then a final frame carrying
+// {"event":"exit","reason":...} is emitted. On context cancellation the
+// subscriber is removed and its exit hook unregistered WITHOUT closing the
+// session.
 //
-// The exit hook is registered per attach (not at open time) because
-// Session.OnExit fires immediately when the child has already exited — a
-// subscriber attaching around exit time still receives its exit event instead
-// of blocking forever.
+// The exit hook is registered per attach (not at open time) for two reasons:
+// Session.OnExit fires immediately when the child has already exited, so an
+// attach racing the exit still gets its event instead of blocking forever;
+// and the returned unregister func lets a detach drop the hook so long-lived
+// sessions don't accumulate one closure per attach/detach cycle.
 func (h *acpHandler) handleAttach(
 	ctx context.Context,
 	params json.RawMessage,
@@ -166,41 +177,28 @@ func (h *acpHandler) handleAttach(
 		return nil, true, fmt.Errorf("acp.attach: session not found: %s", p.SessionID)
 	}
 
-	// Extract the attach request ID embedded in ctx by serve() so the attach
-	// map can be keyed per request (mirrors term.attach) and input frames can
-	// be correlated with active attaches.
-	reqID, _ := ctx.Value(reqIDKey{}).(string)
-
 	st := &acpAttachState{
-		sessionID: p.SessionID,
-		emit:      emit,
-		exited:    make(chan struct{}),
+		emit:   emit,
+		exited: make(chan struct{}),
 	}
 	st.unsub = sess.Subscribe(st.emitChunk)
 
-	h.attachMu.Lock()
-	h.attaches[reqID] = st
-	h.attachMu.Unlock()
-
-	// Fires exactly once when the child exits (immediately if already exited):
-	// deliver the exit event to this subscriber, then clean up.
-	sess.OnExit(func(reason string) {
+	// Fires exactly once when the child exits (immediately if already exited).
+	// unsub blocks until this subscriber's queued backlog has been delivered,
+	// so the exit frame always trails the child's final output.
+	unregExit := sess.OnExit(func(reason string) {
 		st.unsub()
 		st.emitExit(reason)
 	})
 
-	defer func() {
-		h.attachMu.Lock()
-		delete(h.attaches, reqID)
-		h.attachMu.Unlock()
-	}()
-
 	select {
 	case <-st.exited:
-		// Child exited; the exit event has been emitted.
+		// Child exited; the backlog and exit event have been emitted.
 	case <-ctx.Done():
-		// cancel frame received: detach this subscriber, do NOT close the
-		// session (the child keeps running; another client can re-attach).
+		// cancel frame received: detach this subscriber and drop its exit
+		// hook, do NOT close the session (the child keeps running; another
+		// client can re-attach).
+		unregExit()
 		st.unsub()
 	}
 

--- a/apps/node-agent/internal/gateway/acp.go
+++ b/apps/node-agent/internal/gateway/acp.go
@@ -1,0 +1,253 @@
+package gateway
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/acp"
+)
+
+// ACPCommandFunc resolves the ACP spawn command for a station key: argv is the
+// full command line, dir the working directory, env extra KEY=VALUE pairs
+// appended to the inherited environment. The dispatcher resolves the actual
+// descriptor capability, keeping this package free of a direct descriptor
+// import (mirrors LifecycleFunc).
+type ACPCommandFunc func(key string) (argv []string, dir string, env []string, err error)
+
+// acpAttachState tracks one active acp.attach subscription. emit calls come
+// from two goroutines — stdout chunks from the session's dispatcher, the exit
+// event from the session's reaper — so mu serializes them, keeping stream seq
+// numbers monotonic and guaranteeing nothing is emitted after the exit event.
+type acpAttachState struct {
+	sessionID string
+	unsub     func()
+
+	mu   sync.Mutex
+	seq  int
+	done bool // set once the exit event has been emitted
+	emit func(seq int, chunk string, eof bool, enc string) error
+
+	exited chan struct{} // closed after the exit event; unblocks the attach handler
+}
+
+// emitChunk sends one base64 stream frame unless the exit event has already
+// been emitted.
+func (st *acpAttachState) emitChunk(chunk []byte) {
+	encoded := base64.StdEncoding.EncodeToString(chunk)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.done {
+		return
+	}
+	if err := st.emit(st.seq, encoded, false, "base64"); err != nil {
+		return // hub disconnected or attach cancelled — frames stop here
+	}
+	st.seq++
+}
+
+// emitExit sends the final stream frame whose decoded payload is the JSON
+// {"event":"exit","reason":<reason>} exactly once, then unblocks the attach
+// handler. Idempotent.
+func (st *acpAttachState) emitExit(reason string) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.done {
+		return
+	}
+	st.done = true
+	if payload, err := json.Marshal(map[string]string{"event": "exit", "reason": reason}); err == nil {
+		_ = st.emit(st.seq, base64.StdEncoding.EncodeToString(payload), false, "base64")
+		st.seq++
+	}
+	close(st.exited)
+}
+
+// acpHandler wraps an inner Handler and adds routing for the three ACP verbs
+// (acp.open, acp.attach, acp.close) plus inbound input frame handling via the
+// FrameHandler interface. Input frames whose id is not a live ACP session ID
+// pass through to the inner handler (terminal), preserving the frame chain.
+type acpHandler struct {
+	inner Handler
+	mgr   *acp.Manager
+	cmdFn ACPCommandFunc
+
+	attachMu sync.Mutex
+	attaches map[string]*acpAttachState // keyed by attach request ID
+}
+
+// NewACPHandler wraps inner with ACP verb and input frame support.
+//   - mgr is shared across the lifetime of the gateway connection.
+//   - cmdFn resolves the harness ACP spawn command for acp.open.
+//
+// The returned handler implements both Handler and FrameHandler.
+func NewACPHandler(inner Handler, mgr *acp.Manager, cmdFn ACPCommandFunc) Handler {
+	return &acpHandler{
+		inner:    inner,
+		mgr:      mgr,
+		cmdFn:    cmdFn,
+		attaches: make(map[string]*acpAttachState),
+	}
+}
+
+// Handle routes acp.* verbs to the local handlers and delegates everything
+// else to the wrapped inner handler.
+func (h *acpHandler) Handle(
+	ctx context.Context,
+	verb string,
+	params json.RawMessage,
+	emit func(seq int, chunk string, eof bool, enc string) error,
+) (any, bool, error) {
+	switch verb {
+	case "acp.open":
+		return h.handleOpen(params)
+	case "acp.attach":
+		return h.handleAttach(ctx, params, emit)
+	case "acp.close":
+		return h.handleClose(params)
+	default:
+		return h.inner.Handle(ctx, verb, params, emit)
+	}
+}
+
+// handleOpen resolves the ACP spawn command for key, spawns (or reuses) the
+// session, and returns {sessionId}.
+func (h *acpHandler) handleOpen(params json.RawMessage) (any, bool, error) {
+	var p struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, false, fmt.Errorf("acp.open: bad params: %w", err)
+	}
+	if h.cmdFn == nil {
+		return nil, false, fmt.Errorf("acp.open: acp not configured for this node")
+	}
+
+	argv, dir, env, err := h.cmdFn(p.Key)
+	if err != nil {
+		return nil, false, fmt.Errorf("acp.open: %w", err)
+	}
+
+	sess, err := h.mgr.Open(p.Key, argv, dir, env)
+	if err != nil {
+		return nil, false, fmt.Errorf("acp.open: %w", err)
+	}
+
+	return map[string]any{"sessionId": sess.ID()}, false, nil
+}
+
+// handleAttach subscribes to the session's stdout stream and forwards each
+// chunk as a base64-encoded stream frame. It blocks until the context is
+// cancelled (detach via cancel frame) or the child exits — on exit a final
+// frame carrying {"event":"exit","reason":...} is emitted before the handler
+// returns and cleans up. On context cancellation the subscriber is removed
+// WITHOUT closing the session.
+//
+// The exit hook is registered per attach (not at open time) because
+// Session.OnExit fires immediately when the child has already exited — a
+// subscriber attaching around exit time still receives its exit event instead
+// of blocking forever.
+func (h *acpHandler) handleAttach(
+	ctx context.Context,
+	params json.RawMessage,
+	emit func(seq int, chunk string, eof bool, enc string) error,
+) (any, bool, error) {
+	var p struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, true, fmt.Errorf("acp.attach: bad params: %w", err)
+	}
+
+	sess, ok := h.mgr.Get(p.SessionID)
+	if !ok {
+		return nil, true, fmt.Errorf("acp.attach: session not found: %s", p.SessionID)
+	}
+
+	// Extract the attach request ID embedded in ctx by serve() so the attach
+	// map can be keyed per request (mirrors term.attach) and input frames can
+	// be correlated with active attaches.
+	reqID, _ := ctx.Value(reqIDKey{}).(string)
+
+	st := &acpAttachState{
+		sessionID: p.SessionID,
+		emit:      emit,
+		exited:    make(chan struct{}),
+	}
+	st.unsub = sess.Subscribe(st.emitChunk)
+
+	h.attachMu.Lock()
+	h.attaches[reqID] = st
+	h.attachMu.Unlock()
+
+	// Fires exactly once when the child exits (immediately if already exited):
+	// deliver the exit event to this subscriber, then clean up.
+	sess.OnExit(func(reason string) {
+		st.unsub()
+		st.emitExit(reason)
+	})
+
+	defer func() {
+		h.attachMu.Lock()
+		delete(h.attaches, reqID)
+		h.attachMu.Unlock()
+	}()
+
+	select {
+	case <-st.exited:
+		// Child exited; the exit event has been emitted.
+	case <-ctx.Done():
+		// cancel frame received: detach this subscriber, do NOT close the
+		// session (the child keeps running; another client can re-attach).
+		st.unsub()
+	}
+
+	return nil, true, nil
+}
+
+// handleClose terminates the named session and removes it from the manager.
+// Attached subscribers receive their exit event via the per-attach OnExit
+// hooks once the child has been reaped.
+func (h *acpHandler) handleClose(params json.RawMessage) (any, bool, error) {
+	var p struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, false, fmt.Errorf("acp.close: bad params: %w", err)
+	}
+
+	if err := h.mgr.Close(p.SessionID); err != nil {
+		return nil, false, fmt.Errorf("acp.close: %w", err)
+	}
+
+	return map[string]any{"ok": true}, false, nil
+}
+
+// HandleFrame implements FrameHandler for inbound ACP input frames. ACP input
+// rides the shared InputMsg envelope with id carrying the ACP session ID; a
+// frame whose id is not a live ACP session (e.g. a terminal attach request ID)
+// passes through to the inner handler unchanged. ACP has no resize.
+func (h *acpHandler) HandleFrame(frameType, id string, raw json.RawMessage) error {
+	if frameType == "input" {
+		if sess, ok := h.mgr.Get(id); ok {
+			var f struct {
+				Data string `json:"data"`
+			}
+			if err := json.Unmarshal(raw, &f); err != nil {
+				return fmt.Errorf("acp input: bad frame: %w", err)
+			}
+			data, err := base64.StdEncoding.DecodeString(f.Data)
+			if err != nil {
+				return fmt.Errorf("acp input: bad base64: %w", err)
+			}
+			return sess.Write(data)
+		}
+	}
+
+	if fh, ok := h.inner.(FrameHandler); ok {
+		return fh.HandleFrame(frameType, id, raw)
+	}
+	return nil
+}

--- a/apps/node-agent/internal/gateway/dispatch_acp_test.go
+++ b/apps/node-agent/internal/gateway/dispatch_acp_test.go
@@ -1,0 +1,293 @@
+package gateway
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/acp"
+)
+
+// acpTestRig wires a fake hub ↔ node websocket pair around an acpHandler and
+// exposes helpers mirroring dispatch_terminal_test.go.
+type acpTestRig struct {
+	t      *testing.T
+	frames chan []byte
+	hub    *websocket.Conn
+}
+
+// newACPTestRig starts an httptest websocket "hub", connects the node side,
+// and runs the dispatch loop over h.
+func newACPTestRig(t *testing.T, h Handler) *acpTestRig {
+	t.Helper()
+
+	frames := make(chan []byte, 64)
+	hubConnCh := make(chan *websocket.Conn, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "")
+		hubConnCh <- c
+
+		ctx := r.Context()
+		for {
+			_, data, err := c.Read(ctx)
+			if err != nil {
+				return
+			}
+			cp := make([]byte, len(data))
+			copy(cp, data)
+			select {
+			case frames <- cp:
+			default: // drop if test is slow (channel is large enough)
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	nodeConn, _, err := websocket.Dial(context.Background(), "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	go serve(context.Background(), nodeConn, h)
+
+	var hubConn *websocket.Conn
+	select {
+	case hubConn = <-hubConnCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub connection timeout")
+	}
+
+	return &acpTestRig{t: t, frames: frames, hub: hubConn}
+}
+
+// writeHub sends a raw JSON string to the node.
+func (r *acpTestRig) writeHub(msg string) {
+	r.t.Helper()
+	if err := r.hub.Write(context.Background(), websocket.MessageText, []byte(msg)); err != nil {
+		r.t.Errorf("hub write: %v", err)
+	}
+}
+
+// readFrame waits for the next frame from the node with a 3-second timeout.
+func (r *acpTestRig) readFrame() map[string]any {
+	r.t.Helper()
+	select {
+	case data := <-r.frames:
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			r.t.Fatalf("bad JSON frame: %v – raw: %s", err, data)
+		}
+		return m
+	case <-time.After(3 * time.Second):
+		r.t.Fatal("timeout waiting for frame from node")
+		return nil
+	}
+}
+
+// awaitStreamContaining scans stream frames until one's base64-decoded chunk
+// contains want, or the deadline passes.
+func (r *acpTestRig) awaitStreamContaining(want string) bool {
+	r.t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case data := <-r.frames:
+			var m map[string]any
+			json.Unmarshal(data, &m)
+			if m["type"] != "stream" || m["enc"] != "base64" {
+				continue
+			}
+			if eof, _ := m["eof"].(bool); eof {
+				continue
+			}
+			chunk, _ := m["chunk"].(string)
+			decoded, err := base64.StdEncoding.DecodeString(chunk)
+			if err == nil && strings.Contains(string(decoded), want) {
+				return true
+			}
+		case <-time.After(200 * time.Millisecond):
+			// keep polling
+		}
+	}
+	return false
+}
+
+// openACPSession drives acp.open and returns the sessionId.
+func (r *acpTestRig) openACPSession() string {
+	r.t.Helper()
+	r.writeHub(`{"type":"req","id":"open-1","verb":"acp.open","params":{"key":"opencode:test"}}`)
+
+	msg := r.readFrame()
+	if msg["type"] != "res" {
+		r.t.Fatalf("acp.open: expected res frame, got type=%v", msg["type"])
+	}
+	if ok, _ := msg["ok"].(bool); !ok {
+		r.t.Fatalf("acp.open failed: %v", msg["error"])
+	}
+	dataMap, ok := msg["data"].(map[string]any)
+	if !ok {
+		r.t.Fatalf("acp.open: data is %T, want map", msg["data"])
+	}
+	sessionID, _ := dataMap["sessionId"].(string)
+	if sessionID == "" {
+		r.t.Fatal("acp.open: empty sessionId")
+	}
+	return sessionID
+}
+
+// catCommandFunc resolves every key to /bin/cat (echoes stdin → stdout,
+// exits on stdin EOF), spawned in dir.
+func catCommandFunc(dir string) ACPCommandFunc {
+	return func(key string) (argv []string, cdir string, env []string, err error) {
+		return []string{"/bin/cat"}, dir, nil, nil
+	}
+}
+
+// failInner is an inner handler that fails the test if any verb reaches it.
+func failInner(t *testing.T) Handler {
+	return HandlerFunc(func(_ context.Context, v string, _ json.RawMessage, _ func(int, string, bool, string) error) (any, bool, error) {
+		return nil, false, fmt.Errorf("unexpected verb forwarded to inner: %s", v)
+	})
+}
+
+// TestACPVerbs drives the gateway dispatch layer end-to-end for the ACP verb
+// family:
+//
+//  1. acp.open   → returns {sessionId}
+//  2. acp.attach → starts streaming base64 stdout
+//  3. input frame (id = sessionId) → line reaches the child's stdin
+//     (cat echoes it back as a stream frame)
+func TestACPVerbs(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	h := NewACPHandler(failInner(t), mgr, catCommandFunc(t.TempDir()))
+	rig := newACPTestRig(t, h)
+
+	sessionID := rig.openACPSession()
+	t.Logf("sessionId = %s", sessionID)
+
+	// ── acp.attach ───────────────────────────────────────────────────────────
+	rig.writeHub(fmt.Sprintf(
+		`{"type":"req","id":"attach-1","verb":"acp.attach","params":{"sessionId":"%s"}}`,
+		sessionID,
+	))
+
+	// Give the attach goroutine time to subscribe before we send input.
+	time.Sleep(50 * time.Millisecond)
+
+	// ── input frame: id carries the ACP sessionId ────────────────────────────
+	inputB64 := base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":1}` + "\n"))
+	rig.writeHub(fmt.Sprintf(`{"type":"input","id":"%s","data":"%s"}`, sessionID, inputB64))
+
+	if !rig.awaitStreamContaining("jsonrpc") {
+		t.Fatal("no base64 stream frame containing 'jsonrpc' received after input")
+	}
+}
+
+// TestACPCloseEmitsExitEvent verifies that closing an ACP session delivers a
+// final stream frame whose decoded payload is the {"event":"exit",...} JSON
+// to an attached subscriber.
+func TestACPCloseEmitsExitEvent(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	h := NewACPHandler(failInner(t), mgr, catCommandFunc(t.TempDir()))
+	rig := newACPTestRig(t, h)
+
+	sessionID := rig.openACPSession()
+
+	rig.writeHub(fmt.Sprintf(
+		`{"type":"req","id":"attach-1","verb":"acp.attach","params":{"sessionId":"%s"}}`,
+		sessionID,
+	))
+	time.Sleep(50 * time.Millisecond)
+
+	// Kill the child via acp.close and expect the exit event on the stream.
+	rig.writeHub(fmt.Sprintf(
+		`{"type":"req","id":"close-1","verb":"acp.close","params":{"sessionId":"%s"}}`,
+		sessionID,
+	))
+
+	if !rig.awaitStreamContaining(`"event":"exit"`) {
+		t.Fatal(`no stream frame with "event":"exit" received after acp.close`)
+	}
+
+	if _, ok := mgr.Get(sessionID); ok {
+		t.Fatal("session should be removed from the manager after acp.close")
+	}
+}
+
+// recordingFrameHandler is a stub inner handler that records HandleFrame calls.
+type recordingFrameHandler struct {
+	Handler
+
+	mu    sync.Mutex
+	calls []string // "<frameType>:<id>"
+}
+
+func (r *recordingFrameHandler) HandleFrame(frameType, id string, _ json.RawMessage) error {
+	r.mu.Lock()
+	r.calls = append(r.calls, frameType+":"+id)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingFrameHandler) recorded() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+// TestACPInputFrameChainPassthrough verifies that input frames whose id does
+// NOT belong to an ACP session are forwarded to the inner handler (terminal),
+// preserving the existing frame chain.
+func TestACPInputFrameChainPassthrough(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	inner := &recordingFrameHandler{Handler: failInner(t)}
+	h := NewACPHandler(inner, mgr, catCommandFunc(t.TempDir()))
+
+	fh, ok := h.(FrameHandler)
+	if !ok {
+		t.Fatal("acpHandler must implement FrameHandler")
+	}
+
+	raw := json.RawMessage(`{"type":"input","id":"attach-77","data":"aGkK"}`)
+	if err := fh.HandleFrame("input", "attach-77", raw); err != nil {
+		t.Fatalf("HandleFrame: %v", err)
+	}
+
+	got := inner.recorded()
+	if len(got) != 1 || got[0] != "input:attach-77" {
+		t.Fatalf("inner handler calls = %v, want [input:attach-77]", got)
+	}
+
+	// A frame for a live ACP session must NOT reach the inner handler.
+	sess, err := mgr.Open("opencode:test", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	data := base64.StdEncoding.EncodeToString([]byte("x"))
+	rawACP := json.RawMessage(fmt.Sprintf(`{"type":"input","id":"%s","data":"%s"}`, sess.ID(), data))
+	if err := fh.HandleFrame("input", sess.ID(), rawACP); err != nil {
+		t.Fatalf("HandleFrame (acp session): %v", err)
+	}
+	if got := inner.recorded(); len(got) != 1 {
+		t.Fatalf("acp-session input leaked to inner handler: %v", got)
+	}
+}

--- a/apps/node-agent/internal/gateway/dispatch_acp_test.go
+++ b/apps/node-agent/internal/gateway/dispatch_acp_test.go
@@ -231,6 +231,132 @@ func TestACPCloseEmitsExitEvent(t *testing.T) {
 	}
 }
 
+// TestACPAttachDeliversBacklogBeforeExit is the regression test for buffered
+// stdout being silently dropped at exit: the child writes a paced burst and
+// exits while a slow consumer is still draining its per-subscriber queue.
+// Every line must reach the consumer BEFORE the exit event frame — the
+// backlog must never be discarded in favor of the exit event.
+func TestACPAttachDeliversBacklogBeforeExit(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	dir := t.TempDir()
+	burstCmd := ACPCommandFunc(func(string) ([]string, string, []string, error) {
+		// ~20 distinct chunks (paced so the fast read loop sees separate
+		// writes), then immediate exit.
+		return []string{"/bin/sh", "-c",
+			"i=1; while [ $i -le 20 ]; do echo line$i; sleep 0.01; i=$((i+1)); done",
+		}, dir, nil, nil
+	})
+	h := NewACPHandler(failInner(t), mgr, burstCmd)
+
+	res, _, err := h.Handle(context.Background(), "acp.open", json.RawMessage(`{"key":"k"}`), nil)
+	if err != nil {
+		t.Fatalf("acp.open: %v", err)
+	}
+	sessionID := res.(map[string]any)["sessionId"].(string)
+
+	var mu sync.Mutex
+	var frames []string // decoded frame payloads, in emit order
+	slowEmit := func(_ int, chunk string, _ bool, _ string) error {
+		time.Sleep(30 * time.Millisecond) // slow consumer: backlog builds
+		decoded, err := base64.StdEncoding.DecodeString(chunk)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		frames = append(frames, string(decoded))
+		mu.Unlock()
+		return nil
+	}
+
+	attachDone := make(chan error, 1)
+	go func() {
+		_, _, err := h.Handle(context.Background(), "acp.attach",
+			json.RawMessage(fmt.Sprintf(`{"sessionId":%q}`, sessionID)), slowEmit)
+		attachDone <- err
+	}()
+
+	select {
+	case err := <-attachDone:
+		if err != nil {
+			t.Fatalf("acp.attach: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("attach did not return after child exit")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(frames) < 2 {
+		t.Fatalf("got %d frames, want chunks plus an exit event", len(frames))
+	}
+	last := frames[len(frames)-1]
+	if !strings.Contains(last, `"event":"exit"`) {
+		t.Fatalf("last frame = %q, want the exit event", last)
+	}
+	beforeExit := strings.Join(frames[:len(frames)-1], "")
+	for i := 1; i <= 20; i++ {
+		want := fmt.Sprintf("line%d\n", i)
+		if !strings.Contains(beforeExit, want) {
+			t.Fatalf("line%d missing before the exit event (backlog dropped); %d frames", i, len(frames))
+		}
+	}
+}
+
+// TestACPAttachDetachUnregistersExitHook is the regression test for exit-hook
+// leakage: every attach/detach cycle on a long-lived session must remove its
+// OnExit closure, returning the session's registered-callback count to
+// baseline.
+func TestACPAttachDetachUnregistersExitHook(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	h := NewACPHandler(failInner(t), mgr, catCommandFunc(t.TempDir()))
+
+	res, _, err := h.Handle(context.Background(), "acp.open", json.RawMessage(`{"key":"k"}`), nil)
+	if err != nil {
+		t.Fatalf("acp.open: %v", err)
+	}
+	sessionID := res.(map[string]any)["sessionId"].(string)
+	sess, ok := mgr.Get(sessionID)
+	if !ok {
+		t.Fatal("session not registered")
+	}
+	base := sess.OnExitCount() // the manager's own removal hook
+
+	noopEmit := func(int, string, bool, string) error { return nil }
+	params := json.RawMessage(fmt.Sprintf(`{"sessionId":%q}`, sessionID))
+
+	for i := 0; i < 5; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		attachDone := make(chan struct{})
+		go func() {
+			defer close(attachDone)
+			_, _, _ = h.Handle(ctx, "acp.attach", params, noopEmit)
+		}()
+
+		// Wait until this attach has registered its exit hook, then detach.
+		deadline := time.Now().Add(3 * time.Second)
+		for sess.OnExitCount() == base && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Millisecond)
+		}
+		if sess.OnExitCount() != base+1 {
+			cancel()
+			t.Fatalf("iteration %d: OnExitCount = %d, want %d after attach", i, sess.OnExitCount(), base+1)
+		}
+		cancel()
+		select {
+		case <-attachDone:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("iteration %d: attach did not return after cancel", i)
+		}
+		if got := sess.OnExitCount(); got != base {
+			t.Fatalf("iteration %d: OnExitCount = %d after detach, want baseline %d (exit hook leaked)", i, got, base)
+		}
+	}
+}
+
 // recordingFrameHandler is a stub inner handler that records HandleFrame calls.
 type recordingFrameHandler struct {
 	Handler

--- a/docs/superpowers/plans/2026-08-09-acp-slice1-rails.md
+++ b/docs/superpowers/plans/2026-08-09-acp-slice1-rails.md
@@ -1,0 +1,362 @@
+# ACP Slice 1 — Rails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The node-side rails for ACP sessions: contract verbs, node-agent spawn/pipe of harness ACP processes (OpenCode + Hermes), the provisioned-runtime lifecycle fix, and the TailLogs follow bug fix.
+
+**Architecture:** Mirror the terminal subsystem exactly: contract verbs (`acp.open/attach/close` + reused `input` frames), a non-PTY `internal/acp` session manager (plain stdio pipes — ACP is JSON-RPC over stdio; a PTY would corrupt it with echo/CRLF), a gateway `acpHandler` wrapping the dispatch chain like `terminalHandler` does, and a per-descriptor `ACPCommand`. Provisioned opencode containers additionally supervise `opencode serve` as the station's long-running process so Health/lifecycle mean something.
+
+**Tech Stack:** Zod (contract), Go (node-agent), Docker (runtime image). No ACP library anywhere in this slice — the node-agent pipes opaque bytes.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-09-acp-sessions-design.md`. Slice 1 only — no hub session service, no console UI.
+- Commands: contract tests `cd packages/contract && bun test`; node-agent `cd apps/node-agent && go test -race ./...`.
+- Go tests must never leave unreaped children named like pgrep targets; use the existing TestMain re-exec pattern for named process stubs (see repo root CLAUDE.md gotcha).
+- ACP verbs mirror terminal verb naming/shape exactly (`acp.open`/`acp.attach`/`acp.close`).
+- ACP sessions use plain pipes, never a PTY.
+- Conventional commits + trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Work on branch `ui-revamp` in this worktree; never touch `develop` or the main checkout.
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `packages/contract/src/station.ts` | add `"acp"` to `Capability` enum |
+| `packages/contract/src/protocol.ts` (+ `protocol.test.ts`) | `acp.*` verb param/result schemas |
+| `apps/node-agent/internal/acp/session.go`, `manager.go` (+ tests) | non-PTY process session + registry |
+| `apps/node-agent/internal/descriptor/descriptor.go` | `ACPCommander` optional interface |
+| `apps/node-agent/internal/descriptor/opencode.go` (+ test) | opencode ACPCommand + `acp` capability + supervised-serve lifecycle |
+| `apps/node-agent/internal/descriptor/hermes.go` (+ test) | hermes ACPCommand + `acp` capability |
+| `apps/node-agent/internal/descriptor/handler.go` | expose ACPCommand resolution to gateway |
+| `apps/node-agent/internal/gateway/acp.go` (+ `dispatch_acp_test.go`) | `acpHandler` verb routing + frame I/O |
+| `apps/node-agent/internal/descriptor/tail.go` (+ `tail_test.go`) | follow-mode waits for log files |
+| `apps/node-agent/deploy/Dockerfile.opencode`, `node-opencode-entrypoint.sh` | opencode version bump + supervised serve |
+
+---
+
+### Task 1: Contract — `acp` capability + verbs
+
+**Files:**
+- Modify: `packages/contract/src/station.ts:2` (Capability enum)
+- Modify: `packages/contract/src/protocol.ts` (VERB param/result maps — mirror the `term.*` entries at lines ~31-33 and ~51-53)
+- Test: `packages/contract/src/protocol.test.ts` (append)
+
+**Interfaces:**
+- Produces: `Capability` includes `"acp"`; verb schemas:
+  - `"acp.open"` params `{ key: string }` → result `{ sessionId: string }`
+  - `"acp.attach"` params `{ sessionId: string }` → stream (no result entry; same convention as `term.attach`)
+  - `"acp.close"` params `{ sessionId: string }` → result `{ ok: boolean }`
+- ACP input rides the existing `InputMsg` frame (`sessionId` + base64 `data`) — no new frame type. ACP has no resize.
+
+- [ ] **Step 1: Write the failing tests** — in `protocol.test.ts`, following the existing term.* test style:
+
+```ts
+test("acp.open params/result schemas round-trip", () => {
+  expect(VERB_PARAMS["acp.open"].parse({ key: "opencode:c52ddf65" })).toEqual({ key: "opencode:c52ddf65" });
+  expect(VERB_RESULTS["acp.open"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+});
+
+test("acp.attach takes a sessionId; acp.close returns ok", () => {
+  expect(VERB_PARAMS["acp.attach"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+  expect(VERB_PARAMS["acp.close"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+  expect(VERB_RESULTS["acp.close"].parse({ ok: true })).toEqual({ ok: true });
+});
+
+test("station capabilities accept acp", () => {
+  expect(Capability.parse("acp")).toBe("acp");
+});
+```
+
+(Import `Capability` from `./station` alongside the existing imports.)
+
+- [ ] **Step 2:** `cd packages/contract && bun test` — expect the three new tests FAIL (unknown key / invalid enum).
+- [ ] **Step 3:** Implement — add `"acp"` to the `Capability` z.enum; add to `protocol.ts`:
+
+```ts
+// in VERB_PARAMS
+"acp.open":   z.object({ key: z.string() }),
+"acp.attach": z.object({ sessionId: z.string() }),
+"acp.close":  z.object({ sessionId: z.string() }),
+// in VERB_RESULTS
+"acp.open":  z.object({ sessionId: z.string() }),
+"acp.close": z.object({ ok: z.boolean() }),
+// acp.attach streams; no entry needed (same as term.attach).
+```
+
+- [ ] **Step 4:** `bun test` → all pass.
+- [ ] **Step 5:** Commit `feat(contract): acp capability + acp.open/attach/close verb schemas`.
+
+---
+
+### Task 2: node-agent — `internal/acp` session + manager
+
+**Files:**
+- Create: `apps/node-agent/internal/acp/session.go`, `apps/node-agent/internal/acp/manager.go`
+- Test: `apps/node-agent/internal/acp/session_test.go`
+
+**Interfaces (Produces — Task 4 consumes these exact signatures):**
+
+```go
+package acp
+
+type Session struct { /* opaque */ }
+func (s *Session) ID() string
+func (s *Session) Write(p []byte) error                 // → child stdin
+func (s *Session) Subscribe(fn func(chunk []byte)) (unsub func())
+// OnExit registers a callback invoked exactly once when the child exits;
+// reason is "exit" for a clean exit, otherwise the error string.
+func (s *Session) OnExit(fn func(reason string))
+func (s *Session) Close() error                          // SIGTERM → 3s grace → SIGKILL, idempotent
+
+type Manager struct { /* opaque */ }
+func NewManager() *Manager
+// Open spawns argv[0] with argv[1:] in dir with env appended to os.Environ().
+// stdout is streamed to subscribers in chunks; stderr is discarded to a
+// bounded ring (last 4 KiB) exposed via s.StderrTail() for exit reasons.
+func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Session, error)
+func (m *Manager) Get(id string) (*Session, bool)
+func (m *Manager) Close(id string) error
+func (m *Manager) Shutdown()                             // closes every session
+```
+
+Implementation notes (mirror `internal/terminal/manager.go` structure, but **no PTY**): `exec.Command`, `cmd.Dir = dir`, `cmd.Env = append(os.Environ(), env...)`, `StdinPipe`/`StdoutPipe`/`StderrPipe`. A goroutine reads stdout in 32 KiB chunks and fans out to subscribers under a mutex (same subscriber pattern as terminal.Session). A second goroutine drains stderr into the 4 KiB ring. `cmd.Wait()` goroutine fires OnExit callbacks with `"exit"` on success else `err.Error()+": "+stderrTail`. IDs: `"acp_" + <random hex 8>`.
+
+- [ ] **Step 1: Write the failing tests** — use `/bin/cat` as the child (echoes stdin to stdout; exits on stdin close; no pgrep-name hazard):
+
+```go
+func TestSession_EchoRoundTrip(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil { t.Fatal(err) }
+	got := make(chan []byte, 4)
+	unsub := s.Subscribe(func(c []byte) { got <- append([]byte(nil), c...) })
+	defer unsub()
+	if err := s.Write([]byte("{\"jsonrpc\":\"2.0\"}\n")); err != nil { t.Fatal(err) }
+	select {
+	case c := <-got:
+		if !strings.Contains(string(c), "jsonrpc") { t.Fatalf("chunk = %q", c) }
+	case <-time.After(3 * time.Second):
+		t.Fatal("no echo received")
+	}
+}
+
+func TestSession_ExitFiresOnceWithReason(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+	s, _ := m.Open("k", []string{"/bin/sh", "-c", "echo err >&2; exit 3"}, t.TempDir(), nil)
+	reasons := make(chan string, 2)
+	s.OnExit(func(r string) { reasons <- r })
+	select {
+	case r := <-reasons:
+		if !strings.Contains(r, "exit status 3") || !strings.Contains(r, "err") {
+			t.Fatalf("reason = %q", r)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no exit callback")
+	}
+	select { case r := <-reasons: t.Fatalf("second callback: %q", r); case <-time.After(200 * time.Millisecond): }
+}
+
+func TestManager_CloseKillsProcess(t *testing.T) {
+	m := NewManager()
+	s, _ := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	done := make(chan string, 1)
+	s.OnExit(func(r string) { done <- r })
+	if err := m.Close(s.ID()); err != nil { t.Fatal(err) }
+	select { case <-done: case <-time.After(5 * time.Second): t.Fatal("process not reaped") }
+	if _, ok := m.Get(s.ID()); ok { t.Fatal("session still registered after Close") }
+}
+```
+
+- [ ] **Step 2:** `cd apps/node-agent && go test -race ./internal/acp/` → FAIL (package missing).
+- [ ] **Step 3:** Implement session.go + manager.go per the interface block.
+- [ ] **Step 4:** `go test -race ./internal/acp/` → PASS; `go test -race ./...` stays green.
+- [ ] **Step 5:** Commit `feat(node-agent): acp session manager — non-PTY stdio piping`.
+
+---
+
+### Task 3: Descriptors — `ACPCommander` for OpenCode + Hermes, `acp` capability
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/descriptor.go` (add optional interface after `Descriptor`)
+- Modify: `apps/node-agent/internal/descriptor/opencode.go` (implement; add `"acp"` to caps at line ~112)
+- Modify: `apps/node-agent/internal/descriptor/hermes.go` (implement; add `"acp"` to its caps list)
+- Modify: `apps/node-agent/internal/descriptor/handler.go` (resolution helper)
+- Test: `apps/node-agent/internal/descriptor/acp_command_test.go`
+
+**Interfaces (Produces):**
+
+```go
+// ACPCommander is implemented by descriptors whose harness can serve an ACP
+// session. argv is the full command line; dir is the working directory; env
+// is extra environment (may be nil).
+type ACPCommander interface {
+	ACPCommand(key string) (argv []string, dir string, env []string, err error)
+}
+// handler.go resolution used by the gateway (mirrors LifecycleFunc wiring):
+func (h *Handler) ACPCommand(key string) (argv []string, dir string, env []string, err error)
+```
+
+- OpenCode: `argv = ["opencode", "acp"]`, `dir` = the station's workspace path (same resolution `term.open` uses via the workspace resolver — reuse the descriptor's existing workspace lookup for the key), `env = nil`.
+- Hermes: `argv = ["hermes", "-p", <profile>, "acp", "--accept-hooks"]`, `dir` = the profile's workspace directory, `env = nil`. The profile is derived from the station key exactly the way `hermes.go` already parses keys for Health/lifecycle (read `hermes.go` first and reuse its existing key→profile helper; do not invent a second parser).
+- Capability: each implementing descriptor appends `"acp"` to its capabilities list. Handler exposes resolution with a clear error for descriptors that don't implement the interface (`"acp not supported for harness X"`).
+
+- [ ] **Step 1: Write failing tests** (table-driven; no processes spawned — pure command construction):
+
+```go
+func TestOpenCodeACPCommand(t *testing.T) {
+	d := newTestOpenCodeDescriptor(t) // reuse the fixture style of opencode_test.go
+	argv, dir, _, err := d.ACPCommand(testStationKey)
+	if err != nil { t.Fatal(err) }
+	if !reflect.DeepEqual(argv, []string{"opencode", "acp"}) { t.Fatalf("argv = %v", argv) }
+	if dir == "" { t.Fatal("dir must be the station workspace") }
+}
+
+func TestHermesACPCommand_UsesProfileFlag(t *testing.T) {
+	d := newTestHermesDescriptor(t) // reuse hermes_test.go fixture style
+	argv, _, _, err := d.ACPCommand(testHermesKey)
+	if err != nil { t.Fatal(err) }
+	want := []string{"hermes", "-p", testHermesProfile, "acp", "--accept-hooks"}
+	if !reflect.DeepEqual(argv, want) { t.Fatalf("argv = %v want %v", argv, want) }
+}
+
+func TestCapabilitiesIncludeACP(t *testing.T) { /* assert "acp" present in both descriptors' Detect() station capabilities */ }
+
+func TestHandlerACPCommand_UnsupportedHarness(t *testing.T) { /* claude-code descriptor → error containing "acp not supported" */ }
+```
+
+(Adapt fixture names to what `opencode_test.go` / `hermes_test.go` actually provide — read them first; the plan's names are placeholders for those exact existing fixtures, and the implementer must use the real ones.)
+
+- [ ] **Step 2:** `go test -race ./internal/descriptor/` → new tests FAIL.
+- [ ] **Step 3:** Implement per interface block.
+- [ ] **Step 4:** `go test -race ./...` → PASS.
+- [ ] **Step 5:** Commit `feat(node-agent): ACPCommand for opencode + hermes, acp capability`.
+
+---
+
+### Task 4: Gateway — `acpHandler` verb routing + frames
+
+**Files:**
+- Create: `apps/node-agent/internal/gateway/acp.go`
+- Modify: the dispatch construction where `terminalHandler` is wired (grep `terminalHandler{` / `newTerminalHandler` in `apps/node-agent/internal/gateway/` and wire `acpHandler` identically, including Shutdown on gateway disconnect)
+- Test: `apps/node-agent/internal/gateway/dispatch_acp_test.go`
+
+**Interfaces:**
+- Consumes: `acp.Manager` (Task 2), `Handler.ACPCommand` (Task 3) injected as `type ACPCommandFunc func(key string) (argv []string, dir string, env []string, err error)` — mirroring `LifecycleFunc`.
+- Behavior (mirror `terminal.go`'s `terminalHandler` shape):
+  - `acp.open {key}` → resolve ACPCommandFunc → `mgr.Open` → `{sessionId}`; register OnExit → emits a final stream frame `{"event":"exit","reason":<reason>}` (base64 in StreamMsg data, same envelope the terminal uses) to any attached subscriber, then cleans up.
+  - `acp.attach {sessionId}` → subscribe; stdout chunks → StreamMsg frames (base64), same stream-envelope helper the terminal attach uses.
+  - `acp.close {sessionId}` → `mgr.Close` → `{ok:true}`.
+  - Inbound `InputMsg` frames: if `sessionId` belongs to the acp manager, decode base64 → `session.Write`; otherwise pass through to the inner handler (terminal), preserving the existing chain.
+  - Gateway disconnect → `mgr.Shutdown()` alongside the terminal manager's.
+
+- [ ] **Step 1: Write failing dispatch tests** — copy the structure of `dispatch_terminal_test.go` (fake connection, scripted verbs), child = `/bin/cat`:
+  - open → attach → send InputMsg with base64 `{"jsonrpc":"2.0","id":1}` → expect a StreamMsg whose decoded data contains `jsonrpc` (cat echo).
+  - open → kill child externally (send `acp.close`) → expect exit stream frame with `"event":"exit"`.
+  - InputMsg for an unknown sessionId still reaches the terminal handler (chain preserved) — assert via a stub inner handler.
+- [ ] **Step 2:** `go test -race ./internal/gateway/` → FAIL.
+- [ ] **Step 3:** Implement `acp.go`; wire into dispatch construction + disconnect shutdown.
+- [ ] **Step 4:** `go test -race ./...` → PASS.
+- [ ] **Step 5:** Commit `feat(node-agent): acp gateway verbs — open/attach/close + input frames`.
+
+---
+
+### Task 5: TailLogs follow-mode waits for log files
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/tail.go` (the shared tail helper used by `opencode.go` TailLogs at ~line 373)
+- Test: `apps/node-agent/internal/descriptor/tail_test.go` (append)
+
+Behavior: today, follow-mode with zero matching log files returns immediately (hub then closes the SSE instantly — the Logs-tab bug found dogfooding 2026-08-09). New behavior: when `follow == true` and the glob matches nothing, poll the glob every 1s until ctx is cancelled or a file appears, then tail it as normal. `follow == false` keeps returning immediately.
+
+- [ ] **Step 1: Write failing tests:**
+
+```go
+func TestTailFollow_WaitsForFirstLogFile(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got := make(chan []byte, 8)
+	go func() {
+		// adapt call to tail.go's actual exported/internal helper signature
+		_ = tailGlob(ctx, filepath.Join(dir, "*.log"), true, func(b []byte) error { got <- append([]byte(nil), b...); return nil })
+	}()
+	time.Sleep(300 * time.Millisecond) // helper is now waiting, not returned
+	os.WriteFile(filepath.Join(dir, "a.log"), []byte("hello\n"), 0o644)
+	select {
+	case b := <-got:
+		if !strings.Contains(string(b), "hello") { t.Fatalf("chunk = %q", b) }
+	case <-ctx.Done():
+		t.Fatal("no output after log file appeared — follow returned early or never polled")
+	}
+}
+
+func TestTailNoFollow_EmptyDirReturnsImmediately(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	_ = tailGlob(context.Background(), filepath.Join(dir, "*.log"), false, func([]byte) error { return nil })
+	if time.Since(start) > time.Second { t.Fatal("no-follow should return immediately") }
+}
+```
+
+(Adapt `tailGlob` to tail.go's real helper name/signature — read the file first; if the wait logic fits better at the `opencode.go` call site, put it there and test through the descriptor instead.)
+
+- [ ] **Step 2:** `go test -race ./internal/descriptor/ -run TestTail` → first test FAILS (returns early).
+- [ ] **Step 3:** Implement the 1s poll loop.
+- [ ] **Step 4:** `go test -race ./...` → PASS.
+- [ ] **Step 5:** Commit `fix(node-agent): log follow waits for log files instead of closing the stream`.
+
+---
+
+### Task 6: Provisioned opencode — image bump + supervised serve + lifecycle
+
+**Files:**
+- Modify: `apps/node-agent/deploy/Dockerfile.opencode` (line `RUN bun add -g opencode-ai@0.5.5`)
+- Modify: `apps/node-agent/deploy/node-opencode-entrypoint.sh`
+- Modify: `apps/node-agent/internal/descriptor/opencode.go` (lifecycle, gated)
+- Test: `apps/node-agent/internal/descriptor/opencode_test.go` (append)
+
+Requirements:
+1. **Version bump:** replace `opencode-ai@0.5.5` with the newest published version (implementer runs `bun pm view opencode-ai version` / `npm view opencode-ai version` and pins that exact version). The chosen version MUST list `acp` in `opencode --help`; record the version in the Dockerfile comment.
+2. **Entrypoint supervision:** after `enroll`, before the exec, start a supervised serve loop so the station has a living process:
+
+```sh
+# Supervised opencode server: the station's long-running process. Restarts on
+# crash with 2s backoff; killed cleanly when the container stops.
+(
+  while :; do
+    opencode serve >>/var/log/opencode-serve.log 2>&1
+    echo "[entrypoint] opencode serve exited ($?), restarting in 2s" >>/var/log/opencode-serve.log
+    sleep 2
+  done
+) &
+export AGENTPOD_OPENCODE_SUPERVISED=1
+```
+
+   (Keep `cd /workspace` for the serve invocation — `cd /workspace && opencode serve` inside the subshell — so the server roots at the workspace.)
+3. **Descriptor lifecycle, gated:** when env `AGENTPOD_OPENCODE_SUPERVISED=1`, the opencode descriptor implements the same Stop/Start interface the lifecycle dispatcher uses (see `lifecycle_test.go`'s `testLifecycleImpl` for the exact method set): `Stop` = terminate the `opencode serve` process (find via pgrep pattern `opencode.*serve`, TERM → grace → KILL using the existing helpers at `descriptor.go:120-138`); `Start` = re-spawn `opencode serve` detached in `/workspace` appending to the same log. Add `"lifecycle"` to opencode capabilities only when the env var is set. Without the env var (real hosts), behavior is unchanged.
+4. **Health note:** with serve supervised, the existing `pgrep -f opencode` health check turns true on a fresh runtime — no health-code change needed.
+
+- [ ] **Step 1: Write failing descriptor tests** (gate logic only — no real opencode binary): with `t.Setenv("AGENTPOD_OPENCODE_SUPERVISED", "1")` capabilities include `"lifecycle"`; without it they don't. For Stop/Start process handling use a stub script named to match the pgrep pattern via the repo's TestMain re-exec pattern (see `hermes_lifecycle_systemd_test.go` for the established approach) — or, if that pattern doesn't transfer cleanly, unit-test the pgrep-pattern/spawn-command construction and leave process behavior to live verification in Task 7.
+- [ ] **Step 2:** `go test -race ./internal/descriptor/ -run TestOpenCode` → FAIL.
+- [ ] **Step 3:** Implement descriptor gating + entrypoint + Dockerfile bump.
+- [ ] **Step 4:** `go test -race ./...` → PASS. Also `docker build -f apps/node-agent/deploy/Dockerfile.opencode apps/node-agent -t agentpod-node-opencode:test` locally if Docker available; else defer build to Task 7.
+- [ ] **Step 5:** Commit `feat(node-agent): provisioned opencode runs supervised serve with lifecycle control`.
+
+---
+
+### Task 7: Slice gate — full suites + live verification (controller-run)
+
+- [ ] `cd packages/contract && bun test` → green.
+- [ ] `cd apps/node-agent && go test -race ./...` → green.
+- [ ] Push `ui-revamp`; open PR titled `feat: ACP slice 1 — rails (contract verbs, node-agent acp piping, runtime lifecycle, log-follow fix)`; wait for all four CI checks.
+- [ ] Live verification (hub box `root@178.105.68.68`, per docs/DEPLOYMENT.md step 3): rebuild `agentpod-node-opencode:local` from the merged main, provision a fresh runtime from the console, then verify: Health shows **running** with a Start/Stop that works; Logs tab connects and stays connected (no instant-close); `docker exec` confirms `opencode serve` supervised; destroy the runtime and confirm it disappears from the list. Record results in the PR before merge.
+- [ ] Merge on green + verified; deploy hub is NOT needed (no hub changes in this slice); node-agent release/tag is deferred until slice 2 needs fleet-wide binaries — the provisioned image embeds the new binary at build time.
+
+## Self-Review Notes
+
+- Spec coverage: contract verbs (T1), spawn/pipe (T2+T4), ACPCommand opencode+hermes (T3), capability advertising (T3), TailLogs fix (T5), image bump + entrypoint + lifecycle + Start button (T6), live verification (T7). Hub/session/console items are explicitly out of slice.
+- Fixture names in T3 and helper names in T5 are explicitly marked as "use the real existing ones" — implementers must read the neighbouring test files first.
+- Frame reuse (InputMsg) keeps the contract surface minimal; resize intentionally absent for ACP.

--- a/docs/superpowers/specs/2026-08-09-acp-sessions-design.md
+++ b/docs/superpowers/specs/2026-08-09-acp-sessions-design.md
@@ -1,0 +1,97 @@
+# ACP Sessions — Design
+
+**Date:** 2026-08-09 · **Status:** approved (brainstormed with Rakesh)
+
+## Purpose
+
+Drive every onboarded agent from the console through one protocol. AgentPod today observes agents (health/logs/files/terminal); this program makes them *conversable*: a world-class chat surface on each agent, harness-agnostic, built once against the Agent Client Protocol (ACP). It also closes the provisioned-runtime gap found in dogfooding: a provisioned OpenCode runtime arrives with nothing running and no way to start it.
+
+## Decisions (from brainstorm)
+
+1. **Client home:** console-native chat surface; hub exposes the machinery. A raw ACP-over-WS bridge for external clients (e.g. acp-ui) is deferred (slice "Doors").
+2. **Session lifecycle:** **hub-owned**. The agent process keeps working when the browser tab closes; transcripts persist; the console reattaches with replay.
+3. **Slice-1 harnesses:** OpenCode (provisioned runtime story end-to-end) + Hermes (native ACP on the real fleet, proves harness-agnosticism). Claude Code/Codex adapters later.
+4. **Permissions:** per-session mode — `ask` (default; every request prompts in chat), `accept-edits` (file ops auto-approved, exec prompts), `full-auto` (all approved, logged). All decisions audited.
+5. **Architecture:** **hub-terminated ACP** (Approach A). The hub is the protocol-level ACP client; the console speaks a thin session API. Browser-terminated ACP was rejected (sessions would die with the tab); day-one raw bridge rejected (surface without need).
+
+## Verified facts (2026-08-09)
+
+- `hermes acp` exists on the fleet ("Start Hermes Agent in ACP mode"; `--accept-hooks` for non-TTY).
+- `opencode acp` is native in current opencode ([opencode.ai/docs/acp](https://opencode.ai/docs/acp/)); the runtime image pins `opencode-ai@0.5.5` which predates it → slice 1 bumps the pinned version.
+- Official TS SDK: `@zed-industries/agent-client-protocol` (a.k.a. `@agentclientprotocol/sdk`), MIT — typed schema + `ClientSideConnection` over any duplex stream. The hub adopts it; nothing hand-rolls JSON-RPC.
+- `svelte-streamdown` (MIT) — Svelte port of Vercel's Streamdown, built for streaming AI markdown (incomplete-block tolerance, shiki, hardened HTML). The console adopts it for Response rendering.
+- AI Elements is React-only; we mirror its component taxonomy in Svelte on Crisp tokens, not its code.
+- The node-agent needs **no** ACP library: it pipes stdio bytes, exactly like the Terminal.
+
+## Architecture
+
+```
+Console (Svelte)
+  ⇅ session WebSocket: replay (since-cursor) + live events; send prompt; answer permission; set mode
+Hub
+  • ACP client per session: official TS SDK ClientSideConnection over a broker stream
+  • session service: Postgres transcripts, permission queue, mode enforcement, fan-out
+  ⇅ broker stream: raw ACP JSON-RPC bytes (existing gateway rails)
+node-agent (Go)
+  • spawns the harness ACP process in the station workspace; pipes stdio; supervises
+  ⇅ stdio
+opencode acp · hermes acp · (later: claude-agent-acp, codex adapter)
+```
+
+Session states: `starting → idle ⇄ working → waiting (pending permission) → ended(reason)`.
+`waiting` maps to the `starting` status token and surfaces in Needs attention.
+
+## Components
+
+### Contract (`packages/contract`)
+- Verbs: `acp.open` (spawn; returns streamId), `acp.data` (bidirectional byte frames), `acp.close`.
+- `"acp"` joins the station capabilities vocabulary.
+- Zod schemas + tests, mirroring the terminal verb shapes.
+
+### node-agent (Go)
+- Descriptor interface gains `ACPCommand() (argv []string, ok bool)`:
+  - OpenCode: `["opencode", "acp"]`, cwd = workspace.
+  - Hermes: `["hermes", "acp", "--accept-hooks"]` with the profile's environment, cwd = profile workspace (exact profile wiring verified against the fleet during implementation).
+- `acp.open` spawns via the same epoch-guarded stream plumbing as the terminal; process exit → close frame with reason; gateway disconnect kills the process (no zombies).
+- Provisioned-runtime fixes (this slice):
+  - `Dockerfile.opencode`: bump `opencode-ai` to a current pinned version with `acp` support.
+  - opencode descriptor advertises `lifecycle` inside provisioned containers; start/stop manage a supervised harness process so Health's Start button works.
+  - `TailLogs(follow=true)` with no log files **waits/watches** for them instead of returning (fixes the Logs-tab instant-close bug for every harness).
+
+### Hub
+- Tables: `acp_sessions` (id, station_id, user_id, mode, status, created_at, last_event_at, ended_reason) and `acp_events` (session_id, seq, type, payload jsonb, created_at) — append-only replayable transcript (turns, chunks, reasoning, tool calls, permission requests/answers, state changes).
+- Session service: owns one `ClientSideConnection` per live session over a broker stream; translates ACP callbacks → stored events → fan-out to subscribed console sockets; enforces the permission mode (auto-answer or persist as pending); prompt turns recorded in the existing activity log.
+- Console-facing WS: subscribe(sessionId, sinceSeq) → replay + live; `prompt`, `cancel`, `permission-answer`, `set-mode`.
+- Restart semantics: on hub boot, live sessions are marked `ended("hub restarted")`; node-agents kill ACP processes when their gateway connection dies (same rule as terminals). Honest, no zombie agents.
+- Node offline mid-session: session → `waiting` with an in-transcript notice; grace window for node reconnect + broker stream reattach, else `ended("node offline")`.
+
+### Console
+- **Chat tab** on the station page — first tab when the station has the `acp` capability.
+- Adopted: `svelte-streamdown` (Response), official SDK types (event payloads). Component anatomy (AI Elements taxonomy, Crisp tokens):
+  - **Conversation** — virtualized transcript (`content-visibility`, LogTail-style), auto-follow with scroll-away pause + jump-to-bottom, replay on reattach.
+  - **Response** — streamdown streaming markdown; code via existing shiki theming.
+  - **Reasoning** — collapsible thinking block when emitted.
+  - **ToolCall card** — verb + target in mono, live `<Status>`, collapsible input/output, file edits rendered with the ConfigEditor diff view.
+  - **PermissionCard** — inline approve/deny with ACP-provided options; answered cards show who/when; pending pulses the status dot.
+  - **PromptInput** — auto-grow textarea, Enter sends / Shift+Enter newline, stop button (`session/cancel`); slash commands passed through.
+  - **Session header** — mode selector (Ask / Accept edits / Full auto), session `<Status>`, working-while-away indicator.
+- Quality bar: type roles, status tokens, reduced-motion, `aria-live` on turn/permission updates, keyboard-complete. Error copy in the "Couldn't X" grammar.
+
+## Testing
+
+- Contract: schema round-trip tests for the three verbs.
+- node-agent: Go tests with a scripted fake-ACP stdio binary (handshake, streaming, crash, disconnect-kill), TestMain re-exec pattern per repo gotchas.
+- Hub: integration tests with a scripted agent behind a fake broker — replay cursors, permission queue per mode, restart semantics.
+- Console: component tests (replay render, streaming append, permission flow, mode switch); the scripted agent doubles as a Playwright dogfood scenario.
+- Live verification against the real fleet (Hermes) and a provisioned runtime (OpenCode) before slices close — per repo rule.
+
+## Slices (each lands mergeable + green → PR → CI → deploy)
+
+1. **Rails:** contract verbs · node-agent ACP spawn/pipe · OpenCode + Hermes `ACPCommand` · image version bump · provisioned lifecycle + entrypoint supervision · TailLogs follow fix.
+2. **Brain:** hub session service, Postgres persistence, permission queue, session WS.
+3. **Face:** console Chat tab (full component set above).
+4. **Breadth:** Claude Code + Codex adapters, multi-session per agent, session history UI. *(Later door: raw ACP-over-WS bridge for external clients.)*
+
+## Out of scope (this program)
+
+Multi-user shared sessions, programmatic/AI-SDK access to fleet agents, the acp-ui bridge, session branching/forking, cost/token accounting.

--- a/packages/contract/src/protocol.test.ts
+++ b/packages/contract/src/protocol.test.ts
@@ -20,3 +20,15 @@ it("StreamMsg accepts optional base64 enc", () => {
   expect(StreamMsg.parse({ type:"stream", id:"r1", seq:0, chunk:"AA==", eof:false, enc:"base64" })).toBeTruthy();
   expect(StreamMsg.parse({ type:"stream", id:"r1", seq:0, chunk:"hi", eof:false }).enc).toBeUndefined();
 });
+it("acp.open params/result schemas round-trip", () => {
+  expect(VERB_PARAMS["acp.open"].parse({ key: "opencode:c52ddf65" })).toEqual({ key: "opencode:c52ddf65" });
+  expect(VERB_RESULTS["acp.open"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+});
+it("acp.attach takes a sessionId; acp.close returns ok", () => {
+  expect(VERB_PARAMS["acp.attach"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+  expect(VERB_PARAMS["acp.close"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+  expect(VERB_RESULTS["acp.close"].parse({ ok: true })).toEqual({ ok: true });
+});
+it("station capabilities accept acp", () => {
+  expect(Capability.parse("acp")).toBe("acp");
+});

--- a/packages/contract/src/protocol.ts
+++ b/packages/contract/src/protocol.ts
@@ -31,6 +31,9 @@ export const VERB_PARAMS = {
   "term.open":   z.object({ key: z.string(), cols: z.number().int(), rows: z.number().int() }),
   "term.attach": z.object({ sessionId: z.string() }),
   "term.close":  z.object({ sessionId: z.string() }),
+  "acp.open":   z.object({ key: z.string() }),
+  "acp.attach": z.object({ sessionId: z.string() }),
+  "acp.close":  z.object({ sessionId: z.string() }),
 } as const;
 
 // VERB_RESULTS describes what the NODE returns on each verb.
@@ -51,4 +54,7 @@ export const VERB_RESULTS = {
   "term.open":  z.object({ sessionId: z.string() }),
   "term.close": z.object({ ok: z.boolean() }),
   // term.attach streams; no entry needed.
+  "acp.open":  z.object({ sessionId: z.string() }),
+  "acp.close": z.object({ ok: z.boolean() }),
+  // acp.attach streams; no entry needed (same as term.attach).
 } as const;

--- a/packages/contract/src/station.ts
+++ b/packages/contract/src/station.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const Capability = z.enum(["inventory","health","logs","fs.read","fs.write","terminal","lifecycle","cleanup"]);
+export const Capability = z.enum(["inventory","health","logs","fs.read","fs.write","terminal","lifecycle","cleanup","acp"]);
 export type Capability = z.infer<typeof Capability>;
 export const StationKind = z.enum(["composite","leaf"]);
 export const Station = z.object({


### PR DESCRIPTION
First slice of the ACP sessions program (spec: docs/superpowers/specs/2026-08-09-acp-sessions-design.md) — the node-side rails that slices 2 (hub session service) and 3 (console chat) build on.

## What's in it
- **Contract**: `acp` capability + `acp.open/attach/close` verb schemas mirroring the terminal verbs; ACP input rides the existing `InputMsg` frame.
- **node-agent `internal/acp`**: non-PTY stdio session manager (ACP is JSON-RPC over stdio — a PTY would corrupt it). Per-subscriber buffered fan-out with drop-on-overflow, drain-guaranteed unsubscribe, exit callbacks with deregistration, TERM→grace→KILL close. Hardened through two adversarial review rounds (a confirmed Close-from-OnExit deadlock and a blocked-subscriber zombie both reproduced and fixed with regression tests).
- **Gateway `acpHandler`**: open/attach/close routing + input-frame chaining in front of the terminal handler; exit events delivered in-order after the child's final output (drain-then-exit-frame).
- **Descriptors**: `ACPCommand` for OpenCode (`opencode acp` in the workspace) and Hermes (`hermes -p <profile> acp --accept-hooks`); both advertise `acp`.
- **Provisioned opencode runtime**: opencode-ai 0.5.5 → **1.18.15** (first version family with `acp`); entrypoint supervises `opencode serve` (crash-restart with sentinel-halted lifecycle Stop — a `set -e` interaction that made supervision single-shot was caught in review and fixed with real-entrypoint in-container verification); descriptor gains env-gated `lifecycle` so the console's Start/Stop work; obsolete sqlite seed removed (1.18.15 owns its DB; detection uses the dir-fallback).
- **Log-follow fix**: follow-mode with zero log files now explicitly waits (1s poll) across all five harness descriptors.

## Review trail
7 tasks, per-task adversarial reviews + scoped re-reviews + final whole-branch review (mergeable). 15 findings fixed pre-merge incl. 2 Critical; slice-2 carry-ins recorded in the plan ledger.

Tests: contract 28 green; node-agent full `go test -race ./...` green (22 files changed, +2485).

**Live verification (Task 7) to be recorded below before merge**: image rebuild on the hub box, fresh provisioned runtime — Health running + working Start/Stop, Logs tab stable, `opencode acp` reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB