### PR TITLE
feat: ACP slice 3 — console chat

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -28,7 +28,8 @@
     "material-file-icons": "^2.4.0",
     "monaco-editor": "^0.55.1",
     "remark-gfm": "^4.0.1",
-    "shiki": "^3.19.0"
+    "shiki": "^3.19.0",
+    "svelte-streamdown": "3.1.2"
   },
   "devDependencies": {
     "@agentpod/tsconfig": "workspace:*",

--- a/apps/console/src/lib/api/acp.test.ts
+++ b/apps/console/src/lib/api/acp.test.ts
@@ -1,0 +1,258 @@
+/**
+ * acp.test.ts
+ *
+ * Unit tests for the ACP session API client — REST helpers plus the thin
+ * WebSocket wrapper over the hub's ACP session bridge.  Uses a mocked
+ * globalThis.WebSocket (and a fetch spy) so no real network is touched.
+ * Run: cd apps/console && pnpm test src/lib/api/acp.test.ts
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AcpServerMsg, AcpSessionRow } from "@agentpod/contract";
+
+// ─── Minimal WebSocket stub ───────────────────────────────────────────────────
+
+class MockWebSocket {
+  static instance: MockWebSocket | null = null;
+
+  url: string;
+  readyState: number = 0; // CONNECTING
+
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+
+  /** Payloads passed to ws.send(), as raw strings. */
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instance = this;
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3; // CLOSED
+    this.onclose?.(new CloseEvent("close"));
+  }
+
+  /** Test helper: simulate the server opening the connection. */
+  open() {
+    this.readyState = 1; // OPEN
+    this.onopen?.(new Event("open"));
+  }
+
+  /** Test helper: simulate a JSON message from the server. */
+  fireMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+
+  /** Test helper: simulate a raw (possibly non-JSON) frame from the server. */
+  fireRaw(data: string) {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+
+  /** Test helper: simulate a socket-level error (no accompanying close). */
+  fireError() {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  MockWebSocket.instance = null;
+  // Seed localStorage so hubUrl() returns a deterministic host
+  localStorage.setItem("agentpod.apiUrl", "http://hub.test:3001");
+  // Install the stub
+  (globalThis as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  MockWebSocket.instance = null;
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+// ─── Import under test ────────────────────────────────────────────────────────
+// Imported after stubs so the module can read globalThis.WebSocket at call time
+// (it doesn't capture it at import time).
+import { createAcpSocket, createAcpSession, listAcpSessions, endAcpSession } from "./acp";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const sessionRow: AcpSessionRow = {
+  id: "s1",
+  stationId: "st1",
+  userId: "u1",
+  mode: "ask",
+  status: "idle",
+  endedReason: null,
+  createdAt: "2026-08-09T00:00:00.000Z",
+  lastEventAt: "2026-08-09T00:00:00.000Z",
+};
+
+// ─── WebSocket: URL derivation ───────────────────────────────────────────────
+
+test("createAcpSocket opens ws:// URL derived from hubUrl()", () => {
+  createAcpSocket("s1");
+
+  expect(MockWebSocket.instance).toBeTruthy();
+  expect(MockWebSocket.instance!.url).toBe("ws://hub.test:3001/api/acp/sessions/s1/ws");
+});
+
+test("https:// → wss:// in the ACP WebSocket URL", () => {
+  localStorage.setItem("agentpod.apiUrl", "https://hub.prod:443");
+  createAcpSocket("s2");
+
+  expect(MockWebSocket.instance!.url).toBe("wss://hub.prod:443/api/acp/sessions/s2/ws");
+});
+
+// ─── WebSocket: send ─────────────────────────────────────────────────────────
+
+test("send(msg) after open sends the JSON-encoded client message", () => {
+  const socket = createAcpSocket("s1");
+  MockWebSocket.instance!.open();
+  socket.send({ t: "prompt", text: "hello" });
+
+  expect(MockWebSocket.instance!.sent).toHaveLength(1);
+  expect(JSON.parse(MockWebSocket.instance!.sent[0])).toEqual({ t: "prompt", text: "hello" });
+});
+
+test("send(msg) before open is buffered and flushed in order on open", () => {
+  const socket = createAcpSocket("s1");
+  socket.send({ t: "subscribe", sinceSeq: 0 });
+  socket.send({ t: "prompt", text: "hi" });
+
+  expect(MockWebSocket.instance!.sent).toHaveLength(0); // not yet sent
+
+  MockWebSocket.instance!.open();
+
+  expect(MockWebSocket.instance!.sent).toHaveLength(2);
+  expect(JSON.parse(MockWebSocket.instance!.sent[0])).toEqual({ t: "subscribe", sinceSeq: 0 });
+  expect(JSON.parse(MockWebSocket.instance!.sent[1])).toEqual({ t: "prompt", text: "hi" });
+});
+
+// ─── WebSocket: onMessage ────────────────────────────────────────────────────
+
+test("onMessage delivers parsed AcpServerMsg frames", () => {
+  const socket = createAcpSocket("s1");
+  const received: AcpServerMsg[] = [];
+  socket.onMessage((msg) => received.push(msg));
+
+  MockWebSocket.instance!.open();
+  MockWebSocket.instance!.fireMessage({ t: "replay-done", lastSeq: 5 });
+  MockWebSocket.instance!.fireMessage({ t: "session", session: sessionRow });
+
+  expect(received).toEqual([
+    { t: "replay-done", lastSeq: 5 },
+    { t: "session", session: sessionRow },
+  ]);
+});
+
+test("garbage frames (non-JSON, unknown variants) are dropped silently", () => {
+  const socket = createAcpSocket("s1");
+  const received: AcpServerMsg[] = [];
+  socket.onMessage((msg) => received.push(msg));
+
+  MockWebSocket.instance!.open();
+  MockWebSocket.instance!.fireRaw("not json {");
+  MockWebSocket.instance!.fireMessage({ t: "future-variant", stuff: true });
+  MockWebSocket.instance!.fireMessage({ nonsense: 1 });
+  MockWebSocket.instance!.fireMessage({ t: "replay-done", lastSeq: 3 });
+
+  expect(received).toEqual([{ t: "replay-done", lastSeq: 3 }]);
+});
+
+// ─── WebSocket: onClose ──────────────────────────────────────────────────────
+
+test("an unprompted clean close fires onClose('closed')", () => {
+  const socket = createAcpSocket("s1");
+  const reasons: string[] = [];
+  socket.onClose((reason) => reasons.push(reason));
+
+  MockWebSocket.instance!.open();
+  // Server/network drops the socket without the client having called close().
+  MockWebSocket.instance!.onclose?.(new CloseEvent("close"));
+
+  expect(reasons).toEqual(["closed"]);
+});
+
+test("socket error fires onClose('error') exactly once", () => {
+  const socket = createAcpSocket("s1");
+  const reasons: string[] = [];
+  socket.onClose((reason) => reasons.push(reason));
+
+  MockWebSocket.instance!.open();
+  MockWebSocket.instance!.fireError();
+  // Errors are typically followed by a close event — must not double-fire.
+  MockWebSocket.instance!.onclose?.(new CloseEvent("close"));
+
+  expect(reasons).toEqual(["error"]);
+});
+
+test("close() then the resulting socket close does not fire onClose", () => {
+  const socket = createAcpSocket("s1");
+  const reasons: string[] = [];
+  socket.onClose((reason) => reasons.push(reason));
+
+  MockWebSocket.instance!.open();
+  socket.close(); // mock synchronously invokes ws.onclose, as a real close would (async)
+
+  expect(reasons).toEqual([]);
+  expect(MockWebSocket.instance!.readyState).toBe(3); // CLOSED
+});
+
+// ─── REST helpers ────────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("createAcpSession POSTs {mode} to /api/stations/:id/acp/sessions", async () => {
+  const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(sessionRow, 201));
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const row = await createAcpSession("st1", "ask");
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe("http://hub.test:3001/api/stations/st1/acp/sessions");
+  expect(init.method).toBe("POST");
+  expect(JSON.parse(init.body)).toEqual({ mode: "ask" });
+  expect(row).toEqual(sessionRow);
+});
+
+test("listAcpSessions GETs /api/stations/:id/acp/sessions", async () => {
+  const fetchSpy = vi.fn().mockResolvedValue(jsonResponse([sessionRow]));
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const rows = await listAcpSessions("st1");
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe("http://hub.test:3001/api/stations/st1/acp/sessions");
+  expect(init?.method ?? "GET").toBe("GET");
+  expect(rows).toEqual([sessionRow]);
+});
+
+test("endAcpSession DELETEs /api/acp/sessions/:sessionId and resolves on 204", async () => {
+  const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+  vi.stubGlobal("fetch", fetchSpy);
+
+  await expect(endAcpSession("s9")).resolves.toBeUndefined();
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe("http://hub.test:3001/api/acp/sessions/s9");
+  expect(init.method).toBe("DELETE");
+});

--- a/apps/console/src/lib/api/acp.ts
+++ b/apps/console/src/lib/api/acp.ts
@@ -1,0 +1,145 @@
+/**
+ * acp.ts
+ *
+ * Thin client for the hub's ACP session API.
+ *
+ * REST (via client.ts `http`):
+ *   POST   /api/stations/:id/acp/sessions {mode} → 201 AcpSessionRow
+ *   GET    /api/stations/:id/acp/sessions        → AcpSessionRow[]
+ *   DELETE /api/acp/sessions/:sessionId          → 204
+ *
+ * WS (mirrors terminal.ts):
+ *   /api/acp/sessions/:sessionId/ws speaking AcpClientMsg / AcpServerMsg
+ *   from @agentpod/contract. Inbound frames are validated with
+ *   AcpServerMsg.safeParse; frames that fail to parse are dropped silently
+ *   (forward compat — a newer hub may add variants).
+ */
+
+import { AcpServerMsg as AcpServerMsgSchema } from "@agentpod/contract";
+import type { AcpSessionMode } from "@agentpod/contract";
+import { http } from "./client";
+
+export type AcpSessionRow = import("@agentpod/contract").AcpSessionRow;
+export type AcpServerMsg = import("@agentpod/contract").AcpServerMsg;
+export type AcpClientMsg = import("@agentpod/contract").AcpClientMsg;
+
+/** Resolves the hub base URL the same way client.ts does. */
+function hubUrl(): string {
+  const stored =
+    typeof window !== "undefined" ? window.localStorage.getItem("agentpod.apiUrl") : null;
+  return stored ?? (import.meta.env?.PUBLIC_HUB_URL as string | undefined) ?? "http://localhost:3001";
+}
+
+// ─── REST helpers ─────────────────────────────────────────────────────────────
+
+export const createAcpSession = (stationId: string, mode: AcpSessionMode) =>
+  http<AcpSessionRow>(`/api/stations/${stationId}/acp/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode }),
+  });
+
+export const listAcpSessions = (stationId: string) =>
+  http<AcpSessionRow[]>(`/api/stations/${stationId}/acp/sessions`);
+
+export const endAcpSession = (sessionId: string) =>
+  http<void>(`/api/acp/sessions/${sessionId}`, { method: "DELETE" });
+
+// ─── WebSocket client ─────────────────────────────────────────────────────────
+
+/** Reason the ACP session connection ended, passed to an `onClose` callback. */
+export type AcpCloseReason = "error" | "closed";
+
+export interface AcpSocket {
+  /** Send a client message to the hub. Buffered if the socket isn't open yet. */
+  send(msg: AcpClientMsg): void;
+  /** Register a callback that fires for every parsed server message. */
+  onMessage(cb: (msg: AcpServerMsg) => void): void;
+  /**
+   * Register a callback that fires exactly once when the connection ends —
+   * unless it ended because the caller itself called `close()`, in which
+   * case no callback fires (the caller already knows). Last registration
+   * wins. Reasons: "error" (socket error), "closed" (an unprompted clean
+   * close, e.g. network drop).
+   */
+  onClose(cb: (reason: AcpCloseReason) => void): void;
+  /** Close the WebSocket connection. Never fires onClose. */
+  close(): void;
+}
+
+export function createAcpSocket(sessionId: string): AcpSocket {
+  const wsUrl = `${hubUrl().replace(/^http/, "ws")}/api/acp/sessions/${sessionId}/ws`;
+  const ws = new WebSocket(wsUrl);
+
+  let messageCallback: ((msg: AcpServerMsg) => void) | null = null;
+  let closeCallback: ((reason: AcpCloseReason) => void) | null = null;
+
+  /** True once `close()` has been called by the caller — suppresses onClose. */
+  let manualClose = false;
+  /** True once onClose has fired, so it never fires a second time. */
+  let closeFired = false;
+
+  /** Messages queued while the socket is still in CONNECTING state. */
+  const sendQueue: string[] = [];
+
+  function emitClose(reason: AcpCloseReason) {
+    if (closeFired || manualClose) return;
+    closeFired = true;
+    closeCallback?.(reason);
+  }
+
+  ws.onopen = () => {
+    // Flush any messages that were sent before the socket opened
+    for (const payload of sendQueue) {
+      ws.send(payload);
+    }
+    sendQueue.length = 0;
+  };
+
+  ws.onmessage = (event: MessageEvent) => {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(event.data as string);
+    } catch {
+      return;
+    }
+    const parsed = AcpServerMsgSchema.safeParse(raw);
+    if (!parsed.success) return;
+    messageCallback?.(parsed.data);
+  };
+
+  ws.onerror = () => {
+    emitClose("error");
+  };
+
+  ws.onclose = () => {
+    // Any close not already accounted for above (server/network drop) is a
+    // "closed" event, unless it was the direct result of us calling close().
+    emitClose("closed");
+  };
+
+  return {
+    send(msg) {
+      const payload = JSON.stringify(msg);
+      // 1 = WebSocket.OPEN; use literal so the mock in tests doesn't need the static
+      if (ws.readyState === 1) {
+        ws.send(payload);
+      } else {
+        sendQueue.push(payload);
+      }
+    },
+
+    onMessage(cb) {
+      messageCallback = cb;
+    },
+
+    onClose(cb) {
+      closeCallback = cb;
+    },
+
+    close() {
+      manualClose = true;
+      ws.close();
+    },
+  };
+}

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -26,7 +26,7 @@ export function handleUnauthorized(): void {
   }
 }
 
-async function http<T>(path: string, init?: RequestInit): Promise<T> {
+export async function http<T>(path: string, init?: RequestInit): Promise<T> {
   const requestLine = `${init?.method ?? "GET"} ${path}`;
   let res: Response;
   try {

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  /**
+   * ChatHeader — session status, permission-mode selector, session actions.
+   *
+   * Status maps the ACP session vocab onto the console's shared status
+   * tokens (working→starting+pulse, idle→running, waiting→degraded,
+   * ended→stopped). A degraded CONNECTION (reconnecting/disconnected)
+   * overrides the label — transport truth beats stale session state.
+   *
+   * Mode chips are never disabled: pre-session the selection seeds creation,
+   * live it round-trips set-mode, and after end it seeds the next session
+   * (AcpChat.setMode handles all three).
+   *
+   * Ending a session is destructive (the agent process stops) — gated behind
+   * ConfirmDialog. An ended session flips the action to "New session".
+   */
+  import type { AcpSessionMode, AcpSessionStatus } from "@agentpod/contract";
+  import type { AcpSessionRow } from "$lib/api/acp";
+  import type { ChatConnection } from "./acp-chat.svelte";
+  import { Button } from "$lib/components/ui/button";
+  import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
+  import { Status } from "$lib/components/ui/status";
+  import { chipClass } from "$lib/utils/toggle-chip";
+
+  interface Props {
+    session: AcpSessionRow | null;
+    status: AcpSessionStatus;
+    connection: ChatConnection;
+    mode: AcpSessionMode;
+    onModeChange: (mode: AcpSessionMode) => void;
+    onEnd: () => void;
+    onNew: () => void;
+  }
+
+  let { session, status, connection, mode, onModeChange, onEnd, onNew }: Props = $props();
+
+  const STATUS_DOT: Record<AcpSessionStatus, string> = {
+    starting: "starting",
+    working: "starting",
+    idle: "running",
+    waiting: "degraded",
+    ended: "stopped",
+  };
+  const STATUS_LABEL: Record<AcpSessionStatus, string> = {
+    starting: "Starting…",
+    working: "Working…",
+    idle: "Idle",
+    waiting: "Waiting for approval",
+    ended: "Ended",
+  };
+
+  const MODES: Array<{ value: AcpSessionMode; label: string }> = [
+    { value: "ask", label: "Ask" },
+    { value: "accept-edits", label: "Accept edits" },
+    { value: "full-auto", label: "Full auto" },
+  ];
+
+  const dotStatus = $derived(
+    connection === "reconnecting"
+      ? "starting"
+      : connection === "disconnected"
+        ? "error"
+        : session
+          ? STATUS_DOT[status]
+          : "stopped",
+  );
+  const dotAnimate = $derived(
+    connection === "reconnecting" || (connection !== "disconnected" && status === "working"),
+  );
+  const label = $derived(
+    connection === "reconnecting"
+      ? "Reconnecting…"
+      : connection === "disconnected"
+        ? "Disconnected"
+        : session
+          ? STATUS_LABEL[status]
+          : "No session",
+  );
+
+  let confirmEndOpen = $state(false);
+</script>
+
+<div class="flex flex-wrap items-center gap-3">
+  <div role="status" aria-live="polite" class="flex min-w-0 items-center gap-2">
+    <!-- aria-hidden: the visible label is the ONE accessible text; the dot's
+         built-in sr-only label would read as a duplicate. -->
+    <span aria-hidden="true" class="flex">
+      <Status form="dot" status={dotStatus} animate={dotAnimate} {label} />
+    </span>
+    <span class="t-label truncate">{label}</span>
+  </div>
+
+  <div role="group" aria-label="Permission mode" class="flex items-center gap-1 text-xs">
+    {#each MODES as m (m.value)}
+      <button
+        type="button"
+        class={chipClass(mode === m.value)}
+        aria-pressed={mode === m.value}
+        onclick={() => onModeChange(m.value)}
+      >
+        {m.label}
+      </button>
+    {/each}
+  </div>
+
+  {#if session}
+    <div class="ml-auto">
+      {#if status === "ended"}
+        <Button variant="outline" size="sm" onclick={onNew}>New session</Button>
+      {:else}
+        <Button variant="ghost" size="sm" onclick={() => (confirmEndOpen = true)}>
+          End session
+        </Button>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<ConfirmDialog
+  open={confirmEndOpen}
+  title="End this session?"
+  message="The agent process stops and the transcript is kept."
+  confirmLabel="End session"
+  destructive
+  onConfirm={() => {
+    confirmEndOpen = false;
+    onEnd();
+  }}
+  onCancel={() => (confirmEndOpen = false)}
+/>

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -4,8 +4,12 @@
    *
    * Status maps the ACP session vocab onto the console's shared status
    * tokens (working→starting+pulse, idle→running, waiting→degraded,
-   * ended→stopped). A degraded CONNECTION (reconnecting/disconnected)
-   * overrides the label — transport truth beats stale session state.
+   * ended→stopped). Transport state overrides the label — while connecting,
+   * replaying or reconnecting the session state is not yet trustworthy, and it
+   * is also why the composer refuses to send, so the user gets told.
+   *
+   * This is the ONE live region for session status in the panel: Conversation
+   * announces permissions only, so a flip is never read out twice.
    *
    * Mode chips are never disabled: pre-session the selection seeds creation,
    * live it round-trips set-mode, and after end it seeds the next session
@@ -55,26 +59,25 @@
     { value: "full-auto", label: "Full auto" },
   ];
 
+  /** Transport is still catching up: the transcript (and status) is incomplete. */
+  const syncing = $derived(connection === "connecting" || connection === "reconnecting");
+
   const dotStatus = $derived(
-    connection === "reconnecting"
-      ? "starting"
-      : connection === "disconnected"
-        ? "error"
-        : session
-          ? STATUS_DOT[status]
-          : "stopped",
+    syncing ? "starting" : connection === "disconnected" ? "error" : session ? STATUS_DOT[status] : "stopped",
   );
   const dotAnimate = $derived(
-    connection === "reconnecting" || (connection !== "disconnected" && status === "working"),
+    syncing || (connection !== "disconnected" && status === "working"),
   );
   const label = $derived(
-    connection === "reconnecting"
-      ? "Reconnecting…"
-      : connection === "disconnected"
-        ? "Disconnected"
-        : session
-          ? STATUS_LABEL[status]
-          : "No session",
+    connection === "connecting"
+      ? "Connecting…"
+      : connection === "reconnecting"
+        ? "Reconnecting…"
+        : connection === "disconnected"
+          ? "Disconnected"
+          : session
+            ? STATUS_LABEL[status]
+            : "No session",
   );
 
   let confirmEndOpen = $state(false);

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
@@ -66,6 +66,16 @@ test("reconnecting connection overrides the status label", () => {
   expect(region.textContent).not.toContain("Working…");
 });
 
+test("connecting (replay in flight) overrides the status label", () => {
+  // The composer refuses sends until the replay lands, so the header has to say
+  // why rather than showing a stale session status.
+  const { getByRole } = setup({ status: "working", connection: "connecting" });
+
+  const region = getByRole("status");
+  expect(region.textContent).toContain("Connecting…");
+  expect(region.textContent).not.toContain("Working…");
+});
+
 test("disconnected connection overrides the status label", () => {
   const { getByRole } = setup({ connection: "disconnected" });
   expect(getByRole("status").textContent).toContain("Disconnected");

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
@@ -1,0 +1,111 @@
+import { test, expect, vi } from "vitest";
+import { render, waitFor, fireEvent, within } from "@testing-library/svelte";
+import type { ComponentProps } from "svelte";
+import type { AcpSessionRow } from "$lib/api/acp";
+import ChatHeader from "./ChatHeader.svelte";
+
+const row: AcpSessionRow = {
+  id: "ses_1",
+  stationId: "st_1",
+  userId: "u_1",
+  mode: "ask",
+  status: "idle",
+  endedReason: null,
+  createdAt: "2026-08-09T10:00:00.000Z",
+  lastEventAt: "2026-08-09T10:00:00.000Z",
+};
+
+function setup(props: Partial<ComponentProps<typeof ChatHeader>> = {}) {
+  const onModeChange = vi.fn();
+  const onEnd = vi.fn();
+  const onNew = vi.fn();
+  const utils = render(ChatHeader, {
+    props: {
+      session: row,
+      status: "idle",
+      connection: "connected",
+      mode: "ask",
+      onModeChange,
+      onEnd,
+      onNew,
+      ...props,
+    },
+  });
+  return { ...utils, onModeChange, onEnd, onNew };
+}
+
+test("mode chips call onModeChange and mark the active mode pressed", async () => {
+  const { getByRole, onModeChange } = setup({ session: null, status: "starting" });
+
+  const ask = getByRole("button", { name: "Ask" });
+  const acceptEdits = getByRole("button", { name: "Accept edits" });
+  const fullAuto = getByRole("button", { name: "Full auto" });
+
+  expect(ask.getAttribute("aria-pressed")).toBe("true");
+  expect(acceptEdits.getAttribute("aria-pressed")).toBe("false");
+
+  await fireEvent.click(acceptEdits);
+  expect(onModeChange).toHaveBeenCalledWith("accept-edits");
+  await fireEvent.click(fullAuto);
+  expect(onModeChange).toHaveBeenCalledWith("full-auto");
+});
+
+test("status dot + label live in a polite status region", () => {
+  const { getByRole } = setup({ status: "working" });
+
+  const region = getByRole("status");
+  expect(region.getAttribute("aria-live")).toBe("polite");
+  expect(region.textContent).toContain("Working…");
+});
+
+test("reconnecting connection overrides the status label", () => {
+  const { getByRole } = setup({ status: "working", connection: "reconnecting" });
+
+  const region = getByRole("status");
+  expect(region.textContent).toContain("Reconnecting…");
+  expect(region.textContent).not.toContain("Working…");
+});
+
+test("disconnected connection overrides the status label", () => {
+  const { getByRole } = setup({ connection: "disconnected" });
+  expect(getByRole("status").textContent).toContain("Disconnected");
+});
+
+test("End session is gated behind the confirm dialog", async () => {
+  const { getByRole, onEnd } = setup();
+
+  await fireEvent.click(getByRole("button", { name: "End session" }));
+
+  const dialog = await waitFor(() => getByRole("dialog"));
+  expect(within(dialog).getByText("End this session?")).toBeTruthy();
+  expect(
+    within(dialog).getByText("The agent process stops and the transcript is kept."),
+  ).toBeTruthy();
+  expect(onEnd).not.toHaveBeenCalled();
+
+  await fireEvent.click(within(dialog).getByRole("button", { name: "End session" }));
+  await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1));
+});
+
+test("cancelling the confirm dialog does not end the session", async () => {
+  const { getByRole, queryByRole, onEnd } = setup();
+
+  await fireEvent.click(getByRole("button", { name: "End session" }));
+  const dialog = await waitFor(() => getByRole("dialog"));
+
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+  await waitFor(() => expect(queryByRole("dialog")).toBeNull());
+  expect(onEnd).not.toHaveBeenCalled();
+});
+
+test("ended session shows New session instead of End session", async () => {
+  const { getByRole, queryByRole, onNew } = setup({
+    session: { ...row, status: "ended" },
+    status: "ended",
+  });
+
+  expect(queryByRole("button", { name: "End session" })).toBeNull();
+
+  await fireEvent.click(getByRole("button", { name: "New session" }));
+  expect(onNew).toHaveBeenCalledTimes(1);
+});

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  /**
+   * ChatPanel — the station's Chat tab: one AcpChat session controller wired to
+   * the header (status/mode/session actions), the transcript, and the composer.
+   *
+   * Sizing mirrors Terminal.svelte: a full-height bordered column whose middle
+   * row (the transcript) is the only scroller — `flex-1 min-h-0` so a long
+   * conversation never pushes the composer off screen.
+   *
+   * The controller owns every refusal rule; the panel's job is to never let the
+   * user lose text to one. `chat.busy` is true exactly when `prompt()` would
+   * refuse (create in flight / optimistic prompt awaiting its echo / agent
+   * working), and PromptInput only preserves a draft it wasn't allowed to send —
+   * so `busy` must reach it as `working` (mid-turn, where Stop is the action) or
+   * `disabled` (the create + echo window).
+   *
+   * Failures surface twice on purpose: an inline strip above the composer (with
+   * Retry when the transport is dead) plus a toast for a failed session create,
+   * which is the one failure that leaves nothing on screen to explain itself.
+   */
+  import { onMount } from "svelte";
+  import { toast } from "svelte-sonner";
+  import { Button } from "$lib/components/ui/button";
+  import { AcpChat } from "./acp-chat.svelte";
+  import ChatHeader from "./ChatHeader.svelte";
+  import Conversation from "./Conversation.svelte";
+  import PromptInput from "./PromptInput.svelte";
+
+  interface Props {
+    stationId: string;
+  }
+
+  let { stationId }: Props = $props();
+
+  // Plain (non-reactive) ref: the controller holds its own $state internally,
+  // so the template stays reactive while the instance itself is stable for the
+  // lifetime of the panel. The station is fixed at construction on purpose —
+  // the station page keys this panel on `stationId`, so a different station
+  // gets a fresh panel (and a fresh socket) rather than a rebound controller.
+  // svelte-ignore state_referenced_locally
+  let chat = new AcpChat(stationId);
+
+  onMount(() => {
+    void chat.init();
+    // Unmount (including a tab switch that drops this panel) closes the socket
+    // only — the session keeps running on the hub and is re-attached on return.
+    return () => chat.destroy();
+  });
+
+  /**
+   * Session status shown to the user. The transcript's status is stream truth
+   * (working → idle → ended) but starts at the `"starting"` placeholder, which
+   * an attached session that hasn't emitted a state event yet would sit on
+   * forever — so until the stream says otherwise, the session row's own status
+   * wins.
+   */
+  const status = $derived(
+    chat.transcript.status === "starting" && chat.session
+      ? chat.session.status
+      : chat.transcript.status,
+  );
+
+  async function handleSend(text: string) {
+    // The composer is already disabled in every refusal window; this guard just
+    // keeps a stale `error` from being re-toasted if one slips through.
+    if (chat.busy) return;
+    const beforeId = chat.session?.id ?? null;
+    const needsCreate = beforeId === null || chat.transcript.status === "ended";
+
+    await chat.prompt(text);
+
+    // A create that failed leaves the session unchanged and the message in
+    // `chat.error` — the strip shows it, but a toast is what gets noticed when
+    // the panel is otherwise empty.
+    if (needsCreate && chat.error !== null && (chat.session?.id ?? null) === beforeId) {
+      toast.error("Couldn't start the session", { description: chat.error });
+    }
+  }
+</script>
+
+<div class="flex h-full min-h-[320px] flex-col overflow-hidden rounded-lg border bg-background">
+  <div class="shrink-0 border-b px-3 py-2">
+    <ChatHeader
+      session={chat.session}
+      {status}
+      connection={chat.connection}
+      mode={chat.mode}
+      onModeChange={(mode) => chat.setMode(mode)}
+      onEnd={() => {
+        // While disconnected the DELETE still lands, but the ended state
+        // arrives over the event stream — the strip keeps saying "disconnected"
+        // until a retry reconnects and replays it. That's the honest reading.
+        void chat.end();
+      }}
+      onNew={() => chat.newSession()}
+    />
+  </div>
+
+  <div class="min-h-0 flex-1">
+    <Conversation
+      items={chat.transcript.items}
+      {status}
+      onAnswer={(requestSeq, optionId) => chat.answer(requestSeq, optionId)}
+    />
+  </div>
+
+  {#if chat.error}
+    <div class="flex shrink-0 items-center gap-2 border-t px-3 py-1.5" role="alert">
+      <p class="t-label min-w-0 flex-1 text-status-error">{chat.error}</p>
+      {#if chat.connection === "disconnected"}
+        <Button variant="ghost" size="xs" onclick={() => chat.retry()}>Retry</Button>
+      {/if}
+    </div>
+  {/if}
+
+  <div class="shrink-0 border-t p-3">
+    <PromptInput
+      working={chat.working}
+      disabled={chat.busy && !chat.working}
+      onSend={handleSend}
+      onCancel={() => chat.cancel()}
+    />
+  </div>
+</div>

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
@@ -7,12 +7,18 @@
    * row (the transcript) is the only scroller — `flex-1 min-h-0` so a long
    * conversation never pushes the composer off screen.
    *
-   * The controller owns every refusal rule; the panel's job is to never let the
-   * user lose text to one. `chat.busy` is true exactly when `prompt()` would
-   * refuse (create in flight / optimistic prompt awaiting its echo / agent
-   * working), and PromptInput only preserves a draft it wasn't allowed to send —
+   * The controller owns every refusal rule and the ONE status both the header and
+   * the composer read (`chat.status`) — a header saying "Working…" over an
+   * enabled Send button is how a prompt gets sent into someone else's turn and
+   * rejected. `chat.busy` is true exactly when `prompt()` would refuse (create in
+   * flight / optimistic prompt awaiting its echo / agent working / replay in
+   * flight), and PromptInput only preserves a draft it wasn't allowed to send —
    * so `busy` must reach it as `working` (mid-turn, where Stop is the action) or
-   * `disabled` (the create + echo window).
+   * `disabled` (every other refusal window).
+   *
+   * A prompt the hub rejects, or one lost with the socket, hands its text back
+   * through `onPromptFailed` — the controller drops the ghost bubble (which would
+   * otherwise keep `busy` true forever) and the draft reappears in the composer.
    *
    * Failures surface twice on purpose: an inline strip above the composer (with
    * Retry when the transport is dead) plus a toast for a failed session create,
@@ -32,13 +38,21 @@
 
   let { stationId }: Props = $props();
 
+  /** The composer's draft, owned here so a failed prompt can be handed back. */
+  let draft = $state("");
+
   // Plain (non-reactive) ref: the controller holds its own $state internally,
   // so the template stays reactive while the instance itself is stable for the
   // lifetime of the panel. The station is fixed at construction on purpose —
   // the station page keys this panel on `stationId`, so a different station
   // gets a fresh panel (and a fresh socket) rather than a rebound controller.
   // svelte-ignore state_referenced_locally
-  let chat = new AcpChat(stationId);
+  let chat = new AcpChat(stationId, {
+    onPromptFailed: (text) => {
+      // Don't clobber something the user has already started typing instead.
+      if (draft.trim().length === 0) draft = text;
+    },
+  });
 
   onMount(() => {
     void chat.init();
@@ -47,25 +61,12 @@
     return () => chat.destroy();
   });
 
-  /**
-   * Session status shown to the user. The transcript's status is stream truth
-   * (working → idle → ended) but starts at the `"starting"` placeholder, which
-   * an attached session that hasn't emitted a state event yet would sit on
-   * forever — so until the stream says otherwise, the session row's own status
-   * wins.
-   */
-  const status = $derived(
-    chat.transcript.status === "starting" && chat.session
-      ? chat.session.status
-      : chat.transcript.status,
-  );
-
   async function handleSend(text: string) {
     // The composer is already disabled in every refusal window; this guard just
     // keeps a stale `error` from being re-toasted if one slips through.
     if (chat.busy) return;
     const beforeId = chat.session?.id ?? null;
-    const needsCreate = beforeId === null || chat.transcript.status === "ended";
+    const needsCreate = beforeId === null || chat.status === "ended";
 
     await chat.prompt(text);
 
@@ -82,7 +83,7 @@
   <div class="shrink-0 border-b px-3 py-2">
     <ChatHeader
       session={chat.session}
-      {status}
+      status={chat.status}
       connection={chat.connection}
       mode={chat.mode}
       onModeChange={(mode) => chat.setMode(mode)}
@@ -99,7 +100,6 @@
   <div class="min-h-0 flex-1">
     <Conversation
       items={chat.transcript.items}
-      {status}
       onAnswer={(requestSeq, optionId) => chat.answer(requestSeq, optionId)}
     />
   </div>
@@ -115,6 +115,7 @@
 
   <div class="shrink-0 border-t p-3">
     <PromptInput
+      bind:value={draft}
       working={chat.working}
       disabled={chat.busy && !chat.working}
       onSend={handleSend}

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -231,13 +231,103 @@ test("the composer refuses sends while a create is in flight and until the echo 
   // Optimistic prompt still awaiting its echo → still refused.
   expect(box.readOnly).toBe(true);
 
+  // Replay still in flight is also a refusal window (the transcript, and so the
+  // status, isn't trustworthy yet).
   MockWebSocket.latest()!.fireMessage({
     t: "event",
     event: ev(1, "user-prompt", { text: "first" }),
   });
   await tick();
+  expect(box.readOnly).toBe(true);
+
+  MockWebSocket.latest()!.fireMessage({ t: "replay-done", lastSeq: 1 });
+  await tick();
   expect(box.readOnly).toBe(false);
   expect(box.getAttribute("aria-disabled")).toBeNull();
+});
+
+test("reattaching to a working session is not sendable, and says why", async () => {
+  // The header's status and the composer's must come from ONE machine: a header
+  // reading "Working…" over an enabled Send button is how a prompt gets fired
+  // into someone else's turn and rejected by the hub.
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ status: "working" })]);
+  const u = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  await tick();
+
+  // Before replay-done: transport state is what the user is told.
+  expect(u.getByText("Connecting…")).toBeTruthy();
+  expect(u.queryByRole("button", { name: "Send" })).toBeNull();
+  expect(u.getByRole("button", { name: "Stop the current turn" })).toBeTruthy();
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "cut in line" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  // Refused, and the draft is still there to send when the turn ends.
+  expect(box.value).toBe("cut in line");
+  expect(MockWebSocket.latest()!.frames()).not.toContainEqual({
+    t: "prompt",
+    text: "cut in line",
+  });
+
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await tick();
+  expect(u.getByText("Working…")).toBeTruthy(); // row status still says working
+
+  ws.fireMessage({ t: "event", event: ev(1, "state", { status: "idle" }) });
+  await tick();
+  expect(u.getByRole("button", { name: "Send" })).toBeTruthy();
+  expect(box.readOnly).toBe(false);
+});
+
+test("a prompt the hub rejects gives the text back and frees the composer", async () => {
+  const u = await renderConnected();
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "do it" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  await tick();
+  expect(u.getByText("do it")).toBeTruthy(); // optimistic bubble
+  expect(box.readOnly).toBe(true);
+
+  u.ws.fireMessage({
+    t: "event",
+    event: ev(0, "error", { message: "Session is busy — wait for the current turn to finish." }),
+  });
+  await tick();
+
+  // No ghost bubble wedging the composer, the text is back, the error is shown.
+  expect(u.queryByText("do it")).toBeNull();
+  expect(box.readOnly).toBe(false);
+  expect(box.value).toBe("do it");
+  expect(
+    u.getByText("Session is busy — wait for the current turn to finish."),
+  ).toBeTruthy();
+});
+
+test("a prompt lost with the socket comes back when the reconnect budget runs out", async () => {
+  vi.useFakeTimers();
+  const u = await renderConnected();
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "lost in transit" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  await tick();
+  expect(box.readOnly).toBe(true);
+
+  MockWebSocket.latest()!.drop();
+  await vi.advanceTimersByTimeAsync(1000);
+  MockWebSocket.latest()!.drop();
+  await vi.advanceTimersByTimeAsync(2000);
+  MockWebSocket.latest()!.drop();
+  await vi.advanceTimersByTimeAsync(4000);
+  MockWebSocket.latest()!.drop();
+  await tick();
+
+  expect(u.queryByText("lost in transit")).toBeNull(); // no ghost bubble
+  expect(box.readOnly).toBe(false);
+  expect(box.value).toBe("lost in transit");
+  expect(u.getByRole("button", { name: "Retry" })).toBeTruthy();
 });
 
 test("sending keeps focus in the composer, through the create and the echo", async () => {

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -206,7 +206,7 @@ test("the chosen mode chip seeds session creation", async () => {
   await waitFor(() => expect(create).toHaveBeenCalledWith("st1", "accept-edits"));
 });
 
-test("the composer is disabled while a create is in flight and until the echo lands", async () => {
+test("the composer refuses sends while a create is in flight and until the echo lands", async () => {
   const u = await renderIdle();
   let resolveCreate: (r: AcpSessionRow) => void = () => {};
   vi.spyOn(api, "createAcpSession").mockReturnValue(
@@ -222,20 +222,47 @@ test("the composer is disabled while a create is in flight and until the echo la
 
   // Create in flight: a second message must not be typeable-and-lost — the
   // controller would refuse it and PromptInput would clear the draft.
-  expect(box.disabled).toBe(true);
+  expect(box.readOnly).toBe(true);
+  expect(box.getAttribute("aria-disabled")).toBe("true");
 
   resolveCreate(row());
   await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
   await tick();
   // Optimistic prompt still awaiting its echo → still refused.
-  expect(box.disabled).toBe(true);
+  expect(box.readOnly).toBe(true);
 
   MockWebSocket.latest()!.fireMessage({
     t: "event",
     event: ev(1, "user-prompt", { text: "first" }),
   });
   await tick();
-  expect(box.disabled).toBe(false);
+  expect(box.readOnly).toBe(false);
+  expect(box.getAttribute("aria-disabled")).toBeNull();
+});
+
+test("sending keeps focus in the composer, through the create and the echo", async () => {
+  const u = await renderIdle();
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
+
+  const box = composer(u);
+  box.focus();
+  await fireEvent.input(box, { target: { value: "hello agent" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  await tick();
+
+  // The refusal window must never blur the composer: a keyboard user would
+  // otherwise land at <body> and have to Tab through the whole transcript
+  // (tool and permission cards are full of focusable controls) every turn.
+  expect(document.activeElement).toBe(box);
+
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  MockWebSocket.latest()!.fireMessage({
+    t: "event",
+    event: ev(1, "user-prompt", { text: "hello agent" }),
+  });
+  await tick();
+
+  expect(document.activeElement).toBe(box);
 });
 
 test("a failed create surfaces the strip and a toast, and stays sendable", async () => {
@@ -256,7 +283,7 @@ test("a failed create surfaces the strip and a toast, and stays sendable", async
   });
   // Nothing is live, so there's nothing to retry a connection to.
   expect(u.queryByRole("button", { name: "Retry" })).toBeNull();
-  expect(box.disabled).toBe(false);
+  expect(box.readOnly).toBe(false);
 });
 
 // ─── Turn controls ──────────────────────────────────────────────────────────

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -1,0 +1,362 @@
+/**
+ * ChatPanel.svelte.test.ts
+ *
+ * Integration tests for the composed chat panel: the REAL AcpChat controller
+ * driving the real header / conversation / composer against a mocked api layer
+ * (REST spies + a MockWebSocket global). Only Response.svelte is stubbed —
+ * its streamdown/shiki renderer isn't jsdom-friendly.
+ *
+ * Run: cd apps/console && pnpm test src/lib/components/stations/chat/ChatPanel
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import type { AcpEvent, AcpSessionRow } from "@agentpod/contract";
+import * as api from "$lib/api/acp";
+
+// The streamdown-backed markdown renderer doesn't run reliably in jsdom.
+vi.mock("./Response.svelte", () => import("./response.stub.svelte"));
+
+vi.mock("svelte-sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { toast } from "svelte-sonner";
+// Static import: compiled during file collection, not inside a waitFor window.
+import ChatPanel from "./ChatPanel.svelte";
+
+// ─── Minimal WebSocket stub (mirrors acp-chat.svelte.test.ts) ────────────────
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static latest(): MockWebSocket | null {
+    return MockWebSocket.instances.at(-1) ?? null;
+  }
+
+  url: string;
+  readyState = 0; // CONNECTING
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3; // CLOSED
+    this.onclose?.(new CloseEvent("close"));
+  }
+
+  open() {
+    this.readyState = 1; // OPEN
+    this.onopen?.(new Event("open"));
+  }
+
+  fireMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+
+  drop() {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent("close"));
+  }
+
+  frames(): unknown[] {
+    return this.sent.map((s) => JSON.parse(s));
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.mocked(toast.error).mockClear();
+  MockWebSocket.instances = [];
+  localStorage.setItem("agentpod.apiUrl", "http://hub.test:3001");
+  (globalThis as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  MockWebSocket.instances = [];
+  localStorage.clear();
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+function row(over: Partial<AcpSessionRow> = {}): AcpSessionRow {
+  return {
+    id: "s1",
+    stationId: "st1",
+    userId: "u1",
+    mode: "ask",
+    status: "idle",
+    endedReason: null,
+    createdAt: "2026-08-09T00:00:00.000Z",
+    lastEventAt: "2026-08-09T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function ev(seq: number, type: AcpEvent["type"], payload: unknown): AcpEvent {
+  return { sessionId: "s1", seq, type, payload, createdAt: "2026-08-09T00:00:01.000Z" };
+}
+
+/** Renders the panel with no live session (the empty-state path). */
+async function renderIdle() {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([]);
+  const utils = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(api.listAcpSessions).toHaveBeenCalledWith("st1"));
+  await tick();
+  return utils;
+}
+
+/** Renders the panel attached to an existing idle session, fully connected. */
+async function renderConnected() {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const utils = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "session", session: row() });
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await tick();
+  return { ...utils, ws };
+}
+
+const composer = (u: { getByPlaceholderText: (t: string) => HTMLElement }) =>
+  u.getByPlaceholderText("Message the agent…") as HTMLTextAreaElement;
+
+// ─── Mount / attach ─────────────────────────────────────────────────────────
+
+test("mounts, lists sessions, and shows the empty state when there is none", async () => {
+  const u = await renderIdle();
+
+  expect(u.getByText("No conversation yet.")).toBeTruthy();
+  expect(u.getByText("No session")).toBeTruthy();
+  expect(MockWebSocket.instances).toHaveLength(0);
+  // No session → no destructive action offered yet.
+  expect(u.queryByRole("button", { name: "End session" })).toBeNull();
+});
+
+test("attaches to a live session: subscribes and reports the session status", async () => {
+  const u = await renderConnected();
+
+  expect(u.ws.url).toContain("/api/acp/sessions/s1/ws");
+  expect(u.ws.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]);
+  expect(u.getByText("Idle")).toBeTruthy();
+  expect(u.getByRole("button", { name: "End session" })).toBeTruthy();
+});
+
+test("renders replayed transcript items", async () => {
+  const u = await renderConnected();
+
+  u.ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "run the tests" }) });
+  u.ws.fireMessage({
+    t: "event",
+    event: ev(2, "agent-update", {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "on it" },
+    }),
+  });
+  await tick();
+
+  expect(u.getByText("run the tests")).toBeTruthy();
+  expect(u.getByTestId("response-stub").textContent).toContain("on it");
+});
+
+// ─── First prompt (session creation) ────────────────────────────────────────
+
+test("typing + Enter with no session creates one and shows the optimistic bubble", async () => {
+  const u = await renderIdle();
+  const create = vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "hello agent" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(create).toHaveBeenCalledWith("st1", "ask"));
+  await tick();
+
+  expect(u.getByText("hello agent")).toBeTruthy();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  expect(ws.frames()).toEqual([
+    { t: "subscribe", sinceSeq: 0 },
+    { t: "prompt", text: "hello agent" },
+  ]);
+});
+
+test("the chosen mode chip seeds session creation", async () => {
+  const u = await renderIdle();
+  const create = vi.spyOn(api, "createAcpSession").mockResolvedValue(row({ mode: "accept-edits" }));
+
+  await fireEvent.click(u.getByRole("button", { name: "Accept edits" }));
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "edit away" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(create).toHaveBeenCalledWith("st1", "accept-edits"));
+});
+
+test("the composer is disabled while a create is in flight and until the echo lands", async () => {
+  const u = await renderIdle();
+  let resolveCreate: (r: AcpSessionRow) => void = () => {};
+  vi.spyOn(api, "createAcpSession").mockReturnValue(
+    new Promise<AcpSessionRow>((res) => {
+      resolveCreate = res;
+    }),
+  );
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "first" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  await tick();
+
+  // Create in flight: a second message must not be typeable-and-lost — the
+  // controller would refuse it and PromptInput would clear the draft.
+  expect(box.disabled).toBe(true);
+
+  resolveCreate(row());
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  await tick();
+  // Optimistic prompt still awaiting its echo → still refused.
+  expect(box.disabled).toBe(true);
+
+  MockWebSocket.latest()!.fireMessage({
+    t: "event",
+    event: ev(1, "user-prompt", { text: "first" }),
+  });
+  await tick();
+  expect(box.disabled).toBe(false);
+});
+
+test("a failed create surfaces the strip and a toast, and stays sendable", async () => {
+  const u = await renderIdle();
+  vi.spyOn(api, "createAcpSession").mockRejectedValue(
+    new Error("Couldn't start a session — the node is offline."),
+  );
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "hello" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() =>
+    expect(u.getByText("Couldn't start a session — the node is offline.")).toBeTruthy(),
+  );
+  expect(toast.error).toHaveBeenCalledWith("Couldn't start the session", {
+    description: "Couldn't start a session — the node is offline.",
+  });
+  // Nothing is live, so there's nothing to retry a connection to.
+  expect(u.queryByRole("button", { name: "Retry" })).toBeNull();
+  expect(box.disabled).toBe(false);
+});
+
+// ─── Turn controls ──────────────────────────────────────────────────────────
+
+test("while working the composer offers Stop, which cancels the turn", async () => {
+  const u = await renderConnected();
+  u.ws.fireMessage({ t: "event", event: ev(1, "state", { status: "working" }) });
+  await tick();
+
+  expect(u.queryByRole("button", { name: "Send" })).toBeNull();
+  await fireEvent.click(u.getByRole("button", { name: "Stop the current turn" }));
+
+  expect(u.ws.frames()).toContainEqual({ t: "cancel" });
+  expect(u.getByText("Working…")).toBeTruthy();
+});
+
+test("answering a permission request sends permission-answer for that request", async () => {
+  const u = await renderConnected();
+  u.ws.fireMessage({
+    t: "event",
+    event: ev(4, "permission-request", {
+      toolCall: { toolCallId: "t9", title: "Run rm -rf ./dist", kind: "execute" },
+      options: [
+        { optionId: "allow", name: "Allow", kind: "allow_once" },
+        { optionId: "reject", name: "Reject", kind: "reject_once" },
+      ],
+    }),
+  });
+  await tick();
+
+  await fireEvent.click(u.getByRole("button", { name: "Allow" }));
+
+  expect(u.ws.frames()).toContainEqual({
+    t: "permission-answer",
+    requestSeq: 4,
+    optionId: "allow",
+  });
+});
+
+test("ending a session goes through the confirm dialog and DELETEs", async () => {
+  const u = await renderConnected();
+  const end = vi.spyOn(api, "endAcpSession").mockResolvedValue(undefined);
+
+  await fireEvent.click(u.getByRole("button", { name: "End session" }));
+  const confirm = await waitFor(() => {
+    const buttons = u.getAllByRole("button", { name: "End session" });
+    const inDialog = buttons.find((b) => b.closest('[role="dialog"]') !== null);
+    if (!inDialog) throw new Error("confirm button not rendered yet");
+    return inDialog;
+  });
+  await fireEvent.click(confirm);
+
+  await waitFor(() => expect(end).toHaveBeenCalledWith("s1"));
+});
+
+test("after the session ends, New session returns to the empty state", async () => {
+  const u = await renderConnected();
+  u.ws.fireMessage({ t: "event", event: ev(1, "state", { status: "ended", reason: "done" }) });
+  await tick();
+  expect(u.getByText("Ended")).toBeTruthy();
+
+  await fireEvent.click(u.getByRole("button", { name: "New session" }));
+  await tick();
+
+  expect(u.getByText("No conversation yet.")).toBeTruthy();
+  expect(u.getByText("No session")).toBeTruthy();
+});
+
+// ─── Connection failures ────────────────────────────────────────────────────
+
+test("an exhausted reconnect budget shows the offline strip with a working Retry", async () => {
+  vi.useFakeTimers();
+  const u = await renderConnected();
+
+  MockWebSocket.latest()!.drop();
+  await vi.advanceTimersByTimeAsync(1000);
+  MockWebSocket.latest()!.drop();
+  await vi.advanceTimersByTimeAsync(2000);
+  MockWebSocket.latest()!.drop();
+  await vi.advanceTimersByTimeAsync(4000);
+  MockWebSocket.latest()!.drop();
+  await tick();
+
+  expect(u.getByText("Couldn't reach the hub — check your connection.")).toBeTruthy();
+  expect(u.getByText("Disconnected")).toBeTruthy();
+
+  const before = MockWebSocket.instances.length;
+  await fireEvent.click(u.getByRole("button", { name: "Retry" }));
+  await tick();
+
+  expect(MockWebSocket.instances.length).toBe(before + 1);
+  expect(u.queryByText("Couldn't reach the hub — check your connection.")).toBeNull();
+});
+
+test("unmount closes the socket but never ends the session", async () => {
+  const u = await renderConnected();
+  const end = vi.spyOn(api, "endAcpSession");
+
+  u.unmount();
+
+  expect(u.ws.readyState).toBe(3);
+  expect(end).not.toHaveBeenCalled();
+});

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte
@@ -52,14 +52,41 @@
   let follow = $state(true);
   let newItemsCount = $state(0);
   let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * A pin was requested while the container had no layout. The station page
+   * keeps this panel mounted-but-`display:none` across tab switches, and a
+   * hidden element reports `scrollHeight === 0` — pinning then would park the
+   * transcript at the top, following, with nothing to re-trigger it. The pin is
+   * held here and replayed when layout comes back (resize) or items change.
+   */
+  let pinPending = false;
+
+  /** Pin to the newest message. Returns false when there's no layout to pin to. */
+  function pinToBottom(): boolean {
+    if (!containerEl || containerEl.scrollHeight === 0) return false;
+    containerEl.scrollTop = containerEl.scrollHeight;
+    return true;
+  }
 
   function queueScrollToBottom() {
     if (scrollTimer !== null) clearTimeout(scrollTimer);
     scrollTimer = setTimeout(() => {
       scrollTimer = null;
-      if (containerEl) containerEl.scrollTop = containerEl.scrollHeight;
+      pinPending = !pinToBottom();
     }, 0);
   }
+
+  // Becoming visible again resizes the container from 0 → its real height; that
+  // is the signal to replay a pin deferred while the panel was hidden.
+  $effect(() => {
+    const el = containerEl;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      if (pinPending && follow) queueScrollToBottom();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  });
 
   // A manual scroll away from the bottom (>~40px) pauses follow; scrolling
   // back to within the threshold re-enables it.
@@ -103,7 +130,9 @@
     } else if (added < 0) {
       // Transcript replaced (new session) — reset the pill.
       newItemsCount = 0;
-    } else if (tailGrew && follow) {
+    } else if ((tailGrew || pinPending) && follow) {
+      // pinPending: a pin deferred while hidden gets another chance on every
+      // items change, in case the resize signal never arrives.
       queueScrollToBottom();
     }
   });
@@ -145,7 +174,11 @@
   $effect(() => {
     const s = status;
     if (prevStatus !== null && s !== prevStatus) {
-      const msg = STATUS_ANNOUNCEMENTS[s];
+      // "starting" doubles as the transcript's placeholder before any state
+      // event lands, so its resolution to idle is bookkeeping, not news — the
+      // agent never did anything to become idle from.
+      const placeholderResolved = prevStatus === "starting" && s === "idle";
+      const msg = placeholderResolved ? undefined : STATUS_ANNOUNCEMENTS[s];
       if (msg) announcement = msg;
     }
     prevStatus = s;

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+  /**
+   * Conversation — the chat transcript list with follow-tail mechanics.
+   *
+   * Renders ChatItems by kind and keeps the viewport pinned to the newest
+   * message while the reader is at (or near) the bottom — the same follow
+   * model as LogTail: scrolling >40px away pauses follow and new arrivals
+   * count into a floating "N new messages" pill; scrolling back down (or
+   * clicking the pill) re-engages. Streaming growth of the trailing
+   * assistant/reasoning item also holds the pin while following.
+   *
+   * Items are keyed by stable identity (toolCallId / requestSeq / seq) so
+   * Svelte reuses component instances correctly — ToolCallCard and Reasoning
+   * carry edge-triggered collapse state that unkeyed reuse would corrupt.
+   *
+   * An sr-only polite live region announces new permission requests
+   * ("Agent asks to <title>") and working/idle/ended status flips.
+   */
+  import { onDestroy } from "svelte";
+  import type { AcpSessionStatus } from "@agentpod/contract";
+  import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
+  import MessageSquareIcon from "@lucide/svelte/icons/message-square";
+  import { Empty } from "$lib/components/ui/empty";
+  import { cn } from "$lib/utils";
+  import Response from "./Response.svelte";
+  import Reasoning from "./Reasoning.svelte";
+  import ToolCallCard from "./ToolCallCard.svelte";
+  import PermissionCard from "./PermissionCard.svelte";
+  import type { ChatItem } from "./transcript";
+
+  interface Props {
+    items: ChatItem[];
+    status: AcpSessionStatus;
+    onAnswer: (requestSeq: number, optionId: string) => void;
+  }
+
+  let { items, status, onAnswer }: Props = $props();
+
+  /** Stable identity per item — tool/permission items mutate in place across
+   * folds (status updates, answers) and streaming items grow, so the key must
+   * come from their identity, never the array index or object reference. */
+  function keyOf(item: ChatItem): string {
+    if (item.kind === "tool") return `tool:${item.toolCallId}`;
+    if (item.kind === "permission") return `permission:${item.requestSeq}`;
+    return `${item.kind}:${item.seq}`;
+  }
+
+  // ── Follow-tail (mirrors LogTail) ─────────────────────────────────────────
+  const FOLLOW_THRESHOLD_PX = 40;
+
+  let containerEl = $state<HTMLElement | null>(null);
+  let follow = $state(true);
+  let newItemsCount = $state(0);
+  let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function queueScrollToBottom() {
+    if (scrollTimer !== null) clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(() => {
+      scrollTimer = null;
+      if (containerEl) containerEl.scrollTop = containerEl.scrollHeight;
+    }, 0);
+  }
+
+  // A manual scroll away from the bottom (>~40px) pauses follow; scrolling
+  // back to within the threshold re-enables it.
+  function handleScroll() {
+    if (!containerEl) return;
+    const distanceFromBottom =
+      containerEl.scrollHeight - containerEl.scrollTop - containerEl.clientHeight;
+    if (distanceFromBottom > FOLLOW_THRESHOLD_PX) {
+      follow = false;
+    } else {
+      follow = true;
+      newItemsCount = 0;
+    }
+  }
+
+  function jumpToBottom() {
+    follow = true;
+    newItemsCount = 0;
+    queueScrollToBottom();
+  }
+
+  // Growth detection: new items scroll (following) or count into the pill
+  // (paused); trailing-item TEXT growth (a streaming chunk that extends the
+  // last item without appending one) also scrolls while following. Plain lets
+  // hold the previous frame — they must never retrigger the effect.
+  let prevCount = 0;
+  let prevTailLen = 0;
+  $effect(() => {
+    const count = items.length;
+    const tail = items.at(-1);
+    const tailLen =
+      tail && (tail.kind === "assistant" || tail.kind === "reasoning") ? tail.text.length : 0;
+    const added = count - prevCount;
+    const tailGrew = added === 0 && tailLen > prevTailLen;
+    prevCount = count;
+    prevTailLen = tailLen;
+
+    if (added > 0) {
+      if (follow) queueScrollToBottom();
+      else newItemsCount += added;
+    } else if (added < 0) {
+      // Transcript replaced (new session) — reset the pill.
+      newItemsCount = 0;
+    } else if (tailGrew && follow) {
+      queueScrollToBottom();
+    }
+  });
+
+  onDestroy(() => {
+    if (scrollTimer !== null) {
+      clearTimeout(scrollTimer);
+      scrollTimer = null;
+    }
+  });
+
+  // ── Screen-reader announcements ───────────────────────────────────────────
+  const STATUS_ANNOUNCEMENTS: Partial<Record<AcpSessionStatus, string>> = {
+    working: "Agent is working.",
+    idle: "Agent is idle.",
+    ended: "Session ended.",
+  };
+
+  let announcement = $state("");
+  let announcedPermSeq: number | null = null;
+  let prevStatus: AcpSessionStatus | null = null;
+
+  // A newly arrived permission request (including one already parked when the
+  // transcript mounts) is the most actionable thing in the stream — announce.
+  $effect(() => {
+    const perm = items.findLast(
+      (it): it is Extract<ChatItem, { kind: "permission" }> => it.kind === "permission",
+    );
+    if (perm && perm.requestSeq !== announcedPermSeq) {
+      announcedPermSeq = perm.requestSeq;
+      announcement = `Agent asks to ${perm.title}`;
+    }
+  });
+
+  // Status FLIPS only — the initial value is visible in the header already.
+  $effect(() => {
+    const s = status;
+    if (prevStatus !== null && s !== prevStatus) {
+      const msg = STATUS_ANNOUNCEMENTS[s];
+      if (msg) announcement = msg;
+    }
+    prevStatus = s;
+  });
+</script>
+
+<div class="relative h-full min-h-0">
+  <div
+    bind:this={containerEl}
+    data-testid="chat-scroll-container"
+    class="h-full overflow-y-auto"
+    onscroll={handleScroll}
+  >
+    {#if items.length === 0}
+      <Empty
+        title="No conversation yet."
+        description="Send a prompt to start talking to this agent."
+        icon={MessageSquareIcon}
+        class="h-full border-none"
+      />
+    {:else}
+      <div class="flex flex-col gap-3 p-3">
+        {#each items as item (keyOf(item))}
+          <div class="chat-item">
+            {#if item.kind === "user"}
+              <div class="flex justify-end">
+                <div
+                  class={cn(
+                    "t-body max-w-[85%] rounded-lg bg-primary/10 px-3 py-2 whitespace-pre-wrap break-words",
+                    item.pending && "opacity-60",
+                  )}
+                >
+                  {item.text}
+                </div>
+              </div>
+            {:else if item.kind === "assistant"}
+              <Response text={item.text} streaming={item.streaming} />
+            {:else if item.kind === "reasoning"}
+              <Reasoning text={item.text} streaming={item.streaming} />
+            {:else if item.kind === "tool"}
+              <ToolCallCard {item} />
+            {:else if item.kind === "permission"}
+              <PermissionCard
+                {item}
+                onAnswer={(optionId) => onAnswer(item.requestSeq, optionId)}
+              />
+            {:else if item.kind === "notice"}
+              <p
+                class={cn(
+                  "t-label text-center",
+                  item.level === "error" ? "text-status-error" : "text-muted-foreground",
+                )}
+              >
+                {item.text}
+              </p>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  {#if !follow && newItemsCount > 0}
+    <button
+      type="button"
+      class="absolute bottom-2 left-1/2 -translate-x-1/2 flex items-center gap-1 rounded-full border bg-background px-3 py-1 text-xs shadow-md hover:bg-muted"
+      onclick={jumpToBottom}
+    >
+      {newItemsCount} new {newItemsCount === 1 ? "message" : "messages"}
+      <ArrowDownIcon class="size-3" aria-hidden="true" />
+    </button>
+  {/if}
+
+  <div data-testid="chat-announcer" aria-live="polite" class="sr-only">{announcement}</div>
+</div>
+
+<style>
+  /* Long transcripts: skip layout/paint for offscreen items. The intrinsic
+     placeholder keeps scrollbar geometry sane before an item is rendered. */
+  .chat-item {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 4rem;
+  }
+</style>

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte
@@ -126,11 +126,14 @@
   let announcedPermSeq: number | null = null;
   let prevStatus: AcpSessionStatus | null = null;
 
-  // A newly arrived permission request (including one already parked when the
-  // transcript mounts) is the most actionable thing in the stream — announce.
+  // A newly arrived UNANSWERED permission request (including one already
+  // parked when the transcript mounts) is the most actionable thing in the
+  // stream — announce. Answered ones are history: a replayed transcript must
+  // not announce a dead ask.
   $effect(() => {
     const perm = items.findLast(
-      (it): it is Extract<ChatItem, { kind: "permission" }> => it.kind === "permission",
+      (it): it is Extract<ChatItem, { kind: "permission" }> =>
+        it.kind === "permission" && !it.answer,
     );
     if (perm && perm.requestSeq !== announcedPermSeq) {
       announcedPermSeq = perm.requestSeq;

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte
@@ -14,10 +14,11 @@
    * carry edge-triggered collapse state that unkeyed reuse would corrupt.
    *
    * An sr-only polite live region announces new permission requests
-   * ("Agent asks to <title>") and working/idle/ended status flips.
+   * ("Agent asks to <title>"). Session STATUS is deliberately not announced
+   * here — ChatHeader's role="status" region owns that, and two owners meant
+   * every flip was read twice.
    */
   import { onDestroy } from "svelte";
-  import type { AcpSessionStatus } from "@agentpod/contract";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
   import MessageSquareIcon from "@lucide/svelte/icons/message-square";
   import { Empty } from "$lib/components/ui/empty";
@@ -30,11 +31,10 @@
 
   interface Props {
     items: ChatItem[];
-    status: AcpSessionStatus;
     onAnswer: (requestSeq: number, optionId: string) => void;
   }
 
-  let { items, status, onAnswer }: Props = $props();
+  let { items, onAnswer }: Props = $props();
 
   /** Stable identity per item — tool/permission items mutate in place across
    * folds (status updates, answers) and streaming items grow, so the key must
@@ -145,15 +145,9 @@
   });
 
   // ── Screen-reader announcements ───────────────────────────────────────────
-  const STATUS_ANNOUNCEMENTS: Partial<Record<AcpSessionStatus, string>> = {
-    working: "Agent is working.",
-    idle: "Agent is idle.",
-    ended: "Session ended.",
-  };
 
   let announcement = $state("");
   let announcedPermSeq: number | null = null;
-  let prevStatus: AcpSessionStatus | null = null;
 
   // A newly arrived UNANSWERED permission request (including one already
   // parked when the transcript mounts) is the most actionable thing in the
@@ -168,20 +162,6 @@
       announcedPermSeq = perm.requestSeq;
       announcement = `Agent asks to ${perm.title}`;
     }
-  });
-
-  // Status FLIPS only — the initial value is visible in the header already.
-  $effect(() => {
-    const s = status;
-    if (prevStatus !== null && s !== prevStatus) {
-      // "starting" doubles as the transcript's placeholder before any state
-      // event lands, so its resolution to idle is bookkeeping, not news — the
-      // agent never did anything to become idle from.
-      const placeholderResolved = prevStatus === "starting" && s === "idle";
-      const msg = placeholderResolved ? undefined : STATUS_ANNOUNCEMENTS[s];
-      if (msg) announcement = msg;
-    }
-    prevStatus = s;
   });
 </script>
 

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
@@ -100,6 +100,34 @@ test("aria-live region announces the latest permission request", async () => {
   await waitFor(() => expect(region.textContent).toContain("Agent asks to run go test"));
 });
 
+test("an already-answered permission is not announced on mount", async () => {
+  const { getByTestId } = render(Conversation, {
+    props: {
+      items: [permissionItem({ answer: { optionId: "allow-1" } })],
+      status: "idle",
+      onAnswer: vi.fn(),
+    },
+  });
+
+  // Let effects flush before asserting the region stayed silent.
+  await new Promise((r) => setTimeout(r, 0));
+  expect(getByTestId("chat-announcer").textContent ?? "").not.toContain("Agent asks");
+});
+
+test("a permission announces when unanswered, and answering does not re-announce", async () => {
+  const { getByTestId, rerender } = render(Conversation, {
+    props: { items: [permissionItem()], status: "waiting", onAnswer: vi.fn() },
+  });
+
+  const region = getByTestId("chat-announcer");
+  await waitFor(() => expect(region.textContent).toContain("Agent asks to run go test"));
+
+  // The answer folds in; the region content is unchanged (no dead re-announce).
+  await rerender({ items: [permissionItem({ answer: { optionId: "allow-1" } })] as ChatItem[] });
+  await new Promise((r) => setTimeout(r, 0));
+  expect(region.textContent).toContain("Agent asks to run go test");
+});
+
 test("aria-live region announces status flips", async () => {
   const { getByTestId, rerender } = render(Conversation, {
     props: { items: [], status: "working", onAnswer: vi.fn() },

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
@@ -79,7 +79,7 @@ test("renders every item kind", async () => {
   ];
 
   const { getByText, getByTestId } = render(Conversation, {
-    props: { items, status: "idle", onAnswer: vi.fn() },
+    props: { items, onAnswer: vi.fn() },
   });
 
   // user bubble + pending opacity
@@ -106,7 +106,7 @@ test("renders every item kind", async () => {
 
 test("empty state renders Empty copy", () => {
   const { getByText } = render(Conversation, {
-    props: { items: [], status: "starting", onAnswer: vi.fn() },
+    props: { items: [], onAnswer: vi.fn() },
   });
   expect(getByText("No conversation yet.")).toBeTruthy();
   expect(getByText("Send a prompt to start talking to this agent.")).toBeTruthy();
@@ -115,7 +115,7 @@ test("empty state renders Empty copy", () => {
 test("permission answers are curried with the item's requestSeq", async () => {
   const onAnswer = vi.fn();
   const { getByText } = render(Conversation, {
-    props: { items: [permissionItem({ requestSeq: 9, seq: 9 })], status: "waiting", onAnswer },
+    props: { items: [permissionItem({ requestSeq: 9, seq: 9 })], onAnswer },
   });
 
   await fireEvent.click(getByText("Allow"));
@@ -124,7 +124,7 @@ test("permission answers are curried with the item's requestSeq", async () => {
 
 test("aria-live region announces the latest permission request", async () => {
   const { getByTestId } = render(Conversation, {
-    props: { items: [permissionItem()], status: "waiting", onAnswer: vi.fn() },
+    props: { items: [permissionItem()], onAnswer: vi.fn() },
   });
 
   const region = getByTestId("chat-announcer");
@@ -136,7 +136,6 @@ test("an already-answered permission is not announced on mount", async () => {
   const { getByTestId } = render(Conversation, {
     props: {
       items: [permissionItem({ answer: { optionId: "allow-1" } })],
-      status: "idle",
       onAnswer: vi.fn(),
     },
   });
@@ -148,7 +147,7 @@ test("an already-answered permission is not announced on mount", async () => {
 
 test("a permission announces when unanswered, and answering does not re-announce", async () => {
   const { getByTestId, rerender } = render(Conversation, {
-    props: { items: [permissionItem()], status: "waiting", onAnswer: vi.fn() },
+    props: { items: [permissionItem()], onAnswer: vi.fn() },
   });
 
   const region = getByTestId("chat-announcer");
@@ -160,33 +159,16 @@ test("a permission announces when unanswered, and answering does not re-announce
   expect(region.textContent).toContain("Agent asks to run go test");
 });
 
-test("resolving the starting placeholder to idle is not announced", async () => {
-  const { getByTestId, rerender } = render(Conversation, {
-    props: { items: [], status: "starting", onAnswer: vi.fn() },
-  });
-
-  // ChatPanel shows the transcript's "starting" placeholder until the attached
-  // session's real status arrives — that flip is bookkeeping, not news.
-  await rerender({ status: "idle" });
-  await new Promise((r) => setTimeout(r, 0));
-  expect(getByTestId("chat-announcer").textContent ?? "").not.toContain("Agent is idle.");
-
-  // A genuine flip out of the placeholder still announces.
-  await rerender({ status: "working" });
-  await waitFor(() => expect(getByTestId("chat-announcer").textContent).toContain("working"));
-});
-
-test("aria-live region announces status flips", async () => {
-  const { getByTestId, rerender } = render(Conversation, {
-    props: { items: [], status: "working", onAnswer: vi.fn() },
+test("the announcer carries permissions only — status has a single owner in the header", async () => {
+  const { getByTestId } = render(Conversation, {
+    props: { items: [permissionItem()], onAnswer: vi.fn() },
   });
 
   const region = getByTestId("chat-announcer");
-  // First render is not a flip — nothing to announce yet.
-  expect(region.textContent ?? "").not.toContain("idle");
-
-  await rerender({ status: "idle" });
-  await waitFor(() => expect(region.textContent).toContain("Agent is idle."));
+  await waitFor(() => expect(region.textContent).toContain("Agent asks to run go test"));
+  // ChatHeader's role="status" region announces working/idle/ended; announcing
+  // here too meant every flip was read out twice.
+  expect(region.textContent ?? "").not.toContain("Agent is");
 });
 
 test("scroll-away pauses follow; new items show a pill; clicking jumps back", async () => {
@@ -195,7 +177,7 @@ test("scroll-away pauses follow; new items show a pill; clicking jumps back", as
     { kind: "assistant", seq: 2, text: "two", streaming: false },
   ];
   const { getByTestId, getByText, queryByText, rerender } = render(Conversation, {
-    props: { items, status: "working", onAnswer: vi.fn() },
+    props: { items, onAnswer: vi.fn() },
   });
 
   const container = getByTestId("chat-scroll-container");
@@ -222,7 +204,7 @@ test("scroll-away pauses follow; new items show a pill; clicking jumps back", as
 test("a pin requested while the panel is hidden is replayed when layout returns", async () => {
   const items: ChatItem[] = [{ kind: "user", seq: 1, text: "one" }];
   const { getByTestId, queryByText, rerender } = render(Conversation, {
-    props: { items, status: "working", onAnswer: vi.fn() },
+    props: { items, onAnswer: vi.fn() },
   });
 
   const container = getByTestId("chat-scroll-container");
@@ -261,7 +243,7 @@ test("a pin requested while the panel is hidden is replayed when layout returns"
 test("streaming growth of the trailing item scrolls to bottom while following", async () => {
   const items: ChatItem[] = [{ kind: "assistant", seq: 1, text: "a", streaming: true }];
   const { getByTestId, rerender } = render(Conversation, {
-    props: { items, status: "working", onAnswer: vi.fn() },
+    props: { items, onAnswer: vi.fn() },
   });
 
   const container = getByTestId("chat-scroll-container");

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi } from "vitest";
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, waitFor, fireEvent } from "@testing-library/svelte";
 import type { ChatItem } from "./transcript";
 
@@ -7,6 +7,38 @@ vi.mock("./Response.svelte", () => import("./response.stub.svelte"));
 
 // Static import: compiled during file collection, not inside a test's waitFor.
 import Conversation from "./Conversation.svelte";
+
+// A drivable ResizeObserver: the component observes its scroll container to
+// learn when a hidden (keep-alive) panel comes back and gets its layout, and the
+// global vitest stub never fires callbacks.
+class DrivableResizeObserver {
+  static callbacks: Array<() => void> = [];
+  constructor(private cb: () => void) {
+    DrivableResizeObserver.callbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    DrivableResizeObserver.callbacks = DrivableResizeObserver.callbacks.filter(
+      (c) => c !== this.cb,
+    );
+  }
+  /** Test helper: every live observer reports a resize. */
+  static fire() {
+    for (const cb of [...DrivableResizeObserver.callbacks]) cb();
+  }
+}
+
+const realResizeObserver = globalThis.ResizeObserver;
+
+beforeEach(() => {
+  DrivableResizeObserver.callbacks = [];
+  globalThis.ResizeObserver = DrivableResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  globalThis.ResizeObserver = realResizeObserver;
+});
 
 function toolItem(overrides: Partial<Extract<ChatItem, { kind: "tool" }>> = {}): ChatItem {
   return {
@@ -128,6 +160,22 @@ test("a permission announces when unanswered, and answering does not re-announce
   expect(region.textContent).toContain("Agent asks to run go test");
 });
 
+test("resolving the starting placeholder to idle is not announced", async () => {
+  const { getByTestId, rerender } = render(Conversation, {
+    props: { items: [], status: "starting", onAnswer: vi.fn() },
+  });
+
+  // ChatPanel shows the transcript's "starting" placeholder until the attached
+  // session's real status arrives — that flip is bookkeeping, not news.
+  await rerender({ status: "idle" });
+  await new Promise((r) => setTimeout(r, 0));
+  expect(getByTestId("chat-announcer").textContent ?? "").not.toContain("Agent is idle.");
+
+  // A genuine flip out of the placeholder still announces.
+  await rerender({ status: "working" });
+  await waitFor(() => expect(getByTestId("chat-announcer").textContent).toContain("working"));
+});
+
 test("aria-live region announces status flips", async () => {
   const { getByTestId, rerender } = render(Conversation, {
     props: { items: [], status: "working", onAnswer: vi.fn() },
@@ -169,6 +217,45 @@ test("scroll-away pauses follow; new items show a pill; clicking jumps back", as
 
   await fireEvent.click(getByText(/2 new messages/));
   await waitFor(() => expect(queryByText(/new messages/)).toBeNull());
+});
+
+test("a pin requested while the panel is hidden is replayed when layout returns", async () => {
+  const items: ChatItem[] = [{ kind: "user", seq: 1, text: "one" }];
+  const { getByTestId, queryByText, rerender } = render(Conversation, {
+    props: { items, status: "working", onAnswer: vi.fn() },
+  });
+
+  const container = getByTestId("chat-scroll-container");
+  let scrollTop = 0;
+  // display:none (the station page keeps this panel alive across tab switches):
+  // no layout at all, so scrollHeight reads 0.
+  let scrollHeight = 0;
+  Object.defineProperty(container, "scrollTop", {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, "scrollHeight", { get: () => scrollHeight, configurable: true });
+  Object.defineProperty(container, "clientHeight", {
+    get: () => (scrollHeight === 0 ? 0 : 200),
+    configurable: true,
+  });
+
+  // The agent replies while the panel is hidden.
+  await rerender({
+    items: [...items, { kind: "assistant", seq: 2, text: "two", streaming: false }] as ChatItem[],
+  });
+  await new Promise((r) => setTimeout(r, 0));
+  expect(scrollTop).toBe(0); // nothing to pin to yet
+  expect(queryByText(/new message/)).toBeNull(); // still following: no pill
+
+  // Back on the Chat tab: layout returns, which resizes the container.
+  scrollHeight = 800;
+  DrivableResizeObserver.fire();
+
+  await waitFor(() => expect(scrollTop).toBe(800));
 });
 
 test("streaming growth of the trailing item scrolls to bottom while following", async () => {

--- a/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Conversation.svelte.test.ts
@@ -1,0 +1,170 @@
+import { test, expect, vi } from "vitest";
+import { render, waitFor, fireEvent } from "@testing-library/svelte";
+import type { ChatItem } from "./transcript";
+
+// Mock the streamdown-backed renderer — shiki doesn't run reliably in jsdom.
+vi.mock("./Response.svelte", () => import("./response.stub.svelte"));
+
+// Static import: compiled during file collection, not inside a test's waitFor.
+import Conversation from "./Conversation.svelte";
+
+function toolItem(overrides: Partial<Extract<ChatItem, { kind: "tool" }>> = {}): ChatItem {
+  return {
+    kind: "tool",
+    seq: 4,
+    toolCallId: "call_1",
+    title: "read main.go",
+    status: "completed",
+    content: [],
+    locations: [],
+    ...overrides,
+  };
+}
+
+function permissionItem(
+  overrides: Partial<Extract<ChatItem, { kind: "permission" }>> = {},
+): ChatItem {
+  return {
+    kind: "permission",
+    seq: 5,
+    requestSeq: 5,
+    title: "run go test",
+    options: [{ optionId: "allow-1", name: "Allow", kind: "allow_once" }],
+    ...overrides,
+  };
+}
+
+test("renders every item kind", async () => {
+  const items: ChatItem[] = [
+    { kind: "user", seq: 1, text: "hello agent" },
+    { kind: "user", seq: -1, text: "pending prompt", pending: true },
+    { kind: "assistant", seq: 2, text: "assistant reply", streaming: false },
+    { kind: "reasoning", seq: 3, text: "thinking hard", streaming: false },
+    toolItem(),
+    permissionItem(),
+    { kind: "notice", seq: 6, level: "info", text: "Session ended." },
+    { kind: "notice", seq: 7, level: "error", text: "something broke" },
+  ];
+
+  const { getByText, getByTestId } = render(Conversation, {
+    props: { items, status: "idle", onAnswer: vi.fn() },
+  });
+
+  // user bubble + pending opacity
+  expect(getByText("hello agent")).toBeTruthy();
+  const pending = getByText("pending prompt");
+  expect(pending.className).toContain("opacity-60");
+
+  // assistant → stubbed Response
+  expect(getByTestId("response-stub").textContent).toContain("assistant reply");
+
+  // reasoning → collapsible "Thinking" trigger
+  expect(getByText("Thinking")).toBeTruthy();
+
+  // tool + permission cards
+  expect(getByText("read main.go")).toBeTruthy();
+  expect(getByText("run go test")).toBeTruthy();
+  expect(getByText("Allow")).toBeTruthy();
+
+  // notices: centered label, error tinted
+  expect(getByText("Session ended.")).toBeTruthy();
+  const err = getByText("something broke");
+  expect(err.className).toContain("text-status-error");
+});
+
+test("empty state renders Empty copy", () => {
+  const { getByText } = render(Conversation, {
+    props: { items: [], status: "starting", onAnswer: vi.fn() },
+  });
+  expect(getByText("No conversation yet.")).toBeTruthy();
+  expect(getByText("Send a prompt to start talking to this agent.")).toBeTruthy();
+});
+
+test("permission answers are curried with the item's requestSeq", async () => {
+  const onAnswer = vi.fn();
+  const { getByText } = render(Conversation, {
+    props: { items: [permissionItem({ requestSeq: 9, seq: 9 })], status: "waiting", onAnswer },
+  });
+
+  await fireEvent.click(getByText("Allow"));
+  expect(onAnswer).toHaveBeenCalledWith(9, "allow-1");
+});
+
+test("aria-live region announces the latest permission request", async () => {
+  const { getByTestId } = render(Conversation, {
+    props: { items: [permissionItem()], status: "waiting", onAnswer: vi.fn() },
+  });
+
+  const region = getByTestId("chat-announcer");
+  expect(region.getAttribute("aria-live")).toBe("polite");
+  await waitFor(() => expect(region.textContent).toContain("Agent asks to run go test"));
+});
+
+test("aria-live region announces status flips", async () => {
+  const { getByTestId, rerender } = render(Conversation, {
+    props: { items: [], status: "working", onAnswer: vi.fn() },
+  });
+
+  const region = getByTestId("chat-announcer");
+  // First render is not a flip — nothing to announce yet.
+  expect(region.textContent ?? "").not.toContain("idle");
+
+  await rerender({ status: "idle" });
+  await waitFor(() => expect(region.textContent).toContain("Agent is idle."));
+});
+
+test("scroll-away pauses follow; new items show a pill; clicking jumps back", async () => {
+  const items: ChatItem[] = [
+    { kind: "user", seq: 1, text: "one" },
+    { kind: "assistant", seq: 2, text: "two", streaming: false },
+  ];
+  const { getByTestId, getByText, queryByText, rerender } = render(Conversation, {
+    props: { items, status: "working", onAnswer: vi.fn() },
+  });
+
+  const container = getByTestId("chat-scroll-container");
+  // jsdom computes no layout — stub "scrolled far from the bottom" metrics.
+  Object.defineProperty(container, "scrollTop", { value: 0, writable: true, configurable: true });
+  Object.defineProperty(container, "scrollHeight", { value: 1000, configurable: true });
+  Object.defineProperty(container, "clientHeight", { value: 200, configurable: true });
+  await fireEvent.scroll(container);
+
+  await rerender({
+    items: [
+      ...items,
+      { kind: "assistant", seq: 3, text: "three", streaming: false },
+      { kind: "notice", seq: 4, level: "info", text: "notice" },
+    ] as ChatItem[],
+  });
+
+  await waitFor(() => expect(getByText(/2 new messages/)).toBeTruthy());
+
+  await fireEvent.click(getByText(/2 new messages/));
+  await waitFor(() => expect(queryByText(/new messages/)).toBeNull());
+});
+
+test("streaming growth of the trailing item scrolls to bottom while following", async () => {
+  const items: ChatItem[] = [{ kind: "assistant", seq: 1, text: "a", streaming: true }];
+  const { getByTestId, rerender } = render(Conversation, {
+    props: { items, status: "working", onAnswer: vi.fn() },
+  });
+
+  const container = getByTestId("chat-scroll-container");
+  let scrollTop = 0;
+  Object.defineProperty(container, "scrollTop", {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
+  Object.defineProperty(container, "clientHeight", { value: 200, configurable: true });
+
+  // Same item count, longer trailing text — the streaming-growth path.
+  await rerender({
+    items: [{ kind: "assistant", seq: 1, text: "ab", streaming: true }] as ChatItem[],
+  });
+
+  await waitFor(() => expect(scrollTop).toBe(500));
+});

--- a/apps/console/src/lib/components/stations/chat/DiffBlock.svelte
+++ b/apps/console/src/lib/components/stations/chat/DiffBlock.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  /**
+   * DiffBlock — inline line-diff for a tool-call `diff` content block.
+   *
+   * The rendering (diffLines + green/red 15% fills) is copied from
+   * ConfigEditor.svelte's diff view — the ONE sanctioned raw-color exception
+   * to the status-token rule. Future shared component: ConfigEditor should
+   * eventually render through this too (deliberately not refactored here).
+   */
+  import { diffLines } from "diff";
+
+  interface Props {
+    path: string;
+    oldText: string | null;
+    newText: string;
+  }
+
+  let { path, oldText, newText }: Props = $props();
+
+  const diff = $derived(diffLines(oldText ?? "", newText));
+</script>
+
+<div data-testid="diff-block" class="overflow-hidden rounded-md border border-border bg-muted/10">
+  <div class="border-b border-border/60 px-2 py-1 font-mono text-xs text-muted-foreground">
+    {path}
+  </div>
+  <div class="overflow-x-auto p-2 font-mono text-xs leading-relaxed">
+    {#each diff as part, i (i)}
+      {#if part.added}
+        <pre
+          class="m-0 whitespace-pre-wrap break-all rounded px-1 bg-green-500/15 text-green-700 dark:text-green-400"
+        >{part.value}</pre>
+      {:else if part.removed}
+        <pre
+          class="m-0 whitespace-pre-wrap break-all rounded px-1 bg-red-500/15 text-red-700 dark:text-red-400 line-through"
+        >{part.value}</pre>
+      {:else}
+        <pre class="m-0 whitespace-pre-wrap break-all px-1 text-muted-foreground">{part.value}</pre>
+      {/if}
+    {/each}
+  </div>
+</div>

--- a/apps/console/src/lib/components/stations/chat/PermissionCard.svelte
+++ b/apps/console/src/lib/components/stations/chat/PermissionCard.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  /**
+   * PermissionCard — an agent permission request in the transcript.
+   *
+   * Unanswered: pulsing "awaiting approval" dot, mono title, and one real
+   * <Button> per agent-supplied option — the first allow* option is the
+   * primary action, other allow* are secondary, reject* render as outline.
+   * There is deliberately NO extra dismiss affordance: agents supply reject
+   * options themselves, and whole-turn cancellation is the session
+   * controller's cancel(), not this card's concern.
+   *
+   * Answered: muted record of what was chosen ("· auto" when auto-answered
+   * by mode, "Cancelled." when the request was cancelled) with no buttons.
+   */
+  import { Status } from "$lib/components/ui/status";
+  import { Button, type ButtonVariant } from "$lib/components/ui/button";
+  import type { ChatItem } from "./transcript";
+
+  interface Props {
+    item: Extract<ChatItem, { kind: "permission" }>;
+    onAnswer: (optionId: string) => void;
+  }
+
+  let { item, onAnswer }: Props = $props();
+
+  const answer = $derived(item.answer);
+  const firstAllowId = $derived(
+    item.options.find((o) => o.kind.startsWith("allow"))?.optionId,
+  );
+
+  function variantFor(option: { optionId: string; kind: string }): ButtonVariant {
+    if (option.kind.startsWith("allow")) {
+      return option.optionId === firstAllowId ? "default" : "secondary";
+    }
+    return "outline";
+  }
+
+  const chosenName = $derived(
+    item.options.find((o) => o.optionId === answer?.optionId)?.name ??
+      answer?.optionId ??
+      "Answered",
+  );
+</script>
+
+{#if !answer}
+  <div class="rounded-lg border border-border p-3">
+    <div class="flex items-center gap-2">
+      <Status form="dot" status="starting" animate label="awaiting approval" />
+      <span class="min-w-0 truncate font-mono text-sm">{item.title}</span>
+      {#if item.toolKind}
+        <span class="t-label shrink-0">{item.toolKind}</span>
+      {/if}
+    </div>
+    <div class="mt-2 flex flex-wrap gap-2">
+      {#each item.options as option (option.optionId)}
+        <Button size="sm" variant={variantFor(option)} onclick={() => onAnswer(option.optionId)}>
+          {option.name}
+        </Button>
+      {/each}
+    </div>
+  </div>
+{:else}
+  <div class="rounded-lg border border-border/60 p-3 text-muted-foreground">
+    <div class="flex items-center gap-2">
+      <span class="min-w-0 truncate font-mono text-sm">{item.title}</span>
+      {#if item.toolKind}
+        <span class="t-label shrink-0">{item.toolKind}</span>
+      {/if}
+    </div>
+    <p class="t-body mt-1">
+      {#if answer.cancelled}Cancelled.{:else}{chosenName}{#if answer.auto}
+        · auto{/if}{/if}
+    </p>
+  </div>
+{/if}

--- a/apps/console/src/lib/components/stations/chat/PermissionCard.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/PermissionCard.svelte.test.ts
@@ -1,0 +1,154 @@
+import { test, expect, afterEach, vi } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+// Static import: compiled during file collection, not during the test body.
+import PermissionCard from "./PermissionCard.svelte";
+import type { ChatItem } from "./transcript";
+
+afterEach(() => cleanup());
+
+type PermissionItem = Extract<ChatItem, { kind: "permission" }>;
+
+function permissionItem(overrides: Partial<PermissionItem> = {}): PermissionItem {
+  return {
+    kind: "permission",
+    seq: 3,
+    requestSeq: 3,
+    title: "Bash(rm -rf build)",
+    toolKind: "execute",
+    options: [
+      { optionId: "opt-allow-once", name: "Allow once", kind: "allow_once" },
+      { optionId: "opt-allow-always", name: "Always allow", kind: "allow_always" },
+      { optionId: "opt-reject-once", name: "Reject", kind: "reject_once" },
+    ],
+    ...overrides,
+  };
+}
+
+// ── Unanswered ───────────────────────────────────────────────────────────────
+
+test("unanswered: pulsing dot with awaiting-approval label and mono title", () => {
+  const { container, getByText } = render(PermissionCard, {
+    props: { item: permissionItem(), onAnswer: vi.fn() },
+  });
+
+  const dot = container.querySelector("[data-status]");
+  expect(dot?.getAttribute("data-status")).toBe("starting");
+  expect(dot?.querySelector(".motion-safe\\:animate-pulse")).not.toBeNull();
+  expect(getByText("awaiting approval")).toBeTruthy();
+
+  const title = getByText("Bash(rm -rf build)");
+  expect(title.classList.contains("font-mono")).toBe(true);
+});
+
+test("all options render as real, focusable buttons in order", () => {
+  const { getAllByRole } = render(PermissionCard, {
+    props: { item: permissionItem(), onAnswer: vi.fn() },
+  });
+
+  const buttons = getAllByRole("button");
+  expect(buttons.length).toBe(3);
+  expect(buttons.map((b) => b.textContent?.trim())).toEqual([
+    "Allow once",
+    "Always allow",
+    "Reject",
+  ]);
+  for (const b of buttons) {
+    expect(b.tagName).toBe("BUTTON");
+    // Real buttons are keyboard focusable (no tabindex=-1).
+    expect(b.getAttribute("tabindex")).not.toBe("-1");
+  }
+});
+
+test("variant mapping: first allow → default, second allow → secondary, reject → outline", () => {
+  const { getAllByRole } = render(PermissionCard, {
+    props: { item: permissionItem(), onAnswer: vi.fn() },
+  });
+
+  const [first, second, reject] = getAllByRole("button");
+  expect(first.className).toContain("bg-primary");
+  expect(second.className).toContain("bg-secondary");
+  expect(reject.className).toContain("border-border");
+  expect(reject.className).not.toContain("bg-primary");
+});
+
+test("clicking an option calls onAnswer with its optionId", async () => {
+  const onAnswer = vi.fn();
+  const { getByText } = render(PermissionCard, {
+    props: { item: permissionItem(), onAnswer },
+  });
+
+  await fireEvent.click(getByText("Always allow"));
+
+  expect(onAnswer).toHaveBeenCalledTimes(1);
+  expect(onAnswer).toHaveBeenCalledWith("opt-allow-always");
+});
+
+test("reject options are regular buttons that answer with their optionId", async () => {
+  const onAnswer = vi.fn();
+  const { getByText } = render(PermissionCard, {
+    props: { item: permissionItem(), onAnswer },
+  });
+
+  await fireEvent.click(getByText("Reject"));
+
+  expect(onAnswer).toHaveBeenCalledWith("opt-reject-once");
+});
+
+// ── Answered ─────────────────────────────────────────────────────────────────
+
+test("answered: buttons gone, chosen option name shown", () => {
+  const { queryAllByRole, getByText } = render(PermissionCard, {
+    props: {
+      item: permissionItem({ answer: { optionId: "opt-allow-once" } }),
+      onAnswer: vi.fn(),
+    },
+  });
+
+  expect(queryAllByRole("button").length).toBe(0);
+  expect(getByText(/Allow once/)).toBeTruthy();
+});
+
+test("answered with auto shows the · auto suffix", () => {
+  const { container } = render(PermissionCard, {
+    props: {
+      item: permissionItem({ answer: { optionId: "opt-allow-always", auto: true } }),
+      onAnswer: vi.fn(),
+    },
+  });
+
+  expect(container.textContent).toContain("Always allow");
+  expect(container.textContent).toContain("· auto");
+});
+
+test("cancelled shows Cancelled. and no buttons", () => {
+  const { container, queryAllByRole } = render(PermissionCard, {
+    props: {
+      item: permissionItem({ answer: { cancelled: true } }),
+      onAnswer: vi.fn(),
+    },
+  });
+
+  expect(queryAllByRole("button").length).toBe(0);
+  expect(container.textContent).toContain("Cancelled.");
+});
+
+test("answered with an optionId missing from options falls back to the raw id", () => {
+  const { container } = render(PermissionCard, {
+    props: {
+      item: permissionItem({ answer: { optionId: "opt-unknown" } }),
+      onAnswer: vi.fn(),
+    },
+  });
+  expect(container.textContent).toContain("opt-unknown");
+});
+
+test("answered card no longer shows the awaiting-approval dot", () => {
+  const { container, queryByText } = render(PermissionCard, {
+    props: {
+      item: permissionItem({ answer: { optionId: "opt-allow-once" } }),
+      onAnswer: vi.fn(),
+    },
+  });
+  expect(queryByText("awaiting approval")).toBeNull();
+  expect(container.querySelector(".motion-safe\\:animate-pulse")).toBeNull();
+});

--- a/apps/console/src/lib/components/stations/chat/PromptInput.svelte
+++ b/apps/console/src/lib/components/stations/chat/PromptInput.svelte
@@ -23,15 +23,15 @@
   import { Textarea } from "$lib/components/ui/textarea";
 
   interface Props {
+    /** Bindable so the panel can hand back the text of a prompt that failed. */
+    value?: string;
     disabled?: boolean;
     working: boolean;
     onSend: (text: string) => void;
     onCancel: () => void;
   }
 
-  let { disabled = false, working, onSend, onCancel }: Props = $props();
-
-  let value = $state("");
+  let { value = $bindable(""), disabled = false, working, onSend, onCancel }: Props = $props();
   const canSend = $derived(value.trim().length > 0);
 
   function send() {

--- a/apps/console/src/lib/components/stations/chat/PromptInput.svelte
+++ b/apps/console/src/lib/components/stations/chat/PromptInput.svelte
@@ -8,6 +8,14 @@
    * stop button (cancel the turn) and Enter is a no-op that KEEPS the draft —
    * the controller refuses mid-turn prompts, so silently clearing would lose
    * the user's text.
+   *
+   * `disabled` never reaches the textarea as the `disabled` attribute: the
+   * caller sets it in the window right after a send (session create + optimistic
+   * echo), and a focused element that becomes `disabled` is blurred to <body> by
+   * the browser — every turn would throw a keyboard user back to the top of the
+   * transcript. It's `aria-disabled` + `readonly` instead, so focus survives,
+   * and `send()`'s own guard (not the attribute) is what refuses the send and
+   * keeps the draft.
    */
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import SquareIcon from "@lucide/svelte/icons/square";
@@ -45,8 +53,9 @@
     bind:value
     placeholder="Message the agent…"
     aria-label="Message the agent"
-    class="max-h-40 min-h-9"
-    {disabled}
+    class="max-h-40 min-h-9 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+    aria-disabled={disabled ? "true" : undefined}
+    readonly={disabled}
     onkeydown={handleKeydown}
   />
   {#if working}

--- a/apps/console/src/lib/components/stations/chat/PromptInput.svelte
+++ b/apps/console/src/lib/components/stations/chat/PromptInput.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  /**
+   * PromptInput — the chat composer.
+   *
+   * Enter sends the trimmed draft (IME-safe: composition Enter is ignored),
+   * Shift+Enter inserts a newline, and the box clears only when a send
+   * actually happens. While the agent is working the send button becomes a
+   * stop button (cancel the turn) and Enter is a no-op that KEEPS the draft —
+   * the controller refuses mid-turn prompts, so silently clearing would lose
+   * the user's text.
+   */
+  import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
+  import SquareIcon from "@lucide/svelte/icons/square";
+  import { Button } from "$lib/components/ui/button";
+  import { Textarea } from "$lib/components/ui/textarea";
+
+  interface Props {
+    disabled?: boolean;
+    working: boolean;
+    onSend: (text: string) => void;
+    onCancel: () => void;
+  }
+
+  let { disabled = false, working, onSend, onCancel }: Props = $props();
+
+  let value = $state("");
+  const canSend = $derived(value.trim().length > 0);
+
+  function send() {
+    const text = value.trim();
+    if (!text || disabled || working) return;
+    onSend(text);
+    value = "";
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+    event.preventDefault();
+    send();
+  }
+</script>
+
+<div class="flex items-end gap-2">
+  <Textarea
+    bind:value
+    placeholder="Message the agent…"
+    aria-label="Message the agent"
+    class="max-h-40 min-h-9"
+    {disabled}
+    onkeydown={handleKeydown}
+  />
+  {#if working}
+    <Button
+      variant="outline"
+      size="icon-sm"
+      aria-label="Stop the current turn"
+      onclick={onCancel}
+    >
+      <SquareIcon class="size-3 fill-current" aria-hidden="true" />
+    </Button>
+  {:else}
+    <Button size="icon-sm" aria-label="Send" disabled={disabled || !canSend} onclick={send}>
+      <ArrowUpIcon aria-hidden="true" />
+    </Button>
+  {/if}
+</div>

--- a/apps/console/src/lib/components/stations/chat/PromptInput.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/PromptInput.svelte.test.ts
@@ -81,7 +81,23 @@ test("working shows a stop button that calls onCancel; Send is absent", async ()
   expect(textarea.value).toBe("queued thought");
 });
 
-test("disabled disables the textarea", () => {
-  const { textarea } = setup({ disabled: true });
-  expect(textarea.disabled).toBe(true);
+test("disabled marks the textarea read-only WITHOUT blurring it, and refuses sends", async () => {
+  const { getByRole, textarea, onSend } = setup({ disabled: true });
+
+  // A real `disabled` attribute would be blurred to <body> by the browser,
+  // dumping keyboard users out of the composer after every send.
+  expect(textarea.disabled).toBe(false);
+  expect(textarea.readOnly).toBe(true);
+  expect(textarea.getAttribute("aria-disabled")).toBe("true");
+  textarea.focus();
+  expect(document.activeElement).toBe(textarea);
+
+  expect((getByRole("button", { name: "Send" }) as HTMLButtonElement).disabled).toBe(true);
+
+  // The guard in send() — not the attribute — is what refuses and keeps the draft.
+  await fireEvent.input(textarea, { target: { value: "typed anyway" } });
+  await fireEvent.keyDown(textarea, { key: "Enter" });
+  expect(onSend).not.toHaveBeenCalled();
+  expect(textarea.value).toBe("typed anyway");
+  expect(document.activeElement).toBe(textarea);
 });

--- a/apps/console/src/lib/components/stations/chat/PromptInput.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/PromptInput.svelte.test.ts
@@ -1,0 +1,87 @@
+import { test, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import PromptInput from "./PromptInput.svelte";
+
+function setup(props: Partial<{ disabled: boolean; working: boolean }> = {}) {
+  const onSend = vi.fn();
+  const onCancel = vi.fn();
+  const utils = render(PromptInput, {
+    props: { working: false, onSend, onCancel, ...props },
+  });
+  const textarea = utils.getByPlaceholderText("Message the agent…") as HTMLTextAreaElement;
+  return { ...utils, onSend, onCancel, textarea };
+}
+
+test("Enter sends the trimmed text and clears the box", async () => {
+  const { textarea, onSend } = setup();
+
+  await fireEvent.input(textarea, { target: { value: "  hello agent  " } });
+  await fireEvent.keyDown(textarea, { key: "Enter" });
+
+  expect(onSend).toHaveBeenCalledWith("hello agent");
+  expect(textarea.value).toBe("");
+});
+
+test("Shift+Enter does not send", async () => {
+  const { textarea, onSend } = setup();
+
+  await fireEvent.input(textarea, { target: { value: "line one" } });
+  await fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+  expect(onSend).not.toHaveBeenCalled();
+  expect(textarea.value).toBe("line one");
+});
+
+test("Enter with only whitespace does not send", async () => {
+  const { textarea, onSend } = setup();
+
+  await fireEvent.input(textarea, { target: { value: "   " } });
+  await fireEvent.keyDown(textarea, { key: "Enter" });
+
+  expect(onSend).not.toHaveBeenCalled();
+});
+
+test("Enter during IME composition does not send", async () => {
+  const { textarea, onSend } = setup();
+
+  await fireEvent.input(textarea, { target: { value: "こんにちは" } });
+  await fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+
+  expect(onSend).not.toHaveBeenCalled();
+  expect(textarea.value).toBe("こんにちは");
+});
+
+test("send button sends and is disabled while empty", async () => {
+  const { getByRole, textarea, onSend } = setup();
+
+  const send = getByRole("button", { name: "Send" }) as HTMLButtonElement;
+  expect(send.disabled).toBe(true);
+
+  await fireEvent.input(textarea, { target: { value: "do the thing" } });
+  expect(send.disabled).toBe(false);
+
+  await fireEvent.click(send);
+  expect(onSend).toHaveBeenCalledWith("do the thing");
+  expect(textarea.value).toBe("");
+});
+
+test("working shows a stop button that calls onCancel; Send is absent", async () => {
+  const { getByRole, queryByRole, textarea, onSend, onCancel } = setup({ working: true });
+
+  const stop = getByRole("button", { name: "Stop the current turn" });
+  expect(queryByRole("button", { name: "Send" })).toBeNull();
+
+  await fireEvent.click(stop);
+  expect(onCancel).toHaveBeenCalledTimes(1);
+
+  // Enter while working keeps the draft instead of silently losing it.
+  await fireEvent.input(textarea, { target: { value: "queued thought" } });
+  await fireEvent.keyDown(textarea, { key: "Enter" });
+  expect(onSend).not.toHaveBeenCalled();
+  expect(textarea.value).toBe("queued thought");
+});
+
+test("disabled disables the textarea", () => {
+  const { textarea } = setup({ disabled: true });
+  expect(textarea.disabled).toBe(true);
+});

--- a/apps/console/src/lib/components/stations/chat/Reasoning.svelte
+++ b/apps/console/src/lib/components/stations/chat/Reasoning.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  /**
+   * Reasoning — collapsible agent thinking block.
+   *
+   * Thoughts are PLAIN TEXT (whitespace-pre-wrap), never markdown. Open by
+   * default while streaming; auto-collapses exactly once on the streaming
+   * true→false edge, so a reader who re-expands a finished block is never
+   * fought by later prop updates.
+   */
+  import { ChevronDown } from "@lucide/svelte";
+  import * as Collapsible from "$lib/components/ui/collapsible";
+  import { Status } from "$lib/components/ui/status";
+
+  interface Props {
+    text: string;
+    streaming?: boolean;
+  }
+
+  let { text, streaming = false }: Props = $props();
+
+  // Both initializers deliberately capture streaming's INITIAL value: `open`
+  // is user-owned state seeded once, and `wasStreaming` is the previous value
+  // for edge detection (plain let, not $state — it must never retrigger the
+  // effect itself).
+  // svelte-ignore state_referenced_locally
+  let open = $state(streaming);
+  // svelte-ignore state_referenced_locally
+  let wasStreaming = streaming;
+
+  $effect(() => {
+    if (wasStreaming && !streaming) open = false;
+    wasStreaming = streaming;
+  });
+</script>
+
+<Collapsible.Root bind:open>
+  <Collapsible.Trigger
+    class="group flex items-center gap-1.5 rounded-sm py-0.5 text-muted-foreground hover:text-foreground"
+  >
+    <span class="t-label">Thinking</span>
+    <ChevronDown
+      class="size-3 shrink-0 transition-transform motion-reduce:transition-none group-data-[state=closed]:-rotate-90"
+      aria-hidden="true"
+    />
+    {#if streaming}
+      <Status form="dot" status="starting" animate label="thinking" />
+    {/if}
+  </Collapsible.Trigger>
+  <Collapsible.Content>
+    <div
+      data-testid="reasoning-content"
+      class="t-body mt-1 border-l-2 border-border pl-3 whitespace-pre-wrap text-muted-foreground"
+    >
+      {text}
+    </div>
+  </Collapsible.Content>
+</Collapsible.Root>

--- a/apps/console/src/lib/components/stations/chat/Reasoning.svelte
+++ b/apps/console/src/lib/components/stations/chat/Reasoning.svelte
@@ -4,8 +4,9 @@
    *
    * Thoughts are PLAIN TEXT (whitespace-pre-wrap), never markdown. Open by
    * default while streaming; auto-collapses exactly once on the streaming
-   * true→false edge, so a reader who re-expands a finished block is never
-   * fought by later prop updates.
+   * true→false edge and re-opens on the false→true edge (fresh segment on a
+   * reused instance). Between edges `open` is the user's — manual toggles are
+   * never fought by later prop updates.
    */
   import { ChevronDown } from "@lucide/svelte";
   import * as Collapsible from "$lib/components/ui/collapsible";
@@ -27,8 +28,13 @@
   // svelte-ignore state_referenced_locally
   let wasStreaming = streaming;
 
+  // Act on EDGES only, never on same-state reruns: finish (true→false)
+  // collapses, a fresh streaming segment (false→true) re-opens — the same
+  // component instance is reused across reasoning segments, so without the
+  // opening edge a second segment would accumulate collapsed and invisible.
+  // Between edges, `open` belongs to the user.
   $effect(() => {
-    if (wasStreaming && !streaming) open = false;
+    if (wasStreaming !== streaming) open = streaming;
     wasStreaming = streaming;
   });
 </script>

--- a/apps/console/src/lib/components/stations/chat/Reasoning.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Reasoning.svelte.test.ts
@@ -57,6 +57,41 @@ test("collapses exactly once: manual re-expand survives later non-streaming upda
   expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
 });
 
+test("re-opens on a new streaming segment: true → false (collapsed) → true", async () => {
+  const { container, rerender } = render(Reasoning, {
+    props: { text: "block 1", streaming: true },
+  });
+
+  // Block 1 finishes: auto-collapse. User leaves it collapsed.
+  await rerender({ text: "block 1", streaming: false });
+  await waitFor(() => expect(trigger(container).getAttribute("aria-expanded")).toBe("false"));
+
+  // The instance is reused for a fresh reasoning segment — false→true edge
+  // must re-open so new thinking content is not accumulating invisibly.
+  await rerender({ text: "block 2 begins", streaming: true });
+  await waitFor(() => expect(trigger(container).getAttribute("aria-expanded")).toBe("true"));
+});
+
+test("manual collapse mid-stream is not fought by same-state updates", async () => {
+  const { container, rerender } = render(Reasoning, {
+    props: { text: "quiet", streaming: false },
+  });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+
+  // false→true edge opens the block.
+  await rerender({ text: "thinking...", streaming: true });
+  await waitFor(() => expect(trigger(container).getAttribute("aria-expanded")).toBe("true"));
+
+  // User collapses it mid-stream…
+  await fireEvent.click(trigger(container));
+  await waitFor(() => expect(trigger(container).getAttribute("aria-expanded")).toBe("false"));
+
+  // …and streaming text keeps arriving (streaming stays true — no edge):
+  // the block must stay collapsed, not pop back open.
+  await rerender({ text: "thinking... more", streaming: true });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+});
+
 test("starts collapsed when not streaming; manual expand reveals plain text", async () => {
   const { container, getByText } = render(Reasoning, {
     props: { text: "already finished thought", streaming: false },

--- a/apps/console/src/lib/components/stations/chat/Reasoning.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Reasoning.svelte.test.ts
@@ -1,0 +1,72 @@
+import { test, expect, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+// Static import: compiled during file collection, not during the test body.
+import Reasoning from "./Reasoning.svelte";
+
+afterEach(() => cleanup());
+
+function trigger(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[data-slot='collapsible-trigger']");
+  if (!el) throw new Error("collapsible trigger not rendered");
+  return el;
+}
+
+test("renders the Thinking trigger label", () => {
+  const { getByText } = render(Reasoning, { props: { text: "pondering", streaming: false } });
+  expect(getByText("Thinking")).toBeTruthy();
+});
+
+test("open while streaming: thought text and pulsing dot are visible", () => {
+  const { container, getByText } = render(Reasoning, {
+    props: { text: "step 1: look at the file", streaming: true },
+  });
+
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+  expect(getByText(/step 1: look at the file/)).toBeTruthy();
+  // Status dot carries an sr-only label while streaming.
+  expect(getByText("thinking")).toBeTruthy();
+});
+
+test("auto-collapses when streaming flips true → false", async () => {
+  const { container, rerender } = render(Reasoning, {
+    props: { text: "step 1", streaming: true },
+  });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+
+  await rerender({ text: "step 1 done", streaming: false });
+
+  await waitFor(() => {
+    expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+test("collapses exactly once: manual re-expand survives later non-streaming updates", async () => {
+  const { container, rerender } = render(Reasoning, {
+    props: { text: "step 1", streaming: true },
+  });
+
+  await rerender({ text: "step 1 done", streaming: false });
+  await waitFor(() => expect(trigger(container).getAttribute("aria-expanded")).toBe("false"));
+
+  // Reader re-opens the block…
+  await fireEvent.click(trigger(container));
+  await waitFor(() => expect(trigger(container).getAttribute("aria-expanded")).toBe("true"));
+
+  // …and a later prop update (still not streaming) must NOT re-collapse it.
+  await rerender({ text: "step 1 done", streaming: false });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+});
+
+test("starts collapsed when not streaming; manual expand reveals plain text", async () => {
+  const { container, getByText } = render(Reasoning, {
+    props: { text: "already finished thought", streaming: false },
+  });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+
+  await fireEvent.click(trigger(container));
+
+  await waitFor(() => expect(getByText(/already finished thought/)).toBeTruthy());
+  // Thoughts are plain text, not markdown — rendered pre-wrapped, no <strong>.
+  const content = container.querySelector("[data-testid='reasoning-content']");
+  expect(content?.classList.contains("whitespace-pre-wrap")).toBe(true);
+});

--- a/apps/console/src/lib/components/stations/chat/Response.svelte
+++ b/apps/console/src/lib/components/stations/chat/Response.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  /**
+   * Response — streamed assistant markdown.
+   *
+   * Agent output is UNTRUSTED: raw HTML is never rendered and links are
+   * limited to http(s). `streaming` turns on incomplete-markdown parsing so
+   * half-typed constructs (unclosed **bold**, dangling links) render sanely
+   * mid-stream instead of flashing raw syntax.
+   */
+  import { Streamdown } from "svelte-streamdown";
+  import Code from "svelte-streamdown/code";
+  import { bundledThemes, type BundledTheme, type ThemeRegistration } from "shiki";
+  import { themeStore } from "$lib/themes/store.svelte";
+
+  interface Props {
+    text: string;
+    streaming?: boolean;
+  }
+
+  let { text, streaming = false }: Props = $props();
+
+  // The active color scheme's shiki theme for the current light/dark mode.
+  const schemeTheme = $derived(
+    themeStore.isDark ? themeStore.shikiThemes.dark : themeStore.shikiThemes.light,
+  );
+
+  // svelte-streamdown only bundles github-light/github-dark. Any other theme
+  // name must be registered as a loaded ThemeRegistration via `shikiThemes`,
+  // or code blocks never leave their loading skeleton (documented streamdown
+  // behavior). Load the active scheme's theme lazily from shiki's bundle.
+  const BUILTIN = new Set<string>(["github-light", "github-dark"]);
+  let registry = $state<Record<string, ThemeRegistration>>({});
+
+  $effect(() => {
+    const name = schemeTheme;
+    if (BUILTIN.has(name) || name in registry) return;
+    const load = bundledThemes[name as BundledTheme];
+    if (!load) return;
+    let cancelled = false;
+    load().then((mod) => {
+      if (!cancelled) registry = { ...registry, [name]: mod.default as ThemeRegistration };
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  // Fall back to the matching builtin until the scheme's theme has loaded so
+  // streamed code highlights immediately instead of sitting in a skeleton.
+  const shikiTheme = $derived(
+    BUILTIN.has(schemeTheme) || schemeTheme in registry
+      ? schemeTheme
+      : themeStore.isDark
+        ? "github-dark"
+        : "github-light",
+  );
+
+  // Minimal overrides on the tailwind base theme (mergeTheme defaults true):
+  // swap its hard-coded grays/blues for Crisp tokens so borders and muted
+  // text track the active scheme in both modes, and scale headings for chat.
+  const crispTheme = {
+    code: {
+      base: "my-3 flex w-full flex-col overflow-hidden rounded-md border border-border",
+      container: "relative overflow-visible bg-muted/50 p-2 font-mono text-sm",
+      header:
+        "flex items-center justify-between border-b border-border bg-muted/50 p-2 text-xs text-muted-foreground",
+      pre: "overflow-x-auto p-0 font-mono",
+      skeleton:
+        "block scale-y-90 animate-pulse whitespace-nowrap rounded-md bg-muted font-mono text-transparent",
+    },
+    codespan: { base: "rounded bg-muted px-1.5 py-0.5 font-mono text-[0.9em]" },
+    blockquote: { base: "my-3 border-l-2 border-border pl-4 text-muted-foreground" },
+    table: { base: "my-3 max-w-full overflow-x-auto rounded-md border border-border" },
+    hr: { base: "my-4 border-border" },
+    link: {
+      base: "wrap-anywhere font-medium text-primary underline underline-offset-2 hover:opacity-80",
+      blocked: "text-muted-foreground",
+    },
+    h1: { base: "mt-4 mb-2 text-base font-semibold" },
+    h2: { base: "mt-4 mb-2 text-sm font-semibold" },
+    h3: { base: "mt-3 mb-1 text-sm font-semibold" },
+    h4: { base: "mt-3 mb-1 text-sm font-medium" },
+  };
+</script>
+
+<Streamdown
+  content={text}
+  components={{ code: Code }}
+  baseTheme="tailwind"
+  parseIncompleteMarkdown={streaming}
+  renderHtml={false}
+  allowedLinkPrefixes={["https://", "http://"]}
+  {shikiTheme}
+  shikiThemes={registry}
+  theme={crispTheme}
+  class="t-body max-w-none"
+/>

--- a/apps/console/src/lib/components/stations/chat/Response.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Response.svelte.test.ts
@@ -52,6 +52,31 @@ test("streaming: unterminated **bold is completed by incomplete-markdown parsing
   });
 });
 
+test("javascript: links render inert; https links keep their href", async () => {
+  const { container } = render(Response, {
+    props: {
+      text: "[evil](javascript:alert(1)) and [ok](https://example.com)",
+      streaming: false,
+    },
+  });
+
+  await waitFor(() => expect(container.textContent).toContain("evil"));
+
+  // No element anywhere may carry a javascript: href.
+  for (const el of container.querySelectorAll("[href]")) {
+    expect(el.getAttribute("href")).not.toMatch(/^\s*javascript:/i);
+  }
+  // The allowed https link renders as a real anchor (streamdown normalizes
+  // the URL with a trailing slash) hardened with noopener.
+  await waitFor(() => {
+    const anchor = [...container.querySelectorAll("a[href]")].find((a) =>
+      a.getAttribute("href")!.startsWith("https://example.com"),
+    );
+    expect(anchor).toBeTruthy();
+    expect(anchor!.getAttribute("rel")).toContain("noopener");
+  });
+});
+
 test("raw HTML in agent output is not rendered as elements", async () => {
   const { container } = render(Response, {
     props: { text: 'before <img src=x onerror="alert(1)"> after', streaming: false },

--- a/apps/console/src/lib/components/stations/chat/Response.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/Response.svelte.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, afterEach, vi } from "vitest";
+import { render, waitFor, cleanup } from "@testing-library/svelte";
+
+// Response imports the theme store, which touches window.matchMedia at module
+// init — ES imports are hoisted ahead of plain statements, so the stub must go
+// through vi.hoisted() to run before "./Response.svelte" is evaluated (same
+// pattern as store-status-tokens.svelte.test.ts; jsdom has no matchMedia).
+vi.hoisted(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    })),
+  );
+});
+
+// Static import: compiled during file collection, not during the test body.
+import Response from "./Response.svelte";
+
+afterEach(() => cleanup());
+
+test("renders markdown: **bold** lands as a <strong> element", async () => {
+  const { container } = render(Response, {
+    props: { text: "Hello **bold** world", streaming: false },
+  });
+
+  await waitFor(() => {
+    const strong = container.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong!.textContent).toContain("bold");
+  });
+  expect(container.textContent).toContain("Hello");
+  expect(container.textContent).toContain("world");
+});
+
+test("streaming: unterminated **bold is completed by incomplete-markdown parsing", async () => {
+  const { container } = render(Response, {
+    props: { text: "Hello **bol", streaming: true },
+  });
+
+  await waitFor(() => {
+    const strong = container.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong!.textContent).toContain("bol");
+  });
+});
+
+test("raw HTML in agent output is not rendered as elements", async () => {
+  const { container } = render(Response, {
+    props: { text: 'before <img src=x onerror="alert(1)"> after', streaming: false },
+  });
+
+  await waitFor(() => expect(container.textContent).toContain("before"));
+  expect(container.querySelector("img")).toBeNull();
+});

--- a/apps/console/src/lib/components/stations/chat/ToolCallCard.svelte
+++ b/apps/console/src/lib/components/stations/chat/ToolCallCard.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  /**
+   * ToolCallCard — one agent tool invocation in the transcript.
+   *
+   * Header (status dot · mono title · toolKind suffix) is always visible and
+   * doubles as the collapsible trigger when there is content to show. The
+   * body is open by default only while the call is in_progress, auto-collapses
+   * exactly once on the in_progress→done edge (same edge pattern as
+   * Reasoning.svelte) and manual toggles are never fought between edges.
+   *
+   * Tool status → status token mapping lives HERE (tokenFor doesn't know the
+   * ACP vocab): pending/in_progress → starting (pulsing while in_progress),
+   * completed → running, failed → error.
+   */
+  import { ChevronDown } from "@lucide/svelte";
+  import * as Collapsible from "$lib/components/ui/collapsible";
+  import { Status } from "$lib/components/ui/status";
+  import DiffBlock from "./DiffBlock.svelte";
+  import type { ChatItem, ToolStatus } from "./transcript";
+
+  interface Props {
+    item: Extract<ChatItem, { kind: "tool" }>;
+  }
+
+  let { item }: Props = $props();
+
+  const STATUS_TOKEN: Record<ToolStatus, string> = {
+    pending: "starting",
+    in_progress: "starting",
+    completed: "running",
+    failed: "error",
+  };
+
+  const inProgress = $derived(item.status === "in_progress");
+  const hasBody = $derived(item.content.length > 0 || item.locations.length > 0);
+
+  // Both initializers deliberately capture the INITIAL in_progress value:
+  // `open` is user-owned state seeded once, `wasInProgress` is the previous
+  // value for edge detection (plain let, not $state — it must never retrigger
+  // the effect itself).
+  // svelte-ignore state_referenced_locally
+  let open = $state(inProgress);
+  // svelte-ignore state_referenced_locally
+  let wasInProgress = inProgress;
+
+  // Act on EDGES only: finishing (true→false) collapses once, restarting
+  // (false→true) re-opens. Between edges `open` belongs to the user.
+  $effect(() => {
+    if (wasInProgress !== inProgress) open = inProgress;
+    wasInProgress = inProgress;
+  });
+</script>
+
+{#snippet header()}
+  <Status
+    form="dot"
+    status={STATUS_TOKEN[item.status]}
+    animate={inProgress}
+    label={item.status}
+  />
+  <span class="min-w-0 truncate font-mono text-sm">{item.title}</span>
+  {#if item.toolKind}
+    <span class="t-label shrink-0">{item.toolKind}</span>
+  {/if}
+{/snippet}
+
+{#if hasBody}
+  <Collapsible.Root bind:open>
+    <Collapsible.Trigger
+      class="group flex w-full items-center gap-2 rounded-sm py-0.5 text-left hover:text-foreground"
+    >
+      {@render header()}
+      <ChevronDown
+        class="size-3 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none group-data-[state=closed]:-rotate-90"
+        aria-hidden="true"
+      />
+    </Collapsible.Trigger>
+    <Collapsible.Content>
+      <div class="mt-1 space-y-2 border-l-2 border-border pl-3">
+        {#each item.content as block, i (i)}
+          {#if block.type === "text"}
+            <pre
+              data-testid="tool-text"
+              class="t-body m-0 whitespace-pre-wrap break-words text-muted-foreground"
+            >{block.text}</pre>
+          {:else if block.type === "diff"}
+            <DiffBlock path={block.path} oldText={block.oldText} newText={block.newText} />
+          {/if}
+        {/each}
+        {#if item.locations.length > 0}
+          <ul data-testid="tool-locations" class="space-y-0.5">
+            {#each item.locations as loc (loc)}
+              <li class="t-label font-mono">{loc}</li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </Collapsible.Content>
+  </Collapsible.Root>
+{:else}
+  <div class="flex items-center gap-2 py-0.5">
+    {@render header()}
+  </div>
+{/if}

--- a/apps/console/src/lib/components/stations/chat/ToolCallCard.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ToolCallCard.svelte.test.ts
@@ -1,0 +1,185 @@
+import { test, expect, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+// Static import: compiled during file collection, not during the test body.
+import ToolCallCard from "./ToolCallCard.svelte";
+import type { ChatItem } from "./transcript";
+
+afterEach(() => cleanup());
+
+type ToolItem = Extract<ChatItem, { kind: "tool" }>;
+
+function toolItem(overrides: Partial<ToolItem> = {}): ToolItem {
+  return {
+    kind: "tool",
+    seq: 1,
+    toolCallId: "tc-1",
+    title: "read_file(src/main.ts)",
+    toolKind: "read",
+    status: "pending",
+    content: [{ type: "text", text: "tool output" }],
+    locations: [],
+    ...overrides,
+  };
+}
+
+function trigger(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[data-slot='collapsible-trigger']");
+  if (!el) throw new Error("collapsible trigger not rendered");
+  return el;
+}
+
+function statusDot(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[data-status]");
+  if (!el) throw new Error("status dot not rendered");
+  return el;
+}
+
+// ── Status dot mapping ───────────────────────────────────────────────────────
+
+test("pending maps to the starting token without pulse", () => {
+  const { container } = render(ToolCallCard, { props: { item: toolItem({ status: "pending" }) } });
+  const dot = statusDot(container);
+  expect(dot.getAttribute("data-status")).toBe("starting");
+  expect(dot.querySelector(".motion-safe\\:animate-pulse")).toBeNull();
+});
+
+test("in_progress maps to the starting token WITH pulse", () => {
+  const { container } = render(ToolCallCard, {
+    props: { item: toolItem({ status: "in_progress" }) },
+  });
+  const dot = statusDot(container);
+  expect(dot.getAttribute("data-status")).toBe("starting");
+  expect(dot.querySelector(".motion-safe\\:animate-pulse")).not.toBeNull();
+});
+
+test("completed maps to the running token", () => {
+  const { container } = render(ToolCallCard, {
+    props: { item: toolItem({ status: "completed" }) },
+  });
+  expect(statusDot(container).getAttribute("data-status")).toBe("running");
+});
+
+test("failed maps to the error token", () => {
+  const { container } = render(ToolCallCard, { props: { item: toolItem({ status: "failed" }) } });
+  expect(statusDot(container).getAttribute("data-status")).toBe("error");
+});
+
+// ── Header ───────────────────────────────────────────────────────────────────
+
+test("title renders in mono with the toolKind suffix", () => {
+  const { container, getByText } = render(ToolCallCard, {
+    props: { item: toolItem({ title: "Bash(ls -la)", toolKind: "execute" }) },
+  });
+  const title = getByText("Bash(ls -la)");
+  expect(title.classList.contains("font-mono")).toBe(true);
+  expect(container.textContent).toContain("execute");
+});
+
+// ── Collapsible behavior ─────────────────────────────────────────────────────
+
+test("content is open by default while in_progress", () => {
+  const { container, getByText } = render(ToolCallCard, {
+    props: { item: toolItem({ status: "in_progress" }) },
+  });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+  expect(getByText(/tool output/)).toBeTruthy();
+});
+
+test("content is collapsed by default when completed; manual expand reveals it", async () => {
+  const { container, getByText } = render(ToolCallCard, {
+    props: { item: toolItem({ status: "completed" }) },
+  });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+
+  await fireEvent.click(trigger(container));
+
+  await waitFor(() => expect(getByText(/tool output/)).toBeTruthy());
+});
+
+test("auto-collapses on the in_progress → completed edge", async () => {
+  const { container, rerender } = render(ToolCallCard, {
+    props: { item: toolItem({ status: "in_progress" }) },
+  });
+  expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+
+  await rerender({ item: toolItem({ status: "completed" }) });
+
+  await waitFor(() => {
+    expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+test("no collapsible trigger when there is no content and no locations", () => {
+  const { container, getByText } = render(ToolCallCard, {
+    props: { item: toolItem({ content: [], locations: [] }) },
+  });
+  expect(container.querySelector("[data-slot='collapsible-trigger']")).toBeNull();
+  // Header still renders.
+  expect(getByText("read_file(src/main.ts)")).toBeTruthy();
+});
+
+// ── Content rendering ────────────────────────────────────────────────────────
+
+test("text content renders pre-wrapped", () => {
+  const { container } = render(ToolCallCard, {
+    props: {
+      item: toolItem({ status: "in_progress", content: [{ type: "text", text: "line1\nline2" }] }),
+    },
+  });
+  const pre = container.querySelector("[data-testid='tool-text']");
+  expect(pre).not.toBeNull();
+  expect(pre!.textContent).toBe("line1\nline2");
+  expect(pre!.classList.contains("whitespace-pre-wrap")).toBe(true);
+});
+
+test("diff content renders added and removed lines", () => {
+  const { container } = render(ToolCallCard, {
+    props: {
+      item: toolItem({
+        status: "in_progress",
+        content: [
+          { type: "diff", path: "src/app.ts", oldText: "const a = 1;\n", newText: "const a = 2;\n" },
+        ],
+      }),
+    },
+  });
+
+  const block = container.querySelector("[data-testid='diff-block']");
+  expect(block).not.toBeNull();
+  expect(block!.textContent).toContain("src/app.ts");
+
+  const added = block!.querySelector(".bg-green-500\\/15");
+  const removed = block!.querySelector(".bg-red-500\\/15");
+  expect(added?.textContent).toContain("const a = 2;");
+  expect(removed?.textContent).toContain("const a = 1;");
+});
+
+test("diff with null oldText renders the whole newText as added", () => {
+  const { container } = render(ToolCallCard, {
+    props: {
+      item: toolItem({
+        status: "in_progress",
+        content: [{ type: "diff", path: "new.ts", oldText: null, newText: "brand new\n" }],
+      }),
+    },
+  });
+  const added = container.querySelector(".bg-green-500\\/15");
+  expect(added?.textContent).toContain("brand new");
+  expect(container.querySelector(".bg-red-500\\/15")).toBeNull();
+});
+
+test("locations render as a file list", () => {
+  const { container } = render(ToolCallCard, {
+    props: {
+      item: toolItem({
+        status: "in_progress",
+        content: [],
+        locations: ["src/a.ts", "src/b.ts"],
+      }),
+    },
+  });
+  const list = container.querySelector("[data-testid='tool-locations']");
+  expect(list).not.toBeNull();
+  expect(list!.textContent).toContain("src/a.ts");
+  expect(list!.textContent).toContain("src/b.ts");
+});

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -287,7 +287,13 @@ test("busy mirrors every refusal window the composer must respect", async () => 
   resolveCreate(row());
   await inFlight;
 
-  // (2) optimistic prompt awaiting its echo.
+  // (2) replay in flight — the transcript, and so the status, isn't trustworthy.
+  expect(fresh.replaying).toBe(true);
+  expect(fresh.busy).toBe(true);
+  MockWebSocket.latest()!.fireMessage({ t: "replay-done", lastSeq: 0 });
+  expect(fresh.replaying).toBe(false);
+
+  // (3) optimistic prompt awaiting its echo.
   expect(fresh.busy).toBe(true);
   MockWebSocket.latest()!.fireMessage({
     t: "event",
@@ -295,11 +301,34 @@ test("busy mirrors every refusal window the composer must respect", async () => 
   });
   expect(fresh.busy).toBe(false);
 
-  // (3) agent working.
+  // (4) agent working.
   MockWebSocket.latest()!.fireMessage({ t: "event", event: ev(2, "state", { status: "working" }) });
   expect(fresh.busy).toBe(true);
   MockWebSocket.latest()!.fireMessage({ t: "event", event: ev(3, "state", { status: "idle" }) });
   expect(fresh.busy).toBe(false);
+});
+
+test("status and busy follow the session row until the stream speaks", async () => {
+  // Reattaching to a session the hub says is WORKING: the transcript has no
+  // state event yet, so only the row knows — and the composer must not offer to
+  // send into a turn the hub would reject.
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ status: "working" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  expect(chat.status).toBe("working");
+  expect(chat.working).toBe(true);
+  expect(chat.busy).toBe(true);
+
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  // Still working per the row; the stream hasn't contradicted it.
+  expect(chat.busy).toBe(true);
+
+  ws.fireMessage({ t: "event", event: ev(1, "state", { status: "idle" }) });
+  expect(chat.status).toBe("idle");
+  expect(chat.busy).toBe(false);
 });
 
 test("prompt after destroy dials nothing", async () => {
@@ -454,33 +483,67 @@ test("end() DELETEs via the api; the ended state arrives via events, not locally
 
 // ─── Synthetic seq-0 error events ────────────────────────────────────────────
 
-test("seq-0 error with a trailing pending prompt goes to error, not the transcript", async () => {
-  const { chat, ws } = await connectedChat();
+test("a rejected prompt releases the pending item and hands its text back", async () => {
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+
   await chat.prompt("do it");
   expect(chat.transcript.items.at(-1)).toMatchObject({ kind: "user", pending: true });
+  expect(chat.busy).toBe(true);
 
-  ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Agent connection lost." }) });
+  // The hub refuses the turn ("Session is busy — wait for the current turn…").
+  ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Session is busy." }) });
 
-  // Never fold a notice between an optimistic prompt and its echo.
-  expect(chat.transcript.items.at(-1)).toMatchObject({ kind: "user", pending: true });
-  expect(chat.transcript.items.filter((it) => it.kind === "notice")).toHaveLength(0);
-  expect(chat.error).toBe("Agent connection lost.");
+  // No ghost bubble, no notice folded between prompt and echo, composer usable.
+  expect(chat.transcript.items).toEqual([]);
+  expect(chat.busy).toBe(false);
+  expect(chat.error).toBe("Session is busy.");
+  expect(failed).toEqual(["do it"]);
 
-  // The echo still reconciles cleanly afterwards.
-  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "do it" }) });
-  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "do it" }]);
+  // And the session is still usable: the next prompt goes out normally.
+  await chat.prompt("again");
+  expect(ws.frames()).toContainEqual({ t: "prompt", text: "again" });
 });
 
-test("seq-0 error with no live turn folds a notice and sets error; cursor unmoved", async () => {
+test("an exhausted reconnect budget releases a pending prompt instead of wedging", async () => {
+  vi.useFakeTimers();
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  MockWebSocket.latest()!.open();
+  MockWebSocket.latest()!.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await chat.prompt("lost in transit");
+  expect(chat.busy).toBe(true);
+
+  MockWebSocket.latest()!.drop();
+  vi.advanceTimersByTime(1000);
+  MockWebSocket.latest()!.drop();
+  vi.advanceTimersByTime(2000);
+  MockWebSocket.latest()!.drop();
+  vi.advanceTimersByTime(4000);
+  MockWebSocket.latest()!.drop();
+
+  expect(chat.connection).toBe("disconnected");
+  expect(chat.transcript.items).toEqual([]); // the echo will never arrive
+  expect(chat.busy).toBe(false);
+  expect(failed).toEqual(["lost in transit"]);
+  expect(chat.error).toBe("Couldn't reach the hub — check your connection.");
+});
+
+test("seq-0 error with no live turn goes to error only — never both surfaces", async () => {
   const { chat, ws } = await connectedChat();
 
   ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Prompt failed." }) });
 
-  expect(chat.transcript.items.at(-1)).toMatchObject({
-    kind: "notice",
-    level: "error",
-    text: "Prompt failed.",
-  });
+  // The strip owns it: duplicating the sentence as a transcript notice too made
+  // screen readers and eyes read the same failure twice.
+  expect(chat.transcript.items).toEqual([]);
   expect(chat.transcript.lastSeq).toBe(0);
   expect(chat.error).toBe("Prompt failed.");
 });

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -536,6 +536,126 @@ test("an exhausted reconnect budget releases a pending prompt instead of wedging
   expect(chat.error).toBe("Couldn't reach the hub — check your connection.");
 });
 
+test("a reconnect that succeeds without the echo releases the prompt (blip mid-send)", async () => {
+  vi.useFakeTimers();
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const ws1 = MockWebSocket.latest()!;
+  ws1.open();
+  ws1.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await chat.prompt("did the hub see this?");
+  expect(chat.busy).toBe(true);
+
+  // One drop; the FIRST reconnect succeeds and replays — and the replay carries
+  // no echo, which is the hub telling us it never saw the prompt.
+  ws1.drop();
+  vi.advanceTimersByTime(1000);
+  const ws2 = MockWebSocket.latest()!;
+  expect(ws2).not.toBe(ws1);
+  ws2.open();
+  ws2.fireMessage({ t: "replay-done", lastSeq: 0 });
+
+  expect(chat.connection).toBe("connected");
+  expect(chat.transcript.items).toEqual([]); // no ghost bubble
+  expect(chat.busy).toBe(false);
+  expect(failed).toEqual(["did the hub see this?"]);
+  expect(chat.error).toBe("Couldn't send that message — it's back in the box, try again.");
+});
+
+test("replay-done on the socket the prompt was sent on does NOT release it", async () => {
+  // A fresh session answers subscribe before it has finished handling the prompt
+  // flushed right behind it — releasing there would kill a prompt in flight.
+  const failed: string[] = [];
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.prompt("hello");
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "hello", pending: true },
+  ]);
+  expect(failed).toEqual([]);
+  expect(chat.error).toBeNull();
+
+  // …and the echo that follows reconciles it as usual.
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hello" }) });
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "hello" }]);
+  expect(chat.busy).toBe(false);
+});
+
+test("an error for a different client frame never steals the pending prompt", async () => {
+  // The hub's error frame is the catch-all for cancel/permission-answer/set-mode
+  // too, so position alone must not decide whose failure it is — restoring the
+  // draft here would invite a duplicate send while the real prompt is in flight.
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await chat.prompt("real prompt");
+
+  chat.answer(7, "allow"); // whatever the error turns out to be, it's this frame's
+  ws.fireMessage({
+    t: "event",
+    event: ev(0, "error", { message: "No pending permission request." }),
+  });
+
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "real prompt", pending: true },
+  ]);
+  expect(failed).toEqual([]);
+  expect(chat.error).toBe("No pending permission request.");
+
+  // The prompt resolves the normal way when its echo lands.
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "real prompt" }) });
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "real prompt" }]);
+});
+
+test("an ending session releases a pending prompt instead of keeping a phantom", async () => {
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await chat.prompt("too late");
+
+  ws.fireMessage({ t: "event", event: ev(1, "state", { status: "ended", reason: "stopped" }) });
+
+  expect(chat.transcript.status).toBe("ended");
+  expect(chat.transcript.items).toEqual([
+    { kind: "notice", seq: 1, level: "info", text: "Session ended — stopped" },
+  ]);
+  expect(failed).toEqual(["too late"]);
+  expect(chat.busy).toBe(false);
+});
+
+test("bye with a pending prompt leaves no phantom message either", async () => {
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await chat.prompt("never sent");
+
+  ws.fireMessage({ t: "bye", reason: "ended" });
+
+  expect(failed).toEqual(["never sent"]);
+  expect(chat.transcript.items.filter((it) => it.kind === "user")).toEqual([]);
+  expect(chat.transcript.status).toBe("ended");
+  expect(chat.busy).toBe(false);
+});
+
 test("seq-0 error with no live turn goes to error only — never both surfaces", async () => {
   const { chat, ws } = await connectedChat();
 

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -271,6 +271,37 @@ test("prompt while the agent is working is a no-op", async () => {
   expect(chat.transcript.items.filter((it) => it.kind === "user")).toHaveLength(1);
 });
 
+test("busy mirrors every refusal window the composer must respect", async () => {
+  // (1) create in flight — the POST is deliberately left unresolved.
+  let resolveCreate: (r: AcpSessionRow) => void = () => {};
+  vi.spyOn(api, "createAcpSession").mockReturnValue(
+    new Promise<AcpSessionRow>((res) => {
+      resolveCreate = res;
+    }),
+  );
+
+  const fresh = new AcpChat("st1");
+  expect(fresh.busy).toBe(false); // idle, no session
+  const inFlight = fresh.prompt("hello");
+  expect(fresh.busy).toBe(true);
+  resolveCreate(row());
+  await inFlight;
+
+  // (2) optimistic prompt awaiting its echo.
+  expect(fresh.busy).toBe(true);
+  MockWebSocket.latest()!.fireMessage({
+    t: "event",
+    event: ev(1, "user-prompt", { text: "hello" }),
+  });
+  expect(fresh.busy).toBe(false);
+
+  // (3) agent working.
+  MockWebSocket.latest()!.fireMessage({ t: "event", event: ev(2, "state", { status: "working" }) });
+  expect(fresh.busy).toBe(true);
+  MockWebSocket.latest()!.fireMessage({ t: "event", event: ev(3, "state", { status: "idle" }) });
+  expect(fresh.busy).toBe(false);
+});
+
 test("prompt after destroy dials nothing", async () => {
   vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
   const { chat, ws } = await connectedChat();

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -1,0 +1,455 @@
+/**
+ * acp-chat.svelte.test.ts
+ *
+ * Unit tests for the AcpChat session controller — the stateful orchestrator
+ * between the ACP api client (REST + WS) and the pure transcript projection.
+ * Uses a mocked globalThis.WebSocket (the real createAcpSocket runs against
+ * it) plus vi.spyOn on the api module's REST helpers, so no network is
+ * touched.
+ *
+ * Run: cd apps/console && pnpm test src/lib/components/stations/chat/acp-chat
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AcpEvent, AcpSessionRow } from "@agentpod/contract";
+import * as api from "$lib/api/acp";
+import { AcpChat } from "./acp-chat.svelte";
+
+// ─── Minimal WebSocket stub ───────────────────────────────────────────────────
+
+class MockWebSocket {
+  /** Every socket constructed since the last reset, in creation order. */
+  static instances: MockWebSocket[] = [];
+  static latest(): MockWebSocket | null {
+    return MockWebSocket.instances.at(-1) ?? null;
+  }
+
+  url: string;
+  readyState: number = 0; // CONNECTING
+
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+
+  /** Payloads passed to ws.send(), as raw strings. */
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3; // CLOSED
+    this.onclose?.(new CloseEvent("close"));
+  }
+
+  /** Test helper: simulate the server opening the connection. */
+  open() {
+    this.readyState = 1; // OPEN
+    this.onopen?.(new Event("open"));
+  }
+
+  /** Test helper: simulate a JSON message from the server. */
+  fireMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+
+  /** Test helper: the server/network drops the socket (client never called close). */
+  drop() {
+    this.readyState = 3; // CLOSED
+    this.onclose?.(new CloseEvent("close"));
+  }
+
+  /** Test helper: parsed frames sent so far. */
+  frames(): unknown[] {
+    return this.sent.map((s) => JSON.parse(s));
+  }
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  MockWebSocket.instances = [];
+  localStorage.setItem("agentpod.apiUrl", "http://hub.test:3001");
+  (globalThis as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  MockWebSocket.instances = [];
+  localStorage.clear();
+});
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function row(over: Partial<AcpSessionRow> = {}): AcpSessionRow {
+  return {
+    id: "s1",
+    stationId: "st1",
+    userId: "u1",
+    mode: "ask",
+    status: "idle",
+    endedReason: null,
+    createdAt: "2026-08-09T00:00:00.000Z",
+    lastEventAt: "2026-08-09T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function ev(seq: number, type: AcpEvent["type"], payload: unknown): AcpEvent {
+  return { sessionId: "s1", seq, type, payload, createdAt: "2026-08-09T00:00:01.000Z" };
+}
+
+const chunk = (seq: number, text: string) =>
+  ev(seq, "agent-update", { sessionUpdate: "agent_message_chunk", content: { type: "text", text } });
+
+/** Boots a chat attached to an existing idle session and drives it to connected. */
+async function connectedChat(): Promise<{ chat: AcpChat; ws: MockWebSocket }> {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "session", session: row() });
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  return { chat, ws };
+}
+
+// ─── (a) init: attach + replay ───────────────────────────────────────────────
+
+test("init attaches to the newest non-ended session and replays to connected", async () => {
+  const ended = row({ id: "s0", status: "ended", createdAt: "2026-08-08T00:00:00.000Z" });
+  const active = row({ id: "s1", mode: "accept-edits", createdAt: "2026-08-09T00:00:00.000Z" });
+  // Deliberately unsorted: the controller must pick the newest by createdAt.
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([active, ended]);
+
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  expect(api.listAcpSessions).toHaveBeenCalledWith("st1");
+  const ws = MockWebSocket.latest();
+  expect(ws).toBeTruthy();
+  expect(ws!.url).toContain("/api/acp/sessions/s1/ws");
+  expect(chat.connection).toBe("connecting");
+
+  ws!.open();
+  expect(ws!.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]);
+
+  ws!.fireMessage({ t: "session", session: active });
+  ws!.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hi" }) });
+  ws!.fireMessage({ t: "event", event: chunk(2, "hello") });
+  expect(chat.connection).toBe("connecting"); // not connected until replay-done
+  ws!.fireMessage({ t: "replay-done", lastSeq: 2 });
+
+  expect(chat.connection).toBe("connected");
+  expect(chat.session?.id).toBe("s1");
+  expect(chat.mode).toBe("accept-edits"); // synced from the session row
+  expect(chat.transcript.lastSeq).toBe(2);
+  expect(chat.transcript.items.map((it) => it.kind)).toEqual(["user", "assistant"]);
+});
+
+// ─── (b) init: only ended sessions → idle, no socket ─────────────────────────
+
+test("init with only ended sessions stays idle without opening a socket", async () => {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ status: "ended" })]);
+
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  expect(MockWebSocket.instances).toHaveLength(0);
+  expect(chat.session).toBeNull();
+  expect(chat.connection).toBe("idle");
+});
+
+test("init surfaces the api error when listing sessions fails", async () => {
+  vi.spyOn(api, "listAcpSessions").mockRejectedValue(
+    new Error("Couldn't reach the hub — check your connection."),
+  );
+
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  expect(chat.error).toBe("Couldn't reach the hub — check your connection.");
+  expect(chat.connection).toBe("idle");
+  expect(MockWebSocket.instances).toHaveLength(0);
+});
+
+// ─── (c) prompt with no session: create → subscribe → prompt ─────────────────
+
+test("prompt with no session creates one, subscribes, sends, and reconciles the echo", async () => {
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
+
+  const chat = new AcpChat("st1");
+  await chat.prompt("hello");
+
+  expect(api.createAcpSession).toHaveBeenCalledWith("st1", "ask");
+  const ws = MockWebSocket.latest()!;
+  expect(ws.url).toContain("/api/acp/sessions/s1/ws");
+
+  // Optimistic item visible immediately.
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "hello", pending: true },
+  ]);
+
+  ws.open(); // buffered frames flush in order: subscribe first, then prompt
+  expect(ws.frames()).toEqual([
+    { t: "subscribe", sinceSeq: 0 },
+    { t: "prompt", text: "hello" },
+  ]);
+
+  // The echoed user-prompt event replaces the optimistic item.
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hello" }) });
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "hello" }]);
+});
+
+test("prompt surfaces the create failure message and keeps no session", async () => {
+  vi.spyOn(api, "createAcpSession").mockRejectedValue(
+    new Error("That station's node is offline."),
+  );
+
+  const chat = new AcpChat("st1");
+  await chat.prompt("hello");
+
+  expect(chat.error).toBe("That station's node is offline.");
+  expect(chat.session).toBeNull();
+  expect(MockWebSocket.instances).toHaveLength(0);
+  expect(chat.transcript.items).toEqual([]); // no optimistic item for a failed create
+});
+
+// ─── (d) reconnect budget ────────────────────────────────────────────────────
+
+test("unexpected close reconnects and re-subscribes with sinceSeq = lastSeq", async () => {
+  vi.useFakeTimers();
+  const { chat, ws } = await connectedChat();
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hi" }) });
+  ws.fireMessage({ t: "event", event: chunk(2, "yo") });
+  expect(chat.transcript.lastSeq).toBe(2);
+
+  ws.drop();
+  expect(chat.connection).toBe("reconnecting");
+  expect(MockWebSocket.instances).toHaveLength(1); // backoff pending, not yet redialed
+
+  vi.advanceTimersByTime(1000);
+  const ws2 = MockWebSocket.latest()!;
+  expect(ws2).not.toBe(ws);
+  ws2.open();
+  expect(ws2.frames()).toEqual([{ t: "subscribe", sinceSeq: 2 }]);
+
+  ws2.fireMessage({ t: "replay-done", lastSeq: 2 });
+  expect(chat.connection).toBe("connected");
+});
+
+test("three failed reconnects exhaust the budget; retry() resets it", async () => {
+  vi.useFakeTimers();
+  const { chat, ws } = await connectedChat();
+
+  ws.drop();
+  vi.advanceTimersByTime(1000);
+  MockWebSocket.latest()!.drop();
+  vi.advanceTimersByTime(2000);
+  MockWebSocket.latest()!.drop();
+  vi.advanceTimersByTime(4000);
+  MockWebSocket.latest()!.drop();
+
+  expect(chat.connection).toBe("disconnected");
+  expect(chat.error).toBe("Couldn't reach the hub — check your connection.");
+  const count = MockWebSocket.instances.length;
+  vi.advanceTimersByTime(60_000);
+  expect(MockWebSocket.instances).toHaveLength(count); // budget spent — no more dials
+
+  chat.retry();
+  const ws5 = MockWebSocket.latest()!;
+  expect(MockWebSocket.instances).toHaveLength(count + 1);
+  ws5.open();
+  ws5.fireMessage({ t: "replay-done", lastSeq: 0 });
+  expect(chat.connection).toBe("connected");
+  expect(chat.error).toBeNull();
+
+  // The budget was reset: a fresh drop goes back to reconnecting, not disconnected.
+  ws5.drop();
+  expect(chat.connection).toBe("reconnecting");
+});
+
+// ─── (e) bye → session over, no reconnect ────────────────────────────────────
+
+test("bye ends the session: ended notice, idle connection, no reconnect", async () => {
+  vi.useFakeTimers();
+  const { chat, ws } = await connectedChat();
+
+  ws.fireMessage({ t: "bye", reason: "agent exited" });
+
+  expect(chat.transcript.status).toBe("ended");
+  const last = chat.transcript.items.at(-1);
+  expect(last).toMatchObject({ kind: "notice", level: "info" });
+  expect((last as { text: string }).text).toContain("Session ended");
+  expect(chat.connection).toBe("idle");
+
+  // The socket close that follows a bye is expected — never a reconnect.
+  vi.advanceTimersByTime(60_000);
+  expect(MockWebSocket.instances).toHaveLength(1);
+});
+
+test("bye after an ended state event does not duplicate the ended notice", async () => {
+  const { chat, ws } = await connectedChat();
+
+  ws.fireMessage({ t: "event", event: ev(3, "state", { status: "ended", reason: "done" }) });
+  ws.fireMessage({ t: "bye", reason: "ended" });
+
+  const notices = chat.transcript.items.filter((it) => it.kind === "notice");
+  expect(notices).toHaveLength(1);
+  expect(chat.connection).toBe("idle");
+});
+
+// ─── (f) answer ──────────────────────────────────────────────────────────────
+
+test("answer sends optionId, and null sends cancelled:true", async () => {
+  const { ws, chat } = await connectedChat();
+  const before = ws.sent.length;
+
+  chat.answer(5, "allow");
+  chat.answer(6, null);
+
+  expect(ws.frames().slice(before)).toEqual([
+    { t: "permission-answer", requestSeq: 5, optionId: "allow" },
+    { t: "permission-answer", requestSeq: 6, cancelled: true },
+  ]);
+});
+
+// ─── (g) destroy: close only — hub-owned session, never DELETE ───────────────
+
+test("destroy closes the socket without DELETE and never reconnects", async () => {
+  vi.useFakeTimers();
+  const endSpy = vi.spyOn(api, "endAcpSession");
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+  const { chat, ws } = await connectedChat();
+
+  chat.destroy();
+
+  expect(ws.readyState).toBe(3); // CLOSED
+  expect(endSpy).not.toHaveBeenCalled();
+  expect(fetchSpy).not.toHaveBeenCalled(); // no DELETE (or any request) fired
+  vi.advanceTimersByTime(60_000);
+  expect(MockWebSocket.instances).toHaveLength(1);
+  vi.unstubAllGlobals();
+});
+
+// ─── (h) end: DELETE; ended state arrives via events ─────────────────────────
+
+test("end() DELETEs via the api; the ended state arrives via events, not locally", async () => {
+  const endSpy = vi.spyOn(api, "endAcpSession").mockResolvedValue(undefined);
+  const { chat, ws } = await connectedChat();
+
+  await chat.end();
+
+  expect(endSpy).toHaveBeenCalledWith("s1");
+  expect(chat.transcript.status).not.toBe("ended"); // not forced locally
+  expect(chat.session).not.toBeNull();
+
+  ws.fireMessage({ t: "event", event: ev(3, "state", { status: "ended", reason: "ended by user" }) });
+  ws.fireMessage({ t: "bye", reason: "ended" });
+
+  expect(chat.transcript.status).toBe("ended");
+  expect(chat.connection).toBe("idle");
+});
+
+// ─── Synthetic seq-0 error events ────────────────────────────────────────────
+
+test("seq-0 error with a trailing pending prompt goes to error, not the transcript", async () => {
+  const { chat, ws } = await connectedChat();
+  await chat.prompt("do it");
+  expect(chat.transcript.items.at(-1)).toMatchObject({ kind: "user", pending: true });
+
+  ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Agent connection lost." }) });
+
+  // Never fold a notice between an optimistic prompt and its echo.
+  expect(chat.transcript.items.at(-1)).toMatchObject({ kind: "user", pending: true });
+  expect(chat.transcript.items.filter((it) => it.kind === "notice")).toHaveLength(0);
+  expect(chat.error).toBe("Agent connection lost.");
+
+  // The echo still reconciles cleanly afterwards.
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "do it" }) });
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "do it" }]);
+});
+
+test("seq-0 error with no live turn folds a notice and sets error; cursor unmoved", async () => {
+  const { chat, ws } = await connectedChat();
+
+  ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Prompt failed." }) });
+
+  expect(chat.transcript.items.at(-1)).toMatchObject({
+    kind: "notice",
+    level: "error",
+    text: "Prompt failed.",
+  });
+  expect(chat.transcript.lastSeq).toBe(0);
+  expect(chat.error).toBe("Prompt failed.");
+});
+
+test("seq-0 error during a live turn folds a notice without setting error", async () => {
+  const { chat, ws } = await connectedChat();
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "go" }) });
+  ws.fireMessage({ t: "event", event: ev(2, "state", { status: "working" }) });
+  expect(chat.working).toBe(true);
+
+  ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Tool hiccup." }) });
+
+  expect(chat.transcript.items.at(-1)).toMatchObject({ kind: "notice", text: "Tool hiccup." });
+  expect(chat.error).toBeNull();
+});
+
+// ─── Small surface: cancel / setMode / derived getters ───────────────────────
+
+test("cancel sends {t:'cancel'}; setMode sends set-mode and updates locally", async () => {
+  const { chat, ws } = await connectedChat();
+  const before = ws.sent.length;
+
+  chat.cancel();
+  chat.setMode("full-auto");
+
+  expect(chat.mode).toBe("full-auto");
+  expect(ws.frames().slice(before)).toEqual([
+    { t: "cancel" },
+    { t: "set-mode", mode: "full-auto" },
+  ]);
+});
+
+test("pendingPermissions counts unanswered permission items", async () => {
+  const { chat, ws } = await connectedChat();
+
+  ws.fireMessage({
+    t: "event",
+    event: ev(1, "permission-request", {
+      toolCall: { title: "Edit file" },
+      options: [{ optionId: "allow", name: "Allow", kind: "allow_once" }],
+    }),
+  });
+  expect(chat.pendingPermissions).toBe(1);
+
+  ws.fireMessage({
+    t: "event",
+    event: ev(2, "permission-answer", { requestSeq: 1, optionId: "allow" }),
+  });
+  expect(chat.pendingPermissions).toBe(0);
+});
+
+test("newSession resets to the empty state", async () => {
+  const { chat, ws } = await connectedChat();
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hi" }) });
+  ws.fireMessage({ t: "bye", reason: "ended" });
+
+  chat.newSession();
+
+  expect(chat.session).toBeNull();
+  expect(chat.transcript.items).toEqual([]);
+  expect(chat.transcript.lastSeq).toBe(0);
+  expect(chat.connection).toBe("idle");
+  expect(chat.error).toBeNull();
+});

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -223,6 +223,67 @@ test("prompt surfaces the create failure message and keeps no session", async ()
   expect(chat.transcript.items).toEqual([]); // no optimistic item for a failed create
 });
 
+// ─── prompt: double-submission guard ─────────────────────────────────────────
+
+test("concurrent prompts with no session issue exactly one create", async () => {
+  const createSpy = vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
+
+  const chat = new AcpChat("st1");
+  const first = chat.prompt("one");
+  const second = chat.prompt("two"); // refused: create in flight
+  await Promise.all([first, second]);
+
+  expect(createSpy).toHaveBeenCalledTimes(1);
+  expect(MockWebSocket.instances).toHaveLength(1);
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  expect(ws.frames()).toEqual([
+    { t: "subscribe", sinceSeq: 0 },
+    { t: "prompt", text: "one" },
+  ]);
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "one", pending: true },
+  ]);
+});
+
+test("prompt while an optimistic prompt is still pending is a no-op", async () => {
+  const { chat, ws } = await connectedChat();
+  await chat.prompt("first");
+  const framesBefore = ws.sent.length;
+
+  await chat.prompt("second"); // refused: pending echo outstanding
+
+  expect(ws.sent).toHaveLength(framesBefore);
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "first", pending: true },
+  ]);
+});
+
+test("prompt while the agent is working is a no-op", async () => {
+  const { chat, ws } = await connectedChat();
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "go" }) });
+  ws.fireMessage({ t: "event", event: ev(2, "state", { status: "working" }) });
+  const framesBefore = ws.sent.length;
+
+  await chat.prompt("more"); // refused: one turn at a time
+
+  expect(ws.sent).toHaveLength(framesBefore);
+  expect(chat.transcript.items.filter((it) => it.kind === "user")).toHaveLength(1);
+});
+
+test("prompt after destroy dials nothing", async () => {
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(row());
+  const { chat, ws } = await connectedChat();
+  chat.destroy();
+  const count = MockWebSocket.instances.length;
+
+  await chat.prompt("late");
+
+  expect(MockWebSocket.instances).toHaveLength(count); // no redial
+  expect(api.createAcpSession).not.toHaveBeenCalled();
+  expect(ws.sent.filter((s) => (JSON.parse(s) as { t: string }).t === "prompt")).toHaveLength(0);
+});
+
 // ─── (d) reconnect budget ────────────────────────────────────────────────────
 
 test("unexpected close reconnects and re-subscribes with sinceSeq = lastSeq", async () => {
@@ -309,16 +370,16 @@ test("bye after an ended state event does not duplicate the ended notice", async
 
 // ─── (f) answer ──────────────────────────────────────────────────────────────
 
-test("answer sends optionId, and null sends cancelled:true", async () => {
+test("answer sends the permission-answer frame with the chosen optionId", async () => {
   const { ws, chat } = await connectedChat();
   const before = ws.sent.length;
 
   chat.answer(5, "allow");
-  chat.answer(6, null);
+  chat.answer(6, "reject");
 
   expect(ws.frames().slice(before)).toEqual([
     { t: "permission-answer", requestSeq: 5, optionId: "allow" },
-    { t: "permission-answer", requestSeq: 6, cancelled: true },
+    { t: "permission-answer", requestSeq: 6, optionId: "reject" },
   ]);
 });
 

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -1,0 +1,365 @@
+/**
+ * acp-chat.svelte.ts
+ *
+ * AcpChat — the stateful session controller behind a station's chat panel.
+ * One instance per panel (no module-level state). It orchestrates:
+ *
+ *   - the ACP api client ($lib/api/acp): REST session lifecycle + the WS
+ *     bridge (createAcpSocket), and
+ *   - the pure transcript projection (./transcript): every server event is
+ *     folded immutably, so views key off item references.
+ *
+ * Lifecycle contracts (hub-owned sessions):
+ *   - `destroy()` closes the socket ONLY — it never DELETEs. A WS close is
+ *     never session end; the session keeps running on the hub and a later
+ *     socket re-subscribes and replays.
+ *   - `end()` is the only DELETE path. Even then the UI settles on the
+ *     hub's own `state: ended` event / `bye` — nothing is forced locally.
+ *   - Reconnects (budget 3, backoff 1s/2s/4s — mirrors Terminal.svelte)
+ *     re-subscribe with `sinceSeq = transcript.lastSeq` so replay fills the
+ *     gap ("working while away").
+ *   - `bye` arrives as a server MESSAGE; the socket close that follows it is
+ *     expected and must not trigger a reconnect.
+ */
+
+import type { AcpEvent, AcpSessionMode } from "@agentpod/contract";
+import {
+  createAcpSession,
+  createAcpSocket,
+  endAcpSession,
+  listAcpSessions,
+  type AcpClientMsg,
+  type AcpServerMsg,
+  type AcpSessionRow,
+  type AcpSocket,
+} from "$lib/api/acp";
+import { addPendingPrompt, emptyTranscript, foldEvent, type Transcript } from "./transcript";
+
+export type ChatConnection = "idle" | "connecting" | "connected" | "reconnecting" | "disconnected";
+
+const MAX_ATTEMPTS = 3;
+const BACKOFF_MS = [1000, 2000, 4000];
+
+const OFFLINE_COPY = "Couldn't reach the hub — check your connection.";
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+export class AcpChat {
+  // ── Reactive state ($state-backed, exposed via getters) ────────────────────
+  #session = $state<AcpSessionRow | null>(null);
+  #transcript = $state<Transcript>(emptyTranscript());
+  #connection = $state<ChatConnection>("idle");
+  #error = $state<string | null>(null);
+
+  /** Mode selector state; defaults "ask", synced from the session row. */
+  mode = $state<AcpSessionMode>("ask");
+
+  // ── Plain (non-reactive) refs — timers and the live socket ────────────────
+  private readonly stationId: string;
+  private socket: AcpSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Reconnect attempts used since the last successful connect. */
+  private attempt = 0;
+  /** Set on `bye`: the session is over — the following close is expected. */
+  private sessionOver = false;
+  private destroyed = false;
+
+  constructor(stationId: string) {
+    this.stationId = stationId;
+  }
+
+  get session(): AcpSessionRow | null {
+    return this.#session;
+  }
+
+  get transcript(): Transcript {
+    return this.#transcript;
+  }
+
+  get connection(): ChatConnection {
+    return this.#connection;
+  }
+
+  /** Last surfaced failure, "Couldn't …" copy. Cleared on prompt/reconnect. */
+  get error(): string | null {
+    return this.#error;
+  }
+
+  get working(): boolean {
+    return this.#transcript.status === "working";
+  }
+
+  get pendingPermissions(): number {
+    let n = 0;
+    for (const it of this.#transcript.items) {
+      if (it.kind === "permission" && !it.answer) n += 1;
+    }
+    return n;
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /** List sessions; if the newest is non-ended, attach. Else stay idle (empty state). */
+  async init(): Promise<void> {
+    let rows: AcpSessionRow[];
+    try {
+      rows = await listAcpSessions(this.stationId);
+    } catch (err) {
+      this.#error = errMessage(err);
+      return;
+    }
+    if (this.destroyed) return;
+
+    // The hub doesn't guarantee order — pick the newest by createdAt (ISO
+    // strings compare lexicographically).
+    let newest: AcpSessionRow | null = null;
+    for (const row of rows) {
+      if (newest === null || row.createdAt > newest.createdAt) newest = row;
+    }
+    if (!newest || newest.status === "ended") return;
+
+    this.#session = newest;
+    this.mode = newest.mode;
+    this.startConnection();
+  }
+
+  /** Send a prompt, creating a session first if none is live. */
+  async prompt(text: string): Promise<void> {
+    if (!text) return;
+    this.#error = null;
+
+    if (!this.#session || this.sessionOver || this.#transcript.status === "ended") {
+      let row: AcpSessionRow;
+      try {
+        row = await createAcpSession(this.stationId, this.mode);
+      } catch (err) {
+        // The ApiError message already carries the right "Couldn't …" grammar.
+        this.#error = errMessage(err);
+        return;
+      }
+      if (this.destroyed) return;
+      this.teardownSocket();
+      this.sessionOver = false;
+      this.attempt = 0;
+      this.#session = row;
+      this.mode = row.mode;
+      this.#transcript = emptyTranscript();
+      this.startConnection();
+    } else if (!this.socket) {
+      // e.g. after budget exhaustion: reopen before prompting. The socket
+      // buffers pre-open sends, so subscribe still precedes the prompt.
+      this.clearReconnectTimer();
+      this.attempt = 0;
+      this.startConnection();
+    }
+
+    this.#transcript = addPendingPrompt(this.#transcript, text);
+    this.socket?.send({ t: "prompt", text });
+  }
+
+  cancel(): void {
+    this.socket?.send({ t: "cancel" });
+  }
+
+  /** Answer a permission request; `null` means the user dismissed/cancelled it. */
+  answer(requestSeq: number, optionId: string | null): void {
+    if (optionId === null) {
+      // Spec'd wire shape for a user cancel. NOTE: the contract's AcpClientMsg
+      // permission-answer variant doesn't carry `cancelled` yet — the cast
+      // keeps the spec'd frame until the contract/hub grow the variant.
+      this.socket?.send({
+        t: "permission-answer",
+        requestSeq,
+        cancelled: true,
+      } as unknown as AcpClientMsg);
+    } else {
+      this.socket?.send({ t: "permission-answer", requestSeq, optionId });
+    }
+  }
+
+  setMode(mode: AcpSessionMode): void {
+    this.mode = mode;
+    if (this.#session && !this.sessionOver) {
+      this.socket?.send({ t: "set-mode", mode });
+    }
+  }
+
+  /** REST DELETE — the only path that ends a session. UI settles on bye/ended. */
+  async end(): Promise<void> {
+    const session = this.#session;
+    if (!session) return;
+    try {
+      await endAcpSession(session.id);
+    } catch (err) {
+      this.#error = errMessage(err);
+    }
+    // The ended state arrives via the event stream (state: ended → bye);
+    // nothing is forced locally.
+  }
+
+  /** After ended: reset to the empty state (keep nothing but the mode selector). */
+  newSession(): void {
+    this.clearReconnectTimer();
+    this.teardownSocket();
+    this.#session = null;
+    this.#transcript = emptyTranscript();
+    this.#connection = "idle";
+    this.#error = null;
+    this.sessionOver = false;
+    this.attempt = 0;
+  }
+
+  /** Manual reconnect — resets the backoff budget before retrying. */
+  retry(): void {
+    if (this.destroyed || this.sessionOver || !this.#session) return;
+    this.clearReconnectTimer();
+    this.teardownSocket();
+    this.attempt = 0;
+    this.#error = null;
+    this.startConnection();
+  }
+
+  /** Close the socket. NEVER ends the session — it stays live on the hub. */
+  destroy(): void {
+    this.destroyed = true;
+    this.clearReconnectTimer();
+    this.teardownSocket();
+  }
+
+  // ── Connection lifecycle ───────────────────────────────────────────────────
+
+  private startConnection(): void {
+    const session = this.#session;
+    if (!session) return;
+    this.#connection = this.attempt === 0 ? "connecting" : "reconnecting";
+
+    const s = createAcpSocket(session.id);
+    this.socket = s;
+    s.onMessage((msg) => this.handleMessage(s, msg));
+    s.onClose(() => this.handleClose(s));
+    // Replay fills the gap since the cursor — this is the "working while
+    // away" path on reconnect; 0 on a fresh session.
+    s.send({ t: "subscribe", sinceSeq: this.#transcript.lastSeq });
+  }
+
+  private handleMessage(s: AcpSocket, msg: AcpServerMsg): void {
+    // Ignore messages from a socket that's no longer the active one (a
+    // reconnect raced with an in-flight teardown).
+    if (this.socket !== s) return;
+
+    switch (msg.t) {
+      case "session":
+        this.#session = msg.session;
+        this.mode = msg.session.mode;
+        break;
+      case "event":
+        this.applyEvent(msg.event);
+        break;
+      case "replay-done":
+        this.#connection = "connected";
+        this.attempt = 0;
+        this.#error = null;
+        break;
+      case "bye":
+        this.handleBye(msg.reason);
+        break;
+    }
+  }
+
+  private applyEvent(ev: AcpEvent): void {
+    // Synthetic seq-0 errors (hub-side failures outside the persisted stream)
+    // never advance the cursor. Two extra caller rules apply here:
+    if (ev.type === "error" && ev.seq === 0) {
+      const message = isRecord(ev.payload) && typeof ev.payload.message === "string"
+        ? ev.payload.message
+        : "Something went wrong.";
+      const last = this.#transcript.items.at(-1);
+      if (last?.kind === "user" && last.pending) {
+        // Never fold a notice between an optimistic pending prompt and its
+        // echoed user-prompt event — the reconcile only checks the LAST item.
+        this.#error = message;
+        return;
+      }
+      this.#transcript = foldEvent(this.#transcript, ev);
+      const status = this.#transcript.status;
+      if (status !== "working" && status !== "waiting") {
+        // No live turn: also surface via the strip so the input area shows it.
+        this.#error = message;
+      }
+      return;
+    }
+
+    this.#transcript = foldEvent(this.#transcript, ev);
+  }
+
+  private handleBye(reason: string): void {
+    this.sessionOver = true;
+    if (this.#transcript.status !== "ended") {
+      // The hub's ended event didn't make it here — fold a final ended notice
+      // locally (synthetic seq-0 state event: never advances the cursor).
+      this.#transcript = foldEvent(this.#transcript, {
+        sessionId: this.#session?.id ?? "",
+        seq: 0,
+        type: "state",
+        payload: { status: "ended", reason },
+        createdAt: new Date().toISOString(),
+      });
+    }
+    this.clearReconnectTimer();
+    this.teardownSocket(); // the server closes right after bye anyway
+    this.#connection = "idle";
+  }
+
+  private handleClose(s: AcpSocket): void {
+    // Stale-client guard (mirrors Terminal.svelte): a close from a replaced
+    // socket must not touch the live connection.
+    if (this.socket !== s) return;
+    this.socket = null;
+    if (this.destroyed) return;
+
+    if (this.sessionOver || this.#transcript.status === "ended") {
+      // The close after a bye / ended session is expected — no reconnect.
+      this.#connection = "idle";
+      return;
+    }
+    // Note: a socket drop never folds anything into the transcript (a notice
+    // could land between a pending prompt and its echo) — failures surface
+    // via `error` on budget exhaustion only.
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.attempt >= MAX_ATTEMPTS) {
+      this.#connection = "disconnected";
+      this.#error = OFFLINE_COPY;
+      return;
+    }
+    this.#connection = "reconnecting";
+    const delay = BACKOFF_MS[this.attempt];
+    this.attempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.startConnection();
+    }, delay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  /** Close and detach the current socket (manual close — fires no onClose). */
+  private teardownSocket(): void {
+    const s = this.socket;
+    this.socket = null;
+    s?.close();
+  }
+}

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -21,12 +21,17 @@
  *   - `bye` arrives as a server MESSAGE; the socket close that follows it is
  *     expected and must not trigger a reconnect.
  *
+ * Error surfacing: a synthetic seq-0 error appears in ONE place, never two —
+ * as the fate of a trailing optimistic prompt (dropped, text handed back via
+ * `onPromptFailed`, message on `error`), else inline as a transcript notice
+ * while a turn is live, else on `error` for the panel's strip.
+ *
  * Permission dismissal: ACP has no per-request dismiss — agents supply reject
  * options in the request itself (answer with one of those), and `cancel()`
  * rejects ALL parked permissions (hub cancelTurn). Wire the UI accordingly.
  */
 
-import type { AcpEvent, AcpSessionMode } from "@agentpod/contract";
+import type { AcpEvent, AcpSessionMode, AcpSessionStatus } from "@agentpod/contract";
 import {
   createAcpSession,
   createAcpSocket,
@@ -36,7 +41,13 @@ import {
   type AcpSessionRow,
   type AcpSocket,
 } from "$lib/api/acp";
-import { addPendingPrompt, emptyTranscript, foldEvent, type Transcript } from "./transcript";
+import {
+  addPendingPrompt,
+  dropPendingPrompt,
+  emptyTranscript,
+  foldEvent,
+  type Transcript,
+} from "./transcript";
 
 export type ChatConnection = "idle" | "connecting" | "connected" | "reconnecting" | "disconnected";
 
@@ -81,8 +92,16 @@ export class AcpChat {
    */
   #creating = $state(false);
 
-  constructor(stationId: string) {
+  /**
+   * Called with the text of a prompt whose echo will never arrive (the hub
+   * rejected the turn, or the socket died before it landed). The panel hands it
+   * back to the composer so the user's words aren't lost with the turn.
+   */
+  private readonly onPromptFailed?: (text: string) => void;
+
+  constructor(stationId: string, options: { onPromptFailed?: (text: string) => void } = {}) {
     this.stationId = stationId;
+    this.onPromptFailed = options.onPromptFailed;
   }
 
   get session(): AcpSessionRow | null {
@@ -102,18 +121,44 @@ export class AcpChat {
     return this.#error;
   }
 
+  /**
+   * The session status every view must render. Stream truth once it exists, but
+   * `"starting"` doubles as the transcript's pre-event placeholder, so until a
+   * state event lands the session row's own status wins — otherwise reattaching
+   * to a *working* session reads as "starting" and the composer would happily
+   * offer to send into a turn the hub will reject.
+   *
+   * The header, the composer and `working`/`busy` all read THIS. Two views on
+   * two different status machines is how a user gets an enabled Send button
+   * during someone else's turn.
+   */
+  get status(): AcpSessionStatus {
+    return this.#transcript.status === "starting" && this.#session
+      ? this.#session.status
+      : this.#transcript.status;
+  }
+
   get working(): boolean {
-    return this.#transcript.status === "working";
+    return this.status === "working";
+  }
+
+  /** True while a socket is (re)connecting and its replay hasn't finished. */
+  get replaying(): boolean {
+    return (
+      this.#session !== null && (this.#connection === "connecting" || this.#connection === "reconnecting")
+    );
   }
 
   /**
    * True exactly when `prompt()` would refuse: a create is in flight, an
-   * optimistic prompt is still awaiting its echo, or the agent is working.
-   * The composer MUST be disabled (or shown as working) whenever this is
-   * true — PromptInput only keeps a draft it wasn't allowed to send.
+   * optimistic prompt is still awaiting its echo, the agent is working, or a
+   * replay is still in flight (the transcript — and therefore the status — is
+   * not yet trustworthy). The composer MUST be disabled (or shown as working)
+   * whenever this is true — PromptInput only keeps a draft it wasn't allowed
+   * to send.
    */
   get busy(): boolean {
-    return this.#creating || this.working || this.hasPendingPrompt();
+    return this.#creating || this.working || this.hasPendingPrompt() || this.replaying;
   }
 
   get pendingPermissions(): number {
@@ -153,9 +198,10 @@ export class AcpChat {
   /**
    * Send a prompt, creating a session first if none is live.
    *
-   * Double-submission guard: refuses (silent no-op) while a create is in
-   * flight, while a pending optimistic prompt is still awaiting its echo, or
-   * while the agent is working — one turn at a time.
+   * Refuses (silent no-op) whenever `busy` is true: a create in flight, an
+   * optimistic prompt still awaiting its echo, the agent working (one turn at a
+   * time), or a replay still in flight. The composer reads the same `busy`, so a
+   * refused send always keeps its draft.
    */
   async prompt(text: string): Promise<void> {
     if (!text || this.destroyed) return;
@@ -303,29 +349,49 @@ export class AcpChat {
   }
 
   private applyEvent(ev: AcpEvent): void {
-    // Synthetic seq-0 errors (hub-side failures outside the persisted stream)
-    // never advance the cursor. Two extra caller rules apply here:
+    // Synthetic seq-0 errors are hub-side failures outside the persisted stream:
+    // they never advance the cursor, and they surface in exactly ONE place so the
+    // same sentence never appears as both a transcript notice and a strip.
     if (ev.type === "error" && ev.seq === 0) {
       const message = isRecord(ev.payload) && typeof ev.payload.message === "string"
         ? ev.payload.message
         : "Something went wrong.";
-      const last = this.#transcript.items.at(-1);
-      if (last?.kind === "user" && last.pending) {
-        // Never fold a notice between an optimistic pending prompt and its
-        // echoed user-prompt event — the reconcile only checks the LAST item.
+
+      // A trailing optimistic prompt means THIS error is the fate of that
+      // prompt — the hub refused the turn ("Session is busy…", "…still
+      // starting."), so its echo will never arrive. Drop it: the ghost bubble
+      // would otherwise sit there forever with `busy` stuck true (readonly
+      // composer, no recovery short of a page reload), and dropping it is also
+      // what makes folding safe again.
+      if (this.hasPendingPrompt()) {
+        this.releasePendingPrompt();
         this.#error = message;
         return;
       }
-      this.#transcript = foldEvent(this.#transcript, ev);
-      const status = this.#transcript.status;
-      if (status !== "working" && status !== "waiting") {
-        // No live turn: also surface via the strip so the input area shows it.
-        this.#error = message;
+
+      if (this.status === "working" || this.status === "waiting") {
+        // Mid-turn: the error belongs inline, in the turn it happened to.
+        this.#transcript = foldEvent(this.#transcript, ev);
+        return;
       }
+      // No live turn: the strip owns it — it's the actionable surface, next to
+      // the composer the user is about to retype into.
+      this.#error = message;
       return;
     }
 
     this.#transcript = foldEvent(this.#transcript, ev);
+  }
+
+  /**
+   * Drop a trailing optimistic prompt whose echo will never arrive and hand its
+   * text back to the composer. Clears `busy`, so the composer is usable again.
+   */
+  private releasePendingPrompt(): void {
+    const { transcript, text } = dropPendingPrompt(this.#transcript);
+    if (text === null) return;
+    this.#transcript = transcript;
+    this.onPromptFailed?.(text);
   }
 
   private handleBye(reason: string): void {
@@ -367,6 +433,10 @@ export class AcpChat {
   private scheduleReconnect(): void {
     if (this.attempt >= MAX_ATTEMPTS) {
       this.#connection = "disconnected";
+      // The budget is gone: a prompt still awaiting its echo was either never
+      // sent or will never be echoed, so release it rather than wedge the
+      // composer behind a ghost bubble.
+      this.releasePendingPrompt();
       this.#error = OFFLINE_COPY;
       return;
     }

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -22,9 +22,18 @@
  *     expected and must not trigger a reconnect.
  *
  * Error surfacing: a synthetic seq-0 error appears in ONE place, never two —
- * as the fate of a trailing optimistic prompt (dropped, text handed back via
+ * as the fate of an OUTSTANDING prompt (dropped, text handed back via
  * `onPromptFailed`, message on `error`), else inline as a transcript notice
- * while a turn is live, else on `error` for the panel's strip.
+ * while a turn is live, else on `error` for the panel's strip. "Outstanding" is
+ * tracked, not guessed from position: the hub's error frame is the catch-all for
+ * every client frame (cancel, permission-answer, set-mode), so a trailing
+ * pending prompt alone proves nothing.
+ *
+ * An optimistic prompt is never left pending forever — that would freeze `busy`
+ * and the composer with it. It is resolved by exactly one of: the echoed
+ * user-prompt event (reconciled), an error attributed to it, `replay-done` with
+ * the tail still pending (the hub never saw it), reconnect-budget exhaustion
+ * (replay will never happen), or the session ending.
  *
  * Permission dismissal: ACP has no per-request dismiss — agents supply reject
  * options in the request itself (answer with one of those), and `cancel()`
@@ -55,6 +64,7 @@ const MAX_ATTEMPTS = 3;
 const BACKOFF_MS = [1000, 2000, 4000];
 
 const OFFLINE_COPY = "Couldn't reach the hub — check your connection.";
+const LOST_PROMPT_COPY = "Couldn't send that message — it's back in the box, try again.";
 
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -82,6 +92,22 @@ export class AcpChat {
   private attempt = 0;
   /** Set on `bye`: the session is over — the following close is expected. */
   private sessionOver = false;
+  /**
+   * True while a prompt frame is outstanding and NOTHING else has been sent
+   * since. Only then may a hub error be read as that prompt's fate: the hub
+   * uses the same error frame for cancel/permission-answer/set-mode failures,
+   * and misattributing one would restore a draft the user might send twice
+   * while the real prompt is still on its way.
+   */
+  private awaitingEcho = false;
+  /**
+   * The socket a still-pending prompt frame was written to. A `replay-done` from
+   * a DIFFERENT socket proves the hub never saw it (the replay would have
+   * carried the echo); a replay-done from the same socket proves nothing — on a
+   * fresh session the hub answers subscribe before it has finished handling the
+   * prompt that was flushed right behind it.
+   */
+  private promptSocket: AcpSocket | null = null;
   private destroyed = false;
 
   /**
@@ -238,9 +264,12 @@ export class AcpChat {
 
     this.#transcript = addPendingPrompt(this.#transcript, text);
     this.socket?.send({ t: "prompt", text });
+    this.awaitingEcho = true;
+    this.promptSocket = this.socket;
   }
 
   cancel(): void {
+    this.awaitingEcho = false; // a later error could just as well be this frame's
     this.socket?.send({ t: "cancel" });
   }
 
@@ -250,12 +279,14 @@ export class AcpChat {
    * parked permissions — ACP has no per-request dismiss.
    */
   answer(requestSeq: number, optionId: string): void {
+    this.awaitingEcho = false; // e.g. "No pending permission request." is not the prompt's fault
     this.socket?.send({ t: "permission-answer", requestSeq, optionId });
   }
 
   setMode(mode: AcpSessionMode): void {
     this.mode = mode;
     if (this.#session && !this.sessionOver) {
+      this.awaitingEcho = false;
       this.socket?.send({ t: "set-mode", mode });
     }
   }
@@ -282,6 +313,8 @@ export class AcpChat {
     this.#connection = "idle";
     this.#error = null;
     this.sessionOver = false;
+    this.awaitingEcho = false;
+    this.promptSocket = null;
     this.attempt = 0;
   }
 
@@ -341,6 +374,16 @@ export class AcpChat {
         this.#connection = "connected";
         this.attempt = 0;
         this.#error = null;
+        // Replay is the authoritative answer to "did the hub see my prompt?" —
+        // if it did, the echo arrived during this replay and reconciled the
+        // pending item. Still pending after a replay on a DIFFERENT socket means
+        // it never landed (a blip between send and delivery, or a socket that
+        // died with the frame still queued), so release it rather than leave
+        // `busy` — and the composer — stuck forever.
+        if (this.hasPendingPrompt() && this.promptSocket !== s) {
+          this.releasePendingPrompt();
+          this.#error = LOST_PROMPT_COPY;
+        }
         break;
       case "bye":
         this.handleBye(msg.reason);
@@ -357,13 +400,15 @@ export class AcpChat {
         ? ev.payload.message
         : "Something went wrong.";
 
-      // A trailing optimistic prompt means THIS error is the fate of that
-      // prompt — the hub refused the turn ("Session is busy…", "…still
-      // starting."), so its echo will never arrive. Drop it: the ghost bubble
-      // would otherwise sit there forever with `busy` stuck true (readonly
-      // composer, no recovery short of a page reload), and dropping it is also
-      // what makes folding safe again.
-      if (this.hasPendingPrompt()) {
+      // An OUTSTANDING prompt (frame sent, nothing sent since, echo not yet
+      // arrived) makes this error that prompt's fate — the hub refused the turn
+      // ("Session is busy…", "…still starting."), so its echo will never come.
+      // Drop it: the ghost bubble would otherwise sit there forever with `busy`
+      // stuck true (read-only composer, no recovery short of a page reload), and
+      // dropping it is also what makes folding safe again. Without the
+      // attribution the pending item stays and waits for replay-done, budget
+      // exhaustion or the session ending to resolve it.
+      if (this.awaitingEcho && this.hasPendingPrompt()) {
         this.releasePendingPrompt();
         this.#error = message;
         return;
@@ -380,7 +425,18 @@ export class AcpChat {
       return;
     }
 
+    // An ending session appends a notice, which must never land between a
+    // pending prompt and an echo that is now never coming — and a phantom
+    // message in an ended transcript is a lie. Release first.
+    if (ev.type === "state" && isRecord(ev.payload) && ev.payload.status === "ended") {
+      this.releasePendingPrompt();
+    }
+
     this.#transcript = foldEvent(this.#transcript, ev);
+    if (ev.type === "user-prompt") {
+      this.awaitingEcho = false; // reconciled
+      this.promptSocket = null;
+    }
   }
 
   /**
@@ -388,6 +444,8 @@ export class AcpChat {
    * text back to the composer. Clears `busy`, so the composer is usable again.
    */
   private releasePendingPrompt(): void {
+    this.awaitingEcho = false;
+    this.promptSocket = null;
     const { transcript, text } = dropPendingPrompt(this.#transcript);
     if (text === null) return;
     this.#transcript = transcript;
@@ -396,6 +454,8 @@ export class AcpChat {
 
   private handleBye(reason: string): void {
     this.sessionOver = true;
+    // Same rule as a real ended event: no phantom message survives the session.
+    this.releasePendingPrompt();
     if (this.#transcript.status !== "ended") {
       // The hub's ended event didn't make it here — fold a final ended notice
       // locally (synthetic seq-0 state event: never advances the cursor).

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -20,6 +20,10 @@
  *     gap ("working while away").
  *   - `bye` arrives as a server MESSAGE; the socket close that follows it is
  *     expected and must not trigger a reconnect.
+ *
+ * Permission dismissal: ACP has no per-request dismiss — agents supply reject
+ * options in the request itself (answer with one of those), and `cancel()`
+ * rejects ALL parked permissions (hub cancelTurn). Wire the UI accordingly.
  */
 
 import type { AcpEvent, AcpSessionMode } from "@agentpod/contract";
@@ -28,7 +32,6 @@ import {
   createAcpSocket,
   endAcpSession,
   listAcpSessions,
-  type AcpClientMsg,
   type AcpServerMsg,
   type AcpSessionRow,
   type AcpSocket,
@@ -68,6 +71,8 @@ export class AcpChat {
   private attempt = 0;
   /** Set on `bye`: the session is over — the following close is expected. */
   private sessionOver = false;
+  /** True while a createAcpSession POST is in flight (double-submit guard). */
+  private creating = false;
   private destroyed = false;
 
   constructor(stationId: string) {
@@ -129,19 +134,29 @@ export class AcpChat {
     this.startConnection();
   }
 
-  /** Send a prompt, creating a session first if none is live. */
+  /**
+   * Send a prompt, creating a session first if none is live.
+   *
+   * Double-submission guard: refuses (silent no-op) while a create is in
+   * flight, while a pending optimistic prompt is still awaiting its echo, or
+   * while the agent is working — one turn at a time.
+   */
   async prompt(text: string): Promise<void> {
-    if (!text) return;
+    if (!text || this.destroyed) return;
+    if (this.creating || this.working || this.hasPendingPrompt()) return;
     this.#error = null;
 
     if (!this.#session || this.sessionOver || this.#transcript.status === "ended") {
       let row: AcpSessionRow;
+      this.creating = true;
       try {
         row = await createAcpSession(this.stationId, this.mode);
       } catch (err) {
         // The ApiError message already carries the right "Couldn't …" grammar.
         this.#error = errMessage(err);
         return;
+      } finally {
+        this.creating = false;
       }
       if (this.destroyed) return;
       this.teardownSocket();
@@ -167,20 +182,13 @@ export class AcpChat {
     this.socket?.send({ t: "cancel" });
   }
 
-  /** Answer a permission request; `null` means the user dismissed/cancelled it. */
-  answer(requestSeq: number, optionId: string | null): void {
-    if (optionId === null) {
-      // Spec'd wire shape for a user cancel. NOTE: the contract's AcpClientMsg
-      // permission-answer variant doesn't carry `cancelled` yet — the cast
-      // keeps the spec'd frame until the contract/hub grow the variant.
-      this.socket?.send({
-        t: "permission-answer",
-        requestSeq,
-        cancelled: true,
-      } as unknown as AcpClientMsg);
-    } else {
-      this.socket?.send({ t: "permission-answer", requestSeq, optionId });
-    }
+  /**
+   * Answer a permission request with one of its offered options. To reject,
+   * answer with the agent-supplied reject option; `cancel()` rejects all
+   * parked permissions — ACP has no per-request dismiss.
+   */
+  answer(requestSeq: number, optionId: string): void {
+    this.socket?.send({ t: "permission-answer", requestSeq, optionId });
   }
 
   setMode(mode: AcpSessionMode): void {
@@ -230,6 +238,12 @@ export class AcpChat {
     this.destroyed = true;
     this.clearReconnectTimer();
     this.teardownSocket();
+  }
+
+  /** True while the last item is an optimistic prompt awaiting its echo. */
+  private hasPendingPrompt(): boolean {
+    const last = this.#transcript.items.at(-1);
+    return last?.kind === "user" && last.pending === true;
   }
 
   // ── Connection lifecycle ───────────────────────────────────────────────────

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -71,9 +71,15 @@ export class AcpChat {
   private attempt = 0;
   /** Set on `bye`: the session is over — the following close is expected. */
   private sessionOver = false;
-  /** True while a createAcpSession POST is in flight (double-submit guard). */
-  private creating = false;
   private destroyed = false;
+
+  /**
+   * True while a createAcpSession POST is in flight (double-submit guard).
+   * $state-backed because `busy` is read by the view: the composer must be
+   * disabled for the whole create window, or PromptInput would clear a draft
+   * that `prompt()` then silently refuses.
+   */
+  #creating = $state(false);
 
   constructor(stationId: string) {
     this.stationId = stationId;
@@ -98,6 +104,16 @@ export class AcpChat {
 
   get working(): boolean {
     return this.#transcript.status === "working";
+  }
+
+  /**
+   * True exactly when `prompt()` would refuse: a create is in flight, an
+   * optimistic prompt is still awaiting its echo, or the agent is working.
+   * The composer MUST be disabled (or shown as working) whenever this is
+   * true — PromptInput only keeps a draft it wasn't allowed to send.
+   */
+  get busy(): boolean {
+    return this.#creating || this.working || this.hasPendingPrompt();
   }
 
   get pendingPermissions(): number {
@@ -143,12 +159,12 @@ export class AcpChat {
    */
   async prompt(text: string): Promise<void> {
     if (!text || this.destroyed) return;
-    if (this.creating || this.working || this.hasPendingPrompt()) return;
+    if (this.busy) return;
     this.#error = null;
 
     if (!this.#session || this.sessionOver || this.#transcript.status === "ended") {
       let row: AcpSessionRow;
-      this.creating = true;
+      this.#creating = true;
       try {
         row = await createAcpSession(this.stationId, this.mode);
       } catch (err) {
@@ -156,7 +172,7 @@ export class AcpChat {
         this.#error = errMessage(err);
         return;
       } finally {
-        this.creating = false;
+        this.#creating = false;
       }
       if (this.destroyed) return;
       this.teardownSocket();

--- a/apps/console/src/lib/components/stations/chat/response.stub.svelte
+++ b/apps/console/src/lib/components/stations/chat/response.stub.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  /**
+   * Test stub for Response.svelte — later tasks mock the streamdown-backed
+   * renderer with this to keep their component tests fast and jsdom-safe:
+   *   vi.mock("./Response.svelte", () => import("./response.stub.svelte"))
+   */
+  interface Props {
+    text: string;
+    streaming?: boolean;
+  }
+
+  let { text }: Props = $props();
+</script>
+
+<div data-testid="response-stub">{text}</div>

--- a/apps/console/src/lib/components/stations/chat/transcript.test.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.test.ts
@@ -1,6 +1,12 @@
 import { test, expect } from "vitest";
 import type { AcpEvent, AcpEventType } from "@agentpod/contract";
-import { emptyTranscript, foldEvent, addPendingPrompt, type Transcript } from "./transcript";
+import {
+  emptyTranscript,
+  foldEvent,
+  addPendingPrompt,
+  dropPendingPrompt,
+  type Transcript,
+} from "./transcript";
 
 function ev(seq: number, type: AcpEventType, payload: unknown): AcpEvent {
   return { sessionId: "s1", seq, type, payload, createdAt: "2026-08-09T00:00:00.000Z" };
@@ -133,6 +139,54 @@ test("tool_call status defaults to pending; content entries map text and drop un
     content: [{ type: "text", text: "42 passing" }],
     locations: [],
   });
+});
+
+test("a repeated tool_call upserts instead of pushing a duplicate identity", () => {
+  // Views key tool items by toolCallId; two items with the same id throw at
+  // render time and take the whole transcript down, so untrusted agent output
+  // must not be able to create one.
+  const t = fold([
+    ev(1, "agent-update", {
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      title: "Read main.go",
+      status: "pending",
+    }),
+    ev(2, "agent-update", {
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      title: "Read main.go (again)",
+      status: "in_progress",
+      content: [{ type: "content", content: { type: "text", text: "hello" } }],
+    }),
+  ]);
+
+  expect(t.items).toHaveLength(1);
+  expect(t.items[0]).toEqual({
+    kind: "tool",
+    seq: 1, // identity (and key) stays with the first sighting
+    toolCallId: "t1",
+    title: "Read main.go (again)",
+    toolKind: undefined,
+    status: "in_progress",
+    content: [{ type: "text", text: "hello" }],
+    locations: [],
+  });
+  expect(t.lastSeq).toBe(2);
+});
+
+test("dropPendingPrompt removes a trailing pending prompt and returns its text", () => {
+  const withPending = addPendingPrompt(fold([ev(1, "state", { status: "idle" })]), "unsent words");
+
+  const dropped = dropPendingPrompt(withPending);
+  expect(dropped.text).toBe("unsent words");
+  expect(dropped.transcript.items).toEqual([]);
+  expect(dropped.transcript.lastSeq).toBe(1); // cursor untouched
+
+  // No pending tail → same reference, nothing claimed.
+  const noop = dropPendingPrompt(dropped.transcript);
+  expect(noop.transcript).toBe(dropped.transcript);
+  expect(noop.text).toBeNull();
 });
 
 test("tool_call_update for an unknown toolCallId is ignored", () => {

--- a/apps/console/src/lib/components/stations/chat/transcript.test.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.test.ts
@@ -244,16 +244,37 @@ test("duplicate seq delivery is a no-op returning the same object reference", ()
   expect(t3).toBe(t1);
 });
 
-test("seq-0 synthetic error adds a notice but does not move lastSeq", () => {
+test("seq-0 synthetic error adds a notice (unique negative seq) but does not move lastSeq", () => {
   const before = fold([chunk(1, "hi")]);
   const after = foldEvent(before, ev(0, "error", { message: "connection lost" }));
   expect(after.items.at(-1)).toEqual({
     kind: "notice",
-    seq: 0,
+    seq: -1,
     level: "error",
     text: "connection lost",
   });
   expect(after.lastSeq).toBe(1);
+});
+
+test("multiple synthetic events mint distinct seqs — item identity stays keyable", () => {
+  // Two hub-side seq-0 errors followed by the bye-without-ended fallback
+  // (synthetic seq-0 state ended) — the exact pileup an error path produces.
+  const t = fold([
+    chunk(1, "hi"),
+    ev(0, "error", { message: "boom one" }),
+    ev(0, "error", { message: "boom two" }),
+    ev(0, "state", { status: "ended", reason: "gone" }),
+  ]);
+
+  // Keys derivable from items alone must be collision-free (Conversation
+  // keys its {#each} by kind + identity — duplicate `notice:0` would throw).
+  const keys = t.items.map((it) => `${it.kind}:${it.seq}`);
+  expect(new Set(keys).size).toBe(keys.length);
+
+  const notices = t.items.filter((it) => it.kind === "notice");
+  expect(notices.map((n) => n.seq)).toEqual([-1, -2, -3]);
+  expect(notices.map((n) => n.text)).toEqual(["boom one", "boom two", "Session ended — gone"]);
+  expect(t.lastSeq).toBe(1); // synthetics never move the cursor
 });
 
 test("persisted error event adds an error notice and advances lastSeq", () => {

--- a/apps/console/src/lib/components/stations/chat/transcript.test.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.test.ts
@@ -1,0 +1,334 @@
+import { test, expect } from "vitest";
+import type { AcpEvent, AcpEventType } from "@agentpod/contract";
+import { emptyTranscript, foldEvent, addPendingPrompt, type Transcript } from "./transcript";
+
+function ev(seq: number, type: AcpEventType, payload: unknown): AcpEvent {
+  return { sessionId: "s1", seq, type, payload, createdAt: "2026-08-09T00:00:00.000Z" };
+}
+
+function fold(events: AcpEvent[], start: Transcript = emptyTranscript()): Transcript {
+  return events.reduce(foldEvent, start);
+}
+
+function chunk(seq: number, text: string): AcpEvent {
+  return ev(seq, "agent-update", {
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text },
+  });
+}
+
+function thought(seq: number, text: string): AcpEvent {
+  return ev(seq, "agent-update", {
+    sessionUpdate: "agent_thought_chunk",
+    content: { type: "text", text },
+  });
+}
+
+// ─── (a) live-observed opencode sequence ─────────────────────────────────────
+
+test("folds the live opencode smoke sequence into [user, assistant] with usage and status", () => {
+  const t = fold([
+    ev(1, "state", { status: "idle" }),
+    ev(2, "agent-update", { sessionUpdate: "available_commands_update", availableCommands: [] }),
+    ev(3, "user-prompt", { text: "Reply with exactly ACP-SLICE2-OK" }),
+    ev(4, "state", { status: "working" }),
+    chunk(5, "A"),
+    chunk(6, "CP"),
+    chunk(7, "-"),
+    chunk(8, "SLICE"),
+    chunk(9, "2"),
+    chunk(10, "-"),
+    chunk(11, "OK"),
+    ev(12, "agent-update", { sessionUpdate: "usage_update", used: 1234, size: 200000 }),
+    ev(13, "state", { status: "idle" }),
+  ]);
+
+  expect(t.items).toEqual([
+    { kind: "user", seq: 3, text: "Reply with exactly ACP-SLICE2-OK" },
+    { kind: "assistant", seq: 5, text: "ACP-SLICE2-OK", streaming: false },
+  ]);
+  expect(t.status).toBe("idle");
+  expect(t.usage).toEqual({ used: 1234, size: 200000 });
+  expect(t.lastSeq).toBe(13);
+});
+
+// ─── (b) reasoning interleaved with message chunks ───────────────────────────
+
+test("reasoning chunks interleaved with message chunks produce separate items in arrival order", () => {
+  const t = fold([
+    thought(1, "Think"),
+    thought(2, "ing…"),
+    chunk(3, "Hello"),
+    thought(4, "More"),
+    chunk(5, " world"),
+  ]);
+
+  expect(t.items).toEqual([
+    { kind: "reasoning", seq: 1, text: "Thinking…", streaming: true },
+    { kind: "assistant", seq: 3, text: "Hello", streaming: true },
+    { kind: "reasoning", seq: 4, text: "More", streaming: true },
+    { kind: "assistant", seq: 5, text: " world", streaming: true },
+  ]);
+});
+
+// ─── (c) tool_call + tool_call_update merge ──────────────────────────────────
+
+test("tool_call then two tool_call_updates merge status/title/content", () => {
+  const t = fold([
+    chunk(1, "Editing now."),
+    ev(2, "agent-update", {
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      title: "Edit file",
+      kind: "edit",
+      locations: [{ path: "/srv/a.ts" }],
+    }),
+    ev(3, "agent-update", {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "in_progress",
+    }),
+    ev(4, "agent-update", {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+      title: "Edited a.ts",
+      content: [{ type: "diff", path: "/srv/a.ts", oldText: "old", newText: "new" }],
+    }),
+  ]);
+
+  expect(t.items[1]).toEqual({
+    kind: "tool",
+    seq: 2,
+    toolCallId: "t1",
+    title: "Edited a.ts",
+    toolKind: "edit",
+    status: "completed",
+    content: [{ type: "diff", path: "/srv/a.ts", oldText: "old", newText: "new" }],
+    locations: ["/srv/a.ts"],
+  });
+});
+
+test("tool_call status defaults to pending; content entries map text and drop unknown types", () => {
+  const t = fold([
+    ev(1, "agent-update", {
+      sessionUpdate: "tool_call",
+      toolCallId: "t2",
+      title: "Run tests",
+      content: [
+        { type: "content", content: { type: "text", text: "42 passing" } },
+        { type: "content", content: { type: "image", data: "…" } },
+        { type: "terminal", terminalId: "term-1" },
+      ],
+    }),
+  ]);
+
+  expect(t.items[0]).toEqual({
+    kind: "tool",
+    seq: 1,
+    toolCallId: "t2",
+    title: "Run tests",
+    toolKind: undefined,
+    status: "pending",
+    content: [{ type: "text", text: "42 passing" }],
+    locations: [],
+  });
+});
+
+test("tool_call_update for an unknown toolCallId is ignored", () => {
+  const before = fold([chunk(1, "hi")]);
+  const after = foldEvent(
+    before,
+    ev(2, "agent-update", {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "nope",
+      status: "completed",
+    }),
+  );
+  expect(after.items).toEqual(before.items);
+  expect(after.lastSeq).toBe(2);
+});
+
+test("foldEvent reuses untouched item references", () => {
+  const before = fold([
+    ev(1, "user-prompt", { text: "go" }),
+    ev(2, "agent-update", { sessionUpdate: "tool_call", toolCallId: "t1", title: "Read" }),
+  ]);
+  const after = foldEvent(
+    before,
+    ev(3, "agent-update", {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+    }),
+  );
+  expect(after).not.toBe(before);
+  expect(after.items[0]).toBe(before.items[0]); // untouched user item: same ref
+  expect(after.items[1]).not.toBe(before.items[1]); // merged tool item: new ref
+});
+
+// ─── (d) permission request + answer roundtrip ───────────────────────────────
+
+const permReq = {
+  toolCall: { toolCallId: "t9", title: "Run rm -rf ./dist", kind: "execute" },
+  options: [
+    { optionId: "allow", name: "Allow", kind: "allow_once" },
+    { optionId: "reject", name: "Reject", kind: "reject_once" },
+  ],
+};
+
+test("permission request then selected answer", () => {
+  const t = fold([
+    ev(1, "permission-request", permReq),
+    ev(2, "permission-answer", { requestSeq: 1, optionId: "allow" }),
+  ]);
+
+  expect(t.items).toEqual([
+    {
+      kind: "permission",
+      seq: 1,
+      requestSeq: 1,
+      title: "Run rm -rf ./dist",
+      toolKind: "execute",
+      options: [
+        { optionId: "allow", name: "Allow", kind: "allow_once" },
+        { optionId: "reject", name: "Reject", kind: "reject_once" },
+      ],
+      answer: { optionId: "allow", cancelled: undefined, auto: undefined },
+    },
+  ]);
+});
+
+test("permission answer with cancelled:true", () => {
+  const t = fold([
+    ev(1, "permission-request", permReq),
+    ev(2, "permission-answer", { requestSeq: 1, cancelled: true }),
+  ]);
+  expect(t.items[0]).toMatchObject({ kind: "permission", answer: { cancelled: true } });
+});
+
+test("auto-approved permission (accept-edits/full-auto) carries auto:true", () => {
+  const t = fold([
+    ev(1, "permission-request", { ...permReq, auto: true }),
+    ev(2, "permission-answer", { requestSeq: 1, optionId: "allow", auto: true }),
+  ]);
+  expect(t.items[0]).toMatchObject({
+    kind: "permission",
+    answer: { optionId: "allow", auto: true },
+  });
+});
+
+test("permission answer for an unknown requestSeq is ignored", () => {
+  const t = fold([ev(1, "permission-answer", { requestSeq: 99, optionId: "allow" })]);
+  expect(t.items).toEqual([]);
+  expect(t.lastSeq).toBe(1);
+});
+
+test("permission title falls back to the tool name when title is missing", () => {
+  const t = fold([
+    ev(1, "permission-request", {
+      toolCall: { toolCallId: "t9", name: "bash" },
+      options: [{ optionId: "allow", name: "Allow", kind: "allow_once" }],
+    }),
+  ]);
+  expect(t.items[0]).toMatchObject({ kind: "permission", title: "bash" });
+});
+
+// ─── (e) duplicates and seq-0 synthetic events ───────────────────────────────
+
+test("duplicate seq delivery is a no-op returning the same object reference", () => {
+  const t1 = fold([chunk(1, "he"), chunk(2, "llo")]);
+  const t2 = foldEvent(t1, chunk(2, "llo"));
+  expect(t2).toBe(t1);
+  const t3 = foldEvent(t1, chunk(1, "he"));
+  expect(t3).toBe(t1);
+});
+
+test("seq-0 synthetic error adds a notice but does not move lastSeq", () => {
+  const before = fold([chunk(1, "hi")]);
+  const after = foldEvent(before, ev(0, "error", { message: "connection lost" }));
+  expect(after.items.at(-1)).toEqual({
+    kind: "notice",
+    seq: 0,
+    level: "error",
+    text: "connection lost",
+  });
+  expect(after.lastSeq).toBe(1);
+});
+
+test("persisted error event adds an error notice and advances lastSeq", () => {
+  const t = fold([ev(1, "error", { message: "spawn failed: ENOENT" })]);
+  expect(t.items).toEqual([
+    { kind: "notice", seq: 1, level: "error", text: "spawn failed: ENOENT" },
+  ]);
+  expect(t.lastSeq).toBe(1);
+});
+
+// ─── (f) ended state ─────────────────────────────────────────────────────────
+
+test("ended state appends an info notice with the reason", () => {
+  const t = fold([ev(1, "state", { status: "ended", reason: "agent exited" })]);
+  expect(t.status).toBe("ended");
+  expect(t.items).toEqual([
+    { kind: "notice", seq: 1, level: "info", text: "Session ended — agent exited" },
+  ]);
+});
+
+test("ended state without a reason uses the plain copy; other states push nothing", () => {
+  const ended = fold([ev(1, "state", { status: "ended" })]);
+  expect(ended.items).toEqual([{ kind: "notice", seq: 1, level: "info", text: "Session ended." }]);
+
+  const working = fold([ev(1, "state", { status: "working" })]);
+  expect(working.status).toBe("working");
+  expect(working.items).toEqual([]);
+});
+
+test("ended state closes any open streaming items", () => {
+  const t = fold([chunk(1, "partial"), ev(2, "state", { status: "ended", reason: "cancelled" })]);
+  expect(t.items[0]).toMatchObject({ kind: "assistant", text: "partial", streaming: false });
+});
+
+// ─── (g) optimistic pending prompt ───────────────────────────────────────────
+
+test("optimistic pending prompt is replaced by the real user-prompt event, not duplicated", () => {
+  const withPending = addPendingPrompt(fold([ev(1, "state", { status: "idle" })]), "do the thing");
+  expect(withPending.items).toEqual([
+    { kind: "user", seq: -1, text: "do the thing", pending: true },
+  ]);
+  expect(withPending.lastSeq).toBe(1); // pending prompt never moves the cursor
+
+  const t = foldEvent(withPending, ev(2, "user-prompt", { text: "do the thing" }));
+  expect(t.items).toEqual([{ kind: "user", seq: 2, text: "do the thing" }]);
+  expect(t.lastSeq).toBe(2);
+});
+
+test("user-prompt without a pending item pushes normally and closes streaming items", () => {
+  const t = fold([chunk(1, "old answer"), ev(2, "user-prompt", { text: "next question" })]);
+  expect(t.items).toEqual([
+    { kind: "assistant", seq: 1, text: "old answer", streaming: false },
+    { kind: "user", seq: 2, text: "next question" },
+  ]);
+});
+
+// ─── forward compat / malformed payloads ─────────────────────────────────────
+
+test("unknown sessionUpdate values and malformed payloads are ignored but still advance lastSeq", () => {
+  const t = fold([
+    ev(1, "agent-update", { sessionUpdate: "plan", entries: [] }),
+    ev(2, "agent-update", { sessionUpdate: "shiny_new_update", stuff: true }),
+    ev(3, "agent-update", null),
+    ev(4, "agent-update", "not an object"),
+    ev(5, "user-prompt", { text: 42 }),
+    ev(6, "state", { status: "hyperspace" }),
+    ev(7, "error", { message: 7 }),
+    ev(8, "agent-update", { sessionUpdate: "agent_message_chunk", content: { type: "image" } }),
+  ]);
+  expect(t.items).toEqual([]);
+  expect(t.status).toBe("starting");
+  expect(t.lastSeq).toBe(8);
+});
+
+test("emptyTranscript starts at seq 0, starting status, no usage", () => {
+  const t = emptyTranscript();
+  expect(t).toEqual({ items: [], lastSeq: 0, status: "starting", usage: undefined });
+});

--- a/apps/console/src/lib/components/stations/chat/transcript.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.ts
@@ -139,6 +139,22 @@ function mapLocations(v: unknown): string[] {
   return out;
 }
 
+/**
+ * Unique seq for an item minted from a SYNTHETIC event (seq < 1). Real seqs
+ * are positive and hub-assigned; synthetics get monotonically decreasing
+ * negatives derived from the transcript alone, so `{#each}` keys built from
+ * `kind:seq` stay collision-free even when several seq-0 events fold into one
+ * transcript (e.g. a hub-side error notice followed by the bye-without-ended
+ * fallback — both would otherwise key `notice:0`). The optimistic pending
+ * prompt's -1 shares this number line, so synthetics never reuse it either.
+ * Pure: derived from items, no counter state.
+ */
+function syntheticSeq(items: ChatItem[]): number {
+  let min = 0;
+  for (const it of items) if (it.seq < min) min = it.seq;
+  return min - 1;
+}
+
 /** Set `streaming: false` on any open assistant/reasoning items; reuses refs when untouched. */
 function closeStreaming(items: ChatItem[]): ChatItem[] {
   if (!items.some((it) => (it.kind === "assistant" || it.kind === "reasoning") && it.streaming)) {
@@ -332,7 +348,7 @@ function foldState(t: Transcript, ev: AcpEvent): Transcript {
       ...items,
       {
         kind: "notice",
-        seq: ev.seq,
+        seq: ev.seq >= 1 ? ev.seq : syntheticSeq(items),
         level: "info",
         text: reason ? `Session ended — ${reason}` : "Session ended.",
       },
@@ -347,6 +363,14 @@ function foldError(t: Transcript, ev: AcpEvent): Transcript {
   if (message === undefined) return t;
   return {
     ...t,
-    items: [...t.items, { kind: "notice", seq: ev.seq, level: "error", text: message }],
+    items: [
+      ...t.items,
+      {
+        kind: "notice",
+        seq: ev.seq >= 1 ? ev.seq : syntheticSeq(t.items),
+        level: "error",
+        text: message,
+      },
+    ],
   };
 }

--- a/apps/console/src/lib/components/stations/chat/transcript.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.ts
@@ -69,6 +69,22 @@ export function addPendingPrompt(t: Transcript, text: string): Transcript {
   return { ...t, items: [...t.items, { kind: "user", seq: -1, text, pending: true }] };
 }
 
+/**
+ * Remove a trailing optimistic prompt whose echo will never arrive — the hub
+ * rejected the turn, or the frame was lost with the socket. Returns the SAME
+ * reference when the tail isn't a pending prompt, and the dropped text so the
+ * caller can hand it back to the composer instead of losing it.
+ *
+ * Dropping is also what makes folding safe again: `foldUserPrompt` reconciles
+ * against the LAST item only, so nothing may be folded in while a pending prompt
+ * trails.
+ */
+export function dropPendingPrompt(t: Transcript): { transcript: Transcript; text: string | null } {
+  const last = t.items.at(-1);
+  if (last?.kind !== "user" || last.pending !== true) return { transcript: t, text: null };
+  return { transcript: { ...t, items: t.items.slice(0, -1) }, text: last.text };
+}
+
 // ─── Defensive narrowing helpers ─────────────────────────────────────────────
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -220,6 +236,13 @@ function foldAgentUpdate(t: Transcript, ev: AcpEvent): Transcript {
     case "tool_call": {
       const toolCallId = str(payload.toolCallId);
       if (toolCallId === undefined) return t;
+      // UPSERT, not push: a (buggy or hostile) agent repeating a toolCallId must
+      // not produce two items with the same identity — views key tool items by
+      // toolCallId, and duplicate keys throw at render time, taking the whole
+      // transcript with them. A repeat merges exactly like tool_call_update.
+      if (findToolIndex(t, toolCallId) !== -1) {
+        return mergeToolCall(t, toolCallId, payload);
+      }
       const item: ChatItem = {
         kind: "tool",
         seq: ev.seq,
@@ -235,25 +258,7 @@ function foldAgentUpdate(t: Transcript, ev: AcpEvent): Transcript {
     case "tool_call_update": {
       const toolCallId = str(payload.toolCallId);
       if (toolCallId === undefined) return t;
-      const idx = t.items.findLastIndex(
-        (it) => it.kind === "tool" && it.toolCallId === toolCallId,
-      );
-      if (idx === -1) return t; // unknown toolCallId → ignore
-      const prev = t.items[idx] as Extract<ChatItem, { kind: "tool" }>;
-      const merged: ChatItem = {
-        ...prev,
-        title: str(payload.title) ?? prev.title,
-        toolKind: str(payload.kind) ?? prev.toolKind,
-        status: toolStatus(payload.status) ?? prev.status,
-        // Content/locations REPLACE when present (SDK semantics); null/absent keeps prior.
-        content: Array.isArray(payload.content) ? mapToolContent(payload.content) : prev.content,
-        locations: Array.isArray(payload.locations)
-          ? mapLocations(payload.locations)
-          : prev.locations,
-      };
-      const items = t.items.slice();
-      items[idx] = merged;
-      return { ...t, items };
+      return mergeToolCall(t, toolCallId, payload);
     }
     case "usage_update": {
       const used = payload.used;
@@ -266,6 +271,36 @@ function foldAgentUpdate(t: Transcript, ev: AcpEvent): Transcript {
       // anything newer → ignored in v1 (forward compat).
       return t;
   }
+}
+
+function findToolIndex(t: Transcript, toolCallId: string): number {
+  return t.items.findLastIndex((it) => it.kind === "tool" && it.toolCallId === toolCallId);
+}
+
+/**
+ * Merge a tool_call/tool_call_update payload into the existing item for that
+ * toolCallId. Later fields win; content/locations REPLACE only when an array is
+ * present (SDK `null`/absent means "unchanged"). Unknown ids are ignored.
+ */
+function mergeToolCall(
+  t: Transcript,
+  toolCallId: string,
+  payload: Record<string, unknown>,
+): Transcript {
+  const idx = findToolIndex(t, toolCallId);
+  if (idx === -1) return t; // unknown toolCallId → ignore
+  const prev = t.items[idx] as Extract<ChatItem, { kind: "tool" }>;
+  const merged: ChatItem = {
+    ...prev,
+    title: str(payload.title) ?? prev.title,
+    toolKind: str(payload.kind) ?? prev.toolKind,
+    status: toolStatus(payload.status) ?? prev.status,
+    content: Array.isArray(payload.content) ? mapToolContent(payload.content) : prev.content,
+    locations: Array.isArray(payload.locations) ? mapLocations(payload.locations) : prev.locations,
+  };
+  const items = t.items.slice();
+  items[idx] = merged;
+  return { ...t, items };
 }
 
 function appendChunk(

--- a/apps/console/src/lib/components/stations/chat/transcript.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.ts
@@ -1,0 +1,352 @@
+/**
+ * transcript.ts
+ *
+ * Pure projection: fold persisted/live `AcpEvent`s into renderable chat items.
+ * No Svelte imports — plain TypeScript, so the folding rules are unit-testable
+ * and reusable by both the replay path and the live WS stream.
+ *
+ * Contracts that matter to callers:
+ *   - `foldEvent` is pure. It returns a NEW Transcript object but reuses the
+ *     references of every ChatItem it did not touch — Svelte 5 fine-grained
+ *     reactivity keys off those references.
+ *   - Duplicate delivery (ev.seq <= lastSeq, for real seq >= 1 events) is a
+ *     no-op that returns the SAME object reference.
+ *   - `lastSeq` advances only for real events (seq >= 1), even when the
+ *     payload is malformed or unknown — the cursor tracks delivery, not
+ *     renderability. Synthetic seq-0 events (client-side errors) never move it.
+ *   - Payloads are untrusted `unknown`: unknown `sessionUpdate` values and
+ *     malformed payloads are ignored silently (forward compat), never thrown.
+ */
+
+import type { AcpEvent, AcpSessionStatus } from "@agentpod/contract";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ToolStatus = "pending" | "in_progress" | "completed" | "failed";
+
+export type ToolContent =
+  | { type: "text"; text: string }
+  | { type: "diff"; path: string; oldText: string | null; newText: string };
+
+export type ChatItem =
+  | { kind: "user"; seq: number; text: string; pending?: boolean }
+  | { kind: "assistant"; seq: number; text: string; streaming: boolean }
+  | { kind: "reasoning"; seq: number; text: string; streaming: boolean }
+  | {
+      kind: "tool";
+      seq: number;
+      toolCallId: string;
+      title: string;
+      toolKind?: string;
+      status: ToolStatus;
+      content: ToolContent[];
+      locations: string[];
+    }
+  | {
+      kind: "permission";
+      seq: number;
+      requestSeq: number;
+      title: string;
+      toolKind?: string;
+      options: Array<{ optionId: string; name: string; kind: string }>;
+      answer?: { optionId?: string; cancelled?: boolean; auto?: boolean };
+    }
+  | { kind: "notice"; seq: number; level: "info" | "error"; text: string };
+
+export interface Transcript {
+  items: ChatItem[];
+  lastSeq: number;
+  status: AcpSessionStatus;
+  usage?: { used: number; size: number };
+}
+
+export function emptyTranscript(): Transcript {
+  return { items: [], lastSeq: 0, status: "starting", usage: undefined };
+}
+
+/** Optimistic local echo: pushed on send, replaced by the real user-prompt event. */
+export function addPendingPrompt(t: Transcript, text: string): Transcript {
+  return { ...t, items: [...t.items, { kind: "user", seq: -1, text, pending: true }] };
+}
+
+// ─── Defensive narrowing helpers ─────────────────────────────────────────────
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+const TOOL_STATUSES: readonly ToolStatus[] = ["pending", "in_progress", "completed", "failed"];
+function toolStatus(v: unknown): ToolStatus | undefined {
+  return TOOL_STATUSES.includes(v as ToolStatus) ? (v as ToolStatus) : undefined;
+}
+
+const SESSION_STATUSES: readonly AcpSessionStatus[] = [
+  "starting",
+  "idle",
+  "working",
+  "waiting",
+  "ended",
+];
+function sessionStatus(v: unknown): AcpSessionStatus | undefined {
+  return SESSION_STATUSES.includes(v as AcpSessionStatus) ? (v as AcpSessionStatus) : undefined;
+}
+
+/** `{type:"text",text}` content block → its text, else undefined. */
+function chunkText(payload: Record<string, unknown>): string | undefined {
+  const content = payload.content;
+  if (!isRecord(content) || content.type !== "text") return undefined;
+  return str(content.text);
+}
+
+/** Map SDK ToolCallContent entries into renderable ToolContent; unknown types dropped. */
+function mapToolContent(v: unknown): ToolContent[] {
+  if (!Array.isArray(v)) return [];
+  const out: ToolContent[] = [];
+  for (const entry of v) {
+    if (!isRecord(entry)) continue;
+    if (entry.type === "content") {
+      const inner = entry.content;
+      if (isRecord(inner) && inner.type === "text") {
+        const text = str(inner.text);
+        if (text !== undefined) out.push({ type: "text", text });
+      }
+    } else if (entry.type === "diff") {
+      const path = str(entry.path);
+      const newText = str(entry.newText);
+      if (path !== undefined && newText !== undefined) {
+        out.push({ type: "diff", path, oldText: str(entry.oldText) ?? null, newText });
+      }
+    }
+    // Unknown content types (terminal, image, …) → ignored (forward compat).
+  }
+  return out;
+}
+
+/** `[{path}, …]` → path strings; malformed entries dropped. */
+function mapLocations(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const loc of v) {
+    if (isRecord(loc)) {
+      const path = str(loc.path);
+      if (path !== undefined) out.push(path);
+    }
+  }
+  return out;
+}
+
+/** Set `streaming: false` on any open assistant/reasoning items; reuses refs when untouched. */
+function closeStreaming(items: ChatItem[]): ChatItem[] {
+  if (!items.some((it) => (it.kind === "assistant" || it.kind === "reasoning") && it.streaming)) {
+    return items;
+  }
+  return items.map((it) =>
+    (it.kind === "assistant" || it.kind === "reasoning") && it.streaming
+      ? { ...it, streaming: false }
+      : it,
+  );
+}
+
+// ─── Folding ─────────────────────────────────────────────────────────────────
+
+export function foldEvent(t: Transcript, ev: AcpEvent): Transcript {
+  const real = ev.seq >= 1;
+  if (real && ev.seq <= t.lastSeq) return t; // duplicate delivery → idempotent no-op
+  const next: Transcript = { ...t, lastSeq: real ? ev.seq : t.lastSeq };
+
+  switch (ev.type) {
+    case "user-prompt":
+      return foldUserPrompt(next, ev);
+    case "agent-update":
+      return foldAgentUpdate(next, ev);
+    case "permission-request":
+      return foldPermissionRequest(next, ev);
+    case "permission-answer":
+      return foldPermissionAnswer(next, ev);
+    case "state":
+      return foldState(next, ev);
+    case "error":
+      return foldError(next, ev);
+    default:
+      return next; // unknown event type → forward compat
+  }
+}
+
+function foldUserPrompt(t: Transcript, ev: AcpEvent): Transcript {
+  if (!isRecord(ev.payload)) return t;
+  const text = str(ev.payload.text);
+  if (text === undefined) return t;
+
+  const items = closeStreaming(t.items).slice();
+  const last = items.at(-1);
+  const item: ChatItem = { kind: "user", seq: ev.seq, text };
+  if (last?.kind === "user" && last.pending) {
+    items[items.length - 1] = item; // optimistic reconcile: replace, don't duplicate
+  } else {
+    items.push(item);
+  }
+  return { ...t, items };
+}
+
+function foldAgentUpdate(t: Transcript, ev: AcpEvent): Transcript {
+  const payload = ev.payload;
+  if (!isRecord(payload)) return t;
+
+  switch (payload.sessionUpdate) {
+    case "agent_message_chunk":
+      return appendChunk(t, ev.seq, "assistant", chunkText(payload));
+    case "agent_thought_chunk":
+      return appendChunk(t, ev.seq, "reasoning", chunkText(payload));
+    case "tool_call": {
+      const toolCallId = str(payload.toolCallId);
+      if (toolCallId === undefined) return t;
+      const item: ChatItem = {
+        kind: "tool",
+        seq: ev.seq,
+        toolCallId,
+        title: str(payload.title) ?? toolCallId,
+        toolKind: str(payload.kind),
+        status: toolStatus(payload.status) ?? "pending",
+        content: mapToolContent(payload.content),
+        locations: mapLocations(payload.locations),
+      };
+      return { ...t, items: [...t.items, item] };
+    }
+    case "tool_call_update": {
+      const toolCallId = str(payload.toolCallId);
+      if (toolCallId === undefined) return t;
+      const idx = t.items.findLastIndex(
+        (it) => it.kind === "tool" && it.toolCallId === toolCallId,
+      );
+      if (idx === -1) return t; // unknown toolCallId → ignore
+      const prev = t.items[idx] as Extract<ChatItem, { kind: "tool" }>;
+      const merged: ChatItem = {
+        ...prev,
+        title: str(payload.title) ?? prev.title,
+        toolKind: str(payload.kind) ?? prev.toolKind,
+        status: toolStatus(payload.status) ?? prev.status,
+        // Content/locations REPLACE when present (SDK semantics); null/absent keeps prior.
+        content: Array.isArray(payload.content) ? mapToolContent(payload.content) : prev.content,
+        locations: Array.isArray(payload.locations)
+          ? mapLocations(payload.locations)
+          : prev.locations,
+      };
+      const items = t.items.slice();
+      items[idx] = merged;
+      return { ...t, items };
+    }
+    case "usage_update": {
+      const used = payload.used;
+      const size = payload.size;
+      if (typeof used !== "number" || typeof size !== "number") return t;
+      return { ...t, usage: { used, size } };
+    }
+    default:
+      // plan / plan_update / available_commands_update / current_mode_update /
+      // anything newer → ignored in v1 (forward compat).
+      return t;
+  }
+}
+
+function appendChunk(
+  t: Transcript,
+  seq: number,
+  kind: "assistant" | "reasoning",
+  text: string | undefined,
+): Transcript {
+  if (text === undefined) return t;
+  const items = t.items.slice();
+  const last = items.at(-1);
+  if (last && last.kind === kind && last.streaming) {
+    items[items.length - 1] = { ...last, text: last.text + text };
+  } else {
+    items.push({ kind, seq, text, streaming: true });
+  }
+  return { ...t, items };
+}
+
+function foldPermissionRequest(t: Transcript, ev: AcpEvent): Transcript {
+  if (!isRecord(ev.payload)) return t;
+  const toolCall = ev.payload.toolCall;
+  if (!isRecord(toolCall)) return t;
+
+  const options: Array<{ optionId: string; name: string; kind: string }> = [];
+  if (Array.isArray(ev.payload.options)) {
+    for (const opt of ev.payload.options) {
+      if (!isRecord(opt)) continue;
+      const optionId = str(opt.optionId);
+      const name = str(opt.name);
+      const kind = str(opt.kind);
+      if (optionId !== undefined && name !== undefined && kind !== undefined) {
+        options.push({ optionId, name, kind });
+      }
+    }
+  }
+
+  const item: ChatItem = {
+    kind: "permission",
+    seq: ev.seq,
+    requestSeq: ev.seq,
+    title: str(toolCall.title) ?? str(toolCall.name) ?? "Permission request",
+    toolKind: str(toolCall.kind),
+    options,
+  };
+  return { ...t, items: [...t.items, item] };
+}
+
+function foldPermissionAnswer(t: Transcript, ev: AcpEvent): Transcript {
+  if (!isRecord(ev.payload)) return t;
+  const requestSeq = ev.payload.requestSeq;
+  if (typeof requestSeq !== "number") return t;
+  const idx = t.items.findLastIndex(
+    (it) => it.kind === "permission" && it.requestSeq === requestSeq,
+  );
+  if (idx === -1) return t; // unknown requestSeq → ignore
+  const prev = t.items[idx] as Extract<ChatItem, { kind: "permission" }>;
+  const items = t.items.slice();
+  items[idx] = {
+    ...prev,
+    answer: {
+      optionId: str(ev.payload.optionId),
+      cancelled: ev.payload.cancelled === true ? true : undefined,
+      auto: ev.payload.auto === true ? true : undefined,
+    },
+  };
+  return { ...t, items };
+}
+
+function foldState(t: Transcript, ev: AcpEvent): Transcript {
+  if (!isRecord(ev.payload)) return t;
+  const status = sessionStatus(ev.payload.status);
+  if (status === undefined) return t; // unknown status → forward compat
+
+  let items = t.items;
+  if (status === "idle" || status === "ended") items = closeStreaming(items);
+  if (status === "ended") {
+    const reason = str(ev.payload.reason);
+    items = [
+      ...items,
+      {
+        kind: "notice",
+        seq: ev.seq,
+        level: "info",
+        text: reason ? `Session ended — ${reason}` : "Session ended.",
+      },
+    ];
+  }
+  return { ...t, status, items };
+}
+
+function foldError(t: Transcript, ev: AcpEvent): Transcript {
+  if (!isRecord(ev.payload)) return t;
+  const message = str(ev.payload.message);
+  if (message === undefined) return t;
+  return {
+    ...t,
+    items: [...t.items, { kind: "notice", seq: ev.seq, level: "error", text: message }],
+  };
+}

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -15,6 +15,7 @@
   import type { StationRow } from "$lib/api/client";
   import PageHeader from "$lib/components/page-header.svelte";
   import { Button } from "$lib/components/ui/button";
+  import { Skeleton } from "$lib/components/ui/skeleton";
   import HarnessBadge from "$lib/components/fleet/HarnessBadge.svelte";
   import * as Dialog from "$lib/components/ui/dialog";
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
@@ -47,7 +48,12 @@
   // health leads everywhere else.
   const activeTab = $derived.by<Tab>(() => {
     const t = $page.url.searchParams?.get("tab");
-    return VALID_TABS.includes(t as Tab) ? (t as Tab) : defaultTab;
+    const wanted = VALID_TABS.includes(t as Tab) ? (t as Tab) : defaultTab;
+    // The active tab must be one the tab bar actually renders. PageHeader gives
+    // the tablist a roving tabindex keyed on it, so a tab that isn't there (a
+    // ?tab=chat deep link while capabilities load, ?tab=terminal on a station
+    // without one) would leave the WHOLE tablist untabbable.
+    return tabs.some((tab) => tab.id === wanted) ? wanted : defaultTab;
   });
 
   /** Base id PageHeader builds its tab/panel ids from — kept in one place so
@@ -223,10 +229,16 @@
     </div>
   {:else if stationLoad === "loaded"}
     {@render stationPanels()}
+  {:else}
+    <!-- Panels wait for the capability list: which tab is the default depends on
+         it (chat for acp stations, health otherwise), so rendering one earlier
+         would mount — and fetch for — a panel the user never asked for. The
+         shape of the wait is still shown, so the page isn't a bare header. -->
+    <div class="flex flex-col gap-3" data-testid="station-panels-loading" aria-hidden="true">
+      <Skeleton class="h-8 w-48 rounded-lg" />
+      <Skeleton class="h-[320px] w-full rounded-lg" />
+    </div>
   {/if}
-  <!-- Panels wait for the capability list: which tab is the default depends on
-       it (chat for acp stations, health otherwise), so rendering earlier would
-       mount — and fetch for — a panel the user never asked for. -->
 </div>
 
 {#snippet stationPanels()}

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -8,6 +8,7 @@
   import FileBrowser from "$lib/components/stations/FileBrowser.svelte";
   import ConfigEditor from "$lib/components/stations/ConfigEditor.svelte";
   import Terminal from "$lib/components/stations/Terminal.svelte";
+  import ChatPanel from "$lib/components/stations/chat/ChatPanel.svelte";
   import CleanupPanel from "$lib/components/stations/CleanupPanel.svelte";
   import ActivityPanel from "$lib/components/stations/ActivityPanel.svelte";
   import { listStations } from "$lib/api/client";
@@ -23,19 +24,30 @@
   import TerminalIcon from "@lucide/svelte/icons/terminal";
   import Trash2Icon from "@lucide/svelte/icons/trash-2";
   import ActivityIcon from "@lucide/svelte/icons/activity";
+  import MessageSquareIcon from "@lucide/svelte/icons/message-square";
 
   const nodeId = $derived($page.params.id as string);
   const stationId = $derived($page.params.stationId as string);
 
-  type Tab = "health" | "logs" | "files" | "terminal" | "cleanup" | "activity";
-  const VALID_TABS: readonly Tab[] = ["health", "logs", "files", "terminal", "cleanup", "activity"];
+  type Tab = "chat" | "health" | "logs" | "files" | "terminal" | "cleanup" | "activity";
+  const VALID_TABS: readonly Tab[] = [
+    "chat",
+    "health",
+    "logs",
+    "files",
+    "terminal",
+    "cleanup",
+    "activity",
+  ];
 
   // The active tab lives in the URL (?tab=logs) so station views are
   // deep-linkable, survive refresh, and participate in back/forward.
-  // An absent or unknown param falls back to "health".
+  // An absent or unknown param falls back to the station's default tab: talking
+  // to the agent is the point of an ACP-capable station, so chat leads there and
+  // health leads everywhere else.
   const activeTab = $derived.by<Tab>(() => {
     const t = $page.url.searchParams?.get("tab");
-    return VALID_TABS.includes(t as Tab) ? (t as Tab) : "health";
+    return VALID_TABS.includes(t as Tab) ? (t as Tab) : defaultTab;
   });
 
   /** Base id PageHeader builds its tab/panel ids from — kept in one place so
@@ -52,7 +64,10 @@
   let visitedHeavyTabs = $state(new Set<Tab>());
   $effect(() => {
     if (
-      (activeTab === "logs" || activeTab === "files" || activeTab === "terminal") &&
+      (activeTab === "chat" ||
+        activeTab === "logs" ||
+        activeTab === "files" ||
+        activeTab === "terminal") &&
       !visitedHeavyTabs.has(activeTab)
     ) {
       visitedHeavyTabs = new Set(visitedHeavyTabs).add(activeTab);
@@ -70,6 +85,13 @@
    *  content cache for the saved path (see FileBrowser.invalidate). */
   let fileBrowser: FileBrowser | undefined = $state();
   let configEditor: ConfigEditor | undefined = $state();
+
+  const hasAcp = $derived(
+    Array.isArray(station?.capabilities) && station!.capabilities.includes("acp")
+  );
+
+  /** Tab shown when ?tab= is absent — also the one whose selection DELETES the param. */
+  const defaultTab = $derived<Tab>(hasAcp ? "chat" : "health");
 
   const hasTerminal = $derived(
     Array.isArray(station?.capabilities) && station!.capabilities.includes("terminal")
@@ -107,6 +129,7 @@
   });
 
   const tabs = $derived.by(() => [
+    ...(hasAcp ? [{ id: "chat", label: "Chat", icon: MessageSquareIcon }] : []),
     { id: "health", label: "Health", icon: HeartPulseIcon },
     { id: "logs", label: "Logs", icon: ScrollTextIcon },
     { id: "files", label: "Files", icon: FolderIcon },
@@ -117,7 +140,7 @@
 
   function handleTabChange(tabId: string) {
     const url = new URL($page.url);
-    if (tabId === "health") {
+    if (tabId === defaultTab) {
       url.searchParams.delete("tab");
     } else {
       url.searchParams.set("tab", tabId);
@@ -198,12 +221,29 @@
       <p class="text-sm text-destructive">{stationLoadError}</p>
       <Button variant="outline" size="sm" onclick={() => loadStation()}>Retry</Button>
     </div>
-  {:else}
+  {:else if stationLoad === "loaded"}
     {@render stationPanels()}
   {/if}
+  <!-- Panels wait for the capability list: which tab is the default depends on
+       it (chat for acp stations, health otherwise), so rendering earlier would
+       mount — and fetch for — a panel the user never asked for. -->
 </div>
 
 {#snippet stationPanels()}
+  {#if hasAcp}
+    {@render keepAlivePanel("chat", chatContent)}
+    {#snippet chatContent()}
+      <!-- Keyed on the station: the panel's controller binds its session (and
+           socket) at construction, so a different station gets a fresh panel
+           rather than a live socket pointed at the wrong agent. -->
+      {#key stationId}
+        <div class="flex-1 min-h-[320px]">
+          <ChatPanel {stationId} />
+        </div>
+      {/key}
+    {/snippet}
+  {/if}
+
   {@render mountedPanel("health", healthContent)}
   {#snippet healthContent()}
     <HealthPanel {stationId} {canLifecycle} matrixId={station?.matrixId ?? null} />

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -234,7 +234,8 @@
          it (chat for acp stations, health otherwise), so rendering one earlier
          would mount — and fetch for — a panel the user never asked for. The
          shape of the wait is still shown, so the page isn't a bare header. -->
-    <div class="flex flex-col gap-3" data-testid="station-panels-loading" aria-hidden="true">
+    <div class="flex flex-col gap-3" data-testid="station-panels-loading" aria-busy="true">
+      <span class="sr-only">Loading this agent…</span>
       <Skeleton class="h-8 w-48 rounded-lg" />
       <Skeleton class="h-[320px] w-full rounded-lg" />
     </div>

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/page-test-host.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/page-test-host.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  /**
+   * Test host for +page.svelte. PageHeader's tab bar wraps each tab in a
+   * bits-ui Tooltip, which requires a Tooltip.Provider from an ancestor — in
+   * the app that comes from the root +layout, so tests mount the page through
+   * this wrapper (same pattern as page-header-test-host.svelte).
+   */
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import StationPage from "./+page.svelte";
+</script>
+
+<Tooltip.Provider>
+  <StationPage />
+</Tooltip.Provider>

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
@@ -1,0 +1,244 @@
+/**
+ * page.svelte.test.ts
+ *
+ * Tests for the station detail page's tab wiring — specifically the Chat tab
+ * introduced with ACP sessions:
+ *   - an `acp`-capable station gets Chat FIRST and selected by default (no
+ *     ?tab= param), and the panel is really mounted (the composer is there);
+ *   - switching away keeps the chat panel mounted-but-hidden, so its live
+ *     WebSocket survives a tab switch;
+ *   - the default tab is the one that DELETES ?tab=, so Health on an acp
+ *     station is an explicit ?tab=health;
+ *   - a station without `acp` has no Chat tab and still defaults to Health.
+ *
+ * Run: cd apps/console && pnpm test src/routes/nodes/\[id\]/stations
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, waitFor, fireEvent } from "@testing-library/svelte";
+import * as api from "$lib/api/client";
+import type { StationRow } from "$lib/api/client";
+import type { StationHealth } from "@agentpod/contract";
+
+// ─── SvelteKit stubs ────────────────────────────────────────────────────────
+// The page reads the legacy `$app/stores` page store, so the stub has to be a
+// real (writable) store: tests drive ?tab= through it.
+
+const { pageStore, setUrl, goto } = vi.hoisted(() => {
+  const base = "http://localhost/nodes/node_1/stations/station_1";
+  let value = {
+    url: new URL(base),
+    params: { id: "node_1", stationId: "station_1" },
+    data: {},
+    form: null,
+    status: 200,
+    error: null,
+    route: { id: "/nodes/[id]/stations/[stationId]" },
+  };
+  const subscribers = new Set<(v: typeof value) => void>();
+  return {
+    goto: vi.fn(),
+    pageStore: {
+      subscribe(fn: (v: typeof value) => void) {
+        fn(value);
+        subscribers.add(fn);
+        return () => subscribers.delete(fn);
+      },
+    },
+    setUrl(search: string) {
+      value = { ...value, url: new URL(base + search) };
+      for (const fn of subscribers) fn(value);
+    },
+  };
+});
+
+vi.mock("$app/stores", () => ({
+  page: pageStore,
+  navigating: { subscribe: (fn: (v: null) => void) => (fn(null), () => {}) },
+  updated: { subscribe: (fn: (v: boolean) => void) => (fn(false), () => {}) },
+}));
+
+vi.mock("$app/navigation", () => ({ goto }));
+
+vi.mock("svelte-sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+// The chat panel's markdown renderer isn't jsdom-friendly; the ACP api layer is
+// replaced wholesale so mounting the panel touches no network/WebSocket.
+vi.mock("$lib/components/stations/chat/Response.svelte", () =>
+  import("$lib/components/stations/chat/response.stub.svelte"),
+);
+
+vi.mock("$lib/api/acp", () => ({
+  listAcpSessions: vi.fn(async () => []),
+  createAcpSession: vi.fn(),
+  endAcpSession: vi.fn(),
+  createAcpSocket: vi.fn(() => ({
+    send: vi.fn(),
+    onMessage: vi.fn(),
+    onClose: vi.fn(),
+    close: vi.fn(),
+  })),
+}));
+
+import * as acpApi from "$lib/api/acp";
+// Mounted through the Tooltip.Provider host (PageHeader's tabs need it).
+import StationPage from "./page-test-host.svelte";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+function station(capabilities: StationRow["capabilities"]): StationRow {
+  return {
+    id: "station_1",
+    userId: "user_1",
+    nodeId: "node_1",
+    harness: "claude",
+    stationKey: "claude://workspace",
+    kind: "composite",
+    parentStationId: null,
+    displayName: "Workspace",
+    workspacePath: "/home/user/workspace",
+    capabilities,
+    matrixId: null,
+    adoptedAt: "2026-06-22T00:00:00Z",
+    createdAt: "2026-06-22T00:00:00Z",
+  };
+}
+
+const health: StationHealth = {
+  running: true,
+  pid: 42,
+  cpuPct: 1,
+  memBytes: 1024,
+  diskBytes: 1024,
+  uptimeSec: 60,
+  lastActivity: null,
+  note: null,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  goto.mockClear();
+  vi.mocked(acpApi.listAcpSessions).mockClear();
+  setUrl("");
+  vi.spyOn(api, "stationHealth").mockResolvedValue(health);
+});
+
+afterEach(cleanup);
+
+const tabNames = (tabs: HTMLElement[]) => tabs.map((t) => t.getAttribute("aria-label"));
+const selected = (tabs: HTMLElement[]) =>
+  tabs.find((t) => t.getAttribute("aria-selected") === "true")?.getAttribute("aria-label");
+
+// ─── acp station ────────────────────────────────────────────────────────────
+
+test("an acp station gets Chat first and selected by default, with the panel mounted", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "logs", "acp"])]);
+
+  const { getAllByRole, getByPlaceholderText } = render(StationPage);
+
+  await waitFor(() => {
+    const tabs = getAllByRole("tab");
+    expect(tabNames(tabs)[0]).toBe("Chat");
+    expect(selected(tabs)).toBe("Chat");
+  });
+  // The panel is really there (not just the tab), and it booted the controller.
+  expect(getByPlaceholderText("Message the agent…")).toBeTruthy();
+  expect(acpApi.listAcpSessions).toHaveBeenCalledWith("station_1");
+});
+
+test("switching away from Chat keeps the panel mounted so its socket survives", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "acp"])]);
+
+  const { getAllByRole, getByPlaceholderText, getByRole } = render(StationPage);
+  await waitFor(() => expect(selected(getAllByRole("tab"))).toBe("Chat"));
+  const composer = getByPlaceholderText("Message the agent…");
+
+  await fireEvent.click(getByRole("tab", { name: "Health" }));
+  // Health is not the default tab here, so it must be an explicit ?tab=health.
+  expect(String(goto.mock.calls[0][0])).toContain("tab=health");
+  setUrl("?tab=health"); // stand in for the navigation goto would perform
+
+  await waitFor(() => expect(selected(getAllByRole("tab"))).toBe("Health"));
+  expect(composer.isConnected).toBe(true);
+  expect(composer.closest('[role="tabpanel"]')!.className).toContain("hidden");
+  // Exactly one controller boot — the panel was never torn down and re-inited.
+  expect(acpApi.listAcpSessions).toHaveBeenCalledTimes(1);
+});
+
+test("choosing Chat again deletes ?tab= (chat is the default tab for acp)", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "acp"])]);
+  setUrl("?tab=health");
+
+  const { getAllByRole, getByRole } = render(StationPage);
+  // The Chat tab only appears once the station's capabilities have loaded.
+  await waitFor(() => expect(getByRole("tab", { name: "Chat" })).toBeTruthy());
+  expect(selected(getAllByRole("tab"))).toBe("Health");
+
+  await fireEvent.click(getByRole("tab", { name: "Chat" }));
+
+  expect(String(goto.mock.calls[0][0])).not.toContain("tab=");
+});
+
+test("a deep link to ?tab=health on an acp station shows health, not chat", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "acp"])]);
+  setUrl("?tab=health");
+
+  const { getAllByRole, getByRole, queryByPlaceholderText } = render(StationPage);
+
+  // Wait for the loaded state (the Chat tab exists) before asserting absence.
+  await waitFor(() => expect(getByRole("tab", { name: "Chat" })).toBeTruthy());
+  expect(selected(getAllByRole("tab"))).toBe("Health");
+  // Never visited → the chat panel (and its WebSocket) was never created.
+  expect(queryByPlaceholderText("Message the agent…")).toBeNull();
+  expect(acpApi.listAcpSessions).not.toHaveBeenCalled();
+});
+
+test("panels wait for the capability list, so no wrong-default panel is mounted", async () => {
+  let resolve: (rows: StationRow[]) => void = () => {};
+  vi.spyOn(api, "listStations").mockReturnValue(
+    new Promise<StationRow[]>((r) => {
+      resolve = r;
+    }),
+  );
+
+  const { getAllByRole, queryByPlaceholderText } = render(StationPage);
+  await waitFor(() => expect(getAllByRole("tab").length).toBeGreaterThan(0));
+
+  // Which tab is the default depends on the capabilities, so nothing mounts yet.
+  expect(api.stationHealth).not.toHaveBeenCalled();
+  expect(queryByPlaceholderText("Message the agent…")).toBeNull();
+
+  resolve([station(["health", "acp"])]);
+
+  await waitFor(() => expect(queryByPlaceholderText("Message the agent…")).toBeTruthy());
+  // Chat was the default all along — health was never mounted or fetched.
+  expect(api.stationHealth).not.toHaveBeenCalled();
+});
+
+// ─── non-acp station ────────────────────────────────────────────────────────
+
+test("a station without acp has no Chat tab and still defaults to Health", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "logs", "terminal"])]);
+
+  const { getAllByRole, queryByRole, queryByPlaceholderText } = render(StationPage);
+
+  await waitFor(() => {
+    const tabs = getAllByRole("tab");
+    expect(tabNames(tabs)[0]).toBe("Health");
+    expect(selected(tabs)).toBe("Health");
+  });
+  expect(queryByRole("tab", { name: "Chat" })).toBeNull();
+  expect(queryByPlaceholderText("Message the agent…")).toBeNull();
+});
+
+test("on a non-acp station Health still deletes ?tab=", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "logs"])]);
+  setUrl("?tab=logs");
+
+  const { getByRole, getAllByRole } = render(StationPage);
+  await waitFor(() => expect(selected(getAllByRole("tab"))).toBe("Logs"));
+
+  await fireEvent.click(getByRole("tab", { name: "Health" }));
+
+  expect(String(goto.mock.calls[0][0])).not.toContain("tab=");
+});

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
@@ -193,26 +193,47 @@ test("a deep link to ?tab=health on an acp station shows health, not chat", asyn
   expect(acpApi.listAcpSessions).not.toHaveBeenCalled();
 });
 
-test("panels wait for the capability list, so no wrong-default panel is mounted", async () => {
+test("panels wait for the capability list, showing a skeleton instead of a bare header", async () => {
   let resolve: (rows: StationRow[]) => void = () => {};
   vi.spyOn(api, "listStations").mockReturnValue(
     new Promise<StationRow[]>((r) => {
       resolve = r;
     }),
   );
+  setUrl("?tab=chat"); // a deep link to a tab that doesn't exist yet
 
-  const { getAllByRole, queryByPlaceholderText } = render(StationPage);
+  const { getAllByRole, getByTestId, queryByPlaceholderText } = render(StationPage);
   await waitFor(() => expect(getAllByRole("tab").length).toBeGreaterThan(0));
 
-  // Which tab is the default depends on the capabilities, so nothing mounts yet.
+  // Which tab is the default depends on the capabilities, so nothing mounts yet —
+  // but the wait has a shape.
   expect(api.stationHealth).not.toHaveBeenCalled();
   expect(queryByPlaceholderText("Message the agent…")).toBeNull();
+  expect(getByTestId("station-panels-loading")).toBeTruthy();
+
+  // The tablist keeps exactly one tabbable tab: PageHeader's roving tabindex
+  // hangs off the active tab, so an active tab that isn't rendered would leave
+  // the whole tab bar unreachable by keyboard.
+  const tabbable = getAllByRole("tab").filter((t) => t.getAttribute("tabindex") === "0");
+  expect(tabbable).toHaveLength(1);
 
   resolve([station(["health", "acp"])]);
 
   await waitFor(() => expect(queryByPlaceholderText("Message the agent…")).toBeTruthy());
-  // Chat was the default all along — health was never mounted or fetched.
+  // Chat exists now, so the deep link resolves to it — and health was never
+  // mounted or fetched on the way there.
+  expect(selected(getAllByRole("tab"))).toBe("Chat");
   expect(api.stationHealth).not.toHaveBeenCalled();
+});
+
+test("a tab the station doesn't have falls back to the default, keeping the tablist tabbable", async () => {
+  vi.spyOn(api, "listStations").mockResolvedValue([station(["health", "logs"])]);
+  setUrl("?tab=terminal"); // no terminal capability → no such tab
+
+  const { getAllByRole } = render(StationPage);
+
+  await waitFor(() => expect(selected(getAllByRole("tab"))).toBe("Health"));
+  expect(getAllByRole("tab").filter((t) => t.getAttribute("tabindex") === "0")).toHaveLength(1);
 });
 
 // ─── non-acp station ────────────────────────────────────────────────────────

--- a/apps/console/src/vitest-setup.ts
+++ b/apps/console/src/vitest-setup.ts
@@ -23,6 +23,24 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   };
 }
 
+// jsdom has no matchMedia. The theme store resolves the "system" colour scheme
+// with it at module-initialisation time (src/lib/themes/store.svelte.ts), so any
+// test that transitively imports a themed component (Terminal, the monaco
+// editor, the station page) crashes during module evaluation without it. Report
+// light mode and no listeners — tests never assert on the resolved scheme.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
 // Unmount components, then let bits-ui's 24ms body-scroll-lock cleanup timer
 // fire while the DOM still exists. Without the flush, the last dialog-using
 // test in a file races vitest's environment teardown and crashes with

--- a/apps/hub/src/services/provisioner/docker.test.ts
+++ b/apps/hub/src/services/provisioner/docker.test.ts
@@ -162,7 +162,7 @@ describe("DockerRuntimeProvisioner", () => {
       const fake = new FakeDockerOrchestrator();
       await makeProvisioner(fake).provision({ ...BASE_SPEC, resourceTier: "small" });
       expect(fake.capturedConfig!.resources.cpus).toBe("0.5");
-      expect(fake.capturedConfig!.resources.memory).toBe("512m");
+      expect(fake.capturedConfig!.resources.memory).toBe("1g");
     });
 
     it("maps resourceTier medium to 1 CPU / 2g memory", async () => {

--- a/apps/hub/src/services/provisioner/docker.ts
+++ b/apps/hub/src/services/provisioner/docker.ts
@@ -23,7 +23,10 @@ const RUNTIME_RESOURCE_TIERS: Record<
   "small" | "medium" | "large",
   ResourceLimits
 > = {
-  small:  { cpus: "0.5", memory: "512m",  pidsLimit: 100 },
+  // small was 512m; a live opencode runtime OOM-killed its acp session at
+  // 513MB rss (memcg, 2026-08-09) — `opencode serve` + one `opencode acp`
+  // need ≥1g to coexist.
+  small:  { cpus: "0.5", memory: "1g",    pidsLimit: 100 },
   medium: { cpus: "1.0", memory: "2g",    pidsLimit: 256 },
   large:  { cpus: "2.0", memory: "4g",    pidsLimit: 512 },
 };

--- a/docs/superpowers/plans/2026-08-09-acp-slice3-console-chat.md
+++ b/docs/superpowers/plans/2026-08-09-acp-slice3-console-chat.md
@@ -1,0 +1,296 @@
+# ACP Slice 3 — Console Chat Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A world-class Chat tab on the station page that drives any `acp`-capable agent through the hub's slice-2 session API — streamed markdown, reasoning blocks, tool-call cards, inline permission prompts, replayable hub-owned sessions.
+
+**Architecture:** A thin WS/REST client factory (`api/acp.ts`, mirroring `terminal.ts`), a pure event→transcript projection module, and a per-panel session controller class (`AcpChat`) feed a component tree (Conversation / Response / Reasoning / ToolCallCard / PermissionCard / PromptInput / ChatHeader) composed by `ChatPanel`. Sessions are hub-owned: closing the tab only unsubscribes; reattach replays from the last seen seq.
+
+**Tech Stack:** Svelte 5 runes, `svelte-streamdown` (new dep) for streaming markdown + shiki code, existing Crisp design system (`<Status>`, type roles, status tokens, `chipClass`), `@agentpod/contract` ACP schemas, vitest + testing-library with the house `MockWebSocket` pattern.
+
+## Global Constraints
+
+- The chat experience must be world-class (user directive) — no placeholder UX, no deferred core interactions.
+- Copy grammar for every failure: `Couldn't <verb> <object>.` (e.g. "Couldn't reach the hub — check your connection.").
+- Design system only: `<Status>` for all status display (never raw colored dots), type roles `t-page/t-section/t-body/t-label/t-metric`, status tokens via `tokenFor()` — no ad-hoc colors except where a task explicitly says otherwise.
+- Session semantics (hub-owned): client disconnect only unsubscribes — never treat a WS close as session end; only `bye` or a `state: ended` event ends the session in the UI.
+- Synthetic error events arrive with `seq: 0` — they must NEVER advance the replay cursor. The cursor is the max seq of REAL (seq ≥ 1) events seen; do not trust `replay-done.lastSeq` as server max (it echoes bogus client cursors).
+- `renderHtml` stays OFF in streamdown (agent output is untrusted).
+- Accessibility: reduced-motion respected (`motion-safe:` on pulses/animations), `aria-live="polite"` for turn/permission updates, all interactions keyboard-complete, icon-only buttons get `aria-label`.
+- Svelte conventions: runes (`$state`/`$derived`/`$effect`), `$props()` with local `interface Props`, plain `let` for refs needed in `onDestroy`.
+- Tests: static-import components under test; install `MockWebSocket` on `globalThis` BEFORE importing modules that capture it; never remove the vitest-setup scroll-lock teardown; stub heavy children (`streamdown`, monaco) with `.stub.svelte` files.
+- Hub API (slice 2, live): `POST /api/stations/:id/acp/sessions {mode}` → 201 `AcpSessionRow`; `GET /api/stations/:id/acp/sessions` → rows newest-first; `DELETE /api/acp/sessions/:sessionId` → 204; WS `/api/acp/sessions/:sessionId/ws` speaking `AcpClientMsg`/`AcpServerMsg` from `@agentpod/contract`.
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB`
+
+## File Structure
+
+```
+apps/console/src/lib/api/acp.ts                       REST calls + createAcpSocket factory
+apps/console/src/lib/api/acp.test.ts
+apps/console/src/lib/components/stations/chat/
+  transcript.ts                                       pure AcpEvent[] → ChatItem[] projection
+  transcript.test.ts
+  acp-chat.svelte.ts                                  AcpChat controller class (runes)
+  acp-chat.svelte.test.ts
+  Response.svelte                                     streamdown wrapper
+  Reasoning.svelte                                    collapsible thinking block
+  ToolCallCard.svelte
+  PermissionCard.svelte
+  Conversation.svelte                                 transcript list + follow mechanics
+  PromptInput.svelte
+  ChatHeader.svelte                                   mode selector, status, end session
+  ChatPanel.svelte                                    composition root, props { stationId }
+  response.stub.svelte                                test stub for streamdown
+  *.svelte.test.ts                                    colocated component tests
+apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte   Chat tab wiring
+```
+
+---
+
+### Task 1: ACP API client (`api/acp.ts`)
+
+**Files:**
+- Create: `apps/console/src/lib/api/acp.ts`
+- Test: `apps/console/src/lib/api/acp.test.ts`
+
+**Interfaces:**
+- Consumes: `http<T>` is NOT reused — mirror `terminal.ts`'s standalone pattern for the WS; REST goes through the existing `client.ts` conventions (add the three functions THERE or here — put them here, importing `hubUrl`-equivalent logic the same way `terminal.ts` does; REST error handling reuses `http-error.ts` via a local `http`-style helper or by importing and calling `apiError`/`networkError`. Simplest: import the private pattern — copy the 20-line `http<T>` shape locally, or export `http` from `client.ts` and import it. **Do: export `http` from `client.ts`** (one-line `export` keyword change) and import it.)
+- Produces (used by Task 3):
+  ```ts
+  export type AcpSessionRow = import("@agentpod/contract").AcpSessionRow;
+  export type AcpServerMsg = import("@agentpod/contract").AcpServerMsg;
+  export type AcpClientMsg = import("@agentpod/contract").AcpClientMsg;
+  export const createAcpSession: (stationId: string, mode: AcpSessionMode) => Promise<AcpSessionRow>;
+  export const listAcpSessions: (stationId: string) => Promise<AcpSessionRow[]>;
+  export const endAcpSession: (sessionId: string) => Promise<void>;   // DELETE, 204
+  export interface AcpSocket {
+    send(msg: AcpClientMsg): void;          // queues until open, mirrors terminal.ts sendQueue
+    onMessage(cb: (msg: AcpServerMsg) => void): void;
+    onClose(cb: (reason: "error" | "closed") => void): void;  // suppressed after close()
+    close(): void;                           // manualClose — never fires onClose
+  }
+  export function createAcpSocket(sessionId: string): AcpSocket;
+  ```
+- WS URL: `${hubUrl().replace(/^http/, "ws")}/api/acp/sessions/${sessionId}/ws` — same `hubUrl()` resolution as `terminal.ts:14-18` (localStorage override → `PUBLIC_HUB_URL` → localhost:3001).
+- Inbound messages are parsed with `AcpServerMsg.safeParse` (zod, from contract); parse failures are dropped silently (forward compat — a newer hub may add variants).
+
+- [ ] **Step 1 (RED):** Port the structure of `terminal.test.ts` (MockWebSocket class installed before dynamic import, localStorage URL pin). Tests: URL derivation (`ws://hub.test:3001/api/acp/sessions/s1/ws`); `send` before open queues and flushes on open in order; `onMessage` delivers parsed `AcpServerMsg` and drops garbage frames without throwing; `close()` then server close → `onClose` NOT fired; error → `onClose("error")` once; REST helpers hit the right paths/methods (spy on fetch: `POST …/acp/sessions` body `{"mode":"ask"}`, `DELETE …/api/acp/sessions/:id`).
+- [ ] **Step 2:** Run `pnpm test src/lib/api/acp.test.ts` → FAIL (module missing).
+- [ ] **Step 3:** Implement, mirroring `terminal.ts` closely (sendQueue, manualClose, closeFired, numeric readyState literals).
+- [ ] **Step 4:** `pnpm test` file green, `pnpm check` clean.
+- [ ] **Step 5:** Commit `feat(console): acp session api client`.
+
+---
+
+### Task 2: Transcript projection (`chat/transcript.ts`)
+
+**Files:**
+- Create: `apps/console/src/lib/components/stations/chat/transcript.ts`
+- Test: `apps/console/src/lib/components/stations/chat/transcript.test.ts`
+
+Pure module: fold persisted/live `AcpEvent`s into renderable items. No Svelte imports.
+
+**Interfaces (produced, consumed by Tasks 3/6):**
+```ts
+export type ChatItem =
+  | { kind: "user"; seq: number; text: string; pending?: boolean }
+  | { kind: "assistant"; seq: number; text: string; streaming: boolean }
+  | { kind: "reasoning"; seq: number; text: string; streaming: boolean }
+  | { kind: "tool"; seq: number; toolCallId: string; title: string; toolKind?: string;
+      status: "pending" | "in_progress" | "completed" | "failed";
+      content: Array<{ type: "text"; text: string } | { type: "diff"; path: string; oldText: string | null; newText: string }>;
+      locations: string[] }
+  | { kind: "permission"; seq: number; requestSeq: number; title: string; toolKind?: string;
+      options: Array<{ optionId: string; name: string; kind: string }>;
+      answer?: { optionId?: string; cancelled?: boolean; auto?: boolean } }
+  | { kind: "notice"; seq: number; level: "info" | "error"; text: string };  // ended reasons, errors
+
+export interface Transcript { items: ChatItem[]; lastSeq: number; status: AcpSessionStatus; usage?: { used: number; size: number } }
+export function emptyTranscript(): Transcript;
+export function foldEvent(t: Transcript, ev: AcpEvent): Transcript;   // pure; returns new object, reuses untouched item refs
+```
+
+Folding rules (payload shapes verified live on hermes/opencode, hub `acp-sessions.ts`):
+- `user-prompt {text}` → close any open assistant/reasoning item (streaming→false), push `user`. If the last item is a `user` with `pending: true`, REPLACE it (optimistic reconcile) instead of pushing.
+- `agent-update` — switch on `payload.sessionUpdate`:
+  - `agent_message_chunk {content:{type:"text",text}}` → append text to trailing `assistant` item if it is `streaming`, else push new one.
+  - `agent_thought_chunk` → same, on `reasoning` items.
+  - `tool_call {toolCallId, title, kind?, status?, content?, locations?}` → push `tool` item (status default `pending`; map `content` entries: `{type:"content", content:{type:"text",text}}` → text; `{type:"diff", path, oldText, newText}` → diff; ignore unknown types; `locations` → `loc.path` strings).
+  - `tool_call_update {toolCallId, …}` → merge into the matching `tool` item (later fields win; content replaces when present); unknown toolCallId → ignore.
+  - `plan`, `available_commands_update`, `current_mode_update` → ignore (v1).
+  - `usage_update {used, size}` → set `t.usage`, no item.
+  - unknown `sessionUpdate` → ignore (forward compat).
+- `permission-request {toolCall, options}` at seq S → push `permission` (requestSeq = S, title from `toolCall.title` ?? tool name, options mapped).
+- `permission-answer {requestSeq, optionId?, cancelled?, auto?}` → set `answer` on the matching permission item.
+- `state {status, reason?}` → `t.status = status`; `ended` additionally pushes `notice` (`info`, text `reason` ? \`Session ended — ${reason}\` : "Session ended."); non-ended states push nothing.
+- `error {message}` (persisted type `"error"`, or synthetic seq-0 relayed by caller) → push `notice` level `error` with the message.
+- Cursor: `lastSeq = max(lastSeq, ev.seq)` ONLY when `ev.seq >= 1`. Duplicate delivery (ev.seq ≤ lastSeq for seq ≥ 1 events) → return `t` unchanged (idempotent).
+- Optimistic prompt helper: `export function addPendingPrompt(t: Transcript, text: string): Transcript` — pushes `user` with `seq: -1, pending: true`.
+
+- [ ] **Step 1 (RED):** Fixture-driven tests: (a) the live-observed opencode sequence (state idle → agent-update available_commands → user-prompt → state working → 7 message chunks "ACP"…"OK" → usage_update → state idle) folds to [user, assistant("ACP-SLICE2-OK" complete)] with status idle, usage set, lastSeq correct; (b) reasoning chunks interleaved with message chunks produce separate items in arrival order; (c) tool_call + two tool_call_updates merge (status pending→in_progress→completed, diff content); (d) permission request+answer roundtrip incl. `cancelled:true` and `auto:true`; (e) duplicate seq delivery is a no-op; seq-0 error event adds notice but does NOT move lastSeq; (f) ended state appends notice with reason; (g) optimistic pending prompt is replaced by the real user-prompt event (not duplicated).
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** file + `pnpm check` green.
+- [ ] **Step 5:** Commit `feat(console): acp transcript projection`.
+
+---
+
+### Task 3: Session controller (`chat/acp-chat.svelte.ts`)
+
+**Files:**
+- Create: `apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts`
+- Test: `apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 (`createAcpSession/listAcpSessions/endAcpSession/createAcpSocket`), Task 2 (`emptyTranscript/foldEvent/addPendingPrompt`).
+- Produces (consumed by Tasks 6/7): class `AcpChat`, one instance per ChatPanel:
+  ```ts
+  export class AcpChat {
+    constructor(stationId: string);
+    // reactive ($state-backed) getters:
+    readonly session: AcpSessionRow | null;
+    readonly transcript: Transcript;             // items, status, usage, lastSeq
+    readonly connection: "idle" | "connecting" | "connected" | "reconnecting" | "disconnected";
+    readonly error: string | null;               // last surfaced failure, "Couldn't …" copy
+    readonly working: boolean;                    // transcript.status === "working"
+    readonly pendingPermissions: number;
+    mode: AcpSessionMode;                        // selector state; defaults "ask", synced from session row
+    init(): Promise<void>;      // list sessions; if newest is non-ended → attach; else stay idle (empty state)
+    prompt(text: string): Promise<void>;  // creates session first if none (mode = this.mode), optimistic item, sends {t:"prompt"}
+    cancel(): void;                        // {t:"cancel"}
+    answer(requestSeq: number, optionId: string | null): void; // {t:"permission-answer", requestSeq, optionId?…} null → cancelled:true
+    setMode(mode: AcpSessionMode): void;   // {t:"set-mode"} + local
+    end(): Promise<void>;                  // REST DELETE; UI settles on bye/ended event
+    newSession(): void;                    // after ended: reset to empty state (keep nothing)
+    retry(): void;                         // manual reconnect, resets backoff budget
+    destroy(): void;                       // close socket; never ends the session
+  }
+  ```
+- Attach protocol: open socket → `subscribe {sinceSeq: transcript.lastSeq}` → apply `session` msg (row), fold `event`s, `replay-done` marks connection "connected" (before it, "connecting"/"reconnecting"). `bye {reason}` → session over: fold a final ended notice if none arrived, connection "idle", no reconnect.
+- Reconnect: on non-manual close with a live session, budget of 3 attempts, backoff [1000, 2000, 4000] (mirror Terminal.svelte); re-subscribe uses current `lastSeq` (replay fills the gap — this is the "working while away" path). Budget exhausted → connection "disconnected", `error = "Couldn't reach the hub — check your connection."`; `retry()` resets.
+- Synthetic seq-0 `error` events: fold (notice) but they never advance the cursor (Task 2 guarantees); ALSO set `this.error` when the session has no live turn (so the input area can surface it).
+
+- [ ] **Step 1 (RED):** With MockWebSocket + `vi.spyOn` on the api module: (a) `init` with an active session row attaches and replays (events → items, connected after replay-done); (b) `init` with only ended sessions stays idle, no socket; (c) `prompt` with no session: POST create → socket → subscribe → prompt sent, optimistic item visible then reconciled by the echoed user-prompt event; (d) unexpected close mid-session → reconnecting, new socket subscribes with `sinceSeq = lastSeq`; 3 failures → disconnected + error copy; `retry()` reconnects; (e) `bye` → no reconnect attempt, status ended; (f) `answer(seq, null)` sends `{cancelled: true}`; (g) `destroy()` closes without DELETE (hub-owned — assert no fetch to DELETE); (h) `end()` calls DELETE and the ended state arrives via events, not locally forced.
+- [ ] **Step 2:** FAIL. **Step 3:** implement (module-level nothing — all instance state; `$state` fields + getters). **Step 4:** green + `pnpm check`.
+- [ ] **Step 5:** Commit `feat(console): acp chat session controller`.
+
+---
+
+### Task 4: Response + Reasoning components
+
+**Files:**
+- Modify: `apps/console/package.json` (add `svelte-streamdown`, exact version, latest)
+- Create: `chat/Response.svelte`, `chat/Reasoning.svelte`, `chat/response.stub.svelte`
+- Test: `chat/Response.svelte.test.ts`, `chat/Reasoning.svelte.test.ts`
+
+Install: `pnpm add -E svelte-streamdown --filter @agentpod/console` (run from repo root).
+
+**Response.svelte** — `interface Props { text: string; streaming?: boolean }`:
+```svelte
+<script lang="ts">
+  import { Streamdown } from "svelte-streamdown";
+  import Code from "svelte-streamdown/code";
+  import { themeStore } from "$lib/themes/store.svelte";
+  let { text, streaming = false }: Props = $props();
+  const shikiTheme = $derived(themeStore.shikiThemes /* pick current color-scheme name; check store API — it exposes light/dark theme names */);
+</script>
+<Streamdown content={text} components={{ code: Code }} baseTheme="tailwind"
+  parseIncompleteMarkdown={streaming} renderHtml={false}
+  allowedLinkPrefixes={["https://", "http://"]} shikiTheme={/* resolved name */}
+  theme={{ /* map container/prose text to t-body + Crisp borders; keep overrides minimal */ }} />
+```
+Verify the exact `themeStore.shikiThemes` shape (`store.svelte.ts:385-389`) and pick the theme matching the active color scheme reactively.
+
+**Reasoning.svelte** — `interface Props { text: string; streaming?: boolean }`: `Collapsible.Root` (bits-ui passthrough at `ui/collapsible`), trigger row = `t-label` muted "Thinking" + chevron + (streaming ? `<Status form="dot" status="starting" animate label="thinking" />` : null), content = the raw text in `t-body text-muted-foreground whitespace-pre-wrap` (no markdown — thoughts are plain). Default open while `streaming`, auto-collapses when streaming flips false (an `$effect` writing `open = false` exactly once on the true→false edge — track previous with a plain let).
+
+- [ ] **Step 1 (RED):** Reasoning test: renders trigger label; open while streaming; collapses when `streaming` prop flips; content visible after manual expand. Response test: renders markdown text (assert a `<strong>` from `**bold**` lands) — if jsdom+streamdown misbehave, the fallback assertion is that the component mounts and the container carries the text; note the outcome honestly in the report.
+- [ ] **Step 2:** FAIL. **Step 3:** implement + create `response.stub.svelte` (`<div data-testid="response-stub">{text}</div>`) for later tasks. **Step 4:** green; `pnpm check`; `pnpm build` (streamdown must not break the prod build).
+- [ ] **Step 5:** Commit `feat(console): chat response + reasoning components`.
+
+---
+
+### Task 5: ToolCallCard + PermissionCard
+
+**Files:**
+- Create: `chat/ToolCallCard.svelte`, `chat/PermissionCard.svelte`
+- Test: `chat/ToolCallCard.svelte.test.ts`, `chat/PermissionCard.svelte.test.ts`
+
+**ToolCallCard** — `interface Props { item: Extract<ChatItem, {kind:"tool"}> }`:
+- Header row (always visible, is the Collapsible trigger): `<Status form="dot" …>` mapped `pending→starting`, `in_progress→starting` with `animate`, `completed→running`, `failed→error`; title in `font-mono text-sm` (agent-reported → mono per house rule); `toolKind` as `t-label` muted suffix; chevron.
+- Content (collapsible, default open only while `in_progress`): text blocks in `<pre class="t-body … whitespace-pre-wrap">`; diff blocks rendered inline exactly like ConfigEditor's pattern — `diffLines(oldText ?? "", newText)` from the `diff` package, added `bg-green-500/15 text-green-700 dark:text-green-400`, removed `bg-red-500/15 … line-through`, context muted (copy the 15-line `{#each}` from `ConfigEditor.svelte:167-181`, factor it into `chat/DiffBlock.svelte` and note it as a future shared component — do NOT refactor ConfigEditor in this task); `locations` as a `t-label` file list.
+- **PermissionCard** — `interface Props { item: Extract<ChatItem, {kind:"permission"}>; onAnswer: (optionId: string | null) => void }`:
+  - Unanswered: bordered card, `<Status form="dot" status="starting" animate label="awaiting approval" />`, title (mono), option buttons — `kind` starting with `allow` → `variant="default"` (first) / `secondary`; `reject*` → `variant="outline"`; a separate "Dismiss" is NOT needed (reject options come from the agent). All buttons real `<Button>`, focusable, `size="sm"`.
+  - Answered: muted card, chosen option name + (answer.auto ? "· auto (mode)" : "") or "Cancelled."; no buttons.
+- [ ] **Step 1 (RED):** ToolCallCard: status dot mapping for all four statuses; collapsible opens by default when in_progress; diff renders added/removed lines; text content renders. PermissionCard: options render as buttons; clicking calls `onAnswer(optionId)`; answered state hides buttons and shows the chosen label; cancelled shows "Cancelled."
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** green + check.
+- [ ] **Step 5:** Commit `feat(console): tool call + permission cards`.
+
+---
+
+### Task 6: Conversation + PromptInput + ChatHeader
+
+**Files:**
+- Create: `chat/Conversation.svelte`, `chat/PromptInput.svelte`, `chat/ChatHeader.svelte`
+- Test: colocated `.svelte.test.ts` for each
+
+**Conversation** — `interface Props { items: ChatItem[]; status: AcpSessionStatus }`:
+- Scroll container (`data-testid="chat-scroll-container"`, `overflow-y-auto`), items rendered by `{#if}`/switch on `kind`: user → right-aligned bubble (`bg-primary/10 rounded-lg px-3 py-2 t-body`, `pending` → 60% opacity), assistant → `<Response>`, reasoning → `<Reasoning>`, tool → `<ToolCallCard>`, permission → `<PermissionCard>` (needs `onAnswer` — accept `onAnswer(requestSeq, optionId)` prop and curry), notice → centered `t-label` muted (error level → `text-status-error`).
+- Follow mechanics copied from LogTail (L169-196): `follow = $state(true)`, `FOLLOW_THRESHOLD_PX = 40`, `queueScrollToBottom()` on items-length growth AND on trailing-item text growth (streaming), scroll-away sets follow false + counts new items, floating "N new messages" pill (reuse LogTail's pill classes) with `jumpToBottom()`.
+- Each item wrapper gets `content-visibility: auto; contain-intrinsic-size: auto 4rem` (define a `.chat-item` style block).
+- `aria-live="polite"` `sr-only` region announcing: latest permission request ("Agent asks to <title>") and status flips (working/idle/ended).
+- Empty state (no items): `<Empty>` with title "No conversation yet." description "Send a prompt to start talking to this agent."
+
+**PromptInput** — `interface Props { disabled?: boolean; working: boolean; onSend: (text: string) => void; onCancel: () => void }`:
+- `<Textarea>` (auto-grows via existing `field-sizing-content`), placeholder `Message the agent…`, Enter sends (trimmed, non-empty; respects `event.isComposing`), Shift+Enter newline; clears on send; disabled while `disabled`.
+- Right side: while `working` → stop button (`<Button variant="outline" size="icon-sm" aria-label="Stop the current turn">` square icon) calling `onCancel`; else send button (`aria-label="Send"`, disabled when empty).
+**ChatHeader** — `interface Props { session: AcpSessionRow | null; status: AcpSessionStatus; connection: string; mode: AcpSessionMode; onModeChange: (m: AcpSessionMode) => void; onEnd: () => void; onNew: () => void }`:
+- Left: `<Status form="dot" …>` (status vocab: working→starting+animate, idle→running, waiting→degraded, ended→stopped) + `t-label` status text, wrapped `role="status" aria-live="polite"`; connection `reconnecting/disconnected` overrides the label ("Reconnecting…" / with retry handled in panel).
+- Middle: mode selector — three `chipClass`-style buttons (Ask / Accept edits / Full auto), `aria-pressed`, calls `onModeChange`; disabled when no live session (mode still selectable pre-session — it seeds creation).
+- Right: session present & not ended → "End session" `<Button variant="ghost" size="sm">` opening `<ConfirmDialog>` (title "End this session?", message "The agent process stops and the transcript is kept.", destructive); ended → "New session" button calling `onNew`.
+- [ ] **Step 1 (RED):** Conversation: renders each item kind (stub Response via `vi.mock` → `response.stub.svelte`); follow pill appears when scrolled away and new items arrive (jsdom: set scrollTop/scrollHeight manually like LogTail tests); aria-live region updates on permission item. PromptInput: Enter sends trimmed text and clears; Shift+Enter doesn't; empty doesn't; stop button shown while working, calls onCancel. ChatHeader: mode chips call back; End button gated behind confirm dialog; ended shows New session.
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** green + check.
+- [ ] **Step 5:** Commit `feat(console): chat conversation, prompt input, session header`.
+
+---
+
+### Task 7: ChatPanel + station page integration
+
+**Files:**
+- Create: `chat/ChatPanel.svelte`, test `chat/ChatPanel.svelte.test.ts`
+- Modify: `apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte`
+
+**ChatPanel** — `interface Props { stationId: string }`:
+- Instantiates `new AcpChat(stationId)` in a plain let, `onMount(() => { chat.init(); return () => chat.destroy(); })`.
+- Layout: `ChatHeader` / `Conversation` (flex-1 min-h-0) / error strip / `PromptInput` in a full-height column (mirror Terminal.svelte's container sizing).
+- Wiring: `onSend=chat.prompt`, `onCancel=chat.cancel`, `onAnswer=chat.answer`, mode/end/new from header; `chat.error` renders an inline strip above the input (`t-label text-status-error`) with a "Retry" `<Button variant="ghost" size="xs">` when `connection === "disconnected"`.
+- First-prompt flow: no session → header shows mode chips active, conversation empty state; sending creates the session with the chosen mode (Task 3 handles it) — surface create failure via toast `toast.error("Couldn't start the session", { description })` AND the strip.
+**Station page:**
+- `hasAcp` capability boolean (same pattern as `hasTerminal`, L74-88).
+- Tab entry `{ id: "chat", label: "Chat", icon: MessageSquareIcon }` FIRST in the tabs array when `hasAcp` (spec: first tab).
+- Default tab when `?tab=` absent: `chat` if `hasAcp` else `health` — adjust the `$derived.by` fallback AND `handleTabChange`'s delete-param case (the default tab deletes the param; with `hasAcp` that's now "chat", and explicitly choosing "health" sets `?tab=health`).
+- Add `"chat"` to `VALID_TABS`; render via `keepAlivePanel("chat", …)` (live WS must survive tab switches).
+- [ ] **Step 1 (RED):** ChatPanel test (mock `AcpChat` module? No — mock the api layer and MockWebSocket, use the real controller; stub Response): mounts, init lists sessions, empty state renders, typing+Enter creates session and shows optimistic bubble. Station page test (new file, mirror existing route tests with reactive-page-state mock): station with `acp` capability → Chat tab first and default-active; station without → no Chat tab, health default; deep link `?tab=health` on an acp station shows health.
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** full console suite `pnpm check && pnpm test` green.
+- [ ] **Step 5:** Commit `feat(console): chat tab on the station page`.
+
+---
+
+### Task 8: Slice gate — suites, PR, CI, live verification (controller-run)
+
+- [ ] All four suites green (contract, hub w/ :5434 DATABASE_URL, node-agent `-race`, console check+test+build).
+- [ ] Push `ui-revamp`; PR `feat: ACP slice 3 — console chat` (note: branch already carries `1f2f341` small-tier fix — call it out in the PR body); CI green; merge.
+- [ ] Deploy console to Cloudflare Pages with `PUBLIC_HUB_URL=https://hub.agentpod.dev` (check `.github/workflows` / `wrangler.toml` for the established deploy path — the UI milestones M1–M6 shipped through it).
+- [ ] Live verification on the deployed console (browser):
+  1. Chat tab appears first on `opencode-one` and on hermes stations; absent on openclaw stations.
+  2. Real conversation with `hermes:buddhimaan` — streamed markdown renders, reasoning block if emitted, status flips working→idle.
+  3. Permission flow: in `ask` mode prompt hermes to run a shell command → PermissionCard appears, approve, tool card completes. (If hermes never asks, exercise via opencode file-write prompt; if neither harness emits a permission request, record that honestly and cover the flow with the fake-node evidence.)
+  4. Hub-owned semantics: close the tab mid-turn, reopen → replay catches up including turn output ("working while away").
+  5. End session from the header → confirm → transcript keeps, "New session" starts fresh; no acp process remnant on the node.
+- [ ] Update `acp-sessions-program` memory (slice 3 shipped, findings), ledger complete.
+
+## Self-Review Notes
+
+- Slice-2 carry-ins covered: end-session UX (T6/T7), `replay-done.lastSeq` distrust (T2 cursor rule, Global Constraints), error-copy pass (T3/T7 copy).
+- `plan`/`available_commands`/`current_mode` session updates deliberately ignored in v1 (YAGNI — slice 4 revisits with multi-session); usage_update kept because it's one field and the header has a natural home for it later (stored, not yet rendered — T2 stores it, no task renders it; that is intentional).
+- Optimistic prompt reconcile is by pending-flag replacement, not text matching — single-user session, prompts are serialized by the hub's 409-on-concurrent-turn, so the next `user-prompt` event always corresponds to the pending item.
+- `svelte-streamdown` version pinned exact (`-E`) per repo convention; `renderHtml={false}` + link-prefix allowlist is the sanitization decision (no DOMPurify needed).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       shiki:
         specifier: ^3.19.0
         version: 3.19.0
+      svelte-streamdown:
+        specifier: 3.1.2
+        version: 3.1.2(svelte@5.45.5)
     devDependencies:
       '@agentpod/tsconfig':
         specifier: workspace:*
@@ -351,6 +354,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -451,9 +457,15 @@ packages:
   '@better-fetch/fetch@1.1.18':
     resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@capsizecss/unpack@3.0.1':
     resolution: {integrity: sha512-8XqW8xGn++Eqqbz3e9wKuK7mxryeRjs4LOHLxbh2lwKeSbuNR4NFifDZT4KzvjU6HMOPbiNTsWpniK5EJfTWkg==}
     engines: {node: '>=18'}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1030,6 +1042,12 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
@@ -1196,6 +1214,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@noble/ciphers@2.1.1':
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
@@ -1580,6 +1601,99 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1601,6 +1715,9 @@ packages:
 
   '@types/fontkit@2.0.8':
     resolution: {integrity: sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1706,6 +1823,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2132,6 +2252,14 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
@@ -2152,6 +2280,12 @@ packages:
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -2197,6 +2331,162 @@ packages:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -2212,6 +2502,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2253,6 +2546,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2323,6 +2619,9 @@ packages:
 
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2489,6 +2788,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -2816,6 +3118,9 @@ packages:
   h3@1.15.4:
     resolution: {integrity: sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2943,6 +3248,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -3159,8 +3471,15 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -3180,6 +3499,12 @@ packages:
   kysely@0.28.8:
     resolution: {integrity: sha512-QUOgl5ZrS9IRuhq5FvOKFSsD/3+IA6MLE81/bOOTRA/YQpKDza2sFdN5g6JCB9BOpqMJDGefLCQ9F12hRS13TA==}
     engines: {node: '>=20.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3266,6 +3591,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -3311,6 +3639,11 @@ packages:
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   marked@17.0.1:
@@ -3385,6 +3718,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3693,6 +4029,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3739,6 +4078,12 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3980,6 +4325,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.53.3:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3987,6 +4335,9 @@ packages:
 
   rou3@0.7.11:
     resolution: {integrity: sha512-ELguG3ENDw5NKNmWHO3OGEjcgdxkCNvnMR22gKHEgRXuwiriap5RIYdummOaOiqUNcC5yU5txGCHWNm7KlHuAA==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
@@ -4025,6 +4376,9 @@ packages:
     peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -4235,6 +4589,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
@@ -4266,6 +4623,11 @@ packages:
 
   svelte-sonner@1.0.7:
     resolution: {integrity: sha512-1EUFYmd7q/xfs2qCHwJzGPh9n5VJ3X6QjBN10fof2vxgy8fYE7kVfZ7uGnd7i6fQaWIr5KvXcwYXE/cmTEjk5A==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  svelte-streamdown@3.1.2:
+    resolution: {integrity: sha512-yGbe24Bodv/xiPc36+YRAmhb/js+aIPpNud4GMb4qT93yviln40/qMWBw8VfaHOmQ/oQtuTtpr+pyqzEzQa2Zg==}
     peerDependencies:
       svelte: ^5.0.0
 
@@ -4408,6 +4770,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -4640,6 +5006,10 @@ packages:
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -5026,6 +5396,11 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.0.2
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -5164,7 +5539,7 @@ snapshots:
 
   '@balena/dockerignore@1.0.2': {}
 
-  '@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)':
+  '@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
@@ -5175,9 +5550,9 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.1.13
 
-  '@better-auth/telemetry@1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))':
+  '@better-auth/telemetry@1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))':
     dependencies:
-      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
+      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
 
@@ -5185,9 +5560,13 @@ snapshots:
 
   '@better-fetch/fetch@1.1.18': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@capsizecss/unpack@3.0.1':
     dependencies:
       fontkit: 2.0.4
+
+  '@chevrotain/types@11.1.2': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -5556,6 +5935,14 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.0.0':
     optional: true
 
@@ -5711,6 +6098,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@noble/ciphers@2.1.1': {}
 
@@ -6032,6 +6423,123 @@ snapshots:
 
   '@types/cookie@0.6.0': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -6060,6 +6568,8 @@ snapshots:
   '@types/fontkit@2.0.8':
     dependencies:
       '@types/node': 22.19.3
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -6201,6 +6711,11 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -6564,8 +7079,8 @@ snapshots:
 
   better-auth@1.4.6(@sveltejs/kit@2.49.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.45.5):
     dependencies:
-      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
-      '@better-auth/telemetry': 1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))
+      '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
       '@noble/ciphers': 2.1.1
@@ -6761,6 +7276,10 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   common-ancestor-path@1.0.1: {}
 
   concat-map@0.0.1: {}
@@ -6774,6 +7293,14 @@ snapshots:
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cpu-features@0.0.10:
     dependencies:
@@ -6824,6 +7351,190 @@ snapshots:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -6846,6 +7557,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
@@ -6880,6 +7593,10 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.4: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -6949,6 +7666,10 @@ snapshots:
       domelementtype: 2.3.0
 
   dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7106,6 +7827,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.50.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -7573,6 +8296,8 @@ snapshots:
       ufo: 1.6.1
       uncrypto: 0.1.3
 
+  hachure-fill@0.5.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -7781,6 +8506,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -8016,9 +8745,15 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
 
@@ -8029,6 +8764,10 @@ snapshots:
   known-css-properties@0.35.0: {}
 
   kysely@0.28.8: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   levn@0.4.1:
     dependencies:
@@ -8092,6 +8831,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.merge@4.6.2: {}
@@ -8127,6 +8868,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@14.0.0: {}
+
+  marked@16.4.2: {}
 
   marked@17.0.1: {}
 
@@ -8308,6 +9051,30 @@ snapshots:
   mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.16.1:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.13
+      es-toolkit: 1.50.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8783,6 +9550,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -8814,6 +9583,13 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@4.0.1: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9124,6 +9900,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.53.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -9153,6 +9931,13 @@ snapshots:
       fsevents: 2.3.3
 
   rou3@0.7.11: {}
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
 
   rrweb-cssom@0.7.1: {}
 
@@ -9190,6 +9975,8 @@ snapshots:
       svelte: 5.45.5
     optionalDependencies:
       '@sveltejs/kit': 2.49.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+
+  rw@1.3.3: {}
 
   sade@1.8.1:
     dependencies:
@@ -9482,6 +10269,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
@@ -9518,6 +10307,19 @@ snapshots:
     dependencies:
       runed: 0.28.0(svelte@5.45.5)
       svelte: 5.45.5
+
+  svelte-streamdown@3.1.2(svelte@5.45.5):
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      '@shikijs/langs': 3.19.0
+      '@shikijs/themes': 3.19.0
+      clsx: 2.1.1
+      katex: 0.16.47
+      marked: 16.4.2
+      mermaid: 11.16.1
+      shiki: 3.19.0
+      svelte: 5.45.5
+      tailwind-merge: 3.4.0
 
   svelte-toolbelt@0.10.6(@sveltejs/kit@2.49.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.45.5)(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.45.5):
     dependencies:
@@ -9658,6 +10460,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
+
+  ts-dedent@2.3.0: {}
 
   tsconfck@3.1.6(typescript@5.6.3):
     optionalDependencies:
@@ -9864,6 +10668,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@14.0.1: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Slice 3 of the ACP sessions program: **the Chat tab**. Any `acp`-capable agent in the fleet is now conversable from the console — streamed markdown, collapsible reasoning, tool-call cards with diffs, inline permission approvals, and hub-owned sessions that survive a tab close.

Chat becomes the first (and default) tab on stations that advertise `acp`; everything else is unchanged for stations that don't.

## What's in it

- **API client** (`lib/api/acp.ts`) — REST create/list/end plus a WS factory mirroring the terminal client's queue/`manualClose`/single-fire-close mechanics.
- **Transcript projection** (`chat/transcript.ts`) — pure fold of ACP events into renderable items: chunk streaming, tool-call upsert/merge, permission request↔answer pairing, defensive narrowing of untrusted payloads, forward-compatible ignores. Payload shapes verified against the SDK types and the hub's own emit sites.
- **Session controller** (`chat/acp-chat.svelte.ts`) — one status machine, reconnect budget with `sinceSeq` replay ("working while away"), optimistic prompts, permission answers, mode switching, hub-owned teardown (closing the tab never ends the session).
- **Components** — `Conversation` (LogTail-style follow, scroll-away pause, new-message pill, keyed items), `Response` (svelte-streamdown + shiki, `renderHtml` off, link allowlist), `Reasoning`, `ToolCallCard` + `DiffBlock`, `PermissionCard`, `PromptInput`, `ChatHeader` (status, mode chips, end/new session).
- Also carries `1f2f341` from the slice-2 live verification: the `small` runtime tier goes 512m→1g after an OpenCode ACP process was OOM-killed on the live fleet.

## Review

Seven tasks, each adversarially reviewed with fix rounds, then a whole-branch review that returned **not merge-ready** with three blockers — all fixed and re-verified before this PR:

1. A prompt the hub rejected (or a frame lost on a drop) left the optimistic bubble pending forever, disabling the composer with no recovery short of a page reload and losing the user's text. Pending prompts are now resolved on every path — hub error (precisely attributed, since the hub's error frame is a catch-all), replay after reconnect (authoritative), reconnect-budget exhaustion, and session end — with the text handed back into the composer.
2. The header and composer read different status machines, so reattaching to a running turn showed "Working…" beside an enabled Send — the exact trigger for (1). There is now one status, and the composer's refusal rule is provably the same predicate the controller enforces.
3. The station page rendered nothing while loading and could leave the tab bar with no keyboard-reachable tab.

Two more closed in the same pass: a repeated tool-call id could crash the transcript render (worth fixing before slice 4 adds more agent adapters), and status changes were announced twice to screen readers.

Deferred minors are recorded in the SDD ledger for follow-up.

## Tests

- console **615** (was 578 pre-slice) ✅ · `svelte-check` 0/0 ✅ · `pnpm build` ✅ · contract 45 ✅ · hub 352 ✅ · node-agent `-race` ✅
- Coverage includes the wedge paths (hub rejection, lost frame, budget exhaustion), replay-with-reconnect, keep-alive socket survival across tab switches, focus retention after send, `javascript:` links rendered inert, and tab ordering/default/deep-link behavior.

## Live verification (after deploy)

- [ ] Real conversation with a Hermes station and with `opencode-one`
- [ ] Permission flow in `ask` mode: card appears, approve, tool card completes
- [ ] Working-while-away: close the tab mid-turn, reopen, replay catches up
- [ ] End session → transcript kept, New session starts fresh, no process remnant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB