### PR TITLE
fix(console): recover a chat prompt written to a dead socket

### DIFF
--- a/apps/console/src/lib/api/acp.test.ts
+++ b/apps/console/src/lib/api/acp.test.ts
@@ -139,6 +139,21 @@ test("send(msg) before open is buffered and flushed in order on open", () => {
   expect(JSON.parse(MockWebSocket.instance!.sent[1])).toEqual({ t: "prompt", text: "hi" });
 });
 
+test("isOpen tracks the underlying readyState without exposing internals", () => {
+  const socket = createAcpSocket("s1");
+  expect(socket.isOpen).toBe(false); // CONNECTING
+
+  MockWebSocket.instance!.open();
+  expect(socket.isOpen).toBe(true);
+
+  // A socket the browser has noticed is gone (CLOSING/CLOSED) is not open —
+  // callers use this to redial instead of writing into a dead socket.
+  MockWebSocket.instance!.readyState = 2; // CLOSING
+  expect(socket.isOpen).toBe(false);
+  MockWebSocket.instance!.readyState = 3; // CLOSED
+  expect(socket.isOpen).toBe(false);
+});
+
 // ─── WebSocket: onMessage ────────────────────────────────────────────────────
 
 test("onMessage delivers parsed AcpServerMsg frames", () => {

--- a/apps/console/src/lib/api/acp.ts
+++ b/apps/console/src/lib/api/acp.ts
@@ -51,6 +51,17 @@ export const endAcpSession = (sessionId: string) =>
 export type AcpCloseReason = "error" | "closed";
 
 export interface AcpSocket {
+  /**
+   * True only while the underlying WebSocket is OPEN (readyState 1).
+   *
+   * A caller that expects a RESPONSE to its frame must check this: a
+   * CONNECTING socket buffers (fine — the queue flushes on open), but a
+   * CLOSING/CLOSED one silently swallows the frame forever, and `onClose`
+   * doesn't always arrive to say so (a slept laptop can leave a tab holding a
+   * socket the browser calls open until the next write actually fails). Treat
+   * "not open" as "no socket" and redial.
+   */
+  readonly isOpen: boolean;
   /** Send a client message to the hub. Buffered if the socket isn't open yet. */
   send(msg: AcpClientMsg): void;
   /** Register a callback that fires for every parsed server message. */
@@ -119,6 +130,11 @@ export function createAcpSocket(sessionId: string): AcpSocket {
   };
 
   return {
+    // 1 = WebSocket.OPEN; literal so the mock in tests needs no statics.
+    get isOpen() {
+      return ws.readyState === 1;
+    },
+
     send(msg) {
       const payload = JSON.stringify(msg);
       // 1 = WebSocket.OPEN; use literal so the mock in tests doesn't need the static

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -13,7 +13,7 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AcpEvent, AcpSessionRow } from "@agentpod/contract";
 import * as api from "$lib/api/acp";
-import { AcpChat } from "./acp-chat.svelte";
+import { AcpChat, ECHO_DEADLINE_MS, _setEchoDeadlineMsForTest } from "./acp-chat.svelte";
 
 // ─── Minimal WebSocket stub ───────────────────────────────────────────────────
 
@@ -83,6 +83,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  _setEchoDeadlineMsForTest(ECHO_DEADLINE_MS); // module-level hook: never leak an override
   MockWebSocket.instances = [];
   localStorage.clear();
 });
@@ -713,6 +714,150 @@ test("pendingPermissions counts unanswered permission items", async () => {
     event: ev(2, "permission-answer", { requestSeq: 1, optionId: "allow" }),
   });
   expect(chat.pendingPermissions).toBe(0);
+});
+
+// ─── The dead socket: a send into a connection nothing has noticed is gone ───
+//
+// Live-dogfooding defect: after a laptop sleep the browser still held a socket
+// it believed was OPEN (no close event ever fired). The prompt frame went into
+// it, the hub never saw it, and because no close/error/reconnect/replay-done/bye
+// followed, NO existing release path fired — the pending item stayed trailing,
+// `busy` latched true, and the composer was read-only until a page reload.
+
+/** Boots a connected chat that records every prompt handed back. */
+async function chatWithFailures(): Promise<{
+  chat: AcpChat;
+  ws: MockWebSocket;
+  failed: string[];
+}> {
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row()]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  return { chat, ws, failed };
+}
+
+test("a prompt whose echo never arrives is released at the echo deadline", async () => {
+  vi.useFakeTimers();
+  const { chat, ws, failed } = await chatWithFailures();
+
+  await chat.prompt("sent after the laptop woke");
+
+  // The frame was written into a socket the browser still calls OPEN, so no
+  // close, error, reconnect, replay-done or bye is ever coming.
+  expect(ws.frames()).toContainEqual({ t: "prompt", text: "sent after the laptop woke" });
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "sent after the laptop woke", pending: true },
+  ]);
+  expect(chat.busy).toBe(true);
+
+  vi.advanceTimersByTime(ECHO_DEADLINE_MS - 1);
+  expect(chat.busy).toBe(true); // not a hair early — a slow link still wins
+
+  vi.advanceTimersByTime(1);
+
+  expect(chat.transcript.items).toEqual([]); // no ghost bubble
+  expect(chat.busy).toBe(false); // composer usable again
+  expect(failed).toEqual(["sent after the laptop woke"]); // text handed back
+  expect(chat.error).toBe("Couldn't send that message — it's back in the box, try again.");
+
+  // And the panel really is usable: the next prompt is accepted, not refused.
+  await chat.prompt("again");
+  expect(chat.transcript.items).toEqual([
+    { kind: "user", seq: -1, text: "again", pending: true },
+  ]);
+});
+
+test("an echoed prompt clears the echo deadline — nothing fires late", async () => {
+  vi.useFakeTimers();
+  const { chat, ws, failed } = await chatWithFailures();
+
+  await chat.prompt("healthy");
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "healthy" }) });
+
+  expect(vi.getTimerCount()).toBe(0); // no leaked deadline
+  vi.advanceTimersByTime(ECHO_DEADLINE_MS * 3);
+
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "healthy" }]);
+  expect(failed).toEqual([]);
+  expect(chat.error).toBeNull();
+  expect(chat.busy).toBe(false);
+});
+
+test("an attributed error clears the echo deadline too", async () => {
+  vi.useFakeTimers();
+  const { chat, ws, failed } = await chatWithFailures();
+
+  await chat.prompt("rejected");
+  ws.fireMessage({ t: "event", event: ev(0, "error", { message: "Session is busy." }) });
+
+  expect(failed).toEqual(["rejected"]);
+  expect(chat.error).toBe("Session is busy.");
+  expect(vi.getTimerCount()).toBe(0);
+
+  // The deadline must not fire a second release and overwrite the real reason.
+  vi.advanceTimersByTime(ECHO_DEADLINE_MS * 3);
+  expect(failed).toEqual(["rejected"]);
+  expect(chat.error).toBe("Session is busy.");
+});
+
+test("a prompt while the socket is not OPEN redials instead of writing into it", async () => {
+  const { chat, ws, failed } = await chatWithFailures();
+  // The cheap half of the bug: the browser HAS noticed (CLOSED) but no close
+  // event was delivered to this tab, so `socket` is still non-null here.
+  ws.readyState = 3;
+
+  await chat.prompt("redial me");
+
+  expect(MockWebSocket.instances).toHaveLength(2); // redialed, not written into
+  const ws2 = MockWebSocket.latest()!;
+  expect(ws2).not.toBe(ws);
+  expect(ws.frames()).not.toContainEqual({ t: "prompt", text: "redial me" });
+
+  ws2.open(); // buffered frames flush in order: subscribe still precedes the prompt
+  expect(ws2.frames()).toEqual([
+    { t: "subscribe", sinceSeq: 0 },
+    { t: "prompt", text: "redial me" },
+  ]);
+
+  // Replay on the socket the prompt went out on proves nothing — the echo does.
+  ws2.fireMessage({ t: "replay-done", lastSeq: 0 });
+  expect(failed).toEqual([]);
+  ws2.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "redial me" }) });
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 1, text: "redial me" }]);
+  expect(chat.busy).toBe(false);
+});
+
+test("destroy() clears the echo deadline — no release after unmount", async () => {
+  vi.useFakeTimers();
+  _setEchoDeadlineMsForTest(500);
+  const { chat, failed } = await chatWithFailures();
+  await chat.prompt("in flight at unmount");
+
+  chat.destroy();
+
+  expect(vi.getTimerCount()).toBe(0);
+  vi.advanceTimersByTime(60_000);
+  expect(failed).toEqual([]);
+  expect(chat.error).toBeNull();
+});
+
+test("newSession() clears the echo deadline", async () => {
+  vi.useFakeTimers();
+  _setEchoDeadlineMsForTest(500);
+  const { chat, failed } = await chatWithFailures();
+  await chat.prompt("abandoned");
+
+  chat.newSession();
+
+  expect(vi.getTimerCount()).toBe(0);
+  vi.advanceTimersByTime(60_000);
+  expect(chat.transcript.items).toEqual([]);
+  expect(failed).toEqual([]);
+  expect(chat.error).toBeNull();
 });
 
 test("newSession resets to the empty state", async () => {

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -33,7 +33,9 @@
  * and the composer with it. It is resolved by exactly one of: the echoed
  * user-prompt event (reconciled), an error attributed to it, `replay-done` with
  * the tail still pending (the hub never saw it), reconnect-budget exhaustion
- * (replay will never happen), or the session ending.
+ * (replay will never happen), the session ending, or — the backstop for a
+ * socket NOTHING has noticed is dead — the echo deadline (ECHO_DEADLINE_MS).
+ * Every event-driven path needs an event; a slept laptop's socket produces none.
  *
  * Permission dismissal: ACP has no per-request dismiss — agents supply reject
  * options in the request itself (answer with one of those), and `cancel()`
@@ -66,6 +68,28 @@ const BACKOFF_MS = [1000, 2000, 4000];
 const OFFLINE_COPY = "Couldn't reach the hub — check your connection.";
 const LOST_PROMPT_COPY = "Couldn't send that message — it's back in the box, try again.";
 
+/**
+ * How long an optimistic prompt may wait for its echo before we call it lost.
+ *
+ * The hub PERSISTS `user-prompt` before dispatching to the agent, so a healthy
+ * echo comes back sub-second — 20s is generous headroom for a slow link, not a
+ * guess at agent latency (the agent's own thinking happens after the echo).
+ * This is the only release path that needs no inbound event, which is exactly
+ * the case it exists for: a socket the browser still calls OPEN after a sleep,
+ * where no close/error/reconnect/replay-done/bye is ever coming. The cost of a
+ * false positive is small and reversible — the text returns to the composer and
+ * the user re-sends — while the cost of not having it is a wedged composer with
+ * no recovery short of a page reload.
+ */
+export const ECHO_DEADLINE_MS = 20_000;
+
+let echoDeadlineMs: number = ECHO_DEADLINE_MS;
+
+/** Test hook: shrink the echo deadline (mirrors the hub's `_set…ForTest` hooks). */
+export function _setEchoDeadlineMsForTest(ms: number): void {
+  echoDeadlineMs = ms;
+}
+
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -88,6 +112,13 @@ export class AcpChat {
   private readonly stationId: string;
   private socket: AcpSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Armed when a prompt frame is written, disarmed by whatever resolves it. The
+   * ONE release path that doesn't wait on an inbound event — see
+   * ECHO_DEADLINE_MS. Must never outlive the pending prompt (a stray timer would
+   * release a LATER prompt, or fire after destroy()).
+   */
+  private echoTimer: ReturnType<typeof setTimeout> | null = null;
   /** Reconnect attempts used since the last successful connect. */
   private attempt = 0;
   /** Set on `bye`: the session is over — the following close is expected. */
@@ -254,10 +285,17 @@ export class AcpChat {
       this.mode = row.mode;
       this.#transcript = emptyTranscript();
       this.startConnection();
-    } else if (!this.socket) {
-      // e.g. after budget exhaustion: reopen before prompting. The socket
-      // buffers pre-open sends, so subscribe still precedes the prompt.
+    } else if (!this.socket || !this.socket.isOpen) {
+      // No socket (e.g. after budget exhaustion), or one that is CONNECTING /
+      // CLOSING / CLOSED: either way there is nothing here that can carry a
+      // frame and answer it, so redial rather than write into it. A socket the
+      // browser has already noticed is gone still looks live to us until a close
+      // event arrives — and after a laptop sleep that event may never come.
+      // Tear the stale one down first: its close is ours, not a drop to
+      // reconnect from. The new socket buffers pre-open sends, so subscribe
+      // still precedes the prompt.
       this.clearReconnectTimer();
+      this.teardownSocket();
       this.attempt = 0;
       this.startConnection();
     }
@@ -266,6 +304,9 @@ export class AcpChat {
     this.socket?.send({ t: "prompt", text });
     this.awaitingEcho = true;
     this.promptSocket = this.socket;
+    // Nothing above proves the frame LANDED — only the echo does. Arm the
+    // backstop even if `send` went nowhere.
+    this.armEchoDeadline();
   }
 
   cancel(): void {
@@ -307,6 +348,7 @@ export class AcpChat {
   /** After ended: reset to the empty state (keep nothing but the mode selector). */
   newSession(): void {
     this.clearReconnectTimer();
+    this.clearEchoDeadline(); // the prompt it belonged to is gone with the transcript
     this.teardownSocket();
     this.#session = null;
     this.#transcript = emptyTranscript();
@@ -332,6 +374,7 @@ export class AcpChat {
   destroy(): void {
     this.destroyed = true;
     this.clearReconnectTimer();
+    this.clearEchoDeadline(); // an unmounted panel has no composer to hand text to
     this.teardownSocket();
   }
 
@@ -436,6 +479,7 @@ export class AcpChat {
     if (ev.type === "user-prompt") {
       this.awaitingEcho = false; // reconciled
       this.promptSocket = null;
+      this.clearEchoDeadline(); // the echo is here; nothing left to time out
     }
   }
 
@@ -444,6 +488,9 @@ export class AcpChat {
    * text back to the composer. Clears `busy`, so the composer is usable again.
    */
   private releasePendingPrompt(): void {
+    // Unconditionally: every other release path lands here, so this is the one
+    // place that guarantees the deadline can't fire behind them.
+    this.clearEchoDeadline();
     this.awaitingEcho = false;
     this.promptSocket = null;
     const { transcript, text } = dropPendingPrompt(this.#transcript);
@@ -513,6 +560,31 @@ export class AcpChat {
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+  }
+
+  /**
+   * Start the echo deadline for the prompt just written. The frame may have gone
+   * into a socket that will never answer (see ECHO_DEADLINE_MS); when the clock
+   * runs out, release the pending item so `busy` — and the composer with it —
+   * comes back, and hand the text to the user rather than keep it hostage.
+   */
+  private armEchoDeadline(): void {
+    this.clearEchoDeadline();
+    this.echoTimer = setTimeout(() => {
+      this.echoTimer = null;
+      if (this.destroyed || !this.hasPendingPrompt()) return;
+      this.releasePendingPrompt();
+      // Same fate, same sentence as a replay that came back without the echo:
+      // the hub never saw it, and the words are back in the composer.
+      this.#error = LOST_PROMPT_COPY;
+    }, echoDeadlineMs);
+  }
+
+  private clearEchoDeadline(): void {
+    if (this.echoTimer !== null) {
+      clearTimeout(this.echoTimer);
+      this.echoTimer = null;
     }
   }
 


### PR DESCRIPTION
## Why

Found by dogfooding minutes after slice 3 deployed. After the laptop slept, the next message in the Chat tab **silently vanished and left the composer disabled until a page reload**, losing the text.

The browser still held a WebSocket it believed was open (last upgrade 78 minutes earlier), so the frame went into a dead socket: the hub recorded nothing — `acp_sessions.lastEventAt` unchanged, no `user-prompt` event, the agent never saw it — and because no close, error, reconnect, `replay-done` or `bye` ever arrived, none of the pending-prompt release paths could fire. The optimistic bubble stayed trailing, so `busy` latched true.

## Fix

- **Redial when the socket isn't actually open.** `AcpSocket` exposes `isOpen`; `prompt()` treats a non-OPEN socket like an absent one and dials a fresh connection instead of writing into it. This covers the half of the bug the browser has already noticed (CLOSING/CLOSED).
- **A 20s echo deadline** for the half it hasn't. If neither the echoed `user-prompt` event nor an attributed error resolves a pending prompt in time, it's released and the text is handed back to the composer with the existing lost-prompt copy. The hub persists `user-prompt` *before* dispatching to the agent, so a healthy echo is sub-second — 20s is headroom for a slow link, and a false positive only costs a re-send.

The deadline is cleared on every path that resolves or discards a pending prompt (echo reconcile, the release funnel all other paths land in, `newSession()`, `destroy()`), so no timer can fire behind them.

## Tests

622 passed / 65 files; `pnpm check` 0/0; `pnpm build` clean. Seven new tests, all confirmed failing first: deadline release with text handback, echo-before-deadline with no late fire, attributed-error clearing the timer, non-OPEN redial, and timer clearing on `destroy()`/`newSession()`.

Known tradeoff: if the hub ever echoes past 20s, a healthy prompt comes back as a draft and the late echo still folds the message, so the user could re-send a duplicate. `ECHO_DEADLINE_MS` is the knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB