### PR TITLE
fix(hub): provisioned containers run Docker init (zombie children broke pgrep health)

### DIFF
--- a/apps/hub/src/services/provisioner/docker-orchestrator.ts
+++ b/apps/hub/src/services/provisioner/docker-orchestrator.ts
@@ -214,6 +214,13 @@ export class DockerOrchestrator {
         PortBindings: portBindings,
         NetworkMode: network,
         RestartPolicy: { Name: "unless-stopped" },
+        // Docker's built-in init (tini) as PID 1: reaps zombies. Without it,
+        // exited children of the entrypoint (e.g. the opencode supervision
+        // subshell after a lifecycle Stop) linger as <defunct> and their comm
+        // still matches the descriptor's pgrep health check — the station
+        // reports "running" forever after its process died (live-fleet
+        // finding, 2026-08-09).
+        Init: true,
         NanoCpus: resources.cpus
           ? Math.floor(parseFloat(resources.cpus) * 1e9)
           : undefined,


### PR DESCRIPTION
Found during ACP slice-1 live verification: lifecycle Stop worked perfectly at the container level (process dead, sentinel set, supervision halted) but Health kept reporting `running` — the exited supervision subshell lingered as a zombie whose comm still matched `pgrep -f opencode`. Classic zombies-match-by-comm (documented in root CLAUDE.md, now observed in production).

One-line fix: `HostConfig.Init: true` — Docker's built-in tini becomes PID 1 and reaps zombies in every provisioned container.

Hub tests: 309 green (one unrelated station-activity flake passes in isolation and on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB