### PR TITLE
fix(node-agent): double-fork opencode supervision so init reaps it

### DIFF
--- a/apps/node-agent/deploy/node-opencode-entrypoint.sh
+++ b/apps/node-agent/deploy/node-opencode-entrypoint.sh
@@ -48,25 +48,35 @@ mkdir -p "${OPENCODE_DATA}/project/workspace"
 # already exited by then, so the two never race.
 mkdir -p /var/run
 rm -f /var/run/opencode-serve.stop
+# Double-fork: the OUTER subshell backgrounds the loop subshell and exits
+# immediately, so the loop re-parents to the container's init (docker-init,
+# HostConfig.Init) instead of staying a child of this shell — which `exec`s
+# into the Go node-agent below. A direct child would linger as a <defunct>
+# zombie after the loop halts (the Go process never reaps unrelated
+# children), and the zombie's comm still matches the descriptor's pgrep
+# health check, freezing Health at "running" (live-fleet finding 2026-08-09).
 (
-  # `set +e`: the top-level `set -e` (line 2) is inherited into this subshell.
-  # Without disabling it here, any non-zero exit from `opencode serve` (a
-  # crash, or exit 143 from the lifecycle Stop's SIGTERM) would terminate the
-  # subshell at that line — the echo/sleep/loop-back below would never run,
-  # making supervision single-shot instead of restart-on-crash. Scoped to this
-  # subshell only; the outer script keeps `set -e`.
-  set +e
-  cd /workspace
-  while :; do
-    if [ -f /var/run/opencode-serve.stop ]; then
-      echo "[entrypoint] opencode-serve.stop present, halting supervision loop" >>/var/log/opencode-serve.log
-      break
-    fi
-    opencode serve >>/var/log/opencode-serve.log 2>&1
-    echo "[entrypoint] opencode serve exited ($?), restarting in 2s" >>/var/log/opencode-serve.log
-    sleep 2
-  done
+  (
+    # `set +e`: the top-level `set -e` (line 2) is inherited into subshells.
+    # Without disabling it here, any non-zero exit from `opencode serve` (a
+    # crash, or exit 143 from the lifecycle Stop's SIGTERM) would terminate
+    # the subshell at that line — the echo/sleep/loop-back below would never
+    # run, making supervision single-shot instead of restart-on-crash.
+    set +e
+    cd /workspace
+    while :; do
+      if [ -f /var/run/opencode-serve.stop ]; then
+        echo "[entrypoint] opencode-serve.stop present, halting supervision loop" >>/var/log/opencode-serve.log
+        break
+      fi
+      opencode serve >>/var/log/opencode-serve.log 2>&1
+      echo "[entrypoint] opencode serve exited ($?), restarting in 2s" >>/var/log/opencode-serve.log
+      sleep 2
+    done
+  ) &
 ) &
+# Reap the short-lived outer subshell before exec'ing, so IT doesn't zombie.
+wait $!
 export AGENTPOD_OPENCODE_SUPERVISED=1
 
 # Hand off to the run loop. AGENTPOD_OPENCODE_SUPERVISED, exported above,

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -297,10 +297,21 @@ func (o *openCodeDescriptor) Health(key string) (Health, error) {
 	return health, nil
 }
 
-// openCodeProcessRunning checks for any running opencode process via pgrep.
+// openCodeProcessRunning checks for a running opencode process via pgrep.
 // Returns false with a note when the check is unavailable.
+//
+// In supervised (provisioned-container) mode the pattern is the exact serve
+// command line: the broad "opencode" pattern permanently matches unrelated
+// argv substrings inside the container — docker-init's own cmdline carries
+// the entrypoint path "/node-opencode-entrypoint.sh" — so health could never
+// report stopped (live-fleet finding, 2026-08-09). On real hosts the broad
+// pattern is kept: any opencode process (TUI, serve, run) counts as running.
 func openCodeProcessRunning() (running bool, note string) {
-	cmd := exec.Command("pgrep", "-f", "opencode")
+	pattern := "opencode"
+	if openCodeSupervised() {
+		pattern = "opencode serve"
+	}
+	cmd := exec.Command("pgrep", "-f", pattern)
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {


### PR DESCRIPTION
Companion to #215, from the same live verification: with docker-init in place the supervision subshell STILL zombied after lifecycle Stop, because it was a direct child of the shell that `exec`s the node-agent — init only reaps orphans, and the Go process never reaps unrelated children. The zombie's comm kept matching the pgrep health check, freezing Health at `running`.

Classic daemonization double-fork: the outer subshell backgrounds the loop and exits (reaped via `wait` before the exec); the loop re-parents to docker-init, which reaps it when it halts.

`sh -n` clean; node-agent suite green. Live round-trip verification recorded on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB