### PR TITLE
feat: ACP slice 2 — hub session service

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -27,6 +27,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@agentpod/agents": "workspace:*",
     "@agentpod/contract": "workspace:*",
     "@agentpod/tsconfig": "workspace:*",

--- a/apps/hub/src/db/drizzle-migrations/0025_striped_demogoblin.sql
+++ b/apps/hub/src/db/drizzle-migrations/0025_striped_demogoblin.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "acp_events" (
+	"session_id" text NOT NULL,
+	"seq" integer NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" timestamp NOT NULL,
+	CONSTRAINT "acp_events_session_id_seq_pk" PRIMARY KEY("session_id","seq")
+);
+--> statement-breakpoint
+CREATE TABLE "acp_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"station_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"mode" text NOT NULL,
+	"status" text NOT NULL,
+	"ended_reason" text,
+	"node_session_id" text,
+	"created_at" timestamp NOT NULL,
+	"last_event_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "acp_events" ADD CONSTRAINT "acp_events_session_id_acp_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."acp_sessions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "acp_sessions_station_id_idx" ON "acp_sessions" USING btree ("station_id");

--- a/apps/hub/src/db/drizzle-migrations/meta/0025_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0025_snapshot.json
@@ -1,0 +1,1808 @@
+{
+  "id": "30e24d8f-1262-4c23-ad94-34de7bf40522",
+  "prevId": "bdf61082-c126-41ac-9535-2c44ca61db84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "online",
+        "stopped",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1782790802513,
       "tag": "0024_boring_the_hunter",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1786267145481,
+      "tag": "0025_striped_demogoblin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/acp.ts
+++ b/apps/hub/src/db/schema/acp.ts
@@ -1,0 +1,37 @@
+/**
+ * ACP Session Schema
+ *
+ * Persists ACP (Agent Client Protocol) sessions and their event log so a
+ * session's history survives node/hub restarts and can be reconciled
+ * against the node-side acp_* session id via nodeSessionId.
+ *
+ * ACP Slice 2 (hub sessions).
+ */
+
+import { pgTable, text, integer, timestamp, jsonb, primaryKey, index } from "drizzle-orm/pg-core";
+
+export const acpSessions = pgTable("acp_sessions", {
+  id: text("id").primaryKey(),                                        // "acps_" + uuid-ish
+  // Deliberately NOT a FK to stations.id (no ON DELETE CASCADE), mirroring the
+  // station_audit.stationKey precedent: transcripts must survive station
+  // deletion. Destroying a throwaway runtime/station must not silently erase
+  // conversation history. See review finding 2026-08-09 — a cascading FK here
+  // would wipe acp_events (via acp_sessions) the moment the station row is
+  // removed.
+  stationId: text("station_id").notNull(),
+  userId: text("user_id").notNull(),
+  mode: text("mode").notNull(),                                       // ask | accept-edits | full-auto
+  status: text("status").notNull(),                                   // starting|idle|working|waiting|ended
+  endedReason: text("ended_reason"),
+  nodeSessionId: text("node_session_id"),                             // the node-side acp_* id, for reconciliation acp.close
+  createdAt: timestamp("created_at").notNull(),
+  lastEventAt: timestamp("last_event_at").notNull(),
+}, (t) => [index("acp_sessions_station_id_idx").on(t.stationId)]);
+
+export const acpEvents = pgTable("acp_events", {
+  sessionId: text("session_id").notNull().references(() => acpSessions.id, { onDelete: "cascade" }),
+  seq: integer("seq").notNull(),
+  type: text("type").notNull(),
+  payload: jsonb("payload").notNull(),
+  createdAt: timestamp("created_at").notNull(),
+}, (t) => [primaryKey({ columns: [t.sessionId, t.seq] })]);

--- a/apps/hub/src/db/schema/index.ts
+++ b/apps/hub/src/db/schema/index.ts
@@ -22,3 +22,6 @@ export * from "./stations";
 
 // Station audit log (write ops + terminal events, fleet console)
 export * from "./audit";
+
+// ACP sessions + event log (fleet console)
+export * from "./acp";

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -40,6 +40,8 @@ import { fleetActivityRoutes } from './routes/activity-fleet.ts';
 import { stationWriteRoutes } from './routes/station-writes.ts';
 import { stationLifecycleRoutes } from './routes/station-lifecycle.ts';
 import { stationCleanupRoutes } from './routes/station-cleanup.ts';
+// ACP session routes (REST session management + console session WebSocket)
+import { stationAcpRoutes } from './routes/station-acp.ts';
 // Middleware
 import { activityLoggerMiddleware } from './middleware/activity-logger.ts';
 import { registerEnabledProvisioners } from './services/provisioner/bootstrap.ts';
@@ -119,7 +121,8 @@ const app = new Hono()
   // Station write routes (fs.write/mkdir/move/delete — capability-gated, audited)
   .route('/api', stationWriteRoutes)                       // POST /api/stations/:id/fs/{write,mkdir,move,delete}
   .route('/api', stationLifecycleRoutes)                   // POST /api/stations/:id/lifecycle
-  .route('/api', stationCleanupRoutes);                    // POST /api/stations/:id/cleanup/{plan,apply}
+  .route('/api', stationCleanupRoutes)                     // POST /api/stations/:id/cleanup/{plan,apply}
+  .route('/api', stationAcpRoutes);                        // POST/GET /api/stations/:id/acp/sessions, WS /api/acp/sessions/:sessionId/ws
 
 app.onError((err, c) => {
   const requestId = c.req.header('x-request-id') || crypto.randomUUID();

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -45,6 +45,8 @@ import { activityLoggerMiddleware } from './middleware/activity-logger.ts';
 import { registerEnabledProvisioners } from './services/provisioner/bootstrap.ts';
 import { enabledProviders } from './services/provisioner/registry.ts';
 import { startNodeSweeper } from './services/node-sweeper.ts';
+// ACP session boot reconciliation (hub-owned sessions do not survive restarts)
+import { reconcileOnBoot as reconcileAcpSessions } from './services/acp-sessions.ts';
 
 validateConfig();
 
@@ -53,6 +55,10 @@ await initDatabase();
 
 const orphans = await resetOrphanedOnlineNodes();
 if (orphans > 0) console.log(`Reset ${orphans} orphaned online node(s) to offline`);
+
+// Mark ACP sessions from before the restart ended + best-effort close orphaned
+// agent processes on nodes that are already back online.
+await reconcileAcpSessions();
 
 const errorLogger = createLogger('error-handler');
 

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -42,7 +42,11 @@ import {
 } from "../../tests/helpers/acp-fake-node";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { adoptStations } from "../services/station-registry";
-import { endSession, getSession } from "../services/acp-sessions";
+import {
+  endSession,
+  getSession,
+  _subscriberCountForTest,
+} from "../services/acp-sessions";
 import { gatewayRoutes } from "./gateway";
 import { stationAcpRoutes } from "./station-acp";
 import { websocket } from "../ws";
@@ -464,6 +468,127 @@ test(
       );
 
       second.ws.close();
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "disconnect during subscribe's awaits does not leak a live subscriber (regression: unsubscribe-null race)",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-leak-host",
+      { stationKey: "acproute-leak" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      // Race the close frame against handleSubscribe's DB awaits: send
+      // subscribe and close IMMEDIATELY, several times. Without the closed
+      // guard, onClose runs while unsubscribe is still null, then
+      // handleSubscribe resumes and registers a subscriber nothing removes.
+      for (let i = 0; i < 10; i++) {
+        const client = connectClientWs(server.port!, row.id, TEST_USER);
+        await client.opened;
+        // Let onOpen's ownership lookup settle so the message gate is open
+        // and the race lands inside handleSubscribe itself.
+        await new Promise((r) => setTimeout(r, 50));
+        client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+        client.ws.close();
+      }
+
+      // Every subscriber must be gone once the sockets are down.
+      await pollUntil(() => _subscriberCountForTest(row.id) === 0, 5000);
+
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "a second valid subscribe replaces the first subscription — one live subscriber, no double delivery",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-resub-host",
+      { stationKey: "acproute-resub" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      const client = connectClientWs(server.port!, row.id, TEST_USER);
+      await client.opened;
+      client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      await pollUntil(() => client.msgs.find((m) => m.t === "replay-done"));
+
+      // Re-subscribe on the SAME socket: replaces, not stacks.
+      client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      await pollUntil(
+        () => client.msgs.filter((m) => m.t === "replay-done").length >= 2
+      );
+      expect(_subscriberCountForTest(row.id)).toBe(1);
+
+      // A subsequent live event is delivered exactly once.
+      client.ws.send(JSON.stringify({ t: "prompt", text: "once please" }));
+      await pollUntil(() =>
+        receivedEvents(client).find((e) => e.type === "user-prompt")
+      );
+      const promptEvents = receivedEvents(client).filter(
+        (e) => e.type === "user-prompt"
+      );
+      expect(promptEvents.length).toBe(1);
+
+      client.ws.close();
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "WS upgrade with a disallowed Origin is refused (CSWSH)",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-origin-host",
+      { stationKey: "acproute-origin" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      const { closeCode } = await new Promise<{ closeCode: number }>((resolve) => {
+        const ws = new WebSocket(
+          `ws://localhost:${server.port}/api/acp/sessions/${row.id}/ws`,
+          {
+            headers: {
+              "X-Test-User-Id": TEST_USER,
+              Origin: "https://evil.example",
+            },
+          } as RequestInit & { headers: Record<string, string> }
+        );
+        ws.onclose = (e) => resolve({ closeCode: e.code });
+        ws.onerror = () => resolve({ closeCode: 1006 });
+      });
+      expect([1008, 1006, 1000, 1011].includes(closeCode)).toBe(true);
+
       await endSession(TEST_USER, row.id, "test done");
       fake.close();
       await new Promise((r) => setTimeout(r, 100));

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -650,3 +650,105 @@ test(
   },
   20_000
 );
+
+test(
+  "DELETE /api/acp/sessions/:id ends the session: 204 + row ended; 401 anonymous; 404 foreign session",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-del-host",
+      { stationKey: "acproute-del" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      // 401 anonymous (no auth header).
+      const anon = await fetch(`${baseUrl}/api/acp/sessions/${row.id}`, {
+        method: "DELETE",
+      });
+      expect(anon.status).toBe(401);
+
+      // 404 foreign session — and it must NOT end the session.
+      const foreign = await fetch(`${baseUrl}/api/acp/sessions/${row.id}`, {
+        method: "DELETE",
+        headers: { "X-Test-User-Id": OTHER_USER },
+      });
+      expect(foreign.status).toBe(404);
+      expect((await getSession(TEST_USER, row.id))?.status).toBe("idle");
+
+      // 404 unknown session id.
+      const unknown = await fetch(`${baseUrl}/api/acp/sessions/acps_nope`, {
+        method: "DELETE",
+        headers: { "X-Test-User-Id": TEST_USER },
+      });
+      expect(unknown.status).toBe(404);
+
+      // Happy path: 204, row ended.
+      const ended = await fetch(`${baseUrl}/api/acp/sessions/${row.id}`, {
+        method: "DELETE",
+        headers: { "X-Test-User-Id": TEST_USER },
+      });
+      expect(ended.status).toBe(204);
+      const after = await getSession(TEST_USER, row.id);
+      expect(after?.status).toBe("ended");
+      expect(after?.endedReason).toBe("Ended from the console.");
+
+      // Station released: a fresh session starts (no 409 lock).
+      const again = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(again.status).toBe(201);
+      const row2 = (await again.json()) as AcpSessionRow;
+      await endSession(TEST_USER, row2.id, "test done");
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  'attached WS client receives {t:"bye"} when the session is ended over REST',
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-delbye-host",
+      { stationKey: "acproute-delbye" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      const client = connectClientWs(server.port!, row.id, TEST_USER);
+      await client.opened;
+      client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      await pollUntil(() => client.msgs.find((m) => m.t === "replay-done"));
+
+      const res = await fetch(`${baseUrl}/api/acp/sessions/${row.id}`, {
+        method: "DELETE",
+        headers: { "X-Test-User-Id": TEST_USER },
+      });
+      expect(res.status).toBe(204);
+
+      // The service fan-out delivers the state-ended event, then the bye.
+      await pollUntil(() =>
+        receivedEvents(client).find(
+          (e) =>
+            e.type === "state" &&
+            (e.payload as { status?: string }).status === "ended"
+        )
+      );
+      const bye = await pollUntil(() => client.msgs.find((m) => m.t === "bye"));
+      expect(bye.reason).toBe("Ended from the console.");
+      await pollUntil(() => client.getCloseCode() !== null);
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Route Test: ACP session REST + console session WebSocket (Slice 2, Task 5)
+ *
+ * Verifies src/routes/station-acp.ts:
+ *   REST:
+ *     1. POST /api/stations/:id/acp/sessions {mode} → 201 AcpSessionRow;
+ *        error statuses: 400 invalid mode, 401 anonymous, 403 no acp
+ *        capability, 404 unknown station, 409 active session exists,
+ *        502 node offline / acp.open failure.
+ *     2. GET /api/stations/:id/acp/sessions → rows newest first.
+ *   WS (GET /api/acp/sessions/:sessionId/ws):
+ *     3. subscribe → session row, replay of persisted events (seq order),
+ *        replay-done, then live events stream; prompt over the WS produces
+ *        agent-update events.
+ *     4. Client disconnect does NOT end the session (hub-owned); a second WS
+ *        subscribe replays everything.
+ *     5. Unauthenticated / wrong-user upgrade → closed; invalid client
+ *        message → error event, socket stays usable (not closed).
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ * DATABASE_URL must be set before any src/ modules are imported.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import type { AcpEvent, AcpSessionRow, DetectedStation } from "@agentpod/contract";
+
+// src/ imports — DB URL is already set above
+import { rawSql } from "../db/drizzle";
+import { createTestUser } from "../../tests/helpers/database";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import {
+  connectFakeAcpNode,
+  pollUntil,
+  type FakeAcpNodeOpts,
+} from "../../tests/helpers/acp-fake-node";
+import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { adoptStations } from "../services/station-registry";
+import { endSession, getSession } from "../services/acp-sessions";
+import { gatewayRoutes } from "./gateway";
+import { stationAcpRoutes } from "./station-acp";
+import { websocket } from "../ws";
+import type { AuthUser } from "../auth/middleware";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TEST_USER = "test-user-acproute-001";
+const OTHER_USER = "test-user-acproute-002";
+
+// ─── Minimal test app ─────────────────────────────────────────────────────────
+
+// Mirrors station-terminal.test.ts: fake auth middleware + real gateway + routes.
+const testApp = new Hono()
+  .use("/api/*", async (c, next) => {
+    const userId = c.req.header("X-Test-User-Id");
+    if (userId && userId !== "anonymous") {
+      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+    } else {
+      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+    }
+    return next();
+  })
+  .route("/public/nodes", gatewayRoutes)
+  .route("/api", stationAcpRoutes);
+
+// ─── Setup & Teardown ─────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: "acproute-test@example.com",
+    name: "ACP Route Test User",
+  });
+  await createTestUser({
+    id: OTHER_USER,
+    email: "acproute-other@example.com",
+    name: "ACP Route Other User",
+  });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM acp_sessions      WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM station_audit     WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM stations          WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM nodes             WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM "user"            WHERE id IN (${TEST_USER}, ${OTHER_USER})`;
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function enrollTestNode(hostname: string) {
+  const { token } = await mintEnrollmentToken(TEST_USER);
+  return enrollNode(token, {
+    hostname,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+}
+
+function detectedFor(
+  stationKey: string,
+  capabilities: string[],
+  workspacePath = "/workspace/acproute"
+): DetectedStation[] {
+  return [
+    {
+      key: stationKey,
+      harness: "opencode",
+      kind: "leaf",
+      displayName: "ACP Route Test",
+      parentKey: null,
+      workspacePath,
+      capabilities,
+      matrixId: null,
+      adopted: false,
+    },
+  ];
+}
+
+/** Boot a gateway server + fake ACP node + adopted station for TEST_USER. */
+async function setupRig(hostname: string, opts: FakeAcpNodeOpts = {}) {
+  const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+  const { nodeId, nodeSecret } = await enrollTestNode(hostname);
+  const fake = await connectFakeAcpNode(server.port!, nodeId, nodeSecret, opts);
+  const stationKey = opts.stationKey ?? "acp-sess-station";
+  const [station] = await adoptStations(
+    TEST_USER,
+    nodeId,
+    [stationKey],
+    detectedFor(stationKey, ["health", "acp"], opts.workspacePath ?? "/workspace/acptest")
+  );
+  if (!station) throw new Error("station adoption failed");
+  return { server, nodeId, fake, station, baseUrl: `http://localhost:${server.port}` };
+}
+
+function createSessionReq(
+  baseUrl: string,
+  stationId: string,
+  body: unknown,
+  userId: string | null = TEST_USER
+) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (userId) headers["X-Test-User-Id"] = userId;
+  return fetch(`${baseUrl}/api/stations/${stationId}/acp/sessions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+interface WsClient {
+  ws: WebSocket;
+  msgs: Array<Record<string, unknown>>;
+  opened: Promise<void>;
+  getCloseCode: () => number | null;
+}
+
+function connectClientWs(
+  port: number,
+  sessionId: string,
+  userId?: string
+): WsClient {
+  const msgs: Array<Record<string, unknown>> = [];
+  const ws = new WebSocket(
+    `ws://localhost:${port}/api/acp/sessions/${sessionId}/ws`,
+    (userId
+      ? { headers: { "X-Test-User-Id": userId } }
+      : undefined) as RequestInit & { headers: Record<string, string> }
+  );
+  let closeCode: number | null = null;
+  ws.onmessage = (e) => {
+    try {
+      msgs.push(JSON.parse(String(e.data)) as Record<string, unknown>);
+    } catch {
+      // Non-JSON frame — ignore.
+    }
+  };
+  ws.onclose = (e) => {
+    closeCode = e.code;
+  };
+  const opened = new Promise<void>((resolve) => {
+    ws.onopen = () => resolve();
+    ws.onerror = () => resolve();
+  });
+  return { ws, msgs, opened, getCloseCode: () => closeCode };
+}
+
+/** Events (t:"event") received so far, unwrapped. */
+function receivedEvents(client: WsClient): AcpEvent[] {
+  return client.msgs
+    .filter((m) => m.t === "event")
+    .map((m) => m.event as AcpEvent);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test(
+  "POST create → 201 idle row; 400 invalid mode; 401 anonymous; 403 no capability; 404 unknown station; 409 duplicate; GET lists newest first",
+  async () => {
+    const { server, nodeId, fake, station, baseUrl } = await setupRig(
+      "acproute-rest-host"
+    );
+    try {
+      // A second station on the same node WITHOUT the acp capability.
+      const [noAcpStation] = await adoptStations(
+        TEST_USER,
+        nodeId,
+        ["acproute-no-acp"],
+        detectedFor("acproute-no-acp", ["health"])
+      );
+      if (!noAcpStation) throw new Error("no-acp station adoption failed");
+
+      // 400 — invalid mode.
+      const badMode = await createSessionReq(baseUrl, station.id, {
+        mode: "yolo",
+      });
+      expect(badMode.status).toBe(400);
+
+      // 401 — anonymous.
+      const anon = await createSessionReq(baseUrl, station.id, { mode: "ask" }, null);
+      expect(anon.status).toBe(401);
+
+      // 404 — unknown station.
+      const missing = await createSessionReq(baseUrl, "st_does-not-exist", {
+        mode: "ask",
+      });
+      expect(missing.status).toBe(404);
+
+      // 403 — station without the acp capability.
+      const noCap = await createSessionReq(baseUrl, noAcpStation.id, {
+        mode: "ask",
+      });
+      expect(noCap.status).toBe(403);
+
+      // 201 — happy path.
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+      expect(row.stationId).toBe(station.id);
+      expect(row.userId).toBe(TEST_USER);
+      expect(row.mode).toBe("ask");
+      expect(row.status).toBe("idle");
+
+      // 409 — an active session already exists.
+      const dup = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(dup.status).toBe(409);
+
+      // End it, create a second one; GET must list newest first.
+      await endSession(TEST_USER, row.id, "test done");
+      await new Promise((r) => setTimeout(r, 20)); // distinct createdAt
+      const created2 = await createSessionReq(baseUrl, station.id, {
+        mode: "full-auto",
+      });
+      expect(created2.status).toBe(201);
+      const row2 = (await created2.json()) as AcpSessionRow;
+
+      const listRes = await fetch(
+        `${baseUrl}/api/stations/${station.id}/acp/sessions`,
+        { headers: { "X-Test-User-Id": TEST_USER } }
+      );
+      expect(listRes.status).toBe(200);
+      const listed = (await listRes.json()) as AcpSessionRow[];
+      expect(listed.length).toBe(2);
+      expect(listed[0]!.id).toBe(row2.id); // newest first
+      expect(listed[1]!.id).toBe(row.id);
+
+      // GET on an unknown station → 404.
+      const listMissing = await fetch(
+        `${baseUrl}/api/stations/st_does-not-exist/acp/sessions`,
+        { headers: { "X-Test-User-Id": TEST_USER } }
+      );
+      expect(listMissing.status).toBe(404);
+
+      await endSession(TEST_USER, row2.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "POST create → 502 when the node is offline and 502 when acp.open fails",
+  async () => {
+    // Offline node: enrolled but never connected to the gateway.
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+    const baseUrl = `http://localhost:${server.port}`;
+    try {
+      const { nodeId } = await enrollTestNode("acproute-offline-host");
+      const [station] = await adoptStations(
+        TEST_USER,
+        nodeId,
+        ["acproute-offline"],
+        detectedFor("acproute-offline", ["health", "acp"])
+      );
+      if (!station) throw new Error("station adoption failed");
+
+      const offline = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(offline.status).toBe(502);
+
+      // Online node whose acp.open fails.
+      const { nodeId: failNodeId, nodeSecret } = await enrollTestNode(
+        "acproute-failopen-host"
+      );
+      const fake = await connectFakeAcpNode(server.port!, failNodeId, nodeSecret, {
+        stationKey: "acproute-failopen",
+        failOpen: "agent binary missing",
+      });
+      const [failStation] = await adoptStations(
+        TEST_USER,
+        failNodeId,
+        ["acproute-failopen"],
+        detectedFor("acproute-failopen", ["health", "acp"])
+      );
+      if (!failStation) throw new Error("station adoption failed");
+
+      const openFail = await createSessionReq(baseUrl, failStation.id, {
+        mode: "ask",
+      });
+      expect(openFail.status).toBe(502);
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "WS subscribe → session row + replay + replay-done, then live events; prompt over WS produces agent-update",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-ws-host",
+      { stationKey: "acproute-ws" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      const client = connectClientWs(server.port!, row.id, TEST_USER);
+      await client.opened;
+      client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+
+      // session row arrives first.
+      const sessionMsg = await pollUntil(() =>
+        client.msgs.find((m) => m.t === "session")
+      );
+      expect((sessionMsg.session as AcpSessionRow).id).toBe(row.id);
+
+      // Replay: the state-idle event from createSession (seq 1), then replay-done.
+      const replayDone = await pollUntil(() =>
+        client.msgs.find((m) => m.t === "replay-done")
+      );
+      expect(replayDone.lastSeq).toBe(1);
+      const replayed = receivedEvents(client);
+      expect(replayed.length).toBe(1);
+      expect(replayed[0]!.seq).toBe(1);
+      expect(replayed[0]!.type).toBe("state");
+      // replay-done comes AFTER the replayed event.
+      expect(client.msgs.findIndex((m) => m.t === "replay-done")).toBeGreaterThan(
+        client.msgs.findIndex((m) => m.t === "event")
+      );
+
+      // Prompt over the WS → live user-prompt, agent-update(s), back to idle.
+      client.ws.send(JSON.stringify({ t: "prompt", text: "do the thing" }));
+
+      await pollUntil(() =>
+        receivedEvents(client).find(
+          (e) =>
+            e.type === "state" &&
+            (e.payload as { status?: string }).status === "idle" &&
+            e.seq > 1
+        )
+      );
+      const events = receivedEvents(client);
+      const types = events.map((e) => e.type);
+      expect(types).toContain("user-prompt");
+      expect(types).toContain("agent-update");
+      const update = events.find((e) => e.type === "agent-update")!;
+      expect(JSON.stringify(update.payload)).toContain("Working on it");
+      // seq strictly increasing across replay + live.
+      const seqs = events.map((e) => e.seq);
+      for (let i = 1; i < seqs.length; i++) {
+        expect(seqs[i]!).toBeGreaterThan(seqs[i - 1]!);
+      }
+
+      client.ws.close();
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "client disconnect does NOT end the session; a second WS subscribe replays everything",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-disc-host",
+      { stationKey: "acproute-disc" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      // First client: subscribe, prompt, wait for the turn to finish.
+      const first = connectClientWs(server.port!, row.id, TEST_USER);
+      await first.opened;
+      first.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      await pollUntil(() => first.msgs.find((m) => m.t === "replay-done"));
+      first.ws.send(JSON.stringify({ t: "prompt", text: "hello" }));
+      await pollUntil(() =>
+        receivedEvents(first).find(
+          (e) =>
+            e.type === "state" &&
+            (e.payload as { status?: string }).status === "idle" &&
+            e.seq > 1
+        )
+      );
+      const seenLive = receivedEvents(first);
+      const maxSeq = Math.max(...seenLive.map((e) => e.seq));
+
+      // Disconnect. The session is hub-owned and must survive.
+      first.ws.close();
+      await new Promise((r) => setTimeout(r, 200));
+
+      const after = await getSession(TEST_USER, row.id);
+      expect(after).not.toBeNull();
+      expect(after!.status).not.toBe("ended");
+
+      // Second client replays EVERYTHING from seq 0.
+      const second = connectClientWs(server.port!, row.id, TEST_USER);
+      await second.opened;
+      second.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      const replayDone = await pollUntil(() =>
+        second.msgs.find((m) => m.t === "replay-done")
+      );
+      expect(replayDone.lastSeq).toBe(maxSeq);
+      const replayed = receivedEvents(second);
+      expect(replayed.map((e) => e.seq)).toEqual(
+        Array.from({ length: maxSeq }, (_, i) => i + 1)
+      );
+
+      second.ws.close();
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "WS auth: anonymous and wrong-user upgrades are closed; invalid client message → error event, socket stays open",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-auth-host",
+      { stationKey: "acproute-auth" }
+    );
+    try {
+      const created = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(created.status).toBe(201);
+      const row = (await created.json()) as AcpSessionRow;
+
+      // Anonymous → closed.
+      const anon = connectClientWs(server.port!, row.id);
+      await anon.opened;
+      const anonClose = await pollUntil(() => anon.getCloseCode());
+      expect([1008, 1006, 1000, 1011].includes(anonClose)).toBe(true);
+
+      // Wrong user → closed (session not owned).
+      const wrong = connectClientWs(server.port!, row.id, OTHER_USER);
+      await wrong.opened;
+      const wrongClose = await pollUntil(() => wrong.getCloseCode());
+      expect([1008, 1006, 1000, 1011].includes(wrongClose)).toBe(true);
+
+      // Invalid message → error EVENT, not a close.
+      const client = connectClientWs(server.port!, row.id, TEST_USER);
+      await client.opened;
+      client.ws.send("not json at all");
+      await pollUntil(() =>
+        receivedEvents(client).find((e) => e.type === "error")
+      );
+      client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: "nope" }));
+      await pollUntil(
+        () => receivedEvents(client).filter((e) => e.type === "error").length >= 2
+      );
+      expect(client.getCloseCode()).toBeNull(); // still open
+
+      // The socket still works: a valid subscribe replays.
+      client.ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      await pollUntil(() => client.msgs.find((m) => m.t === "replay-done"));
+
+      client.ws.close();
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);

--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -209,6 +209,11 @@ export const stationAcpRoutes = new Hono()
 
       const handleSubscribe = async (ws: Ws, sinceSeq: number) => {
         const row = await acp.getSession(user!.id, sessionId);
+        // Leak guard (station-terminal "Fix 1" pattern): if the client
+        // disconnected while we were awaiting the DB lookup, onClose already
+        // ran — with unsubscribe still null, so it had nothing to remove.
+        // Registering a subscriber now would leak it forever.
+        if (closed) return;
         if (!row) {
           sendError(ws, "Couldn't find that session.");
           return;
@@ -235,6 +240,15 @@ export const stationAcpRoutes = new Hono()
           deliver(ws, e);
         });
 
+        // Leak guard, part two: onClose may have run in the microtask gap
+        // around the await above. It could not cancel (unsubscribe was null
+        // then), so self-unsubscribe now.
+        if (closed) {
+          unsubscribe();
+          unsubscribe = null;
+          return;
+        }
+
         const rows = await db
           .select()
           .from(acpEvents)
@@ -242,6 +256,10 @@ export const stationAcpRoutes = new Hono()
             and(eq(acpEvents.sessionId, sessionId), gt(acpEvents.seq, sinceSeq))
           )
           .orderBy(asc(acpEvents.seq));
+
+        // Disconnected during the replay read: onClose has already removed
+        // the subscription (unsubscribe was set) — just stop.
+        if (closed) return;
 
         // Replay. A state-ended event in the replay defers its bye until
         // after replay-done so the client always sees the full transcript
@@ -297,7 +315,16 @@ export const stationAcpRoutes = new Hono()
           }
 
           // ── 2. Ownership: the session must exist AND belong to the user ──
-          const row = await acp.getSession(user.id, sessionId);
+          // A lookup failure must not strand the socket with the gate pending
+          // (messages would queue unboundedly) — close it instead.
+          let row: Awaited<ReturnType<typeof acp.getSession>>;
+          try {
+            row = await acp.getSession(user.id, sessionId);
+          } catch {
+            allowMessages(false);
+            ws.close(1011, "Couldn't open the session.");
+            return;
+          }
           if (!row) {
             ws.close(1008, "session not found");
             allowMessages(false);

--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -7,6 +7,8 @@
  *         404 unknown station, 409 active session exists,
  *         502 node offline / agent open failure)
  *   GET  /stations/:id/acp/sessions → AcpSessionRow[] (newest first)
+ *   DELETE /acp/sessions/:sessionId → 204 (ends the session; WS clients get
+ *        {t:"bye"}); 401 anonymous, 404 absent/foreign
  *
  * WS: GET /acp/sessions/:sessionId/ws (upgrade)
  *   Mirrors station-terminal.ts for the security preamble: CSWSH origin
@@ -122,6 +124,34 @@ export const stationAcpRoutes = new Hono()
       (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id)
     );
     return c.json(rows);
+  })
+
+  /**
+   * DELETE /api/acp/sessions/:sessionId
+   *
+   * Ends a session (hub-owned). Live sessions tear down the agent process on
+   * the node; attached WS clients receive {t:"bye"} via the service fan-out
+   * (the state-ended event). Stale rows are just marked ended. With
+   * single-session-per-station this is also how a healthy idle session is
+   * released so a new one can start.
+   *
+   * 204 on success (matches the stations/runtimes DELETE precedent);
+   * 404 when the session is absent or belongs to another user.
+   */
+  .delete("/acp/sessions/:sessionId", async (c) => {
+    const user = c.get("user") as AuthUser | undefined;
+    if (!user || user.id === "anonymous") {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const sessionId = c.req.param("sessionId");
+    const row = await acp.getSession(user.id, sessionId);
+    if (!row) {
+      return c.json({ error: "Not Found" }, 404);
+    }
+
+    await acp.endSession(user.id, sessionId, "Ended from the console.");
+    return c.body(null, 204);
   })
 
   /**

--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -1,0 +1,368 @@
+/**
+ * ACP Session Routes — REST session management + console session WebSocket.
+ *
+ * REST (mounted at /api in index.ts):
+ *   POST /stations/:id/acp/sessions {mode} → 201 AcpSessionRow
+ *        (400 invalid mode, 401 anonymous, 403 no acp capability,
+ *         404 unknown station, 409 active session exists,
+ *         502 node offline / agent open failure)
+ *   GET  /stations/:id/acp/sessions → AcpSessionRow[] (newest first)
+ *
+ * WS: GET /acp/sessions/:sessionId/ws (upgrade)
+ *   Mirrors station-terminal.ts for the security preamble: CSWSH origin
+ *   check via isAllowedOrigin, auth via c.get("user"), ownership via
+ *   getSession(userId, sessionId) — all before any work happens.
+ *
+ *   Protocol per @agentpod/contract AcpClientMsg / AcpServerMsg:
+ *     subscribe {sinceSeq} → {t:"session"} row, replay of acp_events with
+ *       seq > sinceSeq in order, {t:"replay-done", lastSeq}, then live
+ *       events as they are persisted.
+ *     prompt / cancel / permission-answer / set-mode → service calls.
+ *   Every inbound message is validated with AcpClientMsg.safeParse; invalid
+ *   input and service errors are surfaced as a synthetic `error` EVENT
+ *   (seq 0, never persisted) — NOT a WS close.
+ *
+ *   Client disconnect only unsubscribes. It must NOT end or cancel the
+ *   session: sessions are hub-owned and survive tab close (the ONE semantic
+ *   difference from the terminal route, which detaches a per-client PTY
+ *   stream). {t:"bye"} is sent when the session itself ends.
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { and, asc, eq, gt } from "drizzle-orm";
+import {
+  AcpClientMsg,
+  AcpSessionMode,
+  type AcpEvent,
+  type AcpEventType,
+  type AcpServerMsg,
+} from "@agentpod/contract";
+import { upgradeWebSocket } from "../ws";
+import { db } from "../db/drizzle";
+import { acpEvents } from "../db/schema/acp";
+import { isAllowedOrigin } from "../config";
+import { getStation } from "../services/station-registry";
+import * as acp from "../services/acp-sessions";
+import type { AuthUser } from "../auth/middleware";
+
+// ─── Error-to-status helper ───────────────────────────────────────────────────
+
+/**
+ * Maps createSession error messages to HTTP statuses. The service throws
+ * plain Errors with stable, user-facing messages (see acp-sessions.ts);
+ * anything unrecognised is an upstream failure (node offline, acp.open
+ * failed, agent handshake broke) → 502.
+ */
+function createErrorStatus(message: string): 403 | 404 | 409 | 502 {
+  if (message === "Station not found.") return 404;
+  if (message === "This station does not support agent sessions.") return 403;
+  if (message === "An active session already exists for this agent.") return 409;
+  return 502;
+}
+
+// ─── Route schemas ────────────────────────────────────────────────────────────
+
+const CreateBody = z.object({ mode: AcpSessionMode });
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+export const stationAcpRoutes = new Hono()
+
+  /**
+   * POST /api/stations/:id/acp/sessions
+   *
+   * Body: { mode: "ask" | "accept-edits" | "full-auto" }
+   * Starts the station's agent process over ACP and returns the session row.
+   * Ownership/capability/online checks live in the service (createSession).
+   */
+  .post(
+    "/stations/:id/acp/sessions",
+    zValidator("json", CreateBody),
+    async (c) => {
+      const user = c.get("user") as AuthUser | undefined;
+      if (!user || user.id === "anonymous") {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const stationId = c.req.param("id");
+      const { mode } = c.req.valid("json");
+
+      try {
+        const row = await acp.createSession({ stationId, userId: user.id, mode });
+        return c.json(row, 201);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, createErrorStatus(message));
+      }
+    }
+  )
+
+  /**
+   * GET /api/stations/:id/acp/sessions
+   *
+   * Lists the caller's sessions for the station, newest first.
+   */
+  .get("/stations/:id/acp/sessions", async (c) => {
+    const user = c.get("user") as AuthUser | undefined;
+    if (!user || user.id === "anonymous") {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const stationId = c.req.param("id");
+    const station = await getStation(user.id, stationId);
+    if (!station) {
+      return c.json({ error: "Not Found" }, 404);
+    }
+
+    const rows = await acp.listSessions(user.id, stationId);
+    // Newest first (createdAt is an ISO string — lexicographic order works).
+    rows.sort(
+      (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id)
+    );
+    return c.json(rows);
+  })
+
+  /**
+   * GET /api/acp/sessions/:sessionId/ws (WebSocket upgrade)
+   *
+   * Console session socket. See the file header for the protocol.
+   */
+  .get(
+    "/acp/sessions/:sessionId/ws",
+    upgradeWebSocket((c) => {
+      // Capture context values at upgrade time — c is available here but NOT
+      // inside the async callbacks (Hono closes over it for us).
+      const user = c.get("user") as AuthUser | undefined;
+      const sessionId = c.req.param("sessionId");
+      // Capture the Origin header now for CSWSH validation inside onOpen.
+      const upgradeOrigin = c.req.header("Origin") ?? null;
+
+      // Mutable state shared across onOpen / onMessage / onClose.
+      let closed = false;
+      let unsubscribe: (() => void) | null = null;
+      /** Highest event seq delivered to this client (replay + live). */
+      let lastSent = 0;
+      /** Serializes message handling so replay/live ordering is deterministic. */
+      let chain: Promise<void> = Promise.resolve();
+      /** Resolves true once onOpen's checks passed (messages wait on it). */
+      let allowMessages!: (ok: boolean) => void;
+      const gate = new Promise<boolean>((resolve) => {
+        allowMessages = resolve;
+      });
+
+      type Ws = { send(data: string): void; close(code?: number, reason?: string): void };
+
+      const send = (ws: Ws, msg: AcpServerMsg) => {
+        try {
+          ws.send(JSON.stringify(msg));
+        } catch {
+          // Client already disconnected.
+        }
+      };
+
+      /**
+       * Surface an error to the client as a synthetic `error` EVENT — never a
+       * WS close. seq 0 marks it as outside the transcript (real seqs start
+       * at 1) so it can never advance a client's replay cursor.
+       */
+      const sendError = (ws: Ws, message: string) => {
+        send(ws, {
+          t: "event",
+          event: {
+            sessionId,
+            seq: 0,
+            type: "error",
+            payload: { message },
+            createdAt: new Date().toISOString(),
+          },
+        });
+      };
+
+      const byeAndClose = (ws: Ws, reason: string) => {
+        if (closed) return;
+        closed = true;
+        send(ws, { t: "bye", reason });
+        try {
+          ws.close(1000, "session ended");
+        } catch {
+          // Already closed.
+        }
+      };
+
+      /** Deliver a LIVE event; a state-ended event also says goodbye. */
+      const deliver = (ws: Ws, e: AcpEvent) => {
+        if (closed || e.seq <= lastSent) return;
+        lastSent = e.seq;
+        send(ws, { t: "event", event: e });
+        if (e.type === "state") {
+          const p = e.payload as { status?: unknown; reason?: unknown };
+          if (p?.status === "ended") {
+            byeAndClose(
+              ws,
+              typeof p.reason === "string" ? p.reason : "Session ended."
+            );
+          }
+        }
+      };
+
+      const handleSubscribe = async (ws: Ws, sinceSeq: number) => {
+        const row = await acp.getSession(user!.id, sessionId);
+        if (!row) {
+          sendError(ws, "Couldn't find that session.");
+          return;
+        }
+
+        // Re-subscribe replaces the previous subscription with a fresh replay.
+        unsubscribe?.();
+        unsubscribe = null;
+        lastSent = sinceSeq;
+
+        send(ws, { t: "session", session: row });
+
+        // Register the live subscription BEFORE reading the DB so no event can
+        // fall in the gap; arrivals during replay buffer and flush after
+        // replay-done (deliver() dedupes by seq against the replayed rows).
+        let replayDone = false;
+        const buffered: AcpEvent[] = [];
+        unsubscribe = acp.subscribe(sessionId, (e) => {
+          if (closed) return;
+          if (!replayDone) {
+            buffered.push(e);
+            return;
+          }
+          deliver(ws, e);
+        });
+
+        const rows = await db
+          .select()
+          .from(acpEvents)
+          .where(
+            and(eq(acpEvents.sessionId, sessionId), gt(acpEvents.seq, sinceSeq))
+          )
+          .orderBy(asc(acpEvents.seq));
+
+        // Replay. A state-ended event in the replay defers its bye until
+        // after replay-done so the client always sees the full transcript
+        // and the replay-done marker first.
+        let endedReason: string | null = null;
+        for (const r of rows) {
+          if (r.seq <= lastSent) continue;
+          lastSent = r.seq;
+          const payload = r.payload;
+          send(ws, {
+            t: "event",
+            event: {
+              sessionId: r.sessionId,
+              seq: r.seq,
+              type: r.type as AcpEventType,
+              payload,
+              createdAt: r.createdAt.toISOString(),
+            },
+          });
+          if (r.type === "state") {
+            const p = payload as { status?: unknown; reason?: unknown };
+            if (p?.status === "ended") {
+              endedReason = typeof p.reason === "string" ? p.reason : "Session ended.";
+            }
+          }
+        }
+
+        send(ws, { t: "replay-done", lastSeq: lastSent });
+        replayDone = true;
+        for (const e of buffered.splice(0)) deliver(ws, e);
+
+        // Ended before this subscriber arrived (possibly before sinceSeq).
+        if (endedReason === null && row.status === "ended") {
+          endedReason = row.endedReason ?? "Session ended.";
+        }
+        if (endedReason !== null) byeAndClose(ws, endedReason);
+      };
+
+      return {
+        async onOpen(_e, ws) {
+          // ── 0. CSWSH origin check (same policy as station-terminal) ──────
+          if (!isAllowedOrigin(upgradeOrigin)) {
+            ws.close(1008, "Forbidden: origin not allowed");
+            allowMessages(false);
+            return;
+          }
+
+          // ── 1. Authenticate ──────────────────────────────────────────────
+          if (!user || user.id === "anonymous") {
+            ws.close(1008, "Unauthorized");
+            allowMessages(false);
+            return;
+          }
+
+          // ── 2. Ownership: the session must exist AND belong to the user ──
+          const row = await acp.getSession(user.id, sessionId);
+          if (!row) {
+            ws.close(1008, "session not found");
+            allowMessages(false);
+            return;
+          }
+
+          allowMessages(true);
+        },
+
+        onMessage(evt, ws) {
+          // Chain so subscribe replay and subsequent actions stay ordered.
+          chain = chain.then(async () => {
+            if (closed || !(await gate)) return;
+
+            let raw: unknown;
+            try {
+              raw = JSON.parse(String(evt.data));
+            } catch {
+              sendError(ws, "Couldn't read that message.");
+              return;
+            }
+            const parsed = AcpClientMsg.safeParse(raw);
+            if (!parsed.success) {
+              sendError(ws, "Couldn't understand that message.");
+              return;
+            }
+
+            const msg = parsed.data;
+            const userId = user!.id;
+            try {
+              switch (msg.t) {
+                case "subscribe":
+                  await handleSubscribe(ws, msg.sinceSeq);
+                  break;
+                case "prompt":
+                  await acp.promptSession(userId, sessionId, msg.text);
+                  break;
+                case "cancel":
+                  await acp.cancelTurn(userId, sessionId);
+                  break;
+                case "permission-answer":
+                  await acp.answerPermission(
+                    userId,
+                    sessionId,
+                    msg.requestSeq,
+                    msg.optionId
+                  );
+                  break;
+                case "set-mode":
+                  await acp.setMode(userId, sessionId, msg.mode);
+                  break;
+              }
+            } catch (err) {
+              sendError(ws, err instanceof Error ? err.message : String(err));
+            }
+          });
+        },
+
+        onClose() {
+          // Unsubscribe ONLY. The session is hub-owned: a tab close must not
+          // end or cancel it — a later socket re-subscribes and replays.
+          closed = true;
+          unsubscribe?.();
+          unsubscribe = null;
+        },
+      };
+    })
+  );

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -62,6 +62,7 @@ import {
   subscribe,
   reconcileOnBoot,
   _setOfflineGraceMsForTest,
+  _setHandshakeTimeoutMsForTest,
 } from "./acp-sessions";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -299,6 +300,62 @@ test(
         createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
       ).rejects.toThrow();
     } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "handshake timeout: an agent that spawns but never responds → createSession rejects, wire closed, station not wedged (maps drained)",
+  async () => {
+    _setHandshakeTimeoutMsForTest(300);
+    const { server, fake, station } = await setupRig("acpsess-hshake-host", {
+      stationKey: "acp-hshake-station",
+      hangHandshake: "initialize",
+    });
+    try {
+      // Wedged on initialize → deadline fires with the standard copy.
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("Couldn't start the agent process");
+
+      // The spawned process is torn down: node saw the best-effort acp.close.
+      await pollUntil(() =>
+        parsedNodeMsgs(fake.nodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+        )
+      );
+
+      // Row ended with the timeout copy + error event.
+      const rows = await listSessions(TEST_USER, station.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.status).toBe("ended");
+      expect(rows[0]!.endedReason).toContain("handshake timed out");
+      const evts = await eventsFor(rows[0]!.id);
+      expect(evts.some((e) => e.type === "error")).toBe(true);
+
+      // Wedged on session/new times out the same way.
+      fake.opts.hangHandshake = "session/new";
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("Couldn't start the agent process");
+
+      // Maps drained: with a healthy agent the station accepts a fresh
+      // session — no "active session already exists" 409-lock.
+      fake.opts.hangHandshake = undefined;
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      expect(row.status).toBe("idle");
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      _setHandshakeTimeoutMsForTest(30_000);
       server.stop(true);
     }
   },

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -286,6 +286,12 @@ test(
       const evts = await eventsFor(rows[0]!.id);
       expect(evts.some((e) => e.type === "error")).toBe(true);
 
+      // The failure exit cleaned the live maps: a retry hits the open failure
+      // again — NOT the single-session guard (which would wedge the station).
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("Couldn't start the agent process");
+
       // Offline node.
       fake.close();
       await new Promise((r) => setTimeout(r, 200));
@@ -318,15 +324,11 @@ test(
       await promptSession(TEST_USER, row.id, "please do the thing");
 
       // Turn ends back at idle (skip seq 1 = the create-time idle event).
-      await pollForEvent(
+      const { all } = await pollForEvent(
         row.id,
-        (e) =>
-          e.type === "state" &&
-          (e.payload as { status?: string }).status === "idle" &&
-          true,
+        (e) => stateWith("idle")(e) && (e as { seq: number }).seq > 1,
         8000
       );
-      const { all } = await pollForEvent(row.id, (e) => e.type === "agent-update");
 
       // Ordering by seq: user-prompt < state working < agent-update < final idle.
       const types = all.map((e) => e.type);
@@ -648,6 +650,236 @@ test(
 );
 
 test(
+  "stale-turn epoch: a cancelled turn's late completion cannot clobber the next turn's status",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-epoch-host", {
+      stationKey: "acp-epoch-station",
+      hangPrompt: true,
+      ignoreCancel: true, // prompts stay pending until releasePrompt()
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+
+      // Turn #1 hangs; cancel it (the fake ignores the cancel, so the SDK
+      // request for turn #1 stays pending).
+      await promptSession(TEST_USER, row.id, "task one");
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "working";
+      });
+      await cancelTurn(TEST_USER, row.id);
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+
+      // Turn #2 starts.
+      await promptSession(TEST_USER, row.id, "task two");
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "working";
+      });
+      const before = (await eventsFor(row.id)).length;
+
+      // NOW turn #1's late response arrives (oldest pending prompt).
+      fake.releasePrompt("end_turn");
+      await new Promise((r) => setTimeout(r, 300));
+
+      // Status must stay working and no spurious state event may appear.
+      const mid = await getSession(TEST_USER, row.id);
+      expect(mid?.status).toBe("working");
+      const after = await eventsFor(row.id);
+      expect(after.length).toBe(before);
+
+      // Turn #2's own completion still lands normally.
+      fake.releasePrompt("end_turn");
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "concurrent createSession for the same station: exactly one wins, the other gets the active-session error",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-race-host", {
+      stationKey: "acp-race-station",
+    });
+    try {
+      const results = await Promise.allSettled([
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" }),
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" }),
+      ]);
+      const won = results.filter((r) => r.status === "fulfilled");
+      const lost = results.filter((r) => r.status === "rejected");
+      expect(won).toHaveLength(1);
+      expect(lost).toHaveLength(1);
+      expect(String((lost[0] as PromiseRejectedResult).reason)).toContain(
+        "An active session already exists for this agent."
+      );
+
+      const winner = (won[0] as PromiseFulfilledResult<{ id: string }>).value;
+      await endSession(TEST_USER, winner.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "endSession mid-parked-ask: parked permission resolves with the cancelled outcome; permission-answer {cancelled:true} persisted",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-endpark-host", {
+      stationKey: "acp-endpark-station",
+      permission: { toolKind: "execute" },
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+
+      await promptSession(TEST_USER, row.id, "risky operation");
+      const { hit: permReq } = await pollForEvent(
+        row.id,
+        (e) => e.type === "permission-request"
+      );
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "waiting";
+      });
+
+      await endSession(TEST_USER, row.id, "user closed mid-permission");
+
+      // The agent received the SDK's cancelled outcome for the parked request.
+      await pollUntil(() => fake.permissionOutcomes.length === 1);
+      expect(fake.permissionOutcomes[0]).toEqual({ outcome: "cancelled" });
+
+      // permission-answer {cancelled:true} persisted with the request's seq.
+      const evts = await eventsFor(row.id);
+      const answer = evts.find((e) => e.type === "permission-answer")!;
+      expect((answer.payload as { cancelled?: boolean }).cancelled).toBe(true);
+      expect((answer.payload as { requestSeq: number }).requestSeq).toBe(
+        (permReq as { seq: number }).seq
+      );
+
+      const ended = await getSession(TEST_USER, row.id);
+      expect(ended?.status).toBe("ended");
+      expect(ended?.endedReason).toBe("user closed mid-permission");
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "boot orphan cleanup: node offline at reconcile keeps the marker; the node's next connect triggers acp.close exactly once",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpsess-orphan-host");
+      // Adopt the station WITHOUT connecting the node (DB-only).
+      const [station] = await adoptStations(TEST_USER, nodeId, ["acp-orphan-station"], [
+        {
+          key: "acp-orphan-station",
+          harness: "opencode",
+          kind: "leaf",
+          displayName: "Orphan Station",
+          parentKey: null,
+          workspacePath: "/workspace/orphan",
+          capabilities: ["health", "acp"],
+          matrixId: null,
+          adopted: false,
+        },
+      ]);
+      const staleId = `acps_${crypto.randomUUID()}`;
+      await db.insert(acpSessions).values({
+        id: staleId,
+        stationId: station!.id,
+        userId: TEST_USER,
+        mode: "ask",
+        status: "working",
+        endedReason: null,
+        nodeSessionId: "acp-proc-orphan-9",
+        createdAt: new Date(),
+        lastEventAt: new Date(),
+      });
+
+      // Boot reconcile with the node offline: row ends, marker survives.
+      await reconcileOnBoot();
+      const afterBoot = await db
+        .select()
+        .from(acpSessions)
+        .where(eq(acpSessions.id, staleId));
+      expect(afterBoot[0]!.status).toBe("ended");
+      expect(afterBoot[0]!.nodeSessionId).toBe("acp-proc-orphan-9");
+
+      // Node connects → hook fires the best-effort acp.close…
+      const fake = await connectFakeAcpNode(server.port!, nodeId, nodeSecret, {
+        stationKey: "acp-orphan-station",
+      });
+      await pollUntil(() =>
+        parsedNodeMsgs(fake.nodeMsgs).find(
+          (m) =>
+            m.type === "req" &&
+            (m as { verb?: string }).verb === "acp.close" &&
+            (m as { params?: { sessionId?: string } }).params?.sessionId ===
+              "acp-proc-orphan-9"
+        )
+      );
+      // …and clears the marker so it's once-only.
+      await pollUntil(async () => {
+        const r = await db
+          .select()
+          .from(acpSessions)
+          .where(eq(acpSessions.id, staleId));
+        return r[0]?.nodeSessionId === null;
+      });
+
+      // Reconnect: no second acp.close for the already-cleared orphan.
+      fake.close();
+      await new Promise((r) => setTimeout(r, 200));
+      const fake2 = await connectFakeAcpNode(server.port!, nodeId, nodeSecret, {
+        stationKey: "acp-orphan-station",
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      expect(
+        parsedNodeMsgs(fake2.nodeMsgs).filter(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+        )
+      ).toHaveLength(0);
+
+      fake2.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
   "node offline mid-session: status waiting with reason, then grace timer ends the session",
   async () => {
     _setOfflineGraceMsForTest(300);
@@ -750,6 +982,21 @@ test(
         )
       );
       expect(closeReq).toBeTruthy();
+
+      // Boot-time close clears the marker (once-only); the station-less
+      // orphan keeps its marker (transcript row survives, nothing to close).
+      await pollUntil(async () => {
+        const r = await db
+          .select()
+          .from(acpSessions)
+          .where(eq(acpSessions.id, staleId));
+        return r[0]?.nodeSessionId === null;
+      });
+      const orphanRow = await db
+        .select()
+        .from(acpSessions)
+        .where(eq(acpSessions.id, orphanId));
+      expect(orphanRow[0]!.nodeSessionId).toBe("acp-proc-gone-7");
 
       fake.close();
       await new Promise((r) => setTimeout(r, 100));

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -1,0 +1,761 @@
+/**
+ * Service Test: ACP session service (hub-owned sessions over the ACP wire)
+ *
+ * Verifies src/services/acp-sessions.ts against a fake node speaking scripted
+ * ACP (tests/helpers/acp-fake-node.ts):
+ *
+ *   1. createSession → row idle + state event persisted; single live session
+ *      per station; capability/ownership/online gates; open-failure marks the
+ *      row ended with an error event.
+ *   2. promptSession → user-prompt / state working / agent-update / state idle
+ *      ordering by seq; audit row (chars only, never text); subscribe fan-out.
+ *   3. ask mode parks the permission (status waiting); answerPermission
+ *      resolves it and restores working; events persisted.
+ *   4. full-auto auto-answers with the first allow option (auto flag).
+ *   5. accept-edits auto-allows edit toolCalls, parks the rest; setMode flips
+ *      enforcement mid-session.
+ *   6. cancelTurn sends session/cancel; prompt resolves cancelled → idle.
+ *   7. wrong-user access → null / empty / throws.
+ *   8. endSession closes the wire (node sees acp.close) + row ended + event.
+ *   9. node offline mid-session → waiting + grace end.
+ *  10. reconcileOnBoot marks stale rows ended and best-effort closes orphans.
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ * DATABASE_URL must be set before any src/ modules are imported.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { asc, eq } from "drizzle-orm";
+import type { AcpEvent, DetectedStation } from "@agentpod/contract";
+
+// src/ imports — DB URL is already set above
+import { db, rawSql } from "../db/drizzle";
+import { acpSessions, acpEvents } from "../db/schema/acp";
+import { createTestUser } from "../../tests/helpers/database";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import {
+  connectFakeAcpNode,
+  parsedNodeMsgs,
+  pollUntil,
+  type FakeAcpNodeOpts,
+} from "../../tests/helpers/acp-fake-node";
+import { mintEnrollmentToken, enrollNode } from "./enrollment";
+import { adoptStations } from "./station-registry";
+import { gatewayRoutes } from "../routes/gateway";
+import { websocket } from "../ws";
+import {
+  createSession,
+  listSessions,
+  getSession,
+  promptSession,
+  cancelTurn,
+  answerPermission,
+  setMode,
+  endSession,
+  subscribe,
+  reconcileOnBoot,
+  _setOfflineGraceMsForTest,
+} from "./acp-sessions";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TEST_USER = "test-user-acpsess-001";
+const OTHER_USER = "test-user-acpsess-002";
+
+// ─── Minimal test app ─────────────────────────────────────────────────────────
+
+const testApp = new Hono().route("/public/nodes", gatewayRoutes);
+
+// ─── Setup & Teardown ─────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: "acpsess-test@example.com",
+    name: "ACP Session Test User",
+  });
+  await createTestUser({
+    id: OTHER_USER,
+    email: "acpsess-other@example.com",
+    name: "ACP Session Other User",
+  });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM acp_sessions      WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM station_audit     WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM stations          WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM nodes             WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
+    await rawSql`DELETE FROM "user"            WHERE id IN (${TEST_USER}, ${OTHER_USER})`;
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function enrollTestNode(hostname: string) {
+  const { token } = await mintEnrollmentToken(TEST_USER);
+  return enrollNode(token, {
+    hostname,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+}
+
+/** Boot a gateway server + fake ACP node + adopted station for TEST_USER. */
+async function setupRig(hostname: string, opts: FakeAcpNodeOpts = {}) {
+  const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+  const { nodeId, nodeSecret } = await enrollTestNode(hostname);
+  const fake = await connectFakeAcpNode(server.port!, nodeId, nodeSecret, opts);
+  const stationKey = opts.stationKey ?? "acp-sess-station";
+  const detected: DetectedStation[] = [
+    {
+      key: stationKey,
+      harness: "opencode",
+      kind: "leaf",
+      displayName: "ACP Session Test",
+      parentKey: null,
+      workspacePath: opts.workspacePath ?? "/workspace/acptest",
+      capabilities: ["health", "acp"],
+      matrixId: null,
+      adopted: false,
+    },
+  ];
+  const [station] = await adoptStations(TEST_USER, nodeId, [stationKey], detected);
+  if (!station) throw new Error("station adoption failed");
+  return { server, nodeId, fake, station };
+}
+
+async function eventsFor(sessionId: string) {
+  return db
+    .select()
+    .from(acpEvents)
+    .where(eq(acpEvents.sessionId, sessionId))
+    .orderBy(asc(acpEvents.seq));
+}
+
+async function pollForEvent(
+  sessionId: string,
+  match: (e: { type: string; payload: unknown }) => boolean,
+  timeoutMs = 8000
+) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const evts = await eventsFor(sessionId);
+    const hit = evts.find(match);
+    if (hit) return { hit, all: evts };
+    if (Date.now() > deadline) {
+      throw new Error(
+        `event not found; have: ${JSON.stringify(evts.map((e) => [e.seq, e.type, e.payload]))}`
+      );
+    }
+    await new Promise((r) => setTimeout(r, 40));
+  }
+}
+
+const stateWith = (status: string) => (e: { type: string; payload: unknown }) =>
+  e.type === "state" && (e.payload as { status?: string }).status === status;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test(
+  "createSession: row idle + state event; duplicate refused; endSession closes wire (node sees acp.close) + row ended + event",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-create-host");
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+
+      expect(row.stationId).toBe(station.id);
+      expect(row.userId).toBe(TEST_USER);
+      expect(row.mode).toBe("ask");
+      expect(row.status).toBe("idle");
+      expect(row.endedReason).toBeNull();
+
+      // state event {status:"idle"} persisted with seq 1.
+      const evts = await eventsFor(row.id);
+      expect(evts).toHaveLength(1);
+      expect(evts[0]!.seq).toBe(1);
+      expect(evts[0]!.type).toBe("state");
+      expect((evts[0]!.payload as { status: string }).status).toBe("idle");
+
+      // Single live session per station.
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("An active session already exists for this agent.");
+
+      // getSession / listSessions surface the row.
+      const fetched = await getSession(TEST_USER, row.id);
+      expect(fetched?.id).toBe(row.id);
+      const listed = await listSessions(TEST_USER, station.id);
+      expect(listed.map((s) => s.id)).toContain(row.id);
+
+      // endSession → node sees acp.close, row ended, state ended event.
+      await endSession(TEST_USER, row.id, "user closed");
+      const closeReq = await pollUntil(() =>
+        parsedNodeMsgs(fake.nodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+        )
+      );
+      expect((closeReq as { params: { sessionId: string } }).params.sessionId).toBe(
+        "acp-proc-1"
+      );
+
+      const ended = await getSession(TEST_USER, row.id);
+      expect(ended?.status).toBe("ended");
+      expect(ended?.endedReason).toBe("user closed");
+      await pollForEvent(row.id, stateWith("ended"));
+
+      // A new session can start once the previous one ended.
+      const row2 = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+      expect(row2.status).toBe("idle");
+      await endSession(TEST_USER, row2.id, "cleanup");
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "createSession gates: missing station, missing acp capability, offline node, open failure marks row ended + error event",
+  async () => {
+    const { server, nodeId, fake, station } = await setupRig(
+      "acpsess-gates-host",
+      { stationKey: "acp-gates-station", failOpen: "harness not found" }
+    );
+    try {
+      // Unknown station.
+      await expect(
+        createSession({ stationId: "station_nope", userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow();
+
+      // Wrong user (not the owner).
+      await expect(
+        createSession({ stationId: station.id, userId: OTHER_USER, mode: "ask" })
+      ).rejects.toThrow();
+
+      // Station without the acp capability.
+      const [noAcp] = await adoptStations(TEST_USER, nodeId, ["no-acp-station"], [
+        {
+          key: "no-acp-station",
+          harness: "hermes",
+          kind: "leaf",
+          displayName: "No ACP",
+          parentKey: null,
+          workspacePath: null,
+          capabilities: ["health"],
+          matrixId: null,
+          adopted: false,
+        },
+      ]);
+      await expect(
+        createSession({ stationId: noAcp!.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow();
+
+      // acp.open failure → throws AND leaves the row ended with an error event.
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow();
+      const rows = await listSessions(TEST_USER, station.id);
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.status).toBe("ended");
+      expect(rows[0]!.endedReason).toContain("Couldn't start the agent process");
+      const evts = await eventsFor(rows[0]!.id);
+      expect(evts.some((e) => e.type === "error")).toBe(true);
+
+      // Offline node.
+      fake.close();
+      await new Promise((r) => setTimeout(r, 200));
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow();
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "promptSession: user-prompt → working → agent-update → idle ordering by seq; audit row records chars, never text; subscribe fan-out",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-prompt-host", {
+      stationKey: "acp-prompt-station",
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+
+      const liveEvents: AcpEvent[] = [];
+      const unsub = subscribe(row.id, (e) => liveEvents.push(e));
+
+      await promptSession(TEST_USER, row.id, "please do the thing");
+
+      // Turn ends back at idle (skip seq 1 = the create-time idle event).
+      await pollForEvent(
+        row.id,
+        (e) =>
+          e.type === "state" &&
+          (e.payload as { status?: string }).status === "idle" &&
+          true,
+        8000
+      );
+      const { all } = await pollForEvent(row.id, (e) => e.type === "agent-update");
+
+      // Ordering by seq: user-prompt < state working < agent-update < final idle.
+      const types = all.map((e) => e.type);
+      const promptIdx = types.indexOf("user-prompt");
+      const workingIdx = all.findIndex(stateWith("working"));
+      const updateIdx = types.indexOf("agent-update");
+      const idleIdx = all.findIndex(
+        (e, i) => i > promptIdx && stateWith("idle")(e)
+      );
+      expect(promptIdx).toBeGreaterThan(-1);
+      expect(workingIdx).toBeGreaterThan(promptIdx);
+      expect(updateIdx).toBeGreaterThan(workingIdx);
+      expect(idleIdx).toBeGreaterThan(updateIdx);
+
+      // seqs strictly increasing and gapless from 1.
+      expect(all.map((e) => e.seq)).toEqual(all.map((_, i) => i + 1));
+
+      // user-prompt payload carries the text (transcript, not audit).
+      expect(
+        (all[promptIdx]!.payload as { text: string }).text
+      ).toBe("please do the thing");
+
+      // agent-update carries the raw SDK update payload.
+      const update = all[updateIdx]!.payload as {
+        sessionUpdate: string;
+        content: { type: string; text: string };
+      };
+      expect(update.sessionUpdate).toBe("agent_message_chunk");
+      expect(update.content.text).toBe("Working on it");
+
+      // Session row is idle again.
+      const after = await getSession(TEST_USER, row.id);
+      expect(after?.status).toBe("idle");
+
+      // Subscribe fan-out delivered the same events (at least prompt→idle).
+      await pollUntil(() => liveEvents.some((e) => stateWith("idle")(e)));
+      expect(liveEvents.some((e) => e.type === "user-prompt")).toBe(true);
+      expect(liveEvents.some((e) => e.type === "agent-update")).toBe(true);
+      unsub();
+
+      // Audit row: verb acp.prompt, chars only — never the prompt text.
+      const audits = await rawSql`
+        SELECT verb, params_summary FROM station_audit
+        WHERE user_id = ${TEST_USER} AND verb = 'acp.prompt'`;
+      expect(audits.length).toBeGreaterThan(0);
+      const summary = audits[0]!.params_summary as Record<string, unknown>;
+      expect(summary.chars).toBe("please do the thing".length);
+      expect(JSON.stringify(summary)).not.toContain("please do the thing");
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "ask mode: permission parks (status waiting), answerPermission resolves it, events persisted, agent sees selected outcome",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-ask-host", {
+      stationKey: "acp-ask-station",
+      permission: { toolKind: "execute" },
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+
+      await promptSession(TEST_USER, row.id, "run a command");
+
+      // permission-request persisted; session parks at waiting.
+      const { hit: permReq } = await pollForEvent(
+        row.id,
+        (e) => e.type === "permission-request"
+      );
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "waiting";
+      });
+      const reqPayload = permReq.payload as {
+        toolCall: { toolCallId: string; kind: string };
+        options: Array<{ optionId: string }>;
+      };
+      expect(reqPayload.toolCall.kind).toBe("execute");
+      expect(reqPayload.options.map((o) => o.optionId)).toContain("allow");
+
+      // The agent has NOT yet received an outcome.
+      expect(fake.permissionOutcomes).toHaveLength(0);
+
+      // Answer → agent unblocks, turn completes, back to idle.
+      const requestSeq = (permReq as { seq: number }).seq;
+      await answerPermission(TEST_USER, row.id, requestSeq, "allow");
+
+      await pollForEvent(row.id, (e) => e.type === "permission-answer");
+      await pollUntil(() => fake.permissionOutcomes.length === 1);
+      expect(fake.permissionOutcomes[0]).toEqual({
+        outcome: "selected",
+        optionId: "allow",
+      });
+
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+      const all = await eventsFor(row.id);
+      const answer = all.find((e) => e.type === "permission-answer")!;
+      expect((answer.payload as { requestSeq: number }).requestSeq).toBe(requestSeq);
+      expect((answer.payload as { optionId: string }).optionId).toBe("allow");
+      expect((answer.payload as { auto?: boolean }).auto).toBeFalsy();
+
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+
+      // Answering again → no pending request.
+      await expect(
+        answerPermission(TEST_USER, row.id, requestSeq, "allow")
+      ).rejects.toThrow();
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "full-auto: auto-answers the first allow option; request+answer events carry the auto flag",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-auto-host", {
+      stationKey: "acp-auto-station",
+      permission: { toolKind: "execute" },
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+
+      await promptSession(TEST_USER, row.id, "just do it");
+
+      await pollUntil(() => fake.permissionOutcomes.length === 1);
+      expect(fake.permissionOutcomes[0]).toEqual({
+        outcome: "selected",
+        optionId: "allow",
+      });
+
+      const { hit: answer, all } = await pollForEvent(
+        row.id,
+        (e) => e.type === "permission-answer"
+      );
+      expect((answer.payload as { auto?: boolean }).auto).toBe(true);
+      expect((answer.payload as { optionId: string }).optionId).toBe("allow");
+      expect(all.some((e) => e.type === "permission-request")).toBe(true);
+
+      // Never parked: no waiting state event.
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+      const finalEvents = await eventsFor(row.id);
+      expect(finalEvents.some(stateWith("waiting"))).toBe(false);
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "accept-edits: edit toolCalls auto-allowed, others park; setMode flips enforcement mid-session",
+  async () => {
+    const permission = { toolKind: "edit" };
+    const { server, fake, station } = await setupRig("acpsess-edits-host", {
+      stationKey: "acp-edits-station",
+      permission,
+    });
+    try {
+      // Start in ask, then flip to accept-edits via setMode.
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      await setMode(TEST_USER, row.id, "accept-edits");
+      const flipped = await getSession(TEST_USER, row.id);
+      expect(flipped?.mode).toBe("accept-edits");
+
+      // Edit toolCall → auto-allowed, no parking.
+      await promptSession(TEST_USER, row.id, "edit the file");
+      await pollUntil(() => fake.permissionOutcomes.length === 1);
+      expect(fake.permissionOutcomes[0]).toEqual({
+        outcome: "selected",
+        optionId: "allow",
+      });
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+
+      // Non-edit toolCall → parks like ask.
+      permission.toolKind = "execute";
+      await promptSession(TEST_USER, row.id, "now run a command");
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "waiting";
+      });
+      const evts = await eventsFor(row.id);
+      const parked = evts.filter((e) => e.type === "permission-request").at(-1)!;
+      await answerPermission(TEST_USER, row.id, parked.seq, "allow");
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "cancelTurn: agent receives session/cancel, hanging prompt resolves cancelled, status back to idle; prompt while working refused",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-cancel-host", {
+      stationKey: "acp-cancel-station",
+      hangPrompt: true,
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+
+      await promptSession(TEST_USER, row.id, "long task");
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "working";
+      });
+
+      // A second prompt while working is refused.
+      await expect(
+        promptSession(TEST_USER, row.id, "another")
+      ).rejects.toThrow();
+
+      await cancelTurn(TEST_USER, row.id);
+
+      // Agent saw the cancel notification.
+      await pollUntil(() =>
+        fake.agentReceived.find((m) => m.method === "session/cancel")
+      );
+
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "wrong-user access: getSession null, listSessions empty, prompt/cancel/end/setMode throw",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-authz-host", {
+      stationKey: "acp-authz-station",
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+
+      expect(await getSession(OTHER_USER, row.id)).toBeNull();
+      expect(await listSessions(OTHER_USER, station.id)).toEqual([]);
+      await expect(promptSession(OTHER_USER, row.id, "hi")).rejects.toThrow();
+      await expect(cancelTurn(OTHER_USER, row.id)).rejects.toThrow();
+      await expect(setMode(OTHER_USER, row.id, "full-auto")).rejects.toThrow();
+      await expect(endSession(OTHER_USER, row.id, "nope")).rejects.toThrow();
+
+      // Still intact for the owner.
+      const mine = await getSession(TEST_USER, row.id);
+      expect(mine?.status).toBe("idle");
+
+      await endSession(TEST_USER, row.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "node offline mid-session: status waiting with reason, then grace timer ends the session",
+  async () => {
+    _setOfflineGraceMsForTest(300);
+    const { server, fake, station } = await setupRig("acpsess-offline-host", {
+      stationKey: "acp-offline-station",
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+
+      // Node drops: wire ends without an exit frame.
+      fake.close();
+
+      const { hit: waiting } = await pollForEvent(row.id, stateWith("waiting"));
+      expect((waiting.payload as { reason?: string }).reason).toBe("node offline");
+
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "ended";
+      });
+      const ended = await getSession(TEST_USER, row.id);
+      expect(ended?.endedReason).toBe("Couldn't reach the node.");
+      await pollForEvent(row.id, stateWith("ended"));
+
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      _setOfflineGraceMsForTest(60_000);
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "reconcileOnBoot: stale non-ended rows marked ended('hub restarted') with a state event; orphaned nodeSessionId best-effort closed on online nodes",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-boot-host", {
+      stationKey: "acp-boot-station",
+    });
+    try {
+      // A stale row as if the hub crashed mid-session.
+      const staleId = `acps_${crypto.randomUUID()}`;
+      await db.insert(acpSessions).values({
+        id: staleId,
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+        status: "working",
+        endedReason: null,
+        nodeSessionId: "acp-proc-stale-42",
+        createdAt: new Date(),
+        lastEventAt: new Date(),
+      });
+      await db.insert(acpEvents).values({
+        sessionId: staleId,
+        seq: 1,
+        type: "state",
+        payload: { status: "idle" },
+        createdAt: new Date(),
+      });
+
+      // A stale row whose station is gone (transcript survives; no close possible).
+      const orphanId = `acps_${crypto.randomUUID()}`;
+      await db.insert(acpSessions).values({
+        id: orphanId,
+        stationId: "station_deleted_long_ago",
+        userId: TEST_USER,
+        mode: "ask",
+        status: "waiting",
+        endedReason: null,
+        nodeSessionId: "acp-proc-gone-7",
+        createdAt: new Date(),
+        lastEventAt: new Date(),
+      });
+
+      await reconcileOnBoot();
+
+      for (const id of [staleId, orphanId]) {
+        const s = await getSession(TEST_USER, id);
+        expect(s?.status).toBe("ended");
+        expect(s?.endedReason).toBe("hub restarted");
+      }
+      // State event appended after the existing seq.
+      const staleEvts = await eventsFor(staleId);
+      expect(staleEvts.at(-1)!.type).toBe("state");
+      expect((staleEvts.at(-1)!.payload as { status: string }).status).toBe("ended");
+      expect(staleEvts.at(-1)!.seq).toBe(2);
+
+      // Online node got a best-effort acp.close for the orphaned process id.
+      const closeReq = await pollUntil(() =>
+        parsedNodeMsgs(fake.nodeMsgs).find(
+          (m) =>
+            m.type === "req" &&
+            (m as { verb?: string }).verb === "acp.close" &&
+            (m as { params?: { sessionId?: string } }).params?.sessionId ===
+              "acp-proc-stale-42"
+        )
+      );
+      expect(closeReq).toBeTruthy();
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -60,6 +60,48 @@ export function _setOfflineGraceMsForTest(ms: number): void {
   offlineGraceMs = ms;
 }
 
+// Deadline for each ACP handshake request (initialize, session/new). An agent
+// process that spawns but never speaks ACP (interactive-prompt/TTY wedge —
+// the class Hermes hit in dogfooding) must not leave createSession pending
+// forever: the live-map entry is registered before the handshake, so a hung
+// await would 409-lock the station until hub restart.
+let handshakeTimeoutMs = 30_000;
+
+/** Test hook: shrink the handshake deadline. */
+export function _setHandshakeTimeoutMsForTest(ms: number): void {
+  handshakeTimeoutMs = ms;
+}
+
+const HANDSHAKE_TIMEOUT_MESSAGE =
+  "Couldn't start the agent process — the agent didn't respond (handshake timed out).";
+
+/**
+ * Reject with `message` if `promise` doesn't settle within `ms`.
+ *
+ * On timeout the underlying promise is left to settle later (the SDK rejects
+ * it when the connection closes) — its eventual rejection is swallowed so it
+ * never becomes an unhandled rejection.
+ */
+function withDeadline<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      promise.catch(() => {});
+      reject(new Error(message));
+    }, ms);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface CreateSessionInput {
@@ -430,17 +472,25 @@ export async function createSession(
       () => void handleWireClosed(live, "wire error")
     );
 
-    await connection.agent.request("initialize", {
-      protocolVersion: PROTOCOL_VERSION,
-      clientCapabilities: {},
-      clientInfo: { name: "agentpod-hub", version: "0.1.0" },
-    });
-    const created = await connection.agent.request("session/new", {
-      // The SDK requires an absolute cwd; the station workspace is the
-      // natural one, "/" the fallback for workspace-less stations.
-      cwd: station.workspacePath ?? "/",
-      mcpServers: [],
-    });
+    await withDeadline(
+      connection.agent.request("initialize", {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+        clientInfo: { name: "agentpod-hub", version: "0.1.0" },
+      }),
+      handshakeTimeoutMs,
+      HANDSHAKE_TIMEOUT_MESSAGE
+    );
+    const created = await withDeadline(
+      connection.agent.request("session/new", {
+        // The SDK requires an absolute cwd; the station workspace is the
+        // natural one, "/" the fallback for workspace-less stations.
+        cwd: station.workspacePath ?? "/",
+        mcpServers: [],
+      }),
+      handshakeTimeoutMs,
+      HANDSHAKE_TIMEOUT_MESSAGE
+    );
     live.acpSessionId = created.sessionId;
 
     await db

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -659,6 +659,11 @@ async function appendEndedState(sessionId: string, reason: string): Promise<void
   });
 }
 
+/** Test hook: live subscriber count for a session (leak detection). */
+export function _subscriberCountForTest(sessionId: string): number {
+  return subscribers.get(sessionId)?.size ?? 0;
+}
+
 /** Subscribe to live events; replay is the caller's job (read acp_events). */
 export function subscribe(
   sessionId: string,

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -1,0 +1,666 @@
+/**
+ * ACP session service — hub-owned agent sessions over the ACP wire.
+ *
+ * The hub is the ACP *client*; the agent process on the node is the ACP
+ * *agent*. Each live session binds the official ACP TypeScript SDK
+ * (fluent `client()` app + `ndJsonStream`) onto the byte streams from
+ * `openAcpWire` (acp-transport.ts) and owns:
+ *
+ *   - the session row in `acp_sessions` (status machine:
+ *     starting → idle ⇄ working ⇄ waiting → ended),
+ *   - the append-only transcript in `acp_events` (per-session `seq`,
+ *     assigned in memory, writes serialized per session),
+ *   - permission-mode enforcement (ask / accept-edits / full-auto) for the
+ *     agent's `session/request_permission` callbacks,
+ *   - live fan-out to subscribers (replay is the caller's job — read
+ *     acp_events).
+ *
+ * Slice 2 scope: single live session per station, no reattach after node
+ * offline (recorded as a slice-3 improvement — on wire eof the session parks
+ * at `waiting` and a grace timer ends it).
+ */
+
+import { and, eq, ne, sql } from "drizzle-orm";
+import {
+  client,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type ClientConnection,
+  type ClientContext,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import type {
+  AcpEvent,
+  AcpEventType,
+  AcpSessionMode,
+  AcpSessionRow,
+  AcpSessionStatus,
+} from "@agentpod/contract";
+import { db } from "../db/drizzle";
+import { acpSessions, acpEvents } from "../db/schema/acp";
+import { stations } from "../db/schema/stations";
+import { createLogger } from "../utils/logger";
+import { getStation } from "./station-registry";
+import { gateCapability } from "../routes/station-writes";
+import { connectionManager } from "./connection-manager";
+import { recordAudit } from "./audit";
+import { openAcpWire, type AcpWire } from "./acp-transport";
+import * as broker from "./broker";
+
+const log = createLogger("acp-sessions");
+
+// How long a session survives at `waiting` after its node goes offline before
+// the hub gives up (no reattach in slice 2).
+let offlineGraceMs = 60_000;
+
+/** Test hook: shrink the offline grace period. */
+export function _setOfflineGraceMsForTest(ms: number): void {
+  offlineGraceMs = ms;
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CreateSessionInput {
+  stationId: string;
+  userId: string;
+  mode: AcpSessionMode;
+}
+
+interface LiveSession {
+  id: string;
+  stationId: string;
+  userId: string;
+  nodeId: string;
+  stationKey: string;
+  mode: AcpSessionMode;
+  status: AcpSessionStatus;
+  /** Last assigned event seq (assigned synchronously; writes are chained). */
+  seq: number;
+  /** Serializes event/row writes so seq order matches insert order. */
+  chain: Promise<void>;
+  /** Parked ask-mode permission requests keyed by the request event's seq. */
+  pending: Map<number, (resp: RequestPermissionResponse) => void>;
+  ended: boolean;
+  wire: AcpWire | null;
+  connection: ClientConnection | null;
+  agent: ClientContext | null;
+  /** ACP protocol session id from session/new (NOT the node process id). */
+  acpSessionId: string;
+  graceTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const liveByStation = new Map<string, LiveSession>();
+const liveById = new Map<string, LiveSession>();
+const subscribers = new Map<string, Set<(e: AcpEvent) => void>>();
+
+// ─── Row mapping ─────────────────────────────────────────────────────────────
+
+type DbRow = typeof acpSessions.$inferSelect;
+
+function toContract(r: DbRow): AcpSessionRow {
+  return {
+    id: r.id,
+    stationId: r.stationId,
+    userId: r.userId,
+    mode: r.mode as AcpSessionMode,
+    status: r.status as AcpSessionStatus,
+    endedReason: r.endedReason,
+    createdAt: r.createdAt.toISOString(),
+    lastEventAt: r.lastEventAt.toISOString(),
+  };
+}
+
+// ─── Event persistence ────────────────────────────────────────────────────────
+
+function fanOut(sessionId: string, event: AcpEvent): void {
+  const set = subscribers.get(sessionId);
+  if (!set) return;
+  for (const fn of set) {
+    try {
+      fn(event);
+    } catch (err) {
+      log.error("ACP subscriber threw", { sessionId, error: String(err) });
+    }
+  }
+}
+
+/** Chain work onto the session's serialized write queue. */
+function enqueue(live: LiveSession, fn: () => Promise<void>): Promise<void> {
+  const p = live.chain.then(fn).catch((err) => {
+    log.error("ACP event write failed", {
+      sessionId: live.id,
+      error: String(err),
+    });
+  });
+  live.chain = p;
+  return p;
+}
+
+/**
+ * Persist the next event: assign seq synchronously, then (serialized) insert
+ * into acp_events, bump last_event_at (+ any extra row columns), and fan out.
+ */
+function persistEvent(
+  live: LiveSession,
+  type: AcpEventType,
+  payload: unknown,
+  rowSet: Partial<typeof acpSessions.$inferInsert> = {}
+): { seq: number; done: Promise<void> } {
+  const seq = ++live.seq;
+  const createdAt = new Date();
+  const done = enqueue(live, async () => {
+    await db.insert(acpEvents).values({
+      sessionId: live.id,
+      seq,
+      type,
+      payload: payload as object,
+      createdAt,
+    });
+    await db
+      .update(acpSessions)
+      .set({ lastEventAt: createdAt, ...rowSet })
+      .where(eq(acpSessions.id, live.id));
+    fanOut(live.id, {
+      sessionId: live.id,
+      seq,
+      type,
+      payload,
+      createdAt: createdAt.toISOString(),
+    });
+  });
+  return { seq, done };
+}
+
+/** Status transition: update the row and persist a `state` event. */
+function setStatus(
+  live: LiveSession,
+  status: AcpSessionStatus,
+  opts: { extra?: Record<string, unknown>; endedReason?: string; force?: boolean } = {}
+): { seq: number; done: Promise<void> } {
+  if (live.status === status && !opts.force) {
+    return { seq: live.seq, done: Promise.resolve() };
+  }
+  live.status = status;
+  return persistEvent(
+    live,
+    "state",
+    { status, ...(opts.extra ?? {}) },
+    {
+      status,
+      ...(opts.endedReason !== undefined ? { endedReason: opts.endedReason } : {}),
+    }
+  );
+}
+
+// ─── Live-session lifecycle helpers ──────────────────────────────────────────
+
+function requireLive(userId: string, sessionId: string): LiveSession {
+  const live = liveById.get(sessionId);
+  if (!live || live.userId !== userId) {
+    throw new Error("Session not found or not active.");
+  }
+  return live;
+}
+
+/** Resolve all parked permission promises with the SDK's cancelled outcome. */
+function rejectPendingPermissions(live: LiveSession): void {
+  for (const [requestSeq, resolve] of live.pending) {
+    resolve({ outcome: { outcome: "cancelled" } });
+    persistEvent(live, "permission-answer", { requestSeq, cancelled: true });
+  }
+  live.pending.clear();
+}
+
+/** Terminal transition: row ended(reason) + state event, wire torn down. */
+async function finalizeEnd(live: LiveSession, reason: string): Promise<void> {
+  if (live.ended) return;
+  live.ended = true;
+  if (live.graceTimer) {
+    clearTimeout(live.graceTimer);
+    live.graceTimer = null;
+  }
+  rejectPendingPermissions(live);
+  const { done } = setStatus(live, "ended", {
+    extra: { reason },
+    endedReason: reason,
+    force: true,
+  });
+  if (liveByStation.get(live.stationId) === live) {
+    liveByStation.delete(live.stationId);
+  }
+  liveById.delete(live.id);
+  try {
+    live.connection?.close();
+  } catch {
+    // Connection already closed — fine.
+  }
+  try {
+    await live.wire?.close();
+  } catch {
+    // Wire already closed — fine.
+  }
+  await done;
+}
+
+/**
+ * Wire ended underneath us. An in-band exit reason means the agent process
+ * died → end the session with it. A bare "eof" means the node went offline
+ * (or the stream was torn down) → park at `waiting` and start the grace timer.
+ */
+async function handleWireClosed(live: LiveSession, reason: string): Promise<void> {
+  try {
+    // Contract note: always close() after `closed` settles (idempotent).
+    await live.wire?.close();
+  } catch {
+    // Already closed — fine.
+  }
+  if (live.ended) return;
+  if (reason === "eof") {
+    rejectPendingPermissions(live);
+    const { done } = setStatus(live, "waiting", {
+      extra: { reason: "node offline" },
+      force: true,
+    });
+    live.graceTimer = setTimeout(() => {
+      void finalizeEnd(live, "Couldn't reach the node.");
+    }, offlineGraceMs);
+    live.graceTimer.unref?.();
+    await done;
+  } else {
+    await finalizeEnd(live, reason);
+  }
+}
+
+// ─── SDK callbacks ───────────────────────────────────────────────────────────
+
+function handleSessionUpdate(live: LiveSession, params: SessionNotification): void {
+  if (live.ended) return;
+  // Every SDK sessionUpdate notification → agent-update with the raw update.
+  persistEvent(live, "agent-update", params.update);
+}
+
+function handlePermissionRequest(
+  live: LiveSession,
+  params: RequestPermissionRequest
+): Promise<RequestPermissionResponse> {
+  if (live.ended) {
+    return Promise.resolve({ outcome: { outcome: "cancelled" } });
+  }
+
+  const autoAllow =
+    live.mode === "full-auto" ||
+    (live.mode === "accept-edits" && params.toolCall.kind === "edit");
+
+  if (autoAllow) {
+    const option =
+      params.options.find(
+        (o) => o.kind === "allow_once" || o.kind === "allow_always"
+      ) ?? params.options[0];
+    const { seq: requestSeq } = persistEvent(live, "permission-request", {
+      toolCall: params.toolCall,
+      options: params.options,
+      auto: true,
+    });
+    if (!option) {
+      persistEvent(live, "permission-answer", { requestSeq, cancelled: true, auto: true });
+      return Promise.resolve({ outcome: { outcome: "cancelled" } });
+    }
+    persistEvent(live, "permission-answer", {
+      requestSeq,
+      optionId: option.optionId,
+      auto: true,
+    });
+    return Promise.resolve({
+      outcome: { outcome: "selected", optionId: option.optionId },
+    });
+  }
+
+  // ask (or accept-edits falling through): park until answerPermission.
+  const { seq: requestSeq } = persistEvent(live, "permission-request", {
+    toolCall: params.toolCall,
+    options: params.options,
+  });
+  setStatus(live, "waiting");
+  return new Promise<RequestPermissionResponse>((resolve) => {
+    live.pending.set(requestSeq, resolve);
+  });
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export async function createSession(
+  input: CreateSessionInput
+): Promise<AcpSessionRow> {
+  const { stationId, userId, mode } = input;
+
+  const station = await getStation(userId, stationId);
+  if (!station) throw new Error("Station not found.");
+  if (!gateCapability(station, "acp")) {
+    throw new Error("This station does not support agent sessions.");
+  }
+  if (!connectionManager.isOnline(station.nodeId)) {
+    throw new Error("Node is offline.");
+  }
+  if (liveByStation.has(stationId)) {
+    throw new Error("An active session already exists for this agent.");
+  }
+
+  const id = `acps_${crypto.randomUUID()}`;
+  const now = new Date();
+  const live: LiveSession = {
+    id,
+    stationId,
+    userId,
+    nodeId: station.nodeId,
+    stationKey: station.stationKey,
+    mode,
+    status: "starting",
+    seq: 0,
+    chain: Promise.resolve(),
+    pending: new Map(),
+    ended: false,
+    wire: null,
+    connection: null,
+    agent: null,
+    acpSessionId: "",
+    graceTimer: null,
+  };
+  // Register before any await so a concurrent createSession is refused
+  // (fresh-process semantics: single session per station in slice 2).
+  liveByStation.set(stationId, live);
+  liveById.set(id, live);
+
+  await db.insert(acpSessions).values({
+    id,
+    stationId,
+    userId,
+    mode,
+    status: "starting",
+    endedReason: null,
+    nodeSessionId: null,
+    createdAt: now,
+    lastEventAt: now,
+  });
+
+  try {
+    const wire = await openAcpWire(station.nodeId, station.stationKey);
+    live.wire = wire;
+
+    const app = client({ name: "agentpod-hub" })
+      .onNotification("session/update", ({ params }) => {
+        handleSessionUpdate(live, params);
+      })
+      .onRequest("session/request_permission", ({ params }) =>
+        handlePermissionRequest(live, params)
+      );
+    const connection = app.connect(ndJsonStream(wire.writable, wire.readable));
+    live.connection = connection;
+    live.agent = connection.agent;
+    connection.closed.catch(() => {
+      // Post-exit stream errors surface here; teardown runs via wire.closed.
+    });
+    void wire.closed.then(
+      (reason) => void handleWireClosed(live, reason),
+      () => void handleWireClosed(live, "wire error")
+    );
+
+    await connection.agent.request("initialize", {
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "agentpod-hub", version: "0.1.0" },
+    });
+    const created = await connection.agent.request("session/new", {
+      // The SDK requires an absolute cwd; the station workspace is the
+      // natural one, "/" the fallback for workspace-less stations.
+      cwd: station.workspacePath ?? "/",
+      mcpServers: [],
+    });
+    live.acpSessionId = created.sessionId;
+
+    await db
+      .update(acpSessions)
+      .set({ nodeSessionId: wire.nodeSessionId })
+      .where(eq(acpSessions.id, id));
+    await setStatus(live, "idle").done;
+
+    const rows = await db
+      .select()
+      .from(acpSessions)
+      .where(eq(acpSessions.id, id));
+    return toContract(rows[0]!);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    persistEvent(live, "error", { message: reason });
+    await finalizeEnd(live, reason);
+    throw err;
+  }
+}
+
+export async function listSessions(
+  userId: string,
+  stationId: string
+): Promise<AcpSessionRow[]> {
+  const rows = await db
+    .select()
+    .from(acpSessions)
+    .where(
+      and(eq(acpSessions.userId, userId), eq(acpSessions.stationId, stationId))
+    );
+  return rows.map(toContract);
+}
+
+export async function getSession(
+  userId: string,
+  sessionId: string
+): Promise<AcpSessionRow | null> {
+  const rows = await db
+    .select()
+    .from(acpSessions)
+    .where(and(eq(acpSessions.id, sessionId), eq(acpSessions.userId, userId)));
+  return rows[0] ? toContract(rows[0]) : null;
+}
+
+export async function promptSession(
+  userId: string,
+  sessionId: string,
+  text: string
+): Promise<void> {
+  const live = requireLive(userId, sessionId);
+  if (live.status !== "idle") {
+    throw new Error("Session is busy — wait for the current turn to finish.");
+  }
+  const agent = live.agent;
+  if (!agent) throw new Error("Session is still starting.");
+
+  const { done: promptWritten } = persistEvent(live, "user-prompt", { text });
+  const { done: statusWritten } = setStatus(live, "working");
+  await Promise.all([promptWritten, statusWritten]);
+
+  // Audit the action, never the prompt text.
+  const audit = await recordAudit(db, {
+    userId,
+    nodeId: live.nodeId,
+    stationKey: live.stationKey,
+    verb: "acp.prompt",
+    params: { chars: text.length },
+  });
+
+  // The turn runs in the background; its completion restores idle. Callers
+  // observe progress via subscribe()/acp_events, not this promise.
+  agent
+    .request("session/prompt", {
+      sessionId: live.acpSessionId,
+      prompt: [{ type: "text", text }],
+    })
+    .then(async () => {
+      await audit.done("ok");
+      if (!live.ended && live.status === "working") {
+        await setStatus(live, "idle").done;
+      }
+    })
+    .catch(async (err) => {
+      await audit
+        .done("error", err instanceof Error ? err.message : String(err))
+        .catch(() => {});
+      // Wire-level failures transition the session via handleWireClosed; only
+      // recover to idle when the session itself is still alive and working.
+      if (!live.ended && live.status === "working") {
+        await setStatus(live, "idle").done;
+      }
+    });
+}
+
+export async function cancelTurn(
+  userId: string,
+  sessionId: string
+): Promise<void> {
+  const live = requireLive(userId, sessionId);
+  if (live.status !== "working" && live.status !== "waiting") return;
+  const agent = live.agent;
+  rejectPendingPermissions(live);
+  if (agent) {
+    await agent
+      .notify("session/cancel", { sessionId: live.acpSessionId })
+      .catch(() => {
+        // Errored writable after wire close — teardown handles the session.
+      });
+  }
+  await setStatus(live, "idle").done;
+}
+
+export async function answerPermission(
+  userId: string,
+  sessionId: string,
+  requestSeq: number,
+  optionId: string
+): Promise<void> {
+  const live = requireLive(userId, sessionId);
+  const resolve = live.pending.get(requestSeq);
+  if (!resolve) throw new Error("No pending permission request.");
+  live.pending.delete(requestSeq);
+  const { done: answerWritten } = persistEvent(live, "permission-answer", {
+    requestSeq,
+    optionId,
+  });
+  const { done: statusWritten } = setStatus(live, "working");
+  resolve({ outcome: { outcome: "selected", optionId } });
+  await Promise.all([answerWritten, statusWritten]);
+}
+
+export async function setMode(
+  userId: string,
+  sessionId: string,
+  mode: AcpSessionMode
+): Promise<void> {
+  const live = liveById.get(sessionId);
+  if (live && live.userId !== userId) throw new Error("Session not found.");
+  const rows = await db
+    .update(acpSessions)
+    .set({ mode })
+    .where(and(eq(acpSessions.id, sessionId), eq(acpSessions.userId, userId)))
+    .returning({ id: acpSessions.id });
+  if (rows.length === 0) throw new Error("Session not found.");
+  if (live) live.mode = mode;
+}
+
+export async function endSession(
+  userId: string,
+  sessionId: string,
+  reason: string
+): Promise<void> {
+  const live = liveById.get(sessionId);
+  if (live) {
+    if (live.userId !== userId) throw new Error("Session not found.");
+    await finalizeEnd(live, reason);
+    return;
+  }
+  // Not live (e.g. found via a stale row): mark the row ended if owned.
+  const rows = await db
+    .select()
+    .from(acpSessions)
+    .where(and(eq(acpSessions.id, sessionId), eq(acpSessions.userId, userId)));
+  if (!rows[0]) throw new Error("Session not found.");
+  if (rows[0].status === "ended") return;
+  await db
+    .update(acpSessions)
+    .set({ status: "ended", endedReason: reason, lastEventAt: new Date() })
+    .where(eq(acpSessions.id, sessionId));
+}
+
+/** Subscribe to live events; replay is the caller's job (read acp_events). */
+export function subscribe(
+  sessionId: string,
+  fn: (e: AcpEvent) => void
+): () => void {
+  let set = subscribers.get(sessionId);
+  if (!set) {
+    set = new Set();
+    subscribers.set(sessionId, set);
+  }
+  set.add(fn);
+  return () => {
+    const current = subscribers.get(sessionId);
+    if (!current) return;
+    current.delete(fn);
+    if (current.size === 0) subscribers.delete(sessionId);
+  };
+}
+
+/**
+ * Boot reconciliation: mark all non-ended sessions ended("hub restarted");
+ * best-effort acp.close each orphaned nodeSessionId whose node is online at
+ * boot (log the rest). Call from index.ts boot after initDatabase.
+ */
+export async function reconcileOnBoot(): Promise<void> {
+  const stale = await db
+    .select()
+    .from(acpSessions)
+    .where(ne(acpSessions.status, "ended"));
+
+  for (const row of stale) {
+    const [agg] = await db
+      .select({ maxSeq: sql<number>`COALESCE(MAX(${acpEvents.seq}), 0)` })
+      .from(acpEvents)
+      .where(eq(acpEvents.sessionId, row.id));
+    const nextSeq = Number(agg?.maxSeq ?? 0) + 1;
+    const now = new Date();
+    await db.insert(acpEvents).values({
+      sessionId: row.id,
+      seq: nextSeq,
+      type: "state",
+      payload: { status: "ended", reason: "hub restarted" },
+      createdAt: now,
+    });
+    await db
+      .update(acpSessions)
+      .set({ status: "ended", endedReason: "hub restarted", lastEventAt: now })
+      .where(eq(acpSessions.id, row.id));
+
+    if (!row.nodeSessionId) continue;
+    // stationId deliberately has no FK — the station may be gone.
+    const stationRows = await db
+      .select({ nodeId: stations.nodeId })
+      .from(stations)
+      .where(eq(stations.id, row.stationId));
+    const nodeId = stationRows[0]?.nodeId;
+    if (nodeId && connectionManager.isOnline(nodeId)) {
+      // Best-effort: broker.request never rejects; result is ignored.
+      void broker.request(nodeId, "acp.close", {
+        sessionId: row.nodeSessionId,
+      });
+    } else {
+      log.info("ACP reconcile: orphaned agent process not closable now", {
+        sessionId: row.id,
+        nodeSessionId: row.nodeSessionId,
+        stationId: row.stationId,
+        nodeOnline: Boolean(nodeId && connectionManager.isOnline(nodeId)),
+      });
+    }
+  }
+
+  if (stale.length > 0) {
+    log.info(`ACP reconcile: ended ${stale.length} stale session(s) from before restart`);
+  }
+}

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -20,7 +20,7 @@
  * at `waiting` and a grace timer ends it).
  */
 
-import { and, eq, ne, sql } from "drizzle-orm";
+import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
 import {
   client,
   ndJsonStream,
@@ -80,6 +80,12 @@ interface LiveSession {
   seq: number;
   /** Serializes event/row writes so seq order matches insert order. */
   chain: Promise<void>;
+  /**
+   * Incremented at each prompt dispatch; the turn-completion handler captures
+   * it and no-ops unless it still matches, so a stale turn's late response
+   * (after cancelTurn + a new prompt) can never clobber the new turn's status.
+   */
+  turnEpoch: number;
   /** Parked ask-mode permission requests keyed by the request event's seq. */
   pending: Map<number, (resp: RequestPermissionResponse) => void>;
   ended: boolean;
@@ -221,7 +227,14 @@ async function finalizeEnd(live: LiveSession, reason: string): Promise<void> {
     clearTimeout(live.graceTimer);
     live.graceTimer = null;
   }
+  const hadParked = live.pending.size > 0;
   rejectPendingPermissions(live);
+  if (hadParked) {
+    // The cancelled outcomes travel to the agent through SDK microtasks and a
+    // synchronous broker send; yield one macrotask so they flush before the
+    // wire is torn down (otherwise the agent may never see them).
+    await new Promise((r) => setTimeout(r, 0));
+  }
   const { done } = setStatus(live, "ended", {
     extra: { reason },
     endedReason: reason,
@@ -242,6 +255,14 @@ async function finalizeEnd(live: LiveSession, reason: string): Promise<void> {
     // Wire already closed — fine.
   }
   await done;
+  if (connectionManager.isOnline(live.nodeId)) {
+    // The wire's best-effort acp.close was deliverable — clear the orphan
+    // marker so the node-online hook won't re-close this process later.
+    await db
+      .update(acpSessions)
+      .set({ nodeSessionId: null })
+      .where(eq(acpSessions.id, live.id));
+  }
 }
 
 /**
@@ -359,6 +380,7 @@ export async function createSession(
     status: "starting",
     seq: 0,
     chain: Promise.resolve(),
+    turnEpoch: 0,
     pending: new Map(),
     ended: false,
     wire: null,
@@ -368,23 +390,25 @@ export async function createSession(
     graceTimer: null,
   };
   // Register before any await so a concurrent createSession is refused
-  // (fresh-process semantics: single session per station in slice 2).
+  // (fresh-process semantics: single session per station in slice 2). Every
+  // failure exit below MUST run finalizeEnd, which removes these entries —
+  // a leaked entry would wedge the station with 409s until restart.
   liveByStation.set(stationId, live);
   liveById.set(id, live);
 
-  await db.insert(acpSessions).values({
-    id,
-    stationId,
-    userId,
-    mode,
-    status: "starting",
-    endedReason: null,
-    nodeSessionId: null,
-    createdAt: now,
-    lastEventAt: now,
-  });
-
   try {
+    await db.insert(acpSessions).values({
+      id,
+      stationId,
+      userId,
+      mode,
+      status: "starting",
+      endedReason: null,
+      nodeSessionId: null,
+      createdAt: now,
+      lastEventAt: now,
+    });
+
     const wire = await openAcpWire(station.nodeId, station.stationKey);
     live.wire = wire;
 
@@ -478,14 +502,31 @@ export async function promptSession(
   const { done: statusWritten } = setStatus(live, "working");
   await Promise.all([promptWritten, statusWritten]);
 
-  // Audit the action, never the prompt text.
-  const audit = await recordAudit(db, {
-    userId,
-    nodeId: live.nodeId,
-    stationKey: live.stationKey,
-    verb: "acp.prompt",
-    params: { chars: text.length },
-  });
+  // Audit the action, never the prompt text. An audit failure must not strand
+  // the session at `working`: revert to idle with an error event and rethrow.
+  let audit: Awaited<ReturnType<typeof recordAudit>>;
+  try {
+    audit = await recordAudit(db, {
+      userId,
+      nodeId: live.nodeId,
+      stationKey: live.stationKey,
+      verb: "acp.prompt",
+      params: { chars: text.length },
+    });
+  } catch (err) {
+    persistEvent(live, "error", {
+      message: "Couldn't record the audit entry — prompt aborted.",
+    });
+    await setStatus(live, "idle").done;
+    throw err;
+  }
+
+  // Stale-turn guard: only the completion of the CURRENT turn may transition
+  // status (a late response from a cancelled turn must not reset a new one).
+  live.turnEpoch += 1;
+  const epoch = live.turnEpoch;
+  const isCurrentTurn = () =>
+    !live.ended && live.turnEpoch === epoch && live.status === "working";
 
   // The turn runs in the background; its completion restores idle. Callers
   // observe progress via subscribe()/acp_events, not this promise.
@@ -496,7 +537,7 @@ export async function promptSession(
     })
     .then(async () => {
       await audit.done("ok");
-      if (!live.ended && live.status === "working") {
+      if (isCurrentTurn()) {
         await setStatus(live, "idle").done;
       }
     })
@@ -505,8 +546,8 @@ export async function promptSession(
         .done("error", err instanceof Error ? err.message : String(err))
         .catch(() => {});
       // Wire-level failures transition the session via handleWireClosed; only
-      // recover to idle when the session itself is still alive and working.
-      if (!live.ended && live.status === "working") {
+      // recover to idle when this turn is still the live one.
+      if (isCurrentTurn()) {
         await setStatus(live, "idle").done;
       }
     });
@@ -583,10 +624,39 @@ export async function endSession(
     .where(and(eq(acpSessions.id, sessionId), eq(acpSessions.userId, userId)));
   if (!rows[0]) throw new Error("Session not found.");
   if (rows[0].status === "ended") return;
+  await appendEndedState(sessionId, reason);
+}
+
+/**
+ * Append a state-ended event (seq = MAX(seq)+1) and mark a NON-LIVE row ended.
+ * Live sessions go through finalizeEnd instead (in-memory seq counter).
+ */
+async function appendEndedState(sessionId: string, reason: string): Promise<void> {
+  const [agg] = await db
+    .select({ maxSeq: sql<number>`COALESCE(MAX(${acpEvents.seq}), 0)` })
+    .from(acpEvents)
+    .where(eq(acpEvents.sessionId, sessionId));
+  const seq = Number(agg?.maxSeq ?? 0) + 1;
+  const createdAt = new Date();
+  const payload = { status: "ended", reason };
+  await db.insert(acpEvents).values({
+    sessionId,
+    seq,
+    type: "state",
+    payload,
+    createdAt,
+  });
   await db
     .update(acpSessions)
-    .set({ status: "ended", endedReason: reason, lastEventAt: new Date() })
+    .set({ status: "ended", endedReason: reason, lastEventAt: createdAt })
     .where(eq(acpSessions.id, sessionId));
+  fanOut(sessionId, {
+    sessionId,
+    seq,
+    type: "state",
+    payload,
+    createdAt: createdAt.toISOString(),
+  });
 }
 
 /** Subscribe to live events; replay is the caller's job (read acp_events). */
@@ -620,23 +690,7 @@ export async function reconcileOnBoot(): Promise<void> {
     .where(ne(acpSessions.status, "ended"));
 
   for (const row of stale) {
-    const [agg] = await db
-      .select({ maxSeq: sql<number>`COALESCE(MAX(${acpEvents.seq}), 0)` })
-      .from(acpEvents)
-      .where(eq(acpEvents.sessionId, row.id));
-    const nextSeq = Number(agg?.maxSeq ?? 0) + 1;
-    const now = new Date();
-    await db.insert(acpEvents).values({
-      sessionId: row.id,
-      seq: nextSeq,
-      type: "state",
-      payload: { status: "ended", reason: "hub restarted" },
-      createdAt: now,
-    });
-    await db
-      .update(acpSessions)
-      .set({ status: "ended", endedReason: "hub restarted", lastEventAt: now })
-      .where(eq(acpSessions.id, row.id));
+    await appendEndedState(row.id, "hub restarted");
 
     if (!row.nodeSessionId) continue;
     // stationId deliberately has no FK — the station may be gone.
@@ -650,12 +704,17 @@ export async function reconcileOnBoot(): Promise<void> {
       void broker.request(nodeId, "acp.close", {
         sessionId: row.nodeSessionId,
       });
+      await db
+        .update(acpSessions)
+        .set({ nodeSessionId: null })
+        .where(eq(acpSessions.id, row.id));
     } else {
-      log.info("ACP reconcile: orphaned agent process not closable now", {
+      // Kept as an orphan marker (non-null node_session_id on an ended row):
+      // the node-online hook below closes it when the node next connects.
+      log.info("ACP reconcile: orphaned agent process awaits node reconnect", {
         sessionId: row.id,
         nodeSessionId: row.nodeSessionId,
         stationId: row.stationId,
-        nodeOnline: Boolean(nodeId && connectionManager.isOnline(nodeId)),
       });
     }
   }
@@ -664,3 +723,54 @@ export async function reconcileOnBoot(): Promise<void> {
     log.info(`ACP reconcile: ended ${stale.length} stale session(s) from before restart`);
   }
 }
+
+// ─── Orphaned-process cleanup on node reconnect ──────────────────────────────
+
+/**
+ * Close agent processes orphaned by a hub restart once their node is back.
+ *
+ * Orphan marker: an ENDED session row that still carries node_session_id
+ * (live/normal ends clear it when the close was deliverable). Fires one
+ * best-effort acp.close per orphan and clears the marker so it's once-only.
+ * Never touches non-ended rows, so live sessions are safe.
+ */
+async function closeOrphanedProcesses(nodeId: string): Promise<void> {
+  const orphans = await db
+    .select({
+      id: acpSessions.id,
+      nodeSessionId: acpSessions.nodeSessionId,
+    })
+    .from(acpSessions)
+    .innerJoin(stations, eq(stations.id, acpSessions.stationId))
+    .where(
+      and(
+        eq(stations.nodeId, nodeId),
+        eq(acpSessions.status, "ended"),
+        isNotNull(acpSessions.nodeSessionId)
+      )
+    );
+  for (const orphan of orphans) {
+    // Best-effort: broker.request never rejects; result is ignored.
+    void broker.request(nodeId, "acp.close", {
+      sessionId: orphan.nodeSessionId!,
+    });
+    await db
+      .update(acpSessions)
+      .set({ nodeSessionId: null })
+      .where(eq(acpSessions.id, orphan.id));
+    log.info("ACP orphan cleanup: closed agent process on reconnected node", {
+      sessionId: orphan.id,
+      nodeId,
+      nodeSessionId: orphan.nodeSessionId,
+    });
+  }
+}
+
+// In production no node is connected when reconcileOnBoot runs, so the
+// boot-time close path never fires — the real cleanup happens here, when
+// each affected node next connects.
+connectionManager.onNodeOnline((nodeId) => {
+  closeOrphanedProcesses(nodeId).catch((err) => {
+    log.error("ACP orphan cleanup failed", { nodeId, error: String(err) });
+  });
+});

--- a/apps/hub/src/services/acp-transport.test.ts
+++ b/apps/hub/src/services/acp-transport.test.ts
@@ -89,6 +89,7 @@ async function connectFakeNode(
     attachIdRef?: [string | null];
     holdStream?: boolean;
     failOpen?: string; // respond to acp.open with ok:false and this error
+    malformedOpen?: boolean; // respond to acp.open with ok:true but no sessionId
   } = {}
 ): Promise<WebSocket> {
   const ws = new WebSocket(
@@ -152,7 +153,16 @@ async function connectFakeNode(
           break;
 
         case "acp.open":
-          if (opts.failOpen) {
+          if (opts.malformedOpen) {
+            ws.send(
+              JSON.stringify({
+                type: "res",
+                id: msg.id,
+                ok: true,
+                data: { pid: 4321 }, // no sessionId
+              })
+            );
+          } else if (opts.failOpen) {
             ws.send(
               JSON.stringify({
                 type: "res",
@@ -409,7 +419,109 @@ test(
 
       expect(await wire.closed).toBe("agent process exited (code 1)");
 
+      // After exit the writable is errored — SDK writes fail fast instead of
+      // silently vanishing.
+      const writer = wire.writable.getWriter();
+      writer.closed.catch(() => {}); // observe the rejection
+      await expect(
+        writer.write(new TextEncoder().encode('{"jsonrpc":"2.0"}\n'))
+      ).rejects.toThrow();
+      writer.releaseLock();
+
       await wire.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "a JSON-RPC line split across two chunks arrives byte-identical through readable",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-split-host");
+
+      // One protocol line split mid-JSON: neither half parses on its own, so
+      // the exit-marker probe must pass the bytes through untouched.
+      const line =
+        '{"jsonrpc":"2.0","id":3,"method":"session/update","params":{"x":1}}\n';
+      const half1 = line.slice(0, 25);
+      const half2 = line.slice(25);
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        streamChunks: [b64(half1), b64(half2)],
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY);
+
+      const text = await readAllText(wire.readable);
+      expect(text).toBe(line);
+      expect(await wire.closed).toBe("eof");
+
+      await wire.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "consumer readable.cancel() runs full teardown: node receives acp.close, closed settles, close() is a no-op",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-rcancel-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        holdStream: true,
+        capturedNodeMsgs,
+        attachIdRef,
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY);
+      await pollUntil(() => attachIdRef[0]);
+
+      // Consumer-side teardown (what the SDK does on connection close) — must
+      // NOT leak the agent process on the node.
+      await wire.readable.cancel();
+
+      // Node received the best-effort acp.close keyed by the session id…
+      const closeReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+        ) as { params: { sessionId: string } } | undefined;
+      });
+      expect(closeReq.params.sessionId).toBe(FAKE_SESSION_ID);
+
+      // …and a cancel for the attach stream.
+      const cancelFrame = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "cancel"
+        ) as { id: string } | undefined;
+      });
+      expect(cancelFrame.id).toBe(attachIdRef[0]!);
+
+      // closed settles.
+      await wire.closed;
+
+      // A subsequent wire.close() is a no-op — still exactly one acp.close.
+      await wire.close();
+      await new Promise((r) => setTimeout(r, 150));
+      const closeReqs = parsedNodeMsgs(capturedNodeMsgs).filter(
+        (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+      );
+      expect(closeReqs).toHaveLength(1);
+
       fakeNode.close();
       await new Promise((r) => setTimeout(r, 100));
     } finally {
@@ -500,6 +612,23 @@ test(
       ).rejects.toThrow("Couldn't start the agent process — node offline.");
 
       fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+
+      // ok:true but no sessionId → malformed open response.
+      const malformed = await enrollTestNode("acpwire-malformed-host");
+      const malformedNode = await connectFakeNode(
+        server.port!,
+        malformed.nodeId,
+        malformed.nodeSecret,
+        { malformedOpen: true }
+      );
+      await expect(
+        openAcpWire(malformed.nodeId, STATION_KEY)
+      ).rejects.toThrow(
+        "Couldn't start the agent process — malformed open response."
+      );
+
+      malformedNode.close();
       await new Promise((r) => setTimeout(r, 100));
     } finally {
       server.stop(true);

--- a/apps/hub/src/services/acp-transport.test.ts
+++ b/apps/hub/src/services/acp-transport.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Service Test: ACP transport adapter (broker ↔ SDK byte streams)
+ *
+ * Verifies openAcpWire() (src/services/acp-transport.ts):
+ *   1. acp.open {key} → acp.attach {sessionId}; base64 chunks surface via
+ *      `readable` in order as raw bytes.
+ *   2. Bytes written to `writable` reach the node as input frames keyed by the
+ *      ACP SESSION id (NOT the attach stream id — that's the terminal's convention).
+ *   3. An in-band exit chunk {"event":"exit","reason":...} resolves `closed`
+ *      with the reason and does NOT leak into `readable`.
+ *   4. close() sends acp.close {sessionId} + a cancel for the attach stream;
+ *      idempotent.
+ *   5. acp.open failure → throws Error("Couldn't start the agent process — ...").
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ * DATABASE_URL must be set before any src/ modules are imported.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+
+// src/ imports — DB URL is already set above
+import { rawSql } from "../db/drizzle";
+import { createTestUser } from "../../tests/helpers/database";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { gatewayRoutes } from "../routes/gateway";
+import { websocket } from "../ws";
+import { openAcpWire } from "./acp-transport";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TEST_USER = "test-user-acpwire-001";
+const STATION_KEY = "acpwire-station";
+const FAKE_SESSION_ID = "acp-session-xyz789";
+
+const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
+
+// ─── Minimal test app ─────────────────────────────────────────────────────────
+
+// Service test: only the node gateway is needed (openAcpWire talks broker-side).
+const testApp = new Hono().route("/public/nodes", gatewayRoutes);
+
+// ─── Setup & Teardown ─────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: "acpwire-test@example.com",
+    name: "ACP Wire Test User",
+  });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM nodes             WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM "user"            WHERE id = ${TEST_USER}`;
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Connect a fake node WS to the gateway and script the ACP verbs.
+ *
+ * - acp.open  → res {sessionId: FAKE_SESSION_ID} (or {ok:false} when failOpen)
+ * - acp.attach → records the attach id, then emits opts.streamChunks (base64)
+ *   followed by eof unless holdStream is set
+ * - input frames → echoed back as stream chunks on the attach id
+ * - acp.close → res {ok:true}
+ */
+async function connectFakeNode(
+  serverPort: number,
+  nodeId: string,
+  nodeSecret: string,
+  opts: {
+    streamChunks?: string[];
+    capturedNodeMsgs?: string[];
+    attachIdRef?: [string | null];
+    holdStream?: boolean;
+    failOpen?: string; // respond to acp.open with ok:false and this error
+  } = {}
+): Promise<WebSocket> {
+  const ws = new WebSocket(
+    `ws://localhost:${serverPort}/public/nodes/gateway`,
+    {
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    } as RequestInit & { headers: Record<string, string> }
+  );
+
+  await new Promise<void>((res, rej) => {
+    ws.onopen = () => res();
+    ws.onerror = () => rej(new Error("Node WS connection error"));
+  });
+
+  let echoSeq = 1000; // scripted chunks use low seqs; echoes use high ones
+
+  ws.onmessage = (e) => {
+    const raw = String(e.data);
+    const msg = JSON.parse(raw);
+
+    if (opts.capturedNodeMsgs) {
+      opts.capturedNodeMsgs.push(raw);
+    }
+
+    // Echo input frames back as stream chunks on the attach stream.
+    if (msg.type === "input" && opts.attachIdRef?.[0]) {
+      ws.send(
+        JSON.stringify({
+          type: "stream",
+          id: opts.attachIdRef[0],
+          seq: echoSeq++,
+          chunk: msg.data,
+          eof: false,
+          enc: "base64",
+        })
+      );
+      return;
+    }
+
+    if (msg.type === "req") {
+      switch (msg.verb) {
+        case "detect":
+          ws.send(
+            JSON.stringify({
+              type: "res",
+              id: msg.id,
+              ok: true,
+              data: [
+                {
+                  key: STATION_KEY,
+                  harness: "opencode",
+                  kind: "leaf",
+                  displayName: "ACP Wire Test",
+                  parentKey: null,
+                  workspacePath: "/workspace/acpwire",
+                  capabilities: ["health", "acp"],
+                },
+              ],
+            })
+          );
+          break;
+
+        case "acp.open":
+          if (opts.failOpen) {
+            ws.send(
+              JSON.stringify({
+                type: "res",
+                id: msg.id,
+                ok: false,
+                error: opts.failOpen,
+              })
+            );
+          } else {
+            ws.send(
+              JSON.stringify({
+                type: "res",
+                id: msg.id,
+                ok: true,
+                data: { sessionId: FAKE_SESSION_ID },
+              })
+            );
+          }
+          break;
+
+        case "acp.attach":
+          if (opts.attachIdRef) {
+            opts.attachIdRef[0] = msg.id;
+          }
+          if (!opts.holdStream) {
+            const chunks = opts.streamChunks ?? [];
+            setTimeout(() => {
+              chunks.forEach((chunk, i) => {
+                ws.send(
+                  JSON.stringify({
+                    type: "stream",
+                    id: msg.id,
+                    seq: i,
+                    chunk,
+                    eof: false,
+                    enc: "base64",
+                  })
+                );
+              });
+              ws.send(
+                JSON.stringify({
+                  type: "stream",
+                  id: msg.id,
+                  seq: chunks.length,
+                  chunk: null,
+                  eof: true,
+                })
+              );
+            }, 50);
+          }
+          break;
+
+        case "acp.close":
+          ws.send(
+            JSON.stringify({
+              type: "res",
+              id: msg.id,
+              ok: true,
+              data: { ok: true },
+            })
+          );
+          break;
+      }
+    }
+  };
+
+  // Allow onOpen → connectionManager.register to settle
+  await new Promise((r) => setTimeout(r, 150));
+  return ws;
+}
+
+async function enrollTestNode(hostname: string) {
+  const { token } = await mintEnrollmentToken(TEST_USER);
+  return enrollNode(token, {
+    hostname,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+}
+
+/** Poll condition() every pollMs until truthy, or throw after timeoutMs. */
+async function pollUntil<T>(
+  condition: () => T | undefined | null | false,
+  timeoutMs = 4000,
+  pollMs = 30
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = condition();
+    if (result) return result as T;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs} ms`);
+}
+
+/** Drain a ReadableStream<Uint8Array> to a UTF-8 string (until close). */
+async function readAllText(
+  readable: ReadableStream<Uint8Array>
+): Promise<string> {
+  const reader = readable.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+function parsedNodeMsgs(raw: string[]): Record<string, unknown>[] {
+  return raw
+    .map((r) => {
+      try {
+        return JSON.parse(r);
+      } catch {
+        return null;
+      }
+    })
+    .filter((m): m is Record<string, unknown> => m !== null);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test(
+  "openAcpWire: acp.open {key} → acp.attach {sessionId}; chunks surface via readable in order; eof resolves closed with 'eof'",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-read-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const line1 = '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1}}\n';
+      const line2 = '{"jsonrpc":"2.0","method":"session/update","params":{}}\n';
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        streamChunks: [b64(line1), b64(line2)],
+        capturedNodeMsgs,
+        attachIdRef,
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY);
+      expect(wire.nodeSessionId).toBe(FAKE_SESSION_ID);
+
+      // acp.open carried the station key; acp.attach carried the session id.
+      const openReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.open"
+        ) as { params: { key: string } } | undefined;
+      });
+      expect(openReq.params.key).toBe(STATION_KEY);
+      const attachReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) =>
+            m.type === "req" && (m as { verb?: string }).verb === "acp.attach"
+        ) as { params: { sessionId: string } } | undefined;
+      });
+      expect(attachReq.params.sessionId).toBe(FAKE_SESSION_ID);
+
+      // Chunks arrive base64-decoded, in order.
+      const text = await readAllText(wire.readable);
+      expect(text).toBe(line1 + line2);
+
+      // eof without exit frame → closed resolves "eof".
+      expect(await wire.closed).toBe("eof");
+
+      await wire.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "writes to writable reach the node as input frames keyed by the SESSION id (not the attach id) and echo back via readable",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-input-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        holdStream: true,
+        capturedNodeMsgs,
+        attachIdRef,
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY);
+      await pollUntil(() => attachIdRef[0]);
+
+      const outbound = '{"jsonrpc":"2.0","id":7,"method":"initialize"}\n';
+      const writer = wire.writable.getWriter();
+      await writer.write(new TextEncoder().encode(outbound));
+      writer.releaseLock();
+
+      // The node must receive an input frame keyed by the ACP SESSION id.
+      const inputFrame = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "input"
+        ) as { id: string; data: string } | undefined;
+      });
+      expect(inputFrame.id).toBe(FAKE_SESSION_ID);
+      expect(inputFrame.id).not.toBe(attachIdRef[0]!);
+      expect(Buffer.from(inputFrame.data, "base64").toString("utf-8")).toBe(
+        outbound
+      );
+
+      // The echoed chunk comes back through readable.
+      const reader = wire.readable.getReader();
+      const { value } = await reader.read();
+      expect(new TextDecoder().decode(value)).toBe(outbound);
+      reader.releaseLock();
+
+      await wire.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "in-band exit frame resolves closed with the reason and does not leak into readable",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-exit-host");
+
+      const protocolLine = '{"jsonrpc":"2.0","id":2,"result":{}}\n';
+      const exitFrame = JSON.stringify({
+        event: "exit",
+        reason: "agent process exited (code 1)",
+      });
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        streamChunks: [b64(protocolLine), b64(exitFrame)],
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY);
+
+      const text = await readAllText(wire.readable);
+      // Protocol bytes surfaced; the exit frame did NOT leak into readable.
+      expect(text).toBe(protocolLine);
+      expect(text).not.toContain('"event"');
+
+      expect(await wire.closed).toBe("agent process exited (code 1)");
+
+      await wire.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "close() sends acp.close {sessionId} + cancel for the attach stream; idempotent",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-close-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        holdStream: true,
+        capturedNodeMsgs,
+        attachIdRef,
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY);
+      await pollUntil(() => attachIdRef[0]);
+
+      await wire.close();
+
+      // Node received a cancel for the attach stream id…
+      const cancelFrame = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "cancel"
+        ) as { id: string } | undefined;
+      });
+      expect(cancelFrame.id).toBe(attachIdRef[0]!);
+
+      // …and a best-effort acp.close keyed by the session id.
+      const closeReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+        ) as { params: { sessionId: string } } | undefined;
+      });
+      expect(closeReq.params.sessionId).toBe(FAKE_SESSION_ID);
+
+      // readable terminates and closed settles.
+      const text = await readAllText(wire.readable);
+      expect(text).toBe("");
+      await wire.closed;
+
+      // Idempotent: a second close() neither throws nor re-sends acp.close.
+      await wire.close();
+      await new Promise((r) => setTimeout(r, 150));
+      const closeReqs = parsedNodeMsgs(capturedNodeMsgs).filter(
+        (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+      );
+      expect(closeReqs).toHaveLength(1);
+
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "acp.open failure and offline node → Error(\"Couldn't start the agent process — ...\")",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-fail-host");
+
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        failOpen: "harness not found",
+      });
+
+      await expect(openAcpWire(nodeId, STATION_KEY)).rejects.toThrow(
+        "Couldn't start the agent process — harness not found."
+      );
+
+      // Offline node (never connected) → broker resolves {ok:false, error:"node offline"}.
+      await expect(
+        openAcpWire("00000000-0000-0000-0000-000000000000", STATION_KEY)
+      ).rejects.toThrow("Couldn't start the agent process — node offline.");
+
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);

--- a/apps/hub/src/services/acp-transport.ts
+++ b/apps/hub/src/services/acp-transport.ts
@@ -1,0 +1,164 @@
+/**
+ * ACP transport adapter — wraps a broker stream to a node into the WHATWG
+ * byte streams the official ACP TypeScript SDK consumes.
+ *
+ * The SDK's `client(...).connect(stream)` wants a `Stream` of parsed JSON-RPC
+ * messages; `ndJsonStream(output, input)` builds one from exactly the pair of
+ * Uint8Array streams exposed here:
+ *
+ *   const wire = await openAcpWire(nodeId, stationKey);
+ *   const stream = ndJsonStream(wire.writable, wire.readable);
+ *
+ * Wire protocol (node-agent acpHandler):
+ *   - `acp.open {key}` starts (or reuses) the agent process → `{sessionId}`.
+ *   - `acp.attach {sessionId}` streams the agent's stdout as base64 chunks.
+ *   - Input frames to the node are keyed by the ACP SESSION id — NOT the
+ *     attach stream id (that is the terminal PTY convention).
+ *   - The node signals process exit IN-BAND: a dedicated chunk whose decoded
+ *     bytes are JSON `{"event":"exit","reason":...}`. That chunk is not
+ *     JSON-RPC and must never be forwarded to the SDK.
+ */
+
+import * as broker from "./broker";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AcpWire {
+  /** WHATWG streams carrying raw JSON-RPC bytes, in the shape the SDK's
+   *  connection constructor/fluent client() expects. */
+  readable: ReadableStream<Uint8Array>; // node → hub (acp.attach chunks, base64-decoded)
+  writable: WritableStream<Uint8Array>; // hub → node (sent as input frames keyed by nodeSessionId)
+  /** Resolves when the node stream ends; carries the exit reason parsed from
+   *  the in-band {"event":"exit","reason":...} frame, or "eof". */
+  closed: Promise<string>;
+  /** Detach + best-effort acp.close on the node. Idempotent. */
+  close(): Promise<void>;
+  nodeSessionId: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const decoder = new TextDecoder();
+
+/**
+ * If the chunk is the node's in-band exit marker, return the exit reason;
+ * otherwise null. The node emits the exit frame as its own dedicated chunk
+ * after draining output, so any complete chunk that parses as
+ * {"event":"exit",...} is the marker (real JSON-RPC never carries "event").
+ */
+function parseExitReason(bytes: Uint8Array): string | null {
+  try {
+    const parsed: unknown = JSON.parse(decoder.decode(bytes));
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { event?: unknown }).event === "exit"
+    ) {
+      const reason = (parsed as { reason?: unknown }).reason;
+      return typeof reason === "string" ? reason : String(reason ?? "exit");
+    }
+  } catch {
+    // Not JSON (or a partial/multi-line protocol chunk) — regular bytes.
+  }
+  return null;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Open an ACP wire to the station's agent process on a node.
+ *
+ * Throws Error("Couldn't start the agent process — <broker error>.") when
+ * acp.open fails or the node is offline.
+ */
+export async function openAcpWire(
+  nodeId: string,
+  stationKey: string
+): Promise<AcpWire> {
+  const opened = await broker.request(nodeId, "acp.open", { key: stationKey });
+  if (!opened.ok) {
+    throw new Error(
+      `Couldn't start the agent process — ${opened.error ?? "unknown error"}.`
+    );
+  }
+  const sessionId = (opened.data as { sessionId: string }).sessionId;
+
+  let resolveClosed!: (reason: string) => void;
+  const closed = new Promise<string>((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  let done = false;
+
+  /** Terminate readable and settle closed exactly once. */
+  const finish = (reason: string) => {
+    if (done) return;
+    done = true;
+    try {
+      controller.close();
+    } catch {
+      // Controller already closed/errored (e.g. consumer cancelled) — fine.
+    }
+    resolveClosed(reason);
+  };
+
+  const readable = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+    cancel() {
+      // Consumer tore down the read side (SDK connection closed) — detach.
+      attach.cancel();
+      finish("eof");
+    },
+  });
+
+  const attach = broker.stream(
+    nodeId,
+    "acp.attach",
+    { sessionId },
+    (_seq, chunk, eof) => {
+      if (chunk !== null && !done) {
+        const bytes = new Uint8Array(Buffer.from(chunk, "base64"));
+        const exitReason = parseExitReason(bytes);
+        if (exitReason !== null) {
+          // In-band exit marker: resolve closed, never forward as protocol bytes.
+          finish(exitReason);
+          return;
+        }
+        try {
+          controller.enqueue(bytes);
+        } catch {
+          // Consumer already gone — drop the chunk.
+        }
+      }
+      if (eof) finish("eof");
+    }
+  );
+
+  const writable = new WritableStream<Uint8Array>({
+    write(bytes) {
+      if (done) return;
+      // CRITICAL: input frames are keyed by the ACP SESSION id from acp.open,
+      // not the attach stream id.
+      broker.sendFrame(nodeId, {
+        type: "input",
+        id: sessionId,
+        data: Buffer.from(bytes).toString("base64"),
+      });
+    },
+  });
+
+  let closeStarted = false;
+  const close = async (): Promise<void> => {
+    if (closeStarted) return;
+    closeStarted = true;
+    attach.cancel();
+    finish("eof");
+    // Best-effort: broker.request never rejects; result is ignored.
+    void broker.request(nodeId, "acp.close", { sessionId });
+  };
+
+  return { readable, writable, closed, close, nodeSessionId: sessionId };
+}

--- a/apps/hub/src/services/acp-transport.ts
+++ b/apps/hub/src/services/acp-transport.ts
@@ -19,7 +19,10 @@
  *     JSON-RPC and must never be forwarded to the SDK.
  */
 
+import { z } from "zod";
 import * as broker from "./broker";
+
+const OpenResponseSchema = z.object({ sessionId: z.string().min(1) });
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -81,7 +84,13 @@ export async function openAcpWire(
       `Couldn't start the agent process — ${opened.error ?? "unknown error"}.`
     );
   }
-  const sessionId = (opened.data as { sessionId: string }).sessionId;
+  const parsedOpen = OpenResponseSchema.safeParse(opened.data);
+  if (!parsedOpen.success) {
+    throw new Error(
+      "Couldn't start the agent process — malformed open response."
+    );
+  }
+  const { sessionId } = parsedOpen.data;
 
   let resolveClosed!: (reason: string) => void;
   const closed = new Promise<string>((resolve) => {
@@ -89,9 +98,10 @@ export async function openAcpWire(
   });
 
   let controller: ReadableStreamDefaultController<Uint8Array>;
+  let writableController: WritableStreamDefaultController;
   let done = false;
 
-  /** Terminate readable and settle closed exactly once. */
+  /** Terminate readable, error writable, and settle closed exactly once. */
   const finish = (reason: string) => {
     if (done) return;
     done = true;
@@ -99,6 +109,12 @@ export async function openAcpWire(
       controller.close();
     } catch {
       // Controller already closed/errored (e.g. consumer cancelled) — fine.
+    }
+    try {
+      // Fail SDK writes fast after the wire ends instead of dropping them.
+      writableController.error(new Error(`ACP wire closed (${reason})`));
+    } catch {
+      // Writable already errored/closed — fine.
     }
     resolveClosed(reason);
   };
@@ -108,9 +124,25 @@ export async function openAcpWire(
       controller = c;
     },
     cancel() {
-      // Consumer tore down the read side (SDK connection closed) — detach.
-      attach.cancel();
-      finish("eof");
+      // Consumer tore down the read side (SDK connection closed) — run the
+      // same teardown as close() so the agent process is not leaked on the node.
+      void close();
+    },
+  });
+
+  const writable = new WritableStream<Uint8Array>({
+    start(c) {
+      writableController = c;
+    },
+    write(bytes) {
+      // CRITICAL: input frames are keyed by the ACP SESSION id from acp.open,
+      // not the attach stream id. After finish() the stream is errored, so
+      // write() is never called on a dead wire.
+      broker.sendFrame(nodeId, {
+        type: "input",
+        id: sessionId,
+        data: Buffer.from(bytes).toString("base64"),
+      });
     },
   });
 
@@ -136,19 +168,6 @@ export async function openAcpWire(
       if (eof) finish("eof");
     }
   );
-
-  const writable = new WritableStream<Uint8Array>({
-    write(bytes) {
-      if (done) return;
-      // CRITICAL: input frames are keyed by the ACP SESSION id from acp.open,
-      // not the attach stream id.
-      broker.sendFrame(nodeId, {
-        type: "input",
-        id: sessionId,
-        data: Buffer.from(bytes).toString("base64"),
-      });
-    },
-  });
 
   let closeStarted = false;
   const close = async (): Promise<void> => {

--- a/apps/hub/src/services/audit.ts
+++ b/apps/hub/src/services/audit.ts
@@ -58,6 +58,7 @@ const SAFE_PARAM_KEYS = new Set<string>([
   "kind",
   "size",
   "totalBytes",
+  "chars",
   "pathCount",
 ]);
 

--- a/apps/hub/src/services/connection-manager.ts
+++ b/apps/hub/src/services/connection-manager.ts
@@ -2,6 +2,9 @@ import type { GatewayServerMessage } from "@agentpod/contract";
 
 export type Send = (msg: GatewayServerMessage) => void;
 
+/** Called (synchronously, exceptions swallowed) when a node registers. */
+export type NodeOnlineHook = (nodeId: string) => void;
+
 export interface NodeConnectionManager {
   register(nodeId: string, send: Send): void;
   unregister(nodeId: string): void;
@@ -10,13 +13,27 @@ export interface NodeConnectionManager {
   send(nodeId: string, msg: GatewayServerMessage): boolean;
   /** True when `send` is the currently registered sender for nodeId (epoch guard). */
   isCurrent(nodeId: string, send: Send): boolean;
+  /** Register a hook invoked every time a node (re)connects. */
+  onNodeOnline(hook: NodeOnlineHook): void;
 }
 
 export class InMemoryConnectionManager implements NodeConnectionManager {
   private conns = new Map<string, Send>();
+  private onlineHooks: NodeOnlineHook[] = [];
 
   register(nodeId: string, send: Send) {
     this.conns.set(nodeId, send);
+    for (const hook of this.onlineHooks) {
+      try {
+        hook(nodeId);
+      } catch {
+        // Hooks must never break node registration.
+      }
+    }
+  }
+
+  onNodeOnline(hook: NodeOnlineHook) {
+    this.onlineHooks.push(hook);
   }
 
   unregister(nodeId: string) {

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -44,6 +44,11 @@ export interface FakeAcpNodeOpts {
   ignoreCancel?: boolean;
   /** Respond to acp.open with ok:false and this error. */
   failOpen?: string;
+  /**
+   * Never answer the named handshake request (wedged-agent simulation).
+   * Mutable — clear it between createSession attempts to let one succeed.
+   */
+  hangHandshake?: "initialize" | "session/new";
 }
 
 export interface FakeAcpNode {
@@ -238,12 +243,14 @@ export async function connectFakeAcpNode(
     const id = msg.id as string | number | undefined;
 
     if (method === "initialize") {
+      if (opts.hangHandshake === "initialize") return; // wedged agent
       sendAgent({
         jsonrpc: "2.0",
         id,
         result: { protocolVersion: 1, agentCapabilities: {} },
       });
     } else if (method === "session/new") {
+      if (opts.hangHandshake === "session/new") return; // wedged agent
       sendAgent({ jsonrpc: "2.0", id, result: { sessionId: agentSessionId } });
     } else if (method === "session/prompt") {
       void runPromptTurn(msg as { id: string | number; params: { sessionId: string } });

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -38,8 +38,10 @@ export interface FakeAcpNodeOpts {
   workspacePath?: string;
   /** When set, session/prompt issues a session/request_permission. Mutable. */
   permission?: FakePermissionConfig | null;
-  /** Hold the prompt turn open until session/cancel arrives. */
+  /** Hold the prompt turn open until session/cancel arrives (or releasePrompt). */
   hangPrompt?: boolean;
+  /** Ignore session/cancel: a hanging prompt stays open until releasePrompt(). */
+  ignoreCancel?: boolean;
   /** Respond to acp.open with ok:false and this error. */
   failOpen?: string;
 }
@@ -53,6 +55,8 @@ export interface FakeAcpNode {
   agentReceived: Array<Record<string, unknown>>;
   /** Outcomes the agent received for its permission requests, in order. */
   permissionOutcomes: unknown[];
+  /** Complete the OLDEST still-hanging prompt turn with the given stopReason. */
+  releasePrompt(stopReason?: string): void;
   close(): void;
 }
 
@@ -110,7 +114,7 @@ export async function connectFakeAcpNode(
   let attachId: string | null = null;
   let streamSeq = 0;
   let inputBuffer = "";
-  let pendingPromptId: string | number | null = null;
+  const pendingPrompts: Array<string | number> = [];
   let permCounter = 0;
   const outQueue: string[] = [];
   const pendingAgentRequests = new Map<
@@ -138,17 +142,26 @@ export async function connectFakeAcpNode(
     );
   };
 
-  const respondPrompt = (result: Record<string, unknown>) => {
-    if (pendingPromptId === null) return;
-    sendAgent({ jsonrpc: "2.0", id: pendingPromptId, result });
-    pendingPromptId = null;
+  /** Respond to a SPECIFIC prompt request (the turn's own id). */
+  const respondTo = (id: string | number, result: Record<string, unknown>) => {
+    const i = pendingPrompts.indexOf(id);
+    if (i === -1) return;
+    pendingPrompts.splice(i, 1);
+    sendAgent({ jsonrpc: "2.0", id, result });
+  };
+
+  /** Respond to the OLDEST pending prompt (cancel + releasePrompt semantics). */
+  const respondOldest = (result: Record<string, unknown>) => {
+    const id = pendingPrompts.shift();
+    if (id === undefined) return;
+    sendAgent({ jsonrpc: "2.0", id, result });
   };
 
   const runPromptTurn = async (msg: {
     id: string | number;
     params: { sessionId: string };
   }) => {
-    pendingPromptId = msg.id;
+    pendingPrompts.push(msg.id);
     sendAgent({
       jsonrpc: "2.0",
       method: "session/update",
@@ -191,19 +204,19 @@ export async function connectFakeAcpNode(
       const outcome = result?.outcome;
       permissionOutcomes.push(outcome ?? resp);
       if (!outcome || outcome.outcome === "cancelled") {
-        respondPrompt({ stopReason: "cancelled" });
+        respondTo(msg.id, { stopReason: "cancelled" });
         return;
       }
       if (
         outcome.outcome === "selected" &&
         String(outcome.optionId).startsWith("reject")
       ) {
-        respondPrompt({ stopReason: "end_turn" });
+        respondTo(msg.id, { stopReason: "end_turn" });
         return;
       }
     }
 
-    if (opts.hangPrompt) return; // held open until session/cancel
+    if (opts.hangPrompt) return; // held open until session/cancel or releasePrompt
 
     sendAgent({
       jsonrpc: "2.0",
@@ -216,7 +229,7 @@ export async function connectFakeAcpNode(
         },
       },
     });
-    respondPrompt({ stopReason: "end_turn" });
+    respondTo(msg.id, { stopReason: "end_turn" });
   };
 
   const handleAgentMsg = (msg: Record<string, unknown>) => {
@@ -235,7 +248,7 @@ export async function connectFakeAcpNode(
     } else if (method === "session/prompt") {
       void runPromptTurn(msg as { id: string | number; params: { sessionId: string } });
     } else if (method === "session/cancel") {
-      respondPrompt({ stopReason: "cancelled" });
+      if (!opts.ignoreCancel) respondOldest({ stopReason: "cancelled" });
     } else if (method === undefined && id !== undefined) {
       // Response to an agent-initiated request (e.g. request_permission).
       pendingAgentRequests.get(String(id))?.(msg);
@@ -350,6 +363,7 @@ export async function connectFakeAcpNode(
     nodeMsgs,
     agentReceived,
     permissionOutcomes,
+    releasePrompt: (stopReason = "end_turn") => respondOldest({ stopReason }),
     close: () => ws.close(),
   };
 }

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -1,0 +1,355 @@
+/**
+ * Fake node with a scripted ACP agent — shared by the ACP session-service
+ * tests (Task 4) and the ACP WS route tests (Task 5).
+ *
+ * Speaks the node-gateway wire protocol (req/res, stream, input, cancel) and,
+ * behind `acp.open` / `acp.attach`, scripts a minimal ACP agent:
+ *
+ *   - `initialize`       → {protocolVersion: 1, agentCapabilities: {}}
+ *   - `session/new`      → {sessionId: opts.agentSessionId}
+ *   - `session/prompt`   → streams a `session/update` agent_message_chunk;
+ *                          optionally issues `session/request_permission` and
+ *                          awaits the client's outcome before finishing the
+ *                          turn with {stopReason: "end_turn"};
+ *                          with `hangPrompt` the turn stays open until cancel.
+ *   - `session/cancel`   → resolves the in-flight prompt with
+ *                          {stopReason: "cancelled"}.
+ *
+ * `opts` is held by reference: tests may mutate `opts.permission` between
+ * prompts (e.g. to flip the toolCall kind for accept-edits coverage).
+ */
+
+const encoder = new TextEncoder();
+
+const b64encode = (s: string) => Buffer.from(encoder.encode(s)).toString("base64");
+
+export interface FakePermissionConfig {
+  /** ToolKind used in the request_permission toolCall (default "execute"). */
+  toolKind?: string;
+  options?: Array<{ optionId: string; name: string; kind: string }>;
+}
+
+export interface FakeAcpNodeOpts {
+  stationKey?: string;
+  /** Node-process session id returned by acp.open (default "acp-proc-1"). */
+  processSessionId?: string;
+  /** ACP protocol session id returned by session/new (default "sess_agent_1"). */
+  agentSessionId?: string;
+  workspacePath?: string;
+  /** When set, session/prompt issues a session/request_permission. Mutable. */
+  permission?: FakePermissionConfig | null;
+  /** Hold the prompt turn open until session/cancel arrives. */
+  hangPrompt?: boolean;
+  /** Respond to acp.open with ok:false and this error. */
+  failOpen?: string;
+}
+
+export interface FakeAcpNode {
+  ws: WebSocket;
+  opts: FakeAcpNodeOpts;
+  /** Raw gateway messages received by the node (JSON strings). */
+  nodeMsgs: string[];
+  /** Parsed JSON-RPC messages the scripted agent received from the hub. */
+  agentReceived: Array<Record<string, unknown>>;
+  /** Outcomes the agent received for its permission requests, in order. */
+  permissionOutcomes: unknown[];
+  close(): void;
+}
+
+export function parsedNodeMsgs(raw: string[]): Record<string, unknown>[] {
+  return raw
+    .map((r) => {
+      try {
+        return JSON.parse(r) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter((m): m is Record<string, unknown> => m !== null);
+}
+
+/** Poll condition() every pollMs until truthy, or throw after timeoutMs. Supports async conditions. */
+export async function pollUntil<T>(
+  condition: () => T | undefined | null | false | Promise<T | undefined | null | false>,
+  timeoutMs = 5000,
+  pollMs = 30
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await condition();
+    if (result) return result as T;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs} ms`);
+}
+
+export async function connectFakeAcpNode(
+  serverPort: number,
+  nodeId: string,
+  nodeSecret: string,
+  opts: FakeAcpNodeOpts = {}
+): Promise<FakeAcpNode> {
+  const stationKey = opts.stationKey ?? "acp-sess-station";
+  const processSessionId = opts.processSessionId ?? "acp-proc-1";
+  const agentSessionId = opts.agentSessionId ?? "sess_agent_1";
+
+  const ws = new WebSocket(`ws://localhost:${serverPort}/public/nodes/gateway`, {
+    headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+  } as RequestInit & { headers: Record<string, string> });
+
+  await new Promise<void>((res, rej) => {
+    ws.onopen = () => res();
+    ws.onerror = () => rej(new Error("Node WS connection error"));
+  });
+
+  const nodeMsgs: string[] = [];
+  const agentReceived: Array<Record<string, unknown>> = [];
+  const permissionOutcomes: unknown[] = [];
+
+  // ── Agent-side state ────────────────────────────────────────────────────────
+  let attachId: string | null = null;
+  let streamSeq = 0;
+  let inputBuffer = "";
+  let pendingPromptId: string | number | null = null;
+  let permCounter = 0;
+  const outQueue: string[] = [];
+  const pendingAgentRequests = new Map<
+    string,
+    (msg: Record<string, unknown>) => void
+  >();
+  const decoder = new TextDecoder();
+
+  /** Send one JSON-RPC message from the agent to the hub (as a stream chunk). */
+  const sendAgent = (msg: Record<string, unknown>) => {
+    const line = JSON.stringify(msg) + "\n";
+    if (attachId === null) {
+      outQueue.push(line);
+      return;
+    }
+    ws.send(
+      JSON.stringify({
+        type: "stream",
+        id: attachId,
+        seq: streamSeq++,
+        chunk: b64encode(line),
+        eof: false,
+        enc: "base64",
+      })
+    );
+  };
+
+  const respondPrompt = (result: Record<string, unknown>) => {
+    if (pendingPromptId === null) return;
+    sendAgent({ jsonrpc: "2.0", id: pendingPromptId, result });
+    pendingPromptId = null;
+  };
+
+  const runPromptTurn = async (msg: {
+    id: string | number;
+    params: { sessionId: string };
+  }) => {
+    pendingPromptId = msg.id;
+    sendAgent({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: agentSessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Working on it" },
+        },
+      },
+    });
+
+    const perm = opts.permission;
+    if (perm) {
+      const permId = `perm-${++permCounter}`;
+      const options = perm.options ?? [
+        { optionId: "allow", name: "Allow", kind: "allow_once" },
+        { optionId: "reject", name: "Reject", kind: "reject_once" },
+      ];
+      const resp = await new Promise<Record<string, unknown>>((resolve) => {
+        pendingAgentRequests.set(permId, resolve);
+        sendAgent({
+          jsonrpc: "2.0",
+          id: permId,
+          method: "session/request_permission",
+          params: {
+            sessionId: agentSessionId,
+            toolCall: {
+              toolCallId: "tc-1",
+              title: "Do the thing",
+              kind: perm.toolKind ?? "execute",
+            },
+            options,
+          },
+        });
+      });
+      const result = resp.result as
+        | { outcome?: { outcome: string; optionId?: string } }
+        | undefined;
+      const outcome = result?.outcome;
+      permissionOutcomes.push(outcome ?? resp);
+      if (!outcome || outcome.outcome === "cancelled") {
+        respondPrompt({ stopReason: "cancelled" });
+        return;
+      }
+      if (
+        outcome.outcome === "selected" &&
+        String(outcome.optionId).startsWith("reject")
+      ) {
+        respondPrompt({ stopReason: "end_turn" });
+        return;
+      }
+    }
+
+    if (opts.hangPrompt) return; // held open until session/cancel
+
+    sendAgent({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: agentSessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Done" },
+        },
+      },
+    });
+    respondPrompt({ stopReason: "end_turn" });
+  };
+
+  const handleAgentMsg = (msg: Record<string, unknown>) => {
+    agentReceived.push(msg);
+    const method = msg.method as string | undefined;
+    const id = msg.id as string | number | undefined;
+
+    if (method === "initialize") {
+      sendAgent({
+        jsonrpc: "2.0",
+        id,
+        result: { protocolVersion: 1, agentCapabilities: {} },
+      });
+    } else if (method === "session/new") {
+      sendAgent({ jsonrpc: "2.0", id, result: { sessionId: agentSessionId } });
+    } else if (method === "session/prompt") {
+      void runPromptTurn(msg as { id: string | number; params: { sessionId: string } });
+    } else if (method === "session/cancel") {
+      respondPrompt({ stopReason: "cancelled" });
+    } else if (method === undefined && id !== undefined) {
+      // Response to an agent-initiated request (e.g. request_permission).
+      pendingAgentRequests.get(String(id))?.(msg);
+      pendingAgentRequests.delete(String(id));
+    } else if (id !== undefined) {
+      sendAgent({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `method not found: ${method}` },
+      });
+    }
+  };
+
+  ws.onmessage = (e) => {
+    const raw = String(e.data);
+    nodeMsgs.push(raw);
+    const msg = JSON.parse(raw) as Record<string, unknown>;
+
+    if (msg.type === "input") {
+      // Hub → agent bytes: buffer, split into JSON-RPC lines, dispatch.
+      inputBuffer += decoder.decode(
+        Buffer.from(String(msg.data), "base64")
+      );
+      let nl: number;
+      while ((nl = inputBuffer.indexOf("\n")) !== -1) {
+        const line = inputBuffer.slice(0, nl).trim();
+        inputBuffer = inputBuffer.slice(nl + 1);
+        if (!line) continue;
+        try {
+          handleAgentMsg(JSON.parse(line) as Record<string, unknown>);
+        } catch {
+          // Not JSON — ignore.
+        }
+      }
+      return;
+    }
+
+    if (msg.type === "req") {
+      const id = msg.id as string;
+      switch (msg.verb) {
+        case "detect":
+          ws.send(
+            JSON.stringify({
+              type: "res",
+              id,
+              ok: true,
+              data: [
+                {
+                  key: stationKey,
+                  harness: "opencode",
+                  kind: "leaf",
+                  displayName: "ACP Session Test",
+                  parentKey: null,
+                  workspacePath: opts.workspacePath ?? "/workspace/acptest",
+                  capabilities: ["health", "acp"],
+                  adopted: false,
+                },
+              ],
+            })
+          );
+          break;
+
+        case "acp.open":
+          if (opts.failOpen) {
+            ws.send(
+              JSON.stringify({ type: "res", id, ok: false, error: opts.failOpen })
+            );
+          } else {
+            ws.send(
+              JSON.stringify({
+                type: "res",
+                id,
+                ok: true,
+                data: { sessionId: processSessionId },
+              })
+            );
+          }
+          break;
+
+        case "acp.attach":
+          attachId = id;
+          // Flush agent messages queued before the attach stream existed.
+          for (const line of outQueue.splice(0)) {
+            ws.send(
+              JSON.stringify({
+                type: "stream",
+                id,
+                seq: streamSeq++,
+                chunk: b64encode(line),
+                eof: false,
+                enc: "base64",
+              })
+            );
+          }
+          break;
+
+        case "acp.close":
+          ws.send(
+            JSON.stringify({ type: "res", id, ok: true, data: { ok: true } })
+          );
+          break;
+      }
+    }
+  };
+
+  // Allow onOpen → connectionManager.register to settle.
+  await new Promise((r) => setTimeout(r, 150));
+
+  return {
+    ws,
+    opts,
+    nodeMsgs,
+    agentReceived,
+    permissionOutcomes,
+    close: () => ws.close(),
+  };
+}

--- a/apps/hub/tests/unit/acp.schema.test.ts
+++ b/apps/hub/tests/unit/acp.schema.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { acpSessions, acpEvents } from "../../src/db/schema/acp";
+
+test("acpSessions table is defined", () => {
+  expect(acpSessions).toBeDefined();
+});
+
+test("acpEvents table is defined", () => {
+  expect(acpEvents).toBeDefined();
+});
+
+test("acpSessions table has required columns", () => {
+  const cols = Object.keys(acpSessions);
+  expect(cols).toContain("id");
+  expect(cols).toContain("stationId");
+  expect(cols).toContain("userId");
+  expect(cols).toContain("mode");
+  expect(cols).toContain("status");
+  expect(cols).toContain("endedReason");
+  expect(cols).toContain("nodeSessionId");
+  expect(cols).toContain("createdAt");
+  expect(cols).toContain("lastEventAt");
+});
+
+test("acpEvents table has required columns", () => {
+  const cols = Object.keys(acpEvents);
+  expect(cols).toContain("sessionId");
+  expect(cols).toContain("seq");
+  expect(cols).toContain("type");
+  expect(cols).toContain("payload");
+  expect(cols).toContain("createdAt");
+});
+
+test("acpSessions has id as primary key", () => {
+  const config = getTableConfig(acpSessions);
+  expect(config.primaryKeys.length + (config.columns.find(c => c.name === "id")?.primary ? 1 : 0)).toBeGreaterThan(0);
+});
+
+test("acpEvents has composite primary key on (session_id, seq)", () => {
+  const config = getTableConfig(acpEvents);
+  expect(config.primaryKeys.length).toBe(1);
+  const pk = config.primaryKeys[0];
+  const pkColumnNames = pk.columns.map((c) => c.name).sort();
+  expect(pkColumnNames).toEqual(["seq", "session_id"]);
+});
+
+test("acpSessions.stationId column is named station_id", () => {
+  const config = getTableConfig(acpSessions);
+  const col = config.columns.find((c) => c.name === "station_id");
+  expect(col).toBeDefined();
+  expect(col?.notNull).toBe(true);
+});
+
+test("acpSessions.stationId has NO foreign key (transcripts must survive station deletion)", () => {
+  const config = getTableConfig(acpSessions);
+  expect(config.foreignKeys.length).toBe(0);
+});
+
+test("acpSessions has an index on station_id", () => {
+  const config = getTableConfig(acpSessions);
+  const idx = config.indexes.find((i) => i.config.name === "acp_sessions_station_id_idx");
+  expect(idx).toBeDefined();
+});
+
+test("acpEvents.sessionId still has a foreign key to acpSessions.id ON DELETE CASCADE", () => {
+  const config = getTableConfig(acpEvents);
+  expect(config.foreignKeys.length).toBe(1);
+  const fk = config.foreignKeys[0];
+  expect(fk.onDelete).toBe("cascade");
+});
+
+test("acpEvents.sessionId column is named session_id", () => {
+  const config = getTableConfig(acpEvents);
+  const col = config.columns.find((c) => c.name === "session_id");
+  expect(col).toBeDefined();
+  expect(col?.notNull).toBe(true);
+});

--- a/docs/superpowers/plans/2026-08-09-acp-slice2-hub-sessions.md
+++ b/docs/superpowers/plans/2026-08-09-acp-slice2-hub-sessions.md
@@ -1,0 +1,241 @@
+# ACP Slice 2 — Hub Session Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hub-owned ACP sessions: the hub terminates the ACP protocol over slice-1's broker rails, persists replayable transcripts in Postgres, enforces per-session permission modes, and exposes a console-facing session WebSocket — everything slice 3's chat UI needs.
+
+**Architecture:** The hub is the protocol-level ACP client. Per live session it holds one broker stream to the node (`acp.open` → `acp.attach` + input frames) wrapped as the byte streams the official TS SDK consumes; SDK callbacks become append-only `acp_events` rows fanned out to subscribed console sockets. Sessions survive console disconnects; hub restart ends sessions honestly with boot reconciliation that best-effort `acp.close`s orphaned node processes (slice-1 carry-in #1).
+
+**Tech Stack:** Bun + Hono + Drizzle/Postgres (existing hub), `@agentclientprotocol/sdk` (official TS SDK — use its modern fluent `client()` API; read the installed d.ts + the repo examples for exact symbols, the plan specifies contracts not SDK symbol names), zod (contract).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-09-acp-sessions-design.md` (Hub + Architecture sections) plus slice-2 carry-ins recorded in `.superpowers/sdd/2026-08-09-acp-slice1-rails/progress.md` and the `acp-sessions-program` memory.
+- Commands: hub tests `cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test`; contract `cd packages/contract && bun test`. DB-touching tests live in `tests/integration/` or next to routes with per-file row cleanup in `afterAll`.
+- WS/gateway tests build a minimal Hono app — never import `src/index.ts`. Reuse `station-terminal.test.ts`'s `connectFakeNode` harness style for scripted nodes.
+- **Frame seam (slice-1 fact):** ACP input frames are keyed by the ACP **session id** (`broker.sendFrame(nodeId, { type: "input", id: <acpSessionId>, data })`) — NOT the attach-stream id the terminal uses. The node's `acpHandler` routes by session id.
+- **`acp.open` is idempotent-by-key** on the node (carry-in #4): opening for a station with a live process returns the existing session. For a fresh process, `acp.close` the old one first.
+- Session states: `starting → idle ⇄ working → waiting → ended(<reason>)`. All user-visible strings use the "Couldn't X." grammar.
+- Conventional commits + trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Branch `ui-revamp` in this worktree; never touch develop/main checkout.
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `packages/contract/src/station.ts` | forward-compatible capability parsing (carry-in #2) |
+| `packages/contract/src/protocol.ts` | InputMsg id-semantics doc comment (carry-in #3) |
+| `packages/contract/src/acp-session.ts` (+ test) | session/event/WS-message schemas shared hub↔console |
+| `apps/hub/src/db/schema/acp.ts` (+ migration per repo pattern, + unit test) | `acp_sessions`, `acp_events` |
+| `apps/hub/src/services/acp-transport.ts` (+ test) | broker stream ↔ SDK byte-stream adapter |
+| `apps/hub/src/services/acp-sessions.ts` (+ integration test) | session lifecycle, persistence, permission queue, reconciliation |
+| `apps/hub/src/routes/station-acp.ts` (+ test) | REST create/list + session WebSocket |
+| `apps/hub/src/index.ts` | mount routes; boot reconciliation hook |
+
+---
+
+### Task 1: Contract — forward-compat capabilities, ACP session schemas, InputMsg doc
+
+**Files:**
+- Modify: `packages/contract/src/station.ts` (capability array parsing)
+- Modify: `packages/contract/src/protocol.ts` (doc comment only, on InputMsg)
+- Create: `packages/contract/src/acp-session.ts`; export from `src/index.ts`
+- Test: `packages/contract/src/acp-session.test.ts` (+ extend `station.test.ts`)
+
+**Interfaces (Produces):**
+
+```ts
+// station.ts — keep the Capability enum, but station rows FILTER unknown
+// capability strings instead of rejecting the whole row (carry-in #2: an old
+// hub must not break auto-adopt when a newer node advertises new capabilities).
+export const CapabilityList = z
+  .array(z.string())
+  .transform((xs) => xs.filter((x): x is Capability => Capability.safeParse(x).success));
+// StationRow.capabilities (and the detect result's station shape) use CapabilityList.
+
+// acp-session.ts
+export const AcpSessionMode = z.enum(["ask", "accept-edits", "full-auto"]);
+export const AcpSessionStatus = z.enum(["starting", "idle", "working", "waiting", "ended"]);
+export const AcpSessionRow = z.object({
+  id: z.string(), stationId: z.string(), userId: z.string(),
+  mode: AcpSessionMode, status: AcpSessionStatus,
+  endedReason: z.string().nullable(),
+  createdAt: z.string(), lastEventAt: z.string(),
+});
+// Append-only transcript event. `payload` is intentionally loose (z.unknown()):
+// it carries the SDK's sessionUpdate/permission payloads verbatim; the console
+// renders known shapes and ignores the rest. `seq` is a per-session monotonic
+// integer assigned by the hub.
+export const AcpEventType = z.enum([
+  "user-prompt", "agent-update", "permission-request", "permission-answer", "state", "error",
+]);
+export const AcpEvent = z.object({
+  sessionId: z.string(), seq: z.number().int(), type: AcpEventType,
+  payload: z.unknown(), createdAt: z.string(),
+});
+// Console → hub over the session WS:
+export const AcpClientMsg = z.discriminatedUnion("t", [
+  z.object({ t: z.literal("subscribe"), sinceSeq: z.number().int().nonnegative() }),
+  z.object({ t: z.literal("prompt"), text: z.string().min(1) }),
+  z.object({ t: z.literal("cancel") }),
+  z.object({ t: z.literal("permission-answer"), requestSeq: z.number().int(), optionId: z.string() }),
+  z.object({ t: z.literal("set-mode"), mode: AcpSessionMode }),
+]);
+// Hub → console:
+export const AcpServerMsg = z.discriminatedUnion("t", [
+  z.object({ t: z.literal("event"), event: AcpEvent }),
+  z.object({ t: z.literal("replay-done"), lastSeq: z.number().int() }),
+  z.object({ t: z.literal("session"), session: AcpSessionRow }),
+  z.object({ t: z.literal("bye"), reason: z.string() }),
+]);
+```
+
+- [ ] **Step 1 (RED):** tests — CapabilityList filters unknowns (`["health","acp","future-cap"] → ["health","acp"]`) and StationRow with an unknown capability parses instead of failing; AcpClientMsg/AcpServerMsg round-trip each variant; AcpEvent accepts arbitrary payloads.
+- [ ] **Step 2:** run `bun test` → new tests fail.
+- [ ] **Step 3:** implement; add the InputMsg doc comment in protocol.ts: terminal input frames use the attach-request id, ACP input frames use the ACP session id (routed by the node's acpHandler).
+- [ ] **Step 4:** `bun test` green (fix any station.test.ts fallout by intent: filtering is the new correct behavior).
+- [ ] **Step 5:** Commit `feat(contract): acp session schemas + forward-compatible capability parsing`.
+
+---
+
+### Task 2: Hub DB — `acp_sessions` + `acp_events`
+
+**Files:**
+- Create: `apps/hub/src/db/schema/acp.ts`; export via `src/db/schema/index.ts`
+- Migration: follow EXACTLY how `provisionedRuntimes` (schema/nodes.ts) got its migration into the boot-applied set — read `src/db/migrations.ts` / the drizzle setup first and replicate the established mechanism.
+- Test: `apps/hub/tests/unit/acp.schema.test.ts` (mirror `runtimes.schema.test.ts`)
+
+Schema (Drizzle, Postgres):
+
+```ts
+export const acpSessions = pgTable("acp_sessions", {
+  id: text("id").primaryKey(),                    // "acps_" + uuid-ish
+  stationId: text("station_id").notNull(),        // FK stations.id ON DELETE CASCADE
+  userId: text("user_id").notNull(),
+  mode: text("mode").notNull(),                   // ask | accept-edits | full-auto
+  status: text("status").notNull(),               // starting|idle|working|waiting|ended
+  endedReason: text("ended_reason"),
+  nodeSessionId: text("node_session_id"),         // the node-side acp_* id, for reconciliation acp.close
+  createdAt: timestamp("created_at").notNull(),
+  lastEventAt: timestamp("last_event_at").notNull(),
+});
+export const acpEvents = pgTable("acp_events", {
+  sessionId: text("session_id").notNull(),        // FK acp_sessions.id ON DELETE CASCADE
+  seq: integer("seq").notNull(),
+  type: text("type").notNull(),
+  payload: jsonb("payload").notNull(),
+  createdAt: timestamp("created_at").notNull(),
+}, (t) => [primaryKey({ columns: [t.sessionId, t.seq] })]);
+```
+
+- [ ] **Step 1 (RED):** schema unit test asserting tables/columns/PKs exist (pattern: runtimes.schema.test.ts).
+- [ ] **Step 2:** fail. **Step 3:** implement schema + migration. **Step 4:** green + full hub suite green (migration applies against the :5434 test DB). **Step 5:** Commit `feat(hub): acp session + event tables`.
+
+---
+
+### Task 3: Hub — ACP transport adapter (broker ↔ SDK streams)
+
+**Files:**
+- Create: `apps/hub/src/services/acp-transport.ts`
+- Test: `apps/hub/src/services/acp-transport.test.ts`
+- Dependency: `cd apps/hub && bun add @agentclientprotocol/sdk` (pin exact installed version in package.json; read its d.ts + examples before coding).
+
+**Interfaces (Produces — Task 4 consumes verbatim):**
+
+```ts
+export interface AcpWire {
+  /** WHATWG streams carrying raw JSON-RPC bytes, in the shape the SDK's
+   *  connection constructor/fluent client() expects. */
+  readable: ReadableStream<Uint8Array>;   // node → hub (acp.attach chunks, base64-decoded)
+  writable: WritableStream<Uint8Array>;   // hub → node (sent as input frames keyed by nodeSessionId)
+  /** Resolves when the node stream ends; carries the exit reason parsed from
+   *  the in-band {"event":"exit","reason":...} frame, or "eof". */
+  closed: Promise<string>;
+  /** Detach + best-effort acp.close on the node. Idempotent. */
+  close(): Promise<void>;
+  nodeSessionId: string;
+}
+export async function openAcpWire(nodeId: string, stationKey: string): Promise<AcpWire>;
+// Throws Error("Couldn't start the agent process — <broker error>.") when
+// acp.open fails or the node is offline.
+```
+
+Behavior: `broker.request(nodeId, "acp.open", { key })` → `{sessionId}`; `broker.stream(nodeId, "acp.attach", { sessionId }, onChunk)` where each non-null chunk is base64-decoded into `readable`; a chunk decoding to JSON `{"event":"exit","reason":...}` resolves `closed` with the reason and terminates `readable` (do NOT forward the exit frame as protocol bytes — it is not JSON-RPC); eof without exit resolves `closed` with `"eof"`. Writes to `writable` are base64-encoded into `broker.sendFrame(nodeId, { type: "input", id: sessionId, data })` (SESSION id — global constraint). `close()` cancels the attach stream and fires `broker.request(nodeId, "acp.close", { sessionId })` best-effort.
+
+- [ ] **Step 1 (RED):** tests with the `connectFakeNode` harness (copy its setup): fake node answers `acp.open`, then on `acp.attach` streams two base64 chunks of ndjson bytes and echoes input frames back as chunks; assert (a) bytes written to `writable` arrive at the fake node as input frames keyed by the SESSION id, (b) chunks surface via `readable` in order, (c) an exit frame resolves `closed` with the reason and does not leak into `readable`, (d) `close()` sends `acp.close` + cancel.
+- [ ] **Step 2:** fail. **Step 3:** implement. **Step 4:** green. **Step 5:** Commit `feat(hub): acp wire — broker stream to SDK byte-stream adapter`.
+
+---
+
+### Task 4: Hub — session service
+
+**Files:**
+- Create: `apps/hub/src/services/acp-sessions.ts`
+- Test: `apps/hub/src/services/acp-sessions.test.ts` (integration: real test DB + fake node speaking scripted ACP)
+
+**Interfaces (Produces — Task 5 consumes verbatim):**
+
+```ts
+export interface CreateSessionInput { stationId: string; userId: string; mode: AcpSessionMode; }
+export async function createSession(input: CreateSessionInput): Promise<AcpSessionRow>;
+export async function listSessions(userId: string, stationId: string): Promise<AcpSessionRow[]>;
+export async function getSession(userId: string, sessionId: string): Promise<AcpSessionRow | null>;
+export async function promptSession(userId: string, sessionId: string, text: string): Promise<void>;
+export async function cancelTurn(userId: string, sessionId: string): Promise<void>;
+export async function answerPermission(userId: string, sessionId: string, requestSeq: number, optionId: string): Promise<void>;
+export async function setMode(userId: string, sessionId: string, mode: AcpSessionMode): Promise<void>;
+export async function endSession(userId: string, sessionId: string, reason: string): Promise<void>;
+/** Subscribe to live events; replay is the caller's job (read acp_events). */
+export function subscribe(sessionId: string, fn: (e: AcpEvent) => void): () => void;
+/** Boot reconciliation: mark all non-ended sessions ended("hub restarted");
+ *  when each affected node next connects, best-effort acp.close its orphaned
+ *  nodeSessionId. Call from index.ts boot after initDatabase. */
+export async function reconcileOnBoot(): Promise<void>;
+```
+
+Behavior requirements:
+1. `createSession`: verify station belongs to user + has the `acp` capability (`gateCapability`) + node online; for fresh-process semantics, if a live in-memory session exists for the station, refuse with "An active session already exists for this agent." (single session per station in slice 2); `openAcpWire` → SDK `initialize` → `session/new` (cwd = station workspace if the SDK requires one; consult d.ts) → insert row (`status: "idle"`, nodeSessionId) → `state` event. On any step failing: row `ended(<reason>)` + `error` event; wire closed.
+2. Events: every persisted event gets the next `seq` (per-session counter held in memory, seeded from MAX(seq)); write to `acp_events`, bump `last_event_at`, then fan out to subscribers. Event mapping: prompt → `user-prompt`; every SDK sessionUpdate notification → `agent-update` with the raw update payload; permission flow → `permission-request` / `permission-answer`; status transitions → `state` `{status}`; wire close → `state` `{status:"ended", reason}` + row update.
+3. `promptSession`: refuse unless status idle; set `working` (state event); call SDK prompt; on turn end → `idle`. Audit via `recordAudit` (verb "acp.prompt", params `{chars: text.length}` — never log prompt text to the audit table).
+4. Permission callback (SDK requestPermission): consult mode — `full-auto`: pick the SDK-provided allow/first-accept option, persist request+answer events (auto flag in payload); `accept-edits`: auto-allow requests whose toolCall kind is a file edit (consult SDK types for the discriminator), else fall through to ask; `ask`: persist `permission-request`, set status `waiting` (state event), park the SDK promise in an in-memory map keyed `(sessionId, requestSeq)`; `answerPermission` resolves it, persists `permission-answer`, restores `working`. Session end/cancel rejects parked promises with the SDK's cancelled outcome.
+5. `cancelTurn`: SDK cancel notification; status back to `idle`.
+6. Node offline mid-session (wire `closed` rejects/resolves while status != ended): status `waiting` + state event `{reason:"node offline"}`; a 60s grace timer then ends the session ("Couldn't reach the node.") — no reattach in slice 2 (recorded as slice-3 improvement).
+7. `reconcileOnBoot` per its doc; use `connectionManager` online events or a simple online-check-on-interval for the best-effort close (keep it simple: attempt close for orphans whose node is online at boot + log others).
+
+- [ ] **Step 1 (RED):** integration tests with a scripted fake-node ACP agent (extend the Task-3 fake: respond to `initialize`, `session/new`, stream a `session/update` on prompt, issue a `session/request_permission`, honor cancel): create→idle with events persisted; prompt→working→agent-update→idle ordering by seq; ask-mode permission parks + answerPermission resolves + events; full-auto auto-answers; wrong-user access returns null/throws; endSession closes wire (fake node sees acp.close); reconcileOnBoot marks stale rows ended.
+- [ ] **Step 2:** fail. **Step 3:** implement. **Step 4:** hub suite green. **Step 5:** Commit `feat(hub): acp session service — hub-owned sessions, permission modes, transcripts`.
+
+---
+
+### Task 5: Hub — REST + session WebSocket routes
+
+**Files:**
+- Create: `apps/hub/src/routes/station-acp.ts`
+- Modify: `apps/hub/src/index.ts` (mount + `reconcileOnBoot()` after initDatabase, before node gateway serves)
+- Test: `apps/hub/src/routes/station-acp.test.ts`
+
+Endpoints:
+- `POST /api/stations/:id/acp/sessions` `{mode}` → 201 AcpSessionRow (session create; 400 invalid mode, 403 capability, 404 station, 409 active-session-exists, 502 node offline/open failure).
+- `GET /api/stations/:id/acp/sessions` → rows (newest first).
+- `GET /api/acp/sessions/:sessionId/ws` (upgrade): mirror `station-terminal.ts` exactly for CSWSH origin check + auth + ownership; protocol per contract AcpClientMsg/AcpServerMsg: on `subscribe` → send `session` row, replay `acp_events` where seq > sinceSeq in order, `replay-done`, then live-subscribe; `prompt`/`cancel`/`permission-answer`/`set-mode` → corresponding service calls, errors surfaced as an `error` event (not a WS close); client disconnect → unsubscribe ONLY (session lives on — hub-owned); `bye` when the session ends.
+
+- [ ] **Step 1 (RED):** route tests (minimal Hono app + fake auth middleware + fake node, per station-terminal.test.ts): create/list happy path + each error status; WS: subscribe replays persisted events then streams a live one; prompt over WS produces agent-update; disconnect does NOT end the session (session row still non-ended; a second WS subscribe replays everything).
+- [ ] **Step 2:** fail. **Step 3:** implement. **Step 4:** hub suite green. **Step 5:** Commit `feat(hub): acp session REST + console session WebSocket`.
+
+---
+
+### Task 6: Slice gate — suites, PR, CI, live verification (controller-run)
+
+- [ ] `cd packages/contract && bun test` and full hub + node-agent + console suites green.
+- [ ] Push; PR `feat: ACP slice 2 — hub session service`; CI green.
+- [ ] Live verification on the box (hub deploy after merge):
+  1. Deploy hub (`git pull`, bun install, restart, health 200; boot log shows reconciliation ran).
+  2. **OpenCode structural**: script (bun, run on the box or via authed WS from dev) → create session on `opencode-one`'s station → expect initialize/session-new success, state events in DB; prompt → opencode replies or errors cleanly (no provider creds is acceptable — the error must land as a transcript event, not a hang); end session → node process closed (`docker exec pgrep` shows no `opencode acp` remnant).
+  3. **Hermes real prompt**: build node-agent linux/amd64 from main, deploy to buddhimaan (scp + `apn restart`), confirm hermes stations re-detect with `acp` capability; create session on a hermes profile station; send a real prompt; verify streamed agent-update events land in `acp_events` and replay over the WS. This is the program's first real cross-harness conversation — record the transcript excerpt in the PR.
+  4. Confirm forward-compat: superchotu/superprocess nodes (old binaries, no acp) still list/adopt fine against the new hub.
+- [ ] Merge on green + verified; update `acp-sessions-program` memory.
+
+## Self-Review Notes
+
+- Carry-ins covered: #1 (reconcileOnBoot + endSession acp.close), #2 (Task 1 CapabilityList), #3 (Task 1 doc), #4 (single-session-per-station + fresh-process refusal), #5 (n/a hub), #6 (WS write deadlines remain node-side — NOT covered here; keep on ledger).
+- SDK symbol names deliberately unspecified (fluent `client()` API; implementer reads installed d.ts) — the contracts pinned are ours: AcpWire, service functions, WS message schemas.
+- Console UI intentionally absent (slice 3). Single-session-per-station is a slice-2 simplification; multi-session is slice 4.

--- a/packages/contract/src/acp-session.test.ts
+++ b/packages/contract/src/acp-session.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "bun:test";
+import {
+  AcpSessionMode,
+  AcpSessionStatus,
+  AcpSessionRow,
+  AcpEventType,
+  AcpEvent,
+  AcpClientMsg,
+  AcpServerMsg,
+} from "./acp-session";
+
+it("AcpSessionRow round-trips a full row", () => {
+  const row = {
+    id: "acp_1", stationId: "station_1", userId: "user_1",
+    mode: "ask", status: "idle", endedReason: null,
+    createdAt: "2026-08-09T00:00:00.000Z", lastEventAt: "2026-08-09T00:00:01.000Z",
+  };
+  expect(AcpSessionRow.parse(row)).toEqual(row);
+});
+
+it("AcpSessionMode and AcpSessionStatus reject unknown values", () => {
+  expect(() => AcpSessionMode.parse("yolo")).toThrow();
+  expect(() => AcpSessionStatus.parse("bogus")).toThrow();
+});
+
+it("AcpEvent accepts an arbitrary payload shape", () => {
+  const event = {
+    sessionId: "acp_1", seq: 3, type: "agent-update",
+    payload: { anything: { nested: [1, 2, 3] }, sessionUpdate: "foo" },
+    createdAt: "2026-08-09T00:00:02.000Z",
+  };
+  expect(AcpEvent.parse(event)).toEqual(event);
+});
+
+it("AcpEventType covers the transcript event kinds", () => {
+  for (const t of ["user-prompt", "agent-update", "permission-request", "permission-answer", "state", "error"]) {
+    expect(AcpEventType.parse(t)).toBe(t);
+  }
+});
+
+describe("AcpClientMsg round-trips each variant", () => {
+  it("subscribe", () => {
+    expect(AcpClientMsg.parse({ t: "subscribe", sinceSeq: 0 })).toEqual({ t: "subscribe", sinceSeq: 0 });
+  });
+  it("prompt", () => {
+    expect(AcpClientMsg.parse({ t: "prompt", text: "hi" })).toEqual({ t: "prompt", text: "hi" });
+    expect(() => AcpClientMsg.parse({ t: "prompt", text: "" })).toThrow();
+  });
+  it("cancel", () => {
+    expect(AcpClientMsg.parse({ t: "cancel" })).toEqual({ t: "cancel" });
+  });
+  it("permission-answer", () => {
+    expect(AcpClientMsg.parse({ t: "permission-answer", requestSeq: 2, optionId: "allow" }))
+      .toEqual({ t: "permission-answer", requestSeq: 2, optionId: "allow" });
+  });
+  it("set-mode", () => {
+    expect(AcpClientMsg.parse({ t: "set-mode", mode: "full-auto" }))
+      .toEqual({ t: "set-mode", mode: "full-auto" });
+  });
+  it("rejects an unknown discriminant", () => {
+    expect(() => AcpClientMsg.parse({ t: "nope" })).toThrow();
+  });
+});
+
+describe("AcpServerMsg round-trips each variant", () => {
+  it("event", () => {
+    const event = { sessionId: "acp_1", seq: 0, type: "state", payload: {}, createdAt: "2026-08-09T00:00:00.000Z" };
+    expect(AcpServerMsg.parse({ t: "event", event })).toEqual({ t: "event", event });
+  });
+  it("replay-done", () => {
+    expect(AcpServerMsg.parse({ t: "replay-done", lastSeq: 5 })).toEqual({ t: "replay-done", lastSeq: 5 });
+  });
+  it("session", () => {
+    const session = {
+      id: "acp_1", stationId: "station_1", userId: "user_1",
+      mode: "accept-edits", status: "working", endedReason: null,
+      createdAt: "2026-08-09T00:00:00.000Z", lastEventAt: "2026-08-09T00:00:00.000Z",
+    };
+    expect(AcpServerMsg.parse({ t: "session", session })).toEqual({ t: "session", session });
+  });
+  it("bye", () => {
+    expect(AcpServerMsg.parse({ t: "bye", reason: "session ended" })).toEqual({ t: "bye", reason: "session ended" });
+  });
+  it("rejects an unknown discriminant", () => {
+    expect(() => AcpServerMsg.parse({ t: "nope" })).toThrow();
+  });
+});

--- a/packages/contract/src/acp-session.ts
+++ b/packages/contract/src/acp-session.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+// ─── ACP session ────────────────────────────────────────────────────────────
+
+export const AcpSessionMode = z.enum(["ask", "accept-edits", "full-auto"]);
+export type AcpSessionMode = z.infer<typeof AcpSessionMode>;
+
+export const AcpSessionStatus = z.enum(["starting", "idle", "working", "waiting", "ended"]);
+export type AcpSessionStatus = z.infer<typeof AcpSessionStatus>;
+
+export const AcpSessionRow = z.object({
+  id: z.string(), stationId: z.string(), userId: z.string(),
+  mode: AcpSessionMode, status: AcpSessionStatus,
+  endedReason: z.string().nullable(),
+  createdAt: z.string(), lastEventAt: z.string(),
+});
+export type AcpSessionRow = z.infer<typeof AcpSessionRow>;
+
+// ─── ACP transcript event ───────────────────────────────────────────────────
+
+// Append-only transcript event. `payload` is intentionally loose (z.unknown()):
+// it carries the SDK's sessionUpdate/permission payloads verbatim; the console
+// renders known shapes and ignores the rest. `seq` is a per-session monotonic
+// integer assigned by the hub.
+export const AcpEventType = z.enum([
+  "user-prompt", "agent-update", "permission-request", "permission-answer", "state", "error",
+]);
+export type AcpEventType = z.infer<typeof AcpEventType>;
+
+export const AcpEvent = z.object({
+  sessionId: z.string(), seq: z.number().int(), type: AcpEventType,
+  payload: z.unknown(), createdAt: z.string(),
+});
+export type AcpEvent = z.infer<typeof AcpEvent>;
+
+// ─── ACP session WS protocol ─────────────────────────────────────────────────
+
+// Console → hub over the session WS:
+export const AcpClientMsg = z.discriminatedUnion("t", [
+  z.object({ t: z.literal("subscribe"), sinceSeq: z.number().int().nonnegative() }),
+  z.object({ t: z.literal("prompt"), text: z.string().min(1) }),
+  z.object({ t: z.literal("cancel") }),
+  z.object({ t: z.literal("permission-answer"), requestSeq: z.number().int(), optionId: z.string() }),
+  z.object({ t: z.literal("set-mode"), mode: AcpSessionMode }),
+]);
+export type AcpClientMsg = z.infer<typeof AcpClientMsg>;
+
+// Hub → console:
+export const AcpServerMsg = z.discriminatedUnion("t", [
+  z.object({ t: z.literal("event"), event: AcpEvent }),
+  z.object({ t: z.literal("replay-done"), lastSeq: z.number().int() }),
+  z.object({ t: z.literal("session"), session: AcpSessionRow }),
+  z.object({ t: z.literal("bye"), reason: z.string() }),
+]);
+export type AcpServerMsg = z.infer<typeof AcpServerMsg>;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -6,3 +6,4 @@ export * from "./station";
 export * from "./protocol";
 export * from "./runtime";
 export * from "./fleet";
+export * from "./acp-session";

--- a/packages/contract/src/protocol.ts
+++ b/packages/contract/src/protocol.ts
@@ -10,6 +10,13 @@ export type RequestMsg = z.infer<typeof RequestMsg>;
 export type ResponseMsg = z.infer<typeof ResponseMsg>;
 export type StreamMsg = z.infer<typeof StreamMsg>;
 
+/**
+ * Keystroke/data frame sent hub → node over the gateway socket.
+ * `id` is dual-purpose depending on which handler owns it:
+ *  - terminal input frames key `id` by the attach-request id (term.attach's id).
+ *  - ACP input frames key `id` by the ACP session id — the node's acpHandler
+ *    routes incoming input by session id, not by attach-request id.
+ */
 export const InputMsg = z.object({ type: z.literal("input"), id: z.string(), data: z.string() });
 export const ResizeMsg = z.object({ type: z.literal("resize"), id: z.string(), cols: z.number().int(), rows: z.number().int() });
 export type InputMsg = z.infer<typeof InputMsg>;

--- a/packages/contract/src/station.test.ts
+++ b/packages/contract/src/station.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect } from "bun:test";
-import { Station } from "./station";
+import { Station, CapabilityList } from "./station";
 
 it("Station accepts an optional nullable matrixId", () => {
   expect(Station.parse({ key:"k", harness:"hermes", kind:"leaf", displayName:"d", parentKey:null, workspacePath:null, capabilities:[], matrixId:"@a:id.agentpod.dev" }).matrixId).toBe("@a:id.agentpod.dev");
   expect(Station.parse({ key:"k", harness:"hermes", kind:"leaf", displayName:"d", parentKey:null, workspacePath:null, capabilities:[] }).matrixId).toBeUndefined();
   expect(Station.parse({ key:"k", harness:"hermes", kind:"leaf", displayName:"d", parentKey:null, workspacePath:null, capabilities:[], matrixId:null }).matrixId).toBeNull();
+});
+
+it("CapabilityList filters unknown capability strings instead of throwing", () => {
+  expect(CapabilityList.parse(["health", "acp", "future-cap"])).toEqual(["health", "acp"]);
+});
+
+it("Station parses (instead of rejecting) when a newer node advertises an unknown capability", () => {
+  const s = Station.parse({
+    key: "k", harness: "hermes", kind: "leaf", displayName: "d", parentKey: null,
+    workspacePath: null, capabilities: ["health", "future-cap"],
+  });
+  expect(s.capabilities).toEqual(["health"]);
 });

--- a/packages/contract/src/station.ts
+++ b/packages/contract/src/station.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 export const Capability = z.enum(["inventory","health","logs","fs.read","fs.write","terminal","lifecycle","cleanup","acp"]);
 export type Capability = z.infer<typeof Capability>;
+// Station capability lists FILTER unknown capability strings instead of
+// rejecting the whole row (carry-in #2: an old hub must not break auto-adopt
+// when a newer node advertises capabilities this hub doesn't know about yet).
+export const CapabilityList = z
+  .array(z.string())
+  .transform((xs) => xs.filter((x): x is Capability => Capability.safeParse(x).success));
 export const StationKind = z.enum(["composite","leaf"]);
 export const Station = z.object({
   key: z.string().min(1), harness: z.string().min(1), kind: StationKind,
   displayName: z.string(), parentKey: z.string().nullable(),
-  workspacePath: z.string().nullable(), capabilities: z.array(Capability),
+  workspacePath: z.string().nullable(), capabilities: CapabilityList,
   matrixId: z.string().nullable().optional(),
 });
 export type Station = z.infer<typeof Station>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
 
   apps/hub:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@3.25.76)
       '@agentpod/agents':
         specifier: workspace:*
         version: link:../../packages/agents
@@ -342,6 +345,11 @@ importers:
         version: 5.6.3
 
 packages:
+
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -5014,6 +5022,10 @@ packages:
 
 snapshots:
 
+  '@agentclientprotocol/sdk@1.3.0(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -5152,7 +5164,7 @@ snapshots:
 
   '@balena/dockerignore@1.0.2': {}
 
-  '@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)':
+  '@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
@@ -5163,9 +5175,9 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.1.13
 
-  '@better-auth/telemetry@1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))':
+  '@better-auth/telemetry@1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))':
     dependencies:
-      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
+      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
 
@@ -6552,8 +6564,8 @@ snapshots:
 
   better-auth@1.4.6(@sveltejs/kit@2.49.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.45.5):
     dependencies:
-      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
-      '@better-auth/telemetry': 1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))
+      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
       '@noble/ciphers': 2.1.1


### PR DESCRIPTION
## Summary

Slice 2 of the ACP sessions program (spec: `docs/superpowers/specs/2026-08-09-acp-sessions-design.md`): the hub now owns ACP sessions end to end — creating them over the slice-1 node rails, persisting full transcripts in Postgres, parking/answering permission requests, and serving a console-facing WebSocket with gap-free replay. Sessions are hub-owned: they survive tab close and hub restarts are reconciled.

**Spec amendment:** `acp_sessions.station_id` deliberately has **no FK** — transcripts survive station deletion (matches the `station_audit` precedent).

## What's in it

- **Contract** (`packages/contract/src/acp-session.ts`): session row/mode/status, transcript event types, and the WS protocol (`AcpClientMsg`/`AcpServerMsg`). Plus forward-compatible capability parsing — unknown capabilities from newer nodes are filtered, not rejected (the exact failure that broke auto-adopt during slice-1 rollout).
- **DB**: `acp_sessions` + `acp_events` (composite PK `(session_id, seq)` — duplicate-seq safe), migration 0025.
- **Wire transport** (`acp-transport.ts`): broker stream ⇄ SDK byte-stream adapter with leak-free cancel/teardown; in-band exit frames resolve `closed` without leaking into the byte stream.
- **Session service** (`acp-sessions.ts`): create/prompt/cancel/permission-answer/set-mode/end/subscribe over the official `@agentclientprotocol/sdk`; per-session serialized event chain with persist-before-fan-out; per-turn epoch guard (stale completions can't clobber a newer turn); 30s handshake deadline (a spawn-then-silent agent can't 409-lock a station); node-offline grace; boot reconciliation + orphan process close on node reconnect.
- **Routes** (`station-acp.ts`): REST create/list/end (201/400/401/403/404/409/502, 204 on end) and the session WebSocket — CSWSH origin check + auth + session-level ownership before the message gate; subscribe → replay (atomic, no missed/duplicated seq) → live stream; client disconnect only unsubscribes (session lives on); `bye` on session end.

## Review

Built via subagent-driven development: per-task adversarial review + fix rounds, then a whole-branch final review (verdict: merge-ready; all residual minors triaged defer-safe and recorded on the slice-3 list). Fixes were differentially verified — regression tests confirmed failing against the pre-fix code.

## Tests

- contract 45 ✅ · hub **352** (was 337 pre-slice) ✅ · node-agent `-race` all packages ✅ · console 465 + build ✅
- New coverage: replay atomicity, disconnect-during-subscribe leak race, handshake-timeout wedge, boot-orphan close on reconnect, cancel-mid-parked-ask, concurrent create, CSWSH rejection, foreign-session 404s.

## Live verification (before merge)

- [ ] Hub deployed; boot log shows reconciliation
- [ ] OpenCode structural session on `opencode-one` (create → prompt → end; no process remnant)
- [ ] Hermes real prompt on buddhimaan — first real cross-harness conversation (transcript below)
- [ ] Old-binary nodes (no `acp`) still list/adopt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB