### PR TITLE
feat: ACP slice 4b — multiple sessions per agent

### DIFF
--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -9,7 +9,20 @@
    * is also why the composer refuses to send, so the user gets told.
    *
    * This is the ONE live region for session status in the panel: Conversation
-   * announces permissions only, so a flip is never read out twice.
+   * announces permissions only, so a flip is never read out twice. The session
+   * switcher below deliberately adds none — it is a control, not an
+   * announcement, and a second region would read every flip twice.
+   *
+   * The switcher appears only once the station has MORE than one session: with
+   * one there is nothing to switch to, and an inert control beside the status
+   * line would be noise. Rows are rendered in the order the hub gave them
+   * (newest-activity-first) — never re-sorted here, or the list would reshuffle
+   * under the pointer. Each row is numbered by creation order so two sessions
+   * that happen to share a status and a rounded age are still tellable apart.
+   *
+   * "New session" is offered whatever the current session's status: a station
+   * can host several at once, so starting another is not something to wait for
+   * the current one to end. It is disabled only while a create is in flight.
    *
    * Mode chips are never disabled: pre-session the selection seeds creation,
    * live it round-trips set-mode, and after end it seeds the next session
@@ -23,20 +36,41 @@
   import type { ChatConnection } from "./acp-chat.svelte";
   import { Button } from "$lib/components/ui/button";
   import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
+  import * as Select from "$lib/components/ui/select";
   import { Status } from "$lib/components/ui/status";
   import { chipClass } from "$lib/utils/toggle-chip";
+  import { relativeTime } from "$lib/utils/relative-time";
 
   interface Props {
     session: AcpSessionRow | null;
+    /** Every session on the station, in the hub's order (newest activity first). */
+    sessions: AcpSessionRow[];
+    /** The one on screen — normally `session.id`, or the pick being attached. */
+    selectedId: string | null;
     status: AcpSessionStatus;
     connection: ChatConnection;
     mode: AcpSessionMode;
+    /** True while a create POST is in flight (disables "New session"). */
+    creating?: boolean;
     onModeChange: (mode: AcpSessionMode) => void;
     onEnd: () => void;
     onNew: () => void;
+    onSelectSession: (sessionId: string) => void;
   }
 
-  let { session, status, connection, mode, onModeChange, onEnd, onNew }: Props = $props();
+  let {
+    session,
+    sessions,
+    selectedId,
+    status,
+    connection,
+    mode,
+    creating = false,
+    onModeChange,
+    onEnd,
+    onNew,
+    onSelectSession,
+  }: Props = $props();
 
   const STATUS_DOT: Record<AcpSessionStatus, string> = {
     starting: "starting",
@@ -80,6 +114,27 @@
             : "No session",
   );
 
+  /**
+   * id → "Session N", numbered by creation order. Computed from a SORTED COPY:
+   * the rendered list keeps the hub's activity order, only the numbers come from
+   * createdAt, so a session's name never changes as it streams.
+   */
+  const sessionNumber = $derived.by(() => {
+    const byAge = [...sessions].sort((a, b) =>
+      a.createdAt === b.createdAt
+        ? a.id.localeCompare(b.id)
+        : a.createdAt.localeCompare(b.createdAt),
+    );
+    return new Map(byAge.map((s, i) => [s.id, i + 1]));
+  });
+
+  /** "Session 2 · working · 5m ago" — status stays lowercase (agent-reported data). */
+  function sessionLabel(s: AcpSessionRow): string {
+    return `Session ${sessionNumber.get(s.id) ?? "?"} · ${s.status} · ${relativeTime(s.lastEventAt)}`;
+  }
+
+  const selectedRow = $derived(sessions.find((s) => s.id === selectedId) ?? session);
+
   let confirmEndOpen = $state(false);
 </script>
 
@@ -92,6 +147,41 @@
     </span>
     <span class="t-label truncate">{label}</span>
   </div>
+
+  {#if sessions.length > 1}
+    <Select.Root
+      type="single"
+      value={selectedId ?? ""}
+      onValueChange={(v) => {
+        // bits-ui re-fires for the value already selected; re-attaching there
+        // would tear down the socket the user is looking at.
+        if (v && v !== selectedId) onSelectSession(v);
+      }}
+    >
+      <Select.Trigger size="sm" class="min-w-0 max-w-56">
+        <!-- aria-hidden: the label carries the status word, so the dot's own
+             sr-only text would read as a duplicate. -->
+        {#if selectedRow}
+          <span aria-hidden="true" class="flex">
+            <Status form="dot" status={STATUS_DOT[selectedRow.status]} />
+          </span>
+          <span class="truncate">{sessionLabel(selectedRow)}</span>
+        {:else}
+          <span class="truncate">Sessions</span>
+        {/if}
+      </Select.Trigger>
+      <Select.Content>
+        {#each sessions as s (s.id)}
+          <Select.Item value={s.id}>
+            <span aria-hidden="true" class="flex">
+              <Status form="dot" status={STATUS_DOT[s.status]} />
+            </span>
+            <span>{sessionLabel(s)}</span>
+          </Select.Item>
+        {/each}
+      </Select.Content>
+    </Select.Root>
+  {/if}
 
   <div role="group" aria-label="Permission mode" class="flex items-center gap-1 text-xs">
     {#each MODES as m (m.value)}
@@ -107,14 +197,13 @@
   </div>
 
   {#if session}
-    <div class="ml-auto">
-      {#if status === "ended"}
-        <Button variant="outline" size="sm" onclick={onNew}>New session</Button>
-      {:else}
+    <div class="ml-auto flex items-center gap-1">
+      {#if status !== "ended"}
         <Button variant="ghost" size="sm" onclick={() => (confirmEndOpen = true)}>
           End session
         </Button>
       {/if}
+      <Button variant="outline" size="sm" disabled={creating} onclick={onNew}>New session</Button>
     </div>
   {/if}
 </div>

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -29,7 +29,8 @@
    * (AcpChat.setMode handles all three).
    *
    * Ending a session is destructive (the agent process stops) — gated behind
-   * ConfirmDialog. An ended session flips the action to "New session".
+   * ConfirmDialog. "New session" sits beside it and is offered whatever the
+   * status; only "End session" disappears once there is nothing left to end.
    */
   import type { AcpSessionMode, AcpSessionStatus } from "@agentpod/contract";
   import type { AcpSessionRow } from "$lib/api/acp";
@@ -158,7 +159,13 @@
         if (v && v !== selectedId) onSelectSession(v);
       }}
     >
-      <Select.Trigger size="sm" class="min-w-0 max-w-56">
+      <Select.Trigger
+        size="sm"
+        class="min-w-0 max-w-56"
+        aria-label={selectedRow
+          ? `Switch session — currently ${sessionLabel(selectedRow)}`
+          : "Switch session"}
+      >
         <!-- aria-hidden: the label carries the status word, so the dot's own
              sr-only text would read as a duplicate. -->
         {#if selectedRow}

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
@@ -2,6 +2,27 @@ import { test, expect, vi } from "vitest";
 import { render, waitFor, fireEvent, within } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import type { AcpSessionRow } from "$lib/api/acp";
+
+// bits-ui's Select opens on `pointerdown` and picks an item on `pointerup`,
+// touching `hasPointerCapture`/`releasePointerCapture` on the way — jsdom has
+// none of those (same polyfill as UserFilters.svelte.test.ts, scoped here).
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  // @ts-expect-error jsdom has no native PointerEvent
+  window.PointerEvent = PointerEventPolyfill;
+}
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+
 import ChatHeader from "./ChatHeader.svelte";
 
 const row: AcpSessionRow = {
@@ -15,23 +36,30 @@ const row: AcpSessionRow = {
   lastEventAt: "2026-08-09T10:00:00.000Z",
 };
 
+/** ISO timestamp `minutes` ago — keeps relative labels deterministic. */
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
 function setup(props: Partial<ComponentProps<typeof ChatHeader>> = {}) {
   const onModeChange = vi.fn();
   const onEnd = vi.fn();
   const onNew = vi.fn();
+  const onSelectSession = vi.fn();
   const utils = render(ChatHeader, {
     props: {
       session: row,
+      sessions: [row],
+      selectedId: row.id,
       status: "idle",
       connection: "connected",
       mode: "ask",
       onModeChange,
       onEnd,
       onNew,
+      onSelectSession,
       ...props,
     },
   });
-  return { ...utils, onModeChange, onEnd, onNew };
+  return { ...utils, onModeChange, onEnd, onNew, onSelectSession };
 }
 
 test("mode chips call onModeChange and mark the active mode pressed", async () => {
@@ -108,7 +136,7 @@ test("cancelling the confirm dialog does not end the session", async () => {
   expect(onEnd).not.toHaveBeenCalled();
 });
 
-test("ended session shows New session instead of End session", async () => {
+test("ended session offers New session and no End session", async () => {
   const { getByRole, queryByRole, onNew } = setup({
     session: { ...row, status: "ended" },
     status: "ended",
@@ -118,4 +146,122 @@ test("ended session shows New session instead of End session", async () => {
 
   await fireEvent.click(getByRole("button", { name: "New session" }));
   expect(onNew).toHaveBeenCalledTimes(1);
+});
+
+test("a live session offers New session alongside End session", async () => {
+  // A station can host several sessions at once, so starting another one is not
+  // something to wait for the current one to end.
+  const { getByRole, onNew } = setup();
+
+  await fireEvent.click(getByRole("button", { name: "New session" }));
+
+  expect(onNew).toHaveBeenCalledTimes(1);
+  expect(getByRole("button", { name: "End session" })).toBeTruthy();
+});
+
+test("New session is disabled while a create is in flight", () => {
+  const { getByRole } = setup({ creating: true });
+  expect((getByRole("button", { name: "New session" }) as HTMLButtonElement).disabled).toBe(true);
+});
+
+// ─── Session switcher ───────────────────────────────────────────────────────
+
+const sessionA: AcpSessionRow = {
+  ...row,
+  id: "ses_a",
+  createdAt: "2026-08-09T10:00:00.000Z",
+  lastEventAt: minutesAgo(90),
+};
+const sessionB: AcpSessionRow = {
+  ...row,
+  id: "ses_b",
+  status: "working",
+  createdAt: "2026-08-09T11:00:00.000Z",
+  lastEventAt: minutesAgo(5),
+};
+
+test("with a single session no switcher is rendered", () => {
+  // Deliberate: one session means there is nothing to switch to, and an inert
+  // control next to the status would just be noise. "New session" is the way to
+  // get a second one, and the switcher appears the moment there is one.
+  const { queryByRole, getByRole } = setup({ sessions: [row] });
+
+  expect(queryByRole("button", { name: /^Session \d/ })).toBeNull();
+  // …and the rest of the header is unchanged.
+  expect(getByRole("status").textContent).toContain("Idle");
+});
+
+test("the switcher lists every session with its status and last activity", async () => {
+  // Newest-activity-first is the hub's SQL order; the header renders it as given.
+  const { getByRole, getAllByRole, onSelectSession } = setup({
+    sessions: [sessionB, sessionA],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  const trigger = getByRole("button", { name: /^Session 2 · working · 5m ago$/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+
+  const options = await waitFor(() => {
+    const found = getAllByRole("option");
+    if (found.length < 2) throw new Error("options not rendered yet");
+    return found;
+  });
+  const current = getByRole("option", { name: /^Session 2 · working · 5m ago$/ });
+  const other = getByRole("option", { name: /^Session 1 · idle · 1h ago$/ });
+  expect(options).toHaveLength(2);
+  expect(options[0]).toBe(current); // server order preserved, not re-sorted
+  expect(options[1]).toBe(other);
+
+  await fireEvent.pointerUp(other, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await waitFor(() => expect(onSelectSession).toHaveBeenCalledWith("ses_a"));
+});
+
+test("picking the session already attached is not re-selected", async () => {
+  const { getByRole, onSelectSession } = setup({
+    sessions: [sessionB, sessionA],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  const trigger = getByRole("button", { name: /^Session 2/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const current = await waitFor(() => getByRole("option", { name: /^Session 2/ }));
+  await fireEvent.pointerUp(current, { pointerId: 1, button: 0, pointerType: "mouse" });
+
+  // bits-ui re-fires onValueChange for the same value; a switch back to the
+  // session we are already on must not tear its socket down.
+  await waitFor(() => expect(getByRole("button", { name: /^Session 2/ })).toBeTruthy());
+  expect(onSelectSession).not.toHaveBeenCalled();
+});
+
+test("the switcher adds no second live region", () => {
+  const { getAllByRole } = setup({
+    sessions: [sessionB, sessionA],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  // The status line is the ONE live region in the panel — a second one here
+  // would announce every session flip twice.
+  expect(getAllByRole("status")).toHaveLength(1);
+});
+
+test("an ended session is still listed, and reads as ended", async () => {
+  const ended: AcpSessionRow = { ...sessionA, status: "ended", lastEventAt: minutesAgo(120) };
+  const { getByRole } = setup({
+    sessions: [sessionB, ended],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  const trigger = getByRole("button", { name: /^Session 2/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+
+  const option = await waitFor(() => getByRole("option", { name: /^Session 1 · ended · 2h ago$/ }));
+  expect(option).toBeTruthy();
 });

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
@@ -186,7 +186,7 @@ test("with a single session no switcher is rendered", () => {
   // get a second one, and the switcher appears the moment there is one.
   const { queryByRole, getByRole } = setup({ sessions: [row] });
 
-  expect(queryByRole("button", { name: /^Session \d/ })).toBeNull();
+  expect(queryByRole("button", { name: /^Switch session/ })).toBeNull();
   // …and the rest of the header is unchanged.
   expect(getByRole("status").textContent).toContain("Idle");
 });
@@ -200,7 +200,10 @@ test("the switcher lists every session with its status and last activity", async
     status: "working",
   });
 
-  const trigger = getByRole("button", { name: /^Session 2 · working · 5m ago$/ });
+  // The trigger says what it switches, then which session is on screen.
+  const trigger = getByRole("button", {
+    name: /^Switch session — currently Session 2 · working · 5m ago$/,
+  });
   await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
 
   const options = await waitFor(() => {
@@ -226,14 +229,14 @@ test("picking the session already attached is not re-selected", async () => {
     status: "working",
   });
 
-  const trigger = getByRole("button", { name: /^Session 2/ });
+  const trigger = getByRole("button", { name: /currently Session 2/ });
   await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
   const current = await waitFor(() => getByRole("option", { name: /^Session 2/ }));
   await fireEvent.pointerUp(current, { pointerId: 1, button: 0, pointerType: "mouse" });
 
   // bits-ui re-fires onValueChange for the same value; a switch back to the
   // session we are already on must not tear its socket down.
-  await waitFor(() => expect(getByRole("button", { name: /^Session 2/ })).toBeTruthy());
+  await waitFor(() => expect(getByRole("button", { name: /currently Session 2/ })).toBeTruthy());
   expect(onSelectSession).not.toHaveBeenCalled();
 });
 
@@ -259,7 +262,7 @@ test("an ended session is still listed, and reads as ended", async () => {
     status: "working",
   });
 
-  const trigger = getByRole("button", { name: /^Session 2/ });
+  const trigger = getByRole("button", { name: /currently Session 2/ });
   await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
 
   const option = await waitFor(() => getByRole("option", { name: /^Session 1 · ended · 2h ago$/ }));

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
@@ -59,8 +59,18 @@
    * back through `onPromptFailed`). Parking per session loses nothing and can
    * misdirect nothing. Entries are dropped when a session ends — there is no
    * composer to return to.
+   *
+   * "No session attached" is a slot of its own (`NEW_SESSION_SLOT`): with every
+   * session ended the switcher is up while nothing is attached, so a draft typed
+   * there has no session id to be filed under. It is parked all the same, and the
+   * next session CREATED inherits it — that text was written for whichever
+   * session came next, and creating one is what makes it exist.
    */
   const drafts = new Map<string, string>();
+
+  /** Draft slot for "nothing attached". Not a valid session id, so it can't collide. */
+  const NEW_SESSION_SLOT = "__new-session__";
+  const draftSlot = (sessionId: string | null) => sessionId ?? NEW_SESSION_SLOT;
 
   /**
    * Which session is on screen. The panel owns this pick; the controller owns
@@ -93,18 +103,37 @@
   });
 
   /**
-   * Park the draft under the session we're leaving and load the one belonging to
-   * the session we landed on. Called only after the controller has actually
-   * moved: a refused switch (a session that's gone) must leave the composer
-   * exactly as the user left it.
+   * Park the on-screen draft under the slot being left and load the slot being
+   * landed on. A no-op when nothing moved, so a refused switch (a session that is
+   * gone) leaves the composer exactly as the user left it.
+   *
+   * `created` marks the landing session as brand new, which is the one case that
+   * inherits the pre-session draft — see NEW_SESSION_SLOT.
    */
-  function swapDraft(from: string | null, to: string | null) {
-    if (from === to) return;
-    if (from !== null) {
-      if (draft.length > 0) drafts.set(from, draft);
-      else drafts.delete(from);
+  function swapDraft(from: string | null, to: string | null, created = false) {
+    const fromSlot = draftSlot(from);
+    const toSlot = draftSlot(to);
+    if (fromSlot === toSlot) return;
+
+    if (draft.length > 0) drafts.set(fromSlot, draft);
+    else drafts.delete(fromSlot);
+
+    if (created && !drafts.has(toSlot)) {
+      const preSession = drafts.get(NEW_SESSION_SLOT);
+      if (preSession !== undefined) {
+        drafts.set(toSlot, preSession);
+        drafts.delete(NEW_SESSION_SLOT);
+      }
     }
-    draft = (to !== null ? drafts.get(to) : undefined) ?? "";
+    draft = drafts.get(toSlot) ?? "";
+  }
+
+  /** Point the header and the drafts at whatever the controller actually attached. */
+  function settleOn(from: string | null, created: boolean) {
+    const landed = chat.session?.id ?? null;
+    selectedId = landed;
+    swapDraft(from, landed, created);
+    return landed;
   }
 
   async function selectSession(id: string) {
@@ -114,23 +143,29 @@
     await chat.attach(id);
     // A refused switch leaves the previous session attached, so the header must
     // fall back to what is really on screen.
-    const landed = chat.session?.id ?? null;
-    selectedId = landed;
-    swapDraft(from, landed);
+    settleOn(from, false);
   }
 
   async function startSession() {
     const from = chat.session?.id ?? null;
     await chat.newSession();
-    const landed = chat.session?.id ?? null;
-    selectedId = landed;
-    swapDraft(from, landed);
+    const landed = settleOn(from, true);
     // Same reasoning as a failed first prompt: the strip shows it, but a toast is
     // what gets noticed when the transcript below hasn't changed.
     if (chat.error !== null && landed === from) {
       toast.error("Couldn't start the session", { description: chat.error });
     }
   }
+
+  /**
+   * An ended session is attachable (its transcript is worth reading), and the
+   * composer stays usable there rather than stranding the user in a read-only
+   * dead end — `prompt()` creates a fresh session for the text. But that also
+   * starts a new agent process on the host, so it is said out loud instead of
+   * happening silently under a header that reads "ended".
+   */
+  const endedNotice = $derived(chat.session !== null && chat.status === "ended");
+  const endedNoticeId = $props.id();
 
   // A parked draft for a session that has since ended is dead post — nothing can
   // be sent into that session again, so drop it rather than hand it back on a
@@ -152,10 +187,17 @@
 
     await chat.prompt(text);
 
+    // Sending is a THIRD way the attached session changes: with nothing attached,
+    // or while reading an ended one, `prompt()` creates a session first. The pick
+    // has to follow, or the header names the session the user was reading while
+    // the transcript below it belongs to a different one — and the stale pick then
+    // swallows the next click on either of them.
+    const landed = settleOn(beforeId, needsCreate);
+
     // A create that failed leaves the session unchanged and the message in
     // `chat.error` — the strip shows it, but a toast is what gets noticed when
     // the panel is otherwise empty.
-    if (needsCreate && chat.error !== null && (chat.session?.id ?? null) === beforeId) {
+    if (needsCreate && chat.error !== null && landed === beforeId) {
       toast.error("Couldn't start the session", { description: chat.error });
     }
   }
@@ -200,10 +242,18 @@
   {/if}
 
   <div class="shrink-0 border-t p-3">
+    {#if endedNotice}
+      <!-- Not a live region: the header owns the ONE status announcement. This is
+           the composer's description, read when focus lands on it. -->
+      <p id={endedNoticeId} class="t-label mb-2 text-muted-foreground">
+        This session has ended — sending starts a new one.
+      </p>
+    {/if}
     <PromptInput
       bind:value={draft}
       working={chat.working}
       disabled={chat.busy && !chat.working}
+      describedBy={endedNotice ? endedNoticeId : undefined}
       onSend={handleSend}
       onCancel={() => chat.cancel()}
     />

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
@@ -23,6 +23,12 @@
    * Failures surface twice on purpose: an inline strip above the composer (with
    * Retry when the transport is dead) plus a toast for a failed session create,
    * which is the one failure that leaves nothing on screen to explain itself.
+   *
+   * A station can host several sessions at once, so this panel is a view onto
+   * ONE of them: the header's switcher picks, `chat.attach` swaps the socket and
+   * the transcript. The panel is deliberately not remounted per session — the
+   * socket lifecycle belongs to the controller, and remounting would also throw
+   * away the draft and the scroll position on every switch.
    */
   import { onMount } from "svelte";
   import { toast } from "svelte-sonner";
@@ -40,6 +46,31 @@
 
   /** The composer's draft, owned here so a failed prompt can be handed back. */
   let draft = $state("");
+
+  /**
+   * Drafts are PER SESSION: switching away from A parks A's text here, switching
+   * back restores it, and B always shows B's own (empty until B has one).
+   *
+   * The two single-buffer alternatives are both wrong. Carrying one draft across
+   * a switch leaves words written for one agent one Enter away from another —
+   * and the header above it now says a different session. Clearing on switch
+   * destroys text the user typed, which is the one thing this panel never does
+   * anywhere else (a refused send keeps its draft; a rejected prompt is handed
+   * back through `onPromptFailed`). Parking per session loses nothing and can
+   * misdirect nothing. Entries are dropped when a session ends — there is no
+   * composer to return to.
+   */
+  const drafts = new Map<string, string>();
+
+  /**
+   * Which session is on screen. The panel owns this pick; the controller owns
+   * the socket for it. Deliberately NOT an `$effect` reconciling `selectedId`
+   * against `chat.session`: an effect re-runs on every controller state change,
+   * so creating a session from the header (which moves `chat.session`, not the
+   * pick) would immediately be switched away from again. A switch happens once,
+   * in the handler for the thing the user actually clicked.
+   */
+  let selectedId = $state<string | null>(null);
 
   // Plain (non-reactive) ref: the controller holds its own $state internally,
   // so the template stays reactive while the instance itself is stable for the
@@ -59,6 +90,57 @@
     // Unmount (including a tab switch that drops this panel) closes the socket
     // only — the session keeps running on the hub and is re-attached on return.
     return () => chat.destroy();
+  });
+
+  /**
+   * Park the draft under the session we're leaving and load the one belonging to
+   * the session we landed on. Called only after the controller has actually
+   * moved: a refused switch (a session that's gone) must leave the composer
+   * exactly as the user left it.
+   */
+  function swapDraft(from: string | null, to: string | null) {
+    if (from === to) return;
+    if (from !== null) {
+      if (draft.length > 0) drafts.set(from, draft);
+      else drafts.delete(from);
+    }
+    draft = (to !== null ? drafts.get(to) : undefined) ?? "";
+  }
+
+  async function selectSession(id: string) {
+    const from = chat.session?.id ?? null;
+    if (id === from) return; // already on it — don't touch the socket or the draft
+    selectedId = id;
+    await chat.attach(id);
+    // A refused switch leaves the previous session attached, so the header must
+    // fall back to what is really on screen.
+    const landed = chat.session?.id ?? null;
+    selectedId = landed;
+    swapDraft(from, landed);
+  }
+
+  async function startSession() {
+    const from = chat.session?.id ?? null;
+    await chat.newSession();
+    const landed = chat.session?.id ?? null;
+    selectedId = landed;
+    swapDraft(from, landed);
+    // Same reasoning as a failed first prompt: the strip shows it, but a toast is
+    // what gets noticed when the transcript below hasn't changed.
+    if (chat.error !== null && landed === from) {
+      toast.error("Couldn't start the session", { description: chat.error });
+    }
+  }
+
+  // A parked draft for a session that has since ended is dead post — nothing can
+  // be sent into that session again, so drop it rather than hand it back on a
+  // switch into a read-only replay. Only the MAP is pruned: text the user can
+  // still see in the composer is never destroyed (with an ended session attached,
+  // sending it creates a new session — see `prompt()`'s lazy create).
+  $effect(() => {
+    for (const s of chat.sessions) {
+      if (s.status === "ended") drafts.delete(s.id);
+    }
   });
 
   async function handleSend(text: string) {
@@ -83,9 +165,12 @@
   <div class="shrink-0 border-b px-3 py-2">
     <ChatHeader
       session={chat.session}
+      sessions={chat.sessions}
+      selectedId={selectedId ?? chat.session?.id ?? null}
       status={chat.status}
       connection={chat.connection}
       mode={chat.mode}
+      creating={chat.creating}
       onModeChange={(mode) => chat.setMode(mode)}
       onEnd={() => {
         // While disconnected the DELETE still lands, but the ended state
@@ -93,7 +178,8 @@
         // until a retry reconnects and replays it. That's the honest reading.
         void chat.end();
       }}
-      onNew={() => chat.newSession()}
+      onNew={() => void startSession()}
+      onSelectSession={(id) => void selectSession(id)}
     />
   </div>
 

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -506,10 +506,10 @@ async function renderTwoSessions() {
 
 /** Opens the switcher and clicks the option whose accessible name matches. */
 async function switchTo(
-  u: Awaited<ReturnType<typeof renderTwoSessions>>,
+  u: { getByRole: (role: string, options: { name: RegExp }) => HTMLElement },
   name: RegExp,
 ): Promise<void> {
-  const trigger = u.getByRole("button", { name: /^Session \d/ });
+  const trigger = u.getByRole("button", { name: /^Switch session/ });
   await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
   const option = await waitFor(() => u.getByRole("option", { name }));
   await fireEvent.pointerUp(option, { pointerId: 1, button: 0, pointerType: "mouse" });
@@ -522,7 +522,9 @@ test("the switcher lists the station's sessions and switching re-attaches", asyn
   vi.stubGlobal("fetch", fetchSpy);
   const u = await renderTwoSessions();
   expect(u.getByText("hello from B")).toBeTruthy();
-  expect(u.getByRole("button", { name: /^Session 2 · idle · 5m ago$/ })).toBeTruthy();
+  expect(
+    u.getByRole("button", { name: /^Switch session — currently Session 2 · idle · 5m ago$/ }),
+  ).toBeTruthy();
 
   await switchTo(u, /^Session 1 · idle · 1h ago$/);
 
@@ -541,7 +543,9 @@ test("the switcher lists the station's sessions and switching re-attaches", asyn
   wsA.fireMessage({ t: "replay-done", lastSeq: 7 });
   await tick();
   expect(u.getByText("hello from A")).toBeTruthy();
-  expect(u.getByRole("button", { name: /^Session 1 · idle · 1h ago$/ })).toBeTruthy();
+  expect(
+    u.getByRole("button", { name: /^Switch session — currently Session 1 · idle · 1h ago$/ }),
+  ).toBeTruthy();
 
   // Sessions are hub-owned: switching never ends one.
   expect(endSpy).not.toHaveBeenCalled();
@@ -613,7 +617,120 @@ test("re-picking the attached session churns nothing", async () => {
 
 test("with one session the panel shows no switcher", async () => {
   const u = await renderConnected();
-  expect(u.queryByRole("button", { name: /^Session \d/ })).toBeNull();
+  expect(u.queryByRole("button", { name: /^Switch session/ })).toBeNull();
+});
+
+// ─── Reading an ended session, and sending from one ─────────────────────────
+
+const endedA = row({
+  id: "sa",
+  status: "ended",
+  createdAt: "2026-08-09T10:00:00.000Z",
+  lastEventAt: minutesAgo(120),
+});
+
+/** Two sessions where the older one has ended; attached to the live one (B). */
+async function renderWithEnded() {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([sessionB, endedA]);
+  const utils = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await tick();
+  return { ...utils, ws };
+}
+
+/** Switches to the ended session A and replays its ended state event. */
+async function readEndedSession(u: Awaited<ReturnType<typeof renderWithEnded>>) {
+  await switchTo(u, /^Session 1 · ended/);
+  const wsA = MockWebSocket.latest()!;
+  wsA.open();
+  wsA.fireMessage({ t: "event", event: ev(3, "state", { status: "ended", reason: "done" }) });
+  wsA.fireMessage({ t: "replay-done", lastSeq: 3 });
+  await tick();
+  return wsA;
+}
+
+test("sending from an ended session re-points the header at the new session", async () => {
+  // Regression: only the switcher and "New session" resynced the pick, so
+  // prompt()'s lazy create left the header naming the ENDED session the user had
+  // been reading while the socket and transcript were the new one's — and the
+  // stale pick then swallowed the next click on either of them.
+  const u = await renderWithEnded();
+  await readEndedSession(u);
+  expect(u.getByRole("button", { name: /currently Session 1 · ended/ })).toBeTruthy();
+
+  const created = row({
+    id: "sc",
+    createdAt: "2026-08-09T12:00:00.000Z",
+    lastEventAt: minutesAgo(0),
+  });
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(created);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([created, sessionB, endedA]);
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "follow-up" } });
+  await fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(api.createAcpSession).toHaveBeenCalledWith("st1", "ask"));
+  await tick();
+
+  // The header names what is actually attached, not what was being read.
+  expect(MockWebSocket.latest()!.url).toContain("/api/acp/sessions/sc/ws");
+  expect(
+    u.getByRole("button", { name: /^Switch session — currently Session 3 · idle · just now$/ }),
+  ).toBeTruthy();
+
+  // …and the session just read is selectable again straight away (no sticky pick).
+  await switchTo(u, /^Session 1 · ended/);
+  await waitFor(() => expect(MockWebSocket.latest()!.url).toContain("/api/acp/sessions/sa/ws"));
+});
+
+test("an attached ended session says plainly that sending starts a new one", async () => {
+  const notice = "This session has ended — sending starts a new one.";
+  const u = await renderWithEnded();
+  expect(u.queryByText(notice)).toBeNull(); // live session: nothing to explain
+
+  await readEndedSession(u);
+
+  const line = u.getByText(notice);
+  const box = composer(u);
+  // Visible AND announced on focus — a composer that quietly spawns a second
+  // agent process on the host is the one thing that must not be a surprise.
+  expect(box.getAttribute("aria-describedby")).toBe(line.id);
+  expect(line.id.length).toBeGreaterThan(0);
+  // Not a dead end: sending is still allowed, it just starts a session.
+  expect(box.readOnly).toBe(false);
+});
+
+test("a draft typed with no session survives switching away to read one", async () => {
+  // Every session ended, so the switcher is up while nothing is attached. This
+  // draft has no session to be parked under — the bug dropped it on the floor.
+  const endedB = { ...sessionB, status: "ended" as const };
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([endedB, endedA]);
+  const u = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(api.listAcpSessions).toHaveBeenCalledWith("st1"));
+  await tick();
+  expect(MockWebSocket.instances).toHaveLength(0); // nothing live to attach
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "typed before any session" } });
+
+  await switchTo(u, /^Session 1 · ended/);
+  expect(box.value).toBe(""); // the session being read has no draft of its own
+
+  // The pre-session text was written for whatever session came next — so it is
+  // waiting in the one this creates, not gone.
+  const created = row({
+    id: "sc",
+    createdAt: "2026-08-09T12:00:00.000Z",
+    lastEventAt: minutesAgo(0),
+  });
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(created);
+  await fireEvent.click(u.getByRole("button", { name: "New session" }));
+  await waitFor(() => expect(api.createAcpSession).toHaveBeenCalled());
+  await tick();
+
+  expect(box.value).toBe("typed before any session");
 });
 
 // ─── Connection failures ────────────────────────────────────────────────────

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -23,6 +23,26 @@ vi.mock("svelte-sonner", () => ({
 }));
 
 import { toast } from "svelte-sonner";
+
+// bits-ui's Select (the session switcher) opens on `pointerdown` and picks on
+// `pointerup`, touching pointer-capture methods jsdom doesn't implement.
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  // @ts-expect-error jsdom has no native PointerEvent
+  window.PointerEvent = PointerEventPolyfill;
+}
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+
 // Static import: compiled during file collection, not inside a waitFor window.
 import ChatPanel from "./ChatPanel.svelte";
 
@@ -86,6 +106,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.unstubAllGlobals();
   MockWebSocket.instances = [];
   localStorage.clear();
 });
@@ -429,17 +450,170 @@ test("ending a session goes through the confirm dialog and DELETEs", async () =>
   await waitFor(() => expect(end).toHaveBeenCalledWith("s1"));
 });
 
-test("after the session ends, New session returns to the empty state", async () => {
+test("after the session ends, New session creates and attaches a fresh one", async () => {
   const u = await renderConnected();
   u.ws.fireMessage({ t: "event", event: ev(1, "state", { status: "ended", reason: "done" }) });
   await tick();
   expect(u.getByText("Ended")).toBeTruthy();
 
+  const created = row({ id: "s2", lastEventAt: minutesAgo(0) });
+  const create = vi.spyOn(api, "createAcpSession").mockResolvedValue(created);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([created, row()]);
+
   await fireEvent.click(u.getByRole("button", { name: "New session" }));
+  await waitFor(() => expect(create).toHaveBeenCalledWith("st1", "ask"));
   await tick();
 
+  // A fresh transcript on a new socket — not a local reset of the old session.
   expect(u.getByText("No conversation yet.")).toBeTruthy();
-  expect(u.getByText("No session")).toBeTruthy();
+  const ws2 = MockWebSocket.latest()!;
+  expect(ws2).not.toBe(u.ws);
+  expect(ws2.url).toContain("/api/acp/sessions/s2/ws");
+  expect(u.ws.readyState).toBe(3);
+  ws2.open();
+  expect(ws2.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]);
+});
+
+// ─── Session switcher ───────────────────────────────────────────────────────
+
+/** ISO timestamp `minutes` ago — keeps relative labels deterministic. */
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+const sessionA = row({
+  id: "sa",
+  createdAt: "2026-08-09T10:00:00.000Z",
+  lastEventAt: minutesAgo(90),
+});
+const sessionB = row({
+  id: "sb",
+  mode: "full-auto",
+  createdAt: "2026-08-09T11:00:00.000Z",
+  lastEventAt: minutesAgo(5),
+});
+
+/** Two live sessions on the station, attached to the newest-activity one (B). */
+async function renderTwoSessions() {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([sessionB, sessionA]);
+  const utils = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hello from B" }) });
+  ws.fireMessage({ t: "replay-done", lastSeq: 1 });
+  await tick();
+  return { ...utils, ws };
+}
+
+/** Opens the switcher and clicks the option whose accessible name matches. */
+async function switchTo(
+  u: Awaited<ReturnType<typeof renderTwoSessions>>,
+  name: RegExp,
+): Promise<void> {
+  const trigger = u.getByRole("button", { name: /^Session \d/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const option = await waitFor(() => u.getByRole("option", { name }));
+  await fireEvent.pointerUp(option, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await tick();
+}
+
+test("the switcher lists the station's sessions and switching re-attaches", async () => {
+  const endSpy = vi.spyOn(api, "endAcpSession");
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+  const u = await renderTwoSessions();
+  expect(u.getByText("hello from B")).toBeTruthy();
+  expect(u.getByRole("button", { name: /^Session 2 · idle · 5m ago$/ })).toBeTruthy();
+
+  await switchTo(u, /^Session 1 · idle · 1h ago$/);
+
+  // The old socket is closed and a new one subscribes to the chosen session.
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2));
+  const wsA = MockWebSocket.latest()!;
+  expect(wsA).not.toBe(u.ws);
+  expect(wsA.url).toContain("/api/acp/sessions/sa/ws");
+  expect(u.ws.readyState).toBe(3);
+  wsA.open();
+  expect(wsA.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]);
+
+  // B's transcript is gone and A's replay takes its place.
+  expect(u.queryByText("hello from B")).toBeNull();
+  wsA.fireMessage({ t: "event", event: ev(7, "user-prompt", { text: "hello from A" }) });
+  wsA.fireMessage({ t: "replay-done", lastSeq: 7 });
+  await tick();
+  expect(u.getByText("hello from A")).toBeTruthy();
+  expect(u.getByRole("button", { name: /^Session 1 · idle · 1h ago$/ })).toBeTruthy();
+
+  // Sessions are hub-owned: switching never ends one.
+  expect(endSpy).not.toHaveBeenCalled();
+  expect(fetchSpy.mock.calls).toEqual([]);
+});
+
+test("drafts are per session: parked on the way out, restored on the way back", async () => {
+  // One shared buffer would leave words written for one agent an Enter away from
+  // another; clearing on switch would destroy them. Parking does neither.
+  const u = await renderTwoSessions();
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "written for B" } });
+
+  await switchTo(u, /^Session 1/);
+  expect(box.value).toBe(""); // A has no draft of its own
+
+  await fireEvent.input(box, { target: { value: "written for A" } });
+  await switchTo(u, /^Session 2/);
+  expect(box.value).toBe("written for B"); // B's own draft came back
+
+  await switchTo(u, /^Session 1/);
+  expect(box.value).toBe("written for A");
+});
+
+test("a parked draft is dropped once its session has ended", async () => {
+  const u = await renderTwoSessions();
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "parked in B" } });
+  await switchTo(u, /^Session 1/); // B's draft is parked
+
+  // Ending A re-reads the list, which is where this panel learns B ended too.
+  vi.spyOn(api, "endAcpSession").mockResolvedValue(undefined);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([
+    { ...sessionB, status: "ended" },
+    sessionA,
+  ]);
+  await fireEvent.click(u.getByRole("button", { name: "End session" }));
+  const confirm = await waitFor(() => {
+    const inDialog = u
+      .getAllByRole("button", { name: "End session" })
+      .find((b) => b.closest('[role="dialog"]') !== null);
+    if (!inDialog) throw new Error("confirm button not rendered yet");
+    return inDialog;
+  });
+  await fireEvent.click(confirm);
+  await waitFor(() => expect(api.endAcpSession).toHaveBeenCalled());
+  await tick();
+
+  await switchTo(u, /^Session 2/);
+
+  // Nothing can be sent into an ended session, so its draft is not handed back.
+  expect(box.value).toBe("");
+});
+
+test("re-picking the attached session churns nothing", async () => {
+  // The list is also a status display, so it gets clicked idly. Re-attaching
+  // there would drop a live socket and replay the transcript for no reason.
+  const u = await renderTwoSessions();
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "still mine" } });
+
+  await switchTo(u, /^Session 2/);
+
+  expect(MockWebSocket.instances).toHaveLength(1);
+  expect(u.ws.readyState).toBe(1);
+  expect(box.value).toBe("still mine");
+  expect(u.getByText("hello from B")).toBeTruthy();
+});
+
+test("with one session the panel shows no switcher", async () => {
+  const u = await renderConnected();
+  expect(u.queryByRole("button", { name: /^Session \d/ })).toBeNull();
 });
 
 // ─── Connection failures ────────────────────────────────────────────────────

--- a/apps/console/src/lib/components/stations/chat/PromptInput.svelte
+++ b/apps/console/src/lib/components/stations/chat/PromptInput.svelte
@@ -27,11 +27,24 @@
     value?: string;
     disabled?: boolean;
     working: boolean;
+    /**
+     * Id of a line explaining what sending will do (e.g. "this starts a new
+     * session"). Reaches the textarea as `aria-describedby`, so the caveat is
+     * announced when focus lands here — not only to people who can see it.
+     */
+    describedBy?: string;
     onSend: (text: string) => void;
     onCancel: () => void;
   }
 
-  let { value = $bindable(""), disabled = false, working, onSend, onCancel }: Props = $props();
+  let {
+    value = $bindable(""),
+    disabled = false,
+    working,
+    describedBy,
+    onSend,
+    onCancel,
+  }: Props = $props();
   const canSend = $derived(value.trim().length > 0);
 
   function send() {
@@ -55,6 +68,7 @@
     aria-label="Message the agent"
     class="max-h-40 min-h-9 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
     aria-disabled={disabled ? "true" : undefined}
+    aria-describedby={describedBy}
     readonly={disabled}
     onkeydown={handleKeydown}
   />

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -1084,6 +1084,39 @@ test("the session frame refreshes that row in the list without reordering it", a
   expect(chat.sessions[0].status).toBe("working");
 });
 
+test("a prompt into an attached ENDED session creates a new one instead", async () => {
+  // Reading an ended session and typing a follow-up is an obvious move now that
+  // the switcher offers them. The row says ended, but a replay that carried no
+  // state event leaves the transcript's own status at the "starting" placeholder
+  // — deciding on that alone writes the frame into a session that can never
+  // answer it.
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([
+    row({ id: "sa" }),
+    row({ id: "se", status: "ended" }),
+  ]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  await chat.attach("se");
+  const wsE = MockWebSocket.latest()!;
+  wsE.open();
+  wsE.fireMessage({ t: "replay-done", lastSeq: 0 });
+  expect(chat.status).toBe("ended");
+  expect(chat.busy).toBe(false);
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(row({ id: "sn" }));
+
+  await chat.prompt("carry on");
+
+  expect(api.createAcpSession).toHaveBeenCalledWith("st1", "ask");
+  expect(chat.session?.id).toBe("sn");
+  expect(wsE.frames()).not.toContainEqual({ t: "prompt", text: "carry on" });
+  const wsN = MockWebSocket.latest()!;
+  wsN.open();
+  expect(wsN.frames()).toEqual([
+    { t: "subscribe", sinceSeq: 0 },
+    { t: "prompt", text: "carry on" },
+  ]);
+});
+
 test("end() refreshes the session list so the switcher shows it ended", async () => {
   vi.spyOn(api, "endAcpSession").mockResolvedValue(undefined);
   const { chat } = await connectedChat();

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -79,6 +79,11 @@ beforeEach(() => {
   MockWebSocket.instances = [];
   localStorage.setItem("agentpod.apiUrl", "http://hub.test:3001");
   (globalThis as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
+  // Default stub for the session-list refresh the controller fires after a
+  // create/end (`sessions` feeds the header's switcher). Tests that care
+  // re-spy with their own rows; without this default the background refresh in
+  // a create-only test would reach the real http client.
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -128,7 +133,8 @@ async function connectedChat(): Promise<{ chat: AcpChat; ws: MockWebSocket }> {
 test("init attaches to the newest non-ended session and replays to connected", async () => {
   const ended = row({ id: "s0", status: "ended", createdAt: "2026-08-08T00:00:00.000Z" });
   const active = row({ id: "s1", mode: "accept-edits", createdAt: "2026-08-09T00:00:00.000Z" });
-  // Deliberately unsorted: the controller must pick the newest by createdAt.
+  // The hub returns newest-ACTIVITY-first from SQL; the controller keeps that
+  // order and attaches the first non-ended row.
   vi.spyOn(api, "listAcpSessions").mockResolvedValue([active, ended]);
 
   const chat = new AcpChat("st1");
@@ -848,10 +854,11 @@ test("destroy() clears the echo deadline — no release after unmount", async ()
 test("newSession() clears the echo deadline", async () => {
   vi.useFakeTimers();
   _setEchoDeadlineMsForTest(500);
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(row({ id: "s2" }));
   const { chat, failed } = await chatWithFailures();
   await chat.prompt("abandoned");
 
-  chat.newSession();
+  await chat.newSession();
 
   expect(vi.getTimerCount()).toBe(0);
   vi.advanceTimersByTime(60_000);
@@ -860,16 +867,230 @@ test("newSession() clears the echo deadline", async () => {
   expect(chat.error).toBeNull();
 });
 
-test("newSession resets to the empty state", async () => {
+test("newSession creates a session and attaches it (no local-reset-only)", async () => {
   const { chat, ws } = await connectedChat();
   ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hi" }) });
   ws.fireMessage({ t: "bye", reason: "ended" });
+  const created = row({ id: "s2", lastEventAt: "2026-08-09T02:00:00.000Z" });
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(created);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([created, row()]);
 
-  chat.newSession();
+  await chat.newSession();
 
-  expect(chat.session).toBeNull();
+  expect(api.createAcpSession).toHaveBeenCalledWith("st1", "ask");
+  expect(chat.session?.id).toBe("s2");
+  expect(chat.sessions.map((s) => s.id)).toEqual(["s2", "s1"]);
   expect(chat.transcript.items).toEqual([]);
   expect(chat.transcript.lastSeq).toBe(0);
-  expect(chat.connection).toBe("idle");
+  expect(chat.connection).toBe("connecting");
   expect(chat.error).toBeNull();
+
+  const ws2 = MockWebSocket.latest()!;
+  expect(ws2).not.toBe(ws);
+  expect(ws2.url).toContain("/api/acp/sessions/s2/ws");
+  ws2.open();
+  expect(ws2.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]);
+});
+
+test("newSession surfaces a failed create and keeps the current session attached", async () => {
+  const { chat, ws } = await connectedChat();
+  vi.spyOn(api, "createAcpSession").mockRejectedValue(new Error("That station's node is offline."));
+
+  await chat.newSession();
+
+  expect(chat.error).toBe("That station's node is offline.");
+  expect(chat.session?.id).toBe("s1");
+  expect(ws.readyState).toBe(1); // the live socket is untouched by a failed create
+  expect(MockWebSocket.instances).toHaveLength(1);
+  expect(chat.busy).toBe(false); // the create window closed
+});
+
+test("concurrent newSession calls issue exactly one create", async () => {
+  const { chat } = await connectedChat();
+  const createSpy = vi.spyOn(api, "createAcpSession").mockResolvedValue(row({ id: "s2" }));
+
+  await Promise.all([chat.newSession(), chat.newSession()]);
+
+  expect(createSpy).toHaveBeenCalledTimes(1);
+});
+
+// ─── Several sessions per station: list + attach (hub-owned, never DELETE) ────
+
+test("init keeps the hub's order and attaches the first live session", async () => {
+  // The hub orders newest-ACTIVITY-first in SQL (lastEventAt desc, id desc).
+  // Re-sorting by createdAt here would bury a session that just streamed under
+  // one that has been idle since the moment it was created.
+  const busyOld = row({
+    id: "old",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    lastEventAt: "2026-08-09T12:00:00.000Z",
+  });
+  const quietNew = row({
+    id: "new",
+    createdAt: "2026-08-09T00:00:00.000Z",
+    lastEventAt: "2026-08-09T00:00:00.000Z",
+  });
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([busyOld, quietNew]);
+
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  expect(chat.sessions.map((s) => s.id)).toEqual(["old", "new"]);
+  expect(chat.session?.id).toBe("old");
+  expect(MockWebSocket.latest()!.url).toContain("/api/acp/sessions/old/ws");
+});
+
+test("init skips an ended session at the head but still lists it", async () => {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([
+    row({ id: "e1", status: "ended" }),
+    row({ id: "s2" }),
+  ]);
+
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  expect(chat.session?.id).toBe("s2");
+  // The ended one stays switchable — its transcript is still worth reading.
+  expect(chat.sessions.map((s) => s.id)).toEqual(["e1", "s2"]);
+});
+
+test("attach swaps the socket and the transcript to another session, DELETEing nothing", async () => {
+  const endSpy = vi.spyOn(api, "endAcpSession");
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+  const a = row({ id: "sa" });
+  const b = row({ id: "sb", mode: "full-auto" });
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([a, b]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  const wsA = MockWebSocket.latest()!;
+  wsA.open();
+  wsA.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "in A" }) });
+  wsA.fireMessage({ t: "replay-done", lastSeq: 1 });
+  expect(chat.transcript.items).toHaveLength(1);
+
+  await chat.attach("sb");
+
+  expect(wsA.readyState).toBe(3); // the old socket is closed…
+  const wsB = MockWebSocket.latest()!;
+  expect(wsB).not.toBe(wsA); // …and replaced
+  expect(wsB.url).toContain("/api/acp/sessions/sb/ws");
+  expect(chat.session?.id).toBe("sb");
+  expect(chat.mode).toBe("full-auto"); // B's mode, not A's
+  expect(chat.transcript.items).toEqual([]); // A's transcript is gone
+  expect(chat.transcript.lastSeq).toBe(0);
+  expect(chat.connection).toBe("connecting");
+
+  wsB.open();
+  expect(wsB.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]); // B replays whole
+
+  wsB.fireMessage({ t: "event", event: ev(4, "user-prompt", { text: "in B" }) });
+  wsB.fireMessage({ t: "replay-done", lastSeq: 4 });
+  expect(chat.transcript.items).toEqual([{ kind: "user", seq: 4, text: "in B" }]);
+  expect(chat.connection).toBe("connected");
+
+  // Switching is navigation, never destruction — the sessions are hub-owned.
+  expect(endSpy).not.toHaveBeenCalled();
+  expect(fetchSpy).not.toHaveBeenCalled();
+  vi.unstubAllGlobals();
+});
+
+test("attach never reconnects the session it left", async () => {
+  vi.useFakeTimers();
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ id: "sa" }), row({ id: "sb" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  MockWebSocket.latest()!.open();
+
+  await chat.attach("sb");
+  const count = MockWebSocket.instances.length;
+  vi.advanceTimersByTime(60_000);
+
+  // A manual close is not a drop: the old socket must not schedule a redial.
+  expect(MockWebSocket.instances).toHaveLength(count);
+});
+
+test("attach mid-pending never leaks the optimistic prompt into the next session", async () => {
+  vi.useFakeTimers();
+  const failed: string[] = [];
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ id: "sa" }), row({ id: "sb" })]);
+  const chat = new AcpChat("st1", { onPromptFailed: (text) => failed.push(text) });
+  await chat.init();
+  const wsA = MockWebSocket.latest()!;
+  wsA.open();
+  wsA.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await chat.prompt("meant for A");
+  expect(chat.busy).toBe(true);
+
+  await chat.attach("sb");
+
+  expect(chat.transcript.items).toEqual([]); // no ghost bubble in B
+  // NOT handed back: the composer now points at another agent's session.
+  expect(failed).toEqual([]);
+  const wsB = MockWebSocket.latest()!;
+  wsB.open();
+  wsB.fireMessage({ t: "replay-done", lastSeq: 0 });
+  expect(chat.busy).toBe(false); // and busy is not latched behind A's prompt
+  expect(vi.getTimerCount()).toBe(0); // A's echo deadline went with it
+
+  vi.advanceTimersByTime(ECHO_DEADLINE_MS * 3);
+  expect(chat.error).toBeNull();
+  expect(failed).toEqual([]);
+});
+
+test("attach to an id that is gone re-reads the list and keeps the live session", async () => {
+  const list = vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ id: "sa" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  const wsA = MockWebSocket.latest()!;
+  wsA.open();
+  wsA.fireMessage({ t: "replay-done", lastSeq: 0 });
+
+  await chat.attach("gone");
+
+  expect(list).toHaveBeenCalledTimes(2); // re-read before giving up
+  expect(chat.session?.id).toBe("sa"); // still attached, socket untouched
+  expect(wsA.readyState).toBe(1);
+  expect(MockWebSocket.instances).toHaveLength(1);
+  expect(chat.error).toBe("Couldn't open that session — it's no longer there.");
+});
+
+test("attach after destroy dials nothing", async () => {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ id: "sa" }), row({ id: "sb" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  chat.destroy();
+  const count = MockWebSocket.instances.length;
+
+  await chat.attach("sb");
+
+  expect(MockWebSocket.instances).toHaveLength(count);
+});
+
+test("the session frame refreshes that row in the list without reordering it", async () => {
+  const a = row({ id: "sa" });
+  const b = row({ id: "sb" });
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([a, b]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+
+  ws.fireMessage({ t: "session", session: { ...a, status: "working" } });
+
+  // The switcher's <Status> must follow the stream, but a list that reshuffles
+  // itself under the pointer is how a user picks the wrong session.
+  expect(chat.sessions.map((s) => s.id)).toEqual(["sa", "sb"]);
+  expect(chat.sessions[0].status).toBe("working");
+});
+
+test("end() refreshes the session list so the switcher shows it ended", async () => {
+  vi.spyOn(api, "endAcpSession").mockResolvedValue(undefined);
+  const { chat } = await connectedChat();
+  expect(chat.sessions.map((s) => s.status)).toEqual(["idle"]);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ status: "ended" })]);
+
+  await chat.end();
+
+  expect(chat.sessions.map((s) => s.status)).toEqual(["ended"]);
 });

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -9,6 +9,22 @@
  *   - the pure transcript projection (./transcript): every server event is
  *     folded immutably, so views key off item references.
  *
+ * A station can host SEVERAL live sessions at once, so one controller is a view
+ * onto one of them at a time:
+ *   - `sessions` is the station's whole list in the hub's own order
+ *     (newest-ACTIVITY-first from SQL — never re-sorted here, or a session that
+ *     just streamed would sink below one idle since it was created). It is
+ *     refreshed after a create and after an end, and the attached row is kept
+ *     fresh in place from the stream's `session` frames.
+ *   - `attach(id)` switches which one is on screen: close this socket, drop the
+ *     transcript, subscribe to that session from seq 0. It is NAVIGATION — it
+ *     ends nothing, exactly like `destroy()`.
+ *   - `newSession()` is an explicit create-and-attach (that is how a second
+ *     concurrent session is started). `prompt()` ALSO creates lazily when
+ *     nothing is attached — that path stays, because it is what makes the empty
+ *     state work with one keystroke, and both routes run through the same
+ *     `#creating` window so `busy` (and the composer) stay honest.
+ *
  * Lifecycle contracts (hub-owned sessions):
  *   - `destroy()` closes the socket ONLY — it never DELETEs. A WS close is
  *     never session end; the session keeps running on the hub and a later
@@ -33,9 +49,11 @@
  * and the composer with it. It is resolved by exactly one of: the echoed
  * user-prompt event (reconciled), an error attributed to it, `replay-done` with
  * the tail still pending (the hub never saw it), reconnect-budget exhaustion
- * (replay will never happen), the session ending, or — the backstop for a
- * socket NOTHING has noticed is dead — the echo deadline (ECHO_DEADLINE_MS).
- * Every event-driven path needs an event; a slept laptop's socket produces none.
+ * (replay will never happen), the session ending, a switch away from its session
+ * (dropped with the transcript — see `discardPendingPrompt`), or — the backstop
+ * for a socket NOTHING has noticed is dead — the echo deadline
+ * (ECHO_DEADLINE_MS). Every event-driven path needs an event; a slept laptop's
+ * socket produces none.
  *
  * Permission dismissal: ACP has no per-request dismiss — agents supply reject
  * options in the request itself (answer with one of those), and `cancel()`
@@ -67,6 +85,7 @@ const BACKOFF_MS = [1000, 2000, 4000];
 
 const OFFLINE_COPY = "Couldn't reach the hub — check your connection.";
 const LOST_PROMPT_COPY = "Couldn't send that message — it's back in the box, try again.";
+const GONE_SESSION_COPY = "Couldn't open that session — it's no longer there.";
 
 /**
  * How long an optimistic prompt may wait for its echo before we call it lost.
@@ -101,6 +120,8 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 export class AcpChat {
   // ── Reactive state ($state-backed, exposed via getters) ────────────────────
   #session = $state<AcpSessionRow | null>(null);
+  /** The station's sessions in the hub's order. Never re-sorted locally. */
+  #sessions = $state<AcpSessionRow[]>([]);
   #transcript = $state<Transcript>(emptyTranscript());
   #connection = $state<ChatConnection>("idle");
   #error = $state<string | null>(null);
@@ -163,6 +184,26 @@ export class AcpChat {
 
   get session(): AcpSessionRow | null {
     return this.#session;
+  }
+
+  /**
+   * Every session this user has on the station, in the hub's order
+   * (newest-activity-first). Feeds the header's switcher; the attached one is
+   * `session`. Ended sessions stay in the list — their transcripts are still
+   * worth reading, and `attach` replays them read-only.
+   */
+  get sessions(): AcpSessionRow[] {
+    return this.#sessions;
+  }
+
+  /**
+   * True while a create POST is in flight (either route: `newSession()` or
+   * `prompt()`'s lazy create). Exposed only so the "New session" button can
+   * disable itself for that window — it is already folded into `busy`, so the
+   * composer's refusal rule needs nothing extra.
+   */
+  get creating(): boolean {
+    return this.#creating;
   }
 
   get transcript(): Transcript {
@@ -228,7 +269,11 @@ export class AcpChat {
 
   // ── Public API ─────────────────────────────────────────────────────────────
 
-  /** List sessions; if the newest is non-ended, attach. Else stay idle (empty state). */
+  /**
+   * List the station's sessions and attach the first live one. Only ended
+   * sessions (or none at all) → stay idle with the empty state, but the list is
+   * still published so the switcher can offer their transcripts.
+   */
   async init(): Promise<void> {
     let rows: AcpSessionRow[];
     try {
@@ -238,18 +283,39 @@ export class AcpChat {
       return;
     }
     if (this.destroyed) return;
+    this.#sessions = rows;
 
-    // The hub doesn't guarantee order — pick the newest by createdAt (ISO
-    // strings compare lexicographically).
-    let newest: AcpSessionRow | null = null;
-    for (const row of rows) {
-      if (newest === null || row.createdAt > newest.createdAt) newest = row;
+    // Server order is authoritative (hub SQL: lastEventAt desc, id desc), so
+    // the first non-ended row IS the most recently active live session.
+    const live = rows.find((row) => row.status !== "ended");
+    if (!live) return;
+    this.attachRow(live);
+  }
+
+  /**
+   * Switch to another of the station's sessions: close this socket, drop this
+   * transcript, subscribe to that one from the start.
+   *
+   * NAVIGATION, not lifecycle — nothing is ended, here or on the hub (the same
+   * contract as `destroy()`). The id is resolved against `sessions` first and
+   * the list is re-read once before giving up, so a stale pick can't take the
+   * live session's socket down with it.
+   */
+  async attach(sessionId: string): Promise<void> {
+    if (this.destroyed) return;
+    if (this.#session?.id === sessionId) return; // already on it — leave the socket alone
+
+    let row = this.#sessions.find((s) => s.id === sessionId);
+    if (!row) {
+      await this.refreshSessions();
+      if (this.destroyed) return;
+      row = this.#sessions.find((s) => s.id === sessionId);
     }
-    if (!newest || newest.status === "ended") return;
-
-    this.#session = newest;
-    this.mode = newest.mode;
-    this.startConnection();
+    if (!row) {
+      this.#error = GONE_SESSION_COPY;
+      return;
+    }
+    this.attachRow(row);
   }
 
   /**
@@ -266,25 +332,12 @@ export class AcpChat {
     this.#error = null;
 
     if (!this.#session || this.sessionOver || this.#transcript.status === "ended") {
-      let row: AcpSessionRow;
-      this.#creating = true;
-      try {
-        row = await createAcpSession(this.stationId, this.mode);
-      } catch (err) {
-        // The ApiError message already carries the right "Couldn't …" grammar.
-        this.#error = errMessage(err);
-        return;
-      } finally {
-        this.#creating = false;
-      }
-      if (this.destroyed) return;
-      this.teardownSocket();
-      this.sessionOver = false;
-      this.attempt = 0;
-      this.#session = row;
-      this.mode = row.mode;
-      this.#transcript = emptyTranscript();
-      this.startConnection();
+      const row = await this.createSession();
+      if (row === null) return;
+      this.attachRow(row);
+      // The list is a secondary surface here — the prompt frame must not wait on
+      // a GET, so the new row goes in optimistically and the refresh lands late.
+      void this.refreshSessions();
     } else if (!this.socket || !this.socket.isOpen) {
       // No socket (e.g. after budget exhaustion), or one that is CONNECTING /
       // CLOSING / CLOSED: either way there is nothing here that can carry a
@@ -340,24 +393,106 @@ export class AcpChat {
       await endAcpSession(session.id);
     } catch (err) {
       this.#error = errMessage(err);
+      return;
     }
     // The ended state arrives via the event stream (state: ended → bye);
-    // nothing is forced locally.
+    // nothing is forced locally. The LIST does need re-reading, though — the
+    // switcher would otherwise keep offering this one as live.
+    await this.refreshSessions();
   }
 
-  /** After ended: reset to the empty state (keep nothing but the mode selector). */
-  newSession(): void {
+  /**
+   * Start another session on the station and switch to it.
+   *
+   * A real create (the station can host several at once), not the old local
+   * reset — so it borrows `prompt()`'s create window: `#creating` makes `busy`
+   * true for the POST, which is exactly the rule `prompt()` refuses on, and a
+   * second click is a no-op rather than a second session.
+   */
+  async newSession(): Promise<void> {
+    const row = await this.createSession();
+    if (row === null) return;
+    this.attachRow(row);
+    await this.refreshSessions();
+  }
+
+  /**
+   * POST a session inside the `#creating` window. Returns null when the create
+   * failed (message already on `error`) or the panel went away mid-flight — the
+   * caller must not touch the socket in either case: the session that IS
+   * attached is still live and usable.
+   */
+  private async createSession(): Promise<AcpSessionRow | null> {
+    if (this.destroyed || this.#creating) return null;
+    this.#creating = true;
+    try {
+      const row = await createAcpSession(this.stationId, this.mode);
+      return this.destroyed ? null : row;
+    } catch (err) {
+      // The ApiError message already carries the right "Couldn't …" grammar.
+      this.#error = errMessage(err);
+      return null;
+    } finally {
+      this.#creating = false;
+    }
+  }
+
+  /**
+   * Re-read the station's sessions. Failures are deliberately silent: this runs
+   * behind create/end/attach, where the actionable message is the one those
+   * paths already surfaced — overwriting it with a list error would tell the
+   * user about the least important half of what just happened. The stale list
+   * stays on screen and the next refresh fixes it.
+   */
+  private async refreshSessions(): Promise<void> {
+    try {
+      const rows = await listAcpSessions(this.stationId);
+      if (this.destroyed) return;
+      this.#sessions = rows;
+    } catch {
+      /* keep the list we have */
+    }
+  }
+
+  /**
+   * Update one row in place, or prepend it when it's new (a just-created session
+   * has the newest activity, which is where the hub's order puts it anyway).
+   * Never re-sorts: a list that reshuffles itself under the pointer is how a
+   * user opens the wrong session.
+   */
+  private syncSessionRow(row: AcpSessionRow): void {
+    const idx = this.#sessions.findIndex((s) => s.id === row.id);
+    if (idx === -1) {
+      this.#sessions = [row, ...this.#sessions];
+      return;
+    }
+    const next = this.#sessions.slice();
+    next[idx] = row;
+    this.#sessions = next;
+  }
+
+  /**
+   * Point the controller at `row`: tear this socket down, start that session's
+   * transcript from scratch and subscribe from seq 0.
+   *
+   * The socket is replaced, never remounted around — the panel keeps one
+   * controller for its whole life, so this is the ONE place a session swap
+   * happens and the one place every per-session flag is reset. A manual
+   * `teardownSocket()` fires no `onClose`, so the session we're leaving is never
+   * reconnected to.
+   */
+  private attachRow(row: AcpSessionRow): void {
     this.clearReconnectTimer();
-    this.clearEchoDeadline(); // the prompt it belonged to is gone with the transcript
+    this.discardPendingPrompt();
     this.teardownSocket();
-    this.#session = null;
+    this.#session = row;
+    this.mode = row.mode;
     this.#transcript = emptyTranscript();
-    this.#connection = "idle";
     this.#error = null;
     this.sessionOver = false;
-    this.awaitingEcho = false;
-    this.promptSocket = null;
     this.attempt = 0;
+    this.syncSessionRow(row);
+    this.startConnection();
   }
 
   /** Manual reconnect — resets the backoff budget before retrying. */
@@ -409,6 +544,9 @@ export class AcpChat {
       case "session":
         this.#session = msg.session;
         this.mode = msg.session.mode;
+        // Keep the switcher's row for this session honest too — its <Status> is
+        // read from the list, not from the attached transcript.
+        this.syncSessionRow(msg.session);
         break;
       case "event":
         this.applyEvent(msg.event);
@@ -497,6 +635,23 @@ export class AcpChat {
     if (text === null) return;
     this.#transcript = transcript;
     this.onPromptFailed?.(text);
+  }
+
+  /**
+   * Forget a pending optimistic prompt WITHOUT handing its text back. The only
+   * caller is `attachRow`, which replaces the transcript wholesale — so the
+   * ghost bubble goes with it (nothing can leak into the session being attached)
+   * and `busy` unlatches because `hasPendingPrompt()` reads the new, empty one.
+   *
+   * The text is NOT returned to the composer on purpose: the composer now points
+   * at a different session, and re-offering words written for another agent one
+   * Enter away from sending them is worse than dropping a copy the hub most
+   * likely persisted (switch back and the replay shows it).
+   */
+  private discardPendingPrompt(): void {
+    this.clearEchoDeadline();
+    this.awaitingEcho = false;
+    this.promptSocket = null;
   }
 
   private handleBye(reason: string): void {

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -331,7 +331,12 @@ export class AcpChat {
     if (this.busy) return;
     this.#error = null;
 
-    if (!this.#session || this.sessionOver || this.#transcript.status === "ended") {
+    // `status`, not the transcript's own: attaching an ENDED session from the
+    // switcher leaves the transcript at its "starting" placeholder until a state
+    // event turns up in the replay, and a session that has ended can never answer
+    // a prompt frame — the text would vanish into a socket the hub is about to
+    // close. The row's verdict is enough to create instead.
+    if (!this.#session || this.sessionOver || this.status === "ended") {
       const row = await this.createSession();
       if (row === null) return;
       this.attachRow(row);

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -5,9 +5,10 @@
  *   REST:
  *     1. POST /api/stations/:id/acp/sessions {mode} → 201 AcpSessionRow;
  *        error statuses: 400 invalid mode, 401 anonymous, 403 no acp
- *        capability, 404 unknown station, 409 active session exists,
- *        502 node offline / acp.open failure.
- *     2. GET /api/stations/:id/acp/sessions → rows newest first.
+ *        capability, 404 unknown station, 409 the node can't host a second
+ *        session, 502 node offline / acp.open failure.
+ *     2. GET /api/stations/:id/acp/sessions → rows newest ACTIVITY first,
+ *        straight from the service's SQL ordering (the route never re-sorts).
  *   WS (GET /api/acp/sessions/:sessionId/ws):
  *     3. subscribe → session row, replay of persisted events (seq order),
  *        replay-done, then live events stream; prompt over the WS produces
@@ -45,6 +46,7 @@ import { adoptStations } from "../services/station-registry";
 import {
   endSession,
   getSession,
+  promptSession,
   _subscriberCountForTest,
 } from "../services/acp-sessions";
 import { gatewayRoutes } from "./gateway";
@@ -212,7 +214,7 @@ function receivedEvents(client: WsClient): AcpEvent[] {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 test(
-  "POST create → 201 idle row; 400 invalid mode; 401 anonymous; 403 no capability; 404 unknown station; 409 duplicate; GET lists newest first",
+  "POST create → 201 idle row; 400 invalid mode; 401 anonymous; 403 no capability; 404 unknown station; a second concurrent session is allowed; GET lists newest first",
   async () => {
     const { server, nodeId, fake, station, baseUrl } = await setupRig(
       "acproute-rest-host"
@@ -258,9 +260,14 @@ test(
       expect(row.mode).toBe("ask");
       expect(row.status).toBe("idle");
 
-      // 409 — an active session already exists.
-      const dup = await createSessionReq(baseUrl, station.id, { mode: "ask" });
-      expect(dup.status).toBe(409);
+      // A second concurrent session is allowed — the node echoes the instance,
+      // so each session gets its own agent process.
+      const second = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(second.status).toBe(201);
+      const rowB = (await second.json()) as AcpSessionRow;
+      expect(rowB.id).not.toBe(row.id);
+      await endSession(TEST_USER, rowB.id, "test done");
+      await rawSql`DELETE FROM acp_sessions WHERE id = ${rowB.id}`;
 
       // End it, create a second one; GET must list newest first.
       await endSession(TEST_USER, row.id, "test done");
@@ -289,6 +296,82 @@ test(
       expect(listMissing.status).toBe(404);
 
       await endSession(TEST_USER, row2.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "POST → 409 when the node cannot host a second session (it never echoes the instance)",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-legacy-host",
+      { stationKey: "acproute-legacy", legacyOpen: true }
+    );
+    try {
+      const first = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(first.status).toBe(201);
+      const row = (await first.json()) as AcpSessionRow;
+
+      const dup = await createSessionReq(baseUrl, station.id, { mode: "ask" });
+      expect(dup.status).toBe(409);
+      expect(((await dup.json()) as { error: string }).error).toBe(
+        "An active session already exists for this agent."
+      );
+
+      await endSession(TEST_USER, row.id, "test done");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "GET lists sessions newest-ACTIVITY first (from SQL): a prompt floats the older session above a newer idle one",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-order-host",
+      { stationKey: "acproute-order" }
+    );
+    const listIds = async () => {
+      const res = await fetch(
+        `${baseUrl}/api/stations/${station.id}/acp/sessions`,
+        { headers: { "X-Test-User-Id": TEST_USER } }
+      );
+      return ((await res.json()) as AcpSessionRow[]).map((r) => r.id);
+    };
+    try {
+      const aRes = await createSessionReq(baseUrl, station.id, {
+        mode: "full-auto",
+      });
+      expect(aRes.status).toBe(201);
+      const a = (await aRes.json()) as AcpSessionRow;
+      await new Promise((r) => setTimeout(r, 30)); // distinct timestamps
+      const bRes = await createSessionReq(baseUrl, station.id, {
+        mode: "full-auto",
+      });
+      expect(bRes.status).toBe(201);
+      const b = (await bRes.json()) as AcpSessionRow;
+
+      // Both live: the newer one leads.
+      expect(await listIds()).toEqual([b.id, a.id]);
+
+      // Activity on the OLDER session floats it to the top — a createdAt sort
+      // would still report the newer one first.
+      await new Promise((r) => setTimeout(r, 30));
+      await promptSession(TEST_USER, a.id, "wake up");
+      await pollUntil(async () => (await listIds())[0] === a.id);
+      expect(await listIds()).toEqual([a.id, b.id]);
+
+      await endSession(TEST_USER, a.id, "test done");
+      await endSession(TEST_USER, b.id, "test done");
       fake.close();
       await new Promise((r) => setTimeout(r, 100));
     } finally {

--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -4,9 +4,9 @@
  * REST (mounted at /api in index.ts):
  *   POST /stations/:id/acp/sessions {mode} → 201 AcpSessionRow
  *        (400 invalid mode, 401 anonymous, 403 no acp capability,
- *         404 unknown station, 409 active session exists,
+ *         404 unknown station, 409 the node can't host a second session,
  *         502 node offline / agent open failure)
- *   GET  /stations/:id/acp/sessions → AcpSessionRow[] (newest first)
+ *   GET  /stations/:id/acp/sessions → AcpSessionRow[] (newest activity first)
  *   DELETE /acp/sessions/:sessionId → 204 (ends the session; WS clients get
  *        {t:"bye"}); 401 anonymous, 404 absent/foreign
  *
@@ -60,6 +60,8 @@ import type { AuthUser } from "../auth/middleware";
 function createErrorStatus(message: string): 403 | 404 | 409 | 502 {
   if (message === "Station not found.") return 404;
   if (message === "This station does not support agent sessions.") return 403;
+  // Raised only when the node can't key processes per session (no instance
+  // echo) and one is already live — the exact string the service throws.
   if (message === "An active session already exists for this agent.") return 409;
   return 502;
 }
@@ -104,7 +106,8 @@ export const stationAcpRoutes = new Hono()
   /**
    * GET /api/stations/:id/acp/sessions
    *
-   * Lists the caller's sessions for the station, newest first.
+   * Lists the caller's sessions for the station, newest ACTIVITY first (the
+   * service orders in SQL by last_event_at desc, id desc).
    */
   .get("/stations/:id/acp/sessions", async (c) => {
     const user = c.get("user") as AuthUser | undefined;
@@ -118,22 +121,18 @@ export const stationAcpRoutes = new Hono()
       return c.json({ error: "Not Found" }, 404);
     }
 
+    // Already ordered newest-activity-first in SQL — never re-sort here.
     const rows = await acp.listSessions(user.id, stationId);
-    // Newest first (createdAt is an ISO string — lexicographic order works).
-    rows.sort(
-      (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id)
-    );
     return c.json(rows);
   })
 
   /**
    * DELETE /api/acp/sessions/:sessionId
    *
-   * Ends a session (hub-owned). Live sessions tear down the agent process on
-   * the node; attached WS clients receive {t:"bye"} via the service fan-out
-   * (the state-ended event). Stale rows are just marked ended. With
-   * single-session-per-station this is also how a healthy idle session is
-   * released so a new one can start.
+   * Ends a session (hub-owned). Live sessions tear down their OWN agent process
+   * on the node — siblings on the same station keep running; attached WS clients
+   * receive {t:"bye"} via the service fan-out (the state-ended event). Stale
+   * rows are just marked ended.
    *
    * 204 on success (matches the stations/runtimes DELETE precedent);
    * 404 when the session is absent or belongs to another user.

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -1175,8 +1175,11 @@ test(
 test(
   "two concurrent sessions on one station: each acp.open carries its own instance, transcripts stream independently, ending one leaves the other live",
   async () => {
+    // exitOnClose: ending one session really kills its agent process, so
+    // "the sibling survives" is a claim about the code, not about the fake.
     const { server, fake, station } = await setupRig("acpsess-multi-host", {
       stationKey: "acp-multi-station",
+      exitOnClose: true,
     });
     try {
       const a = await createSession({
@@ -1323,8 +1326,11 @@ test(
 test(
   "a node that stops echoing the instance mid-life: the post-open layer tears the new wire down and refuses, leaving no live entry",
   async () => {
+    // exitOnClose: closing an agent process really kills it here, so the
+    // teardown's effect on the session sharing that process is not hidden.
     const { server, fake, station } = await setupRig("acpsess-noecho-host", {
       stationKey: "acp-noecho-station",
+      exitOnClose: true,
     });
     try {
       const a = await createSession({
@@ -1354,10 +1360,20 @@ test(
       const refusedEvents = await eventsFor(refused.id);
       expect(refusedEvents.some((e) => e.type === "error")).toBe(true);
 
-      // A's row is still live, and no live entry leaked: once A ends a fresh
-      // session starts (the node still can't echo, so one at a time).
-      expect((await getSession(TEST_USER, a.id))?.status).toBe("idle");
-      await endSession(TEST_USER, a.id, "cleanup");
+      // KNOWN RESIDUAL HAZARD, pinned rather than hidden: the node handed back
+      // A's process, so tearing the refused wire down closes it and takes A with
+      // it. This costs one session instead of bleeding two conversations into one
+      // process, and layer 1 keeps it unreachable for any node that never echoes
+      // (only a node that echoed and then stopped can get here).
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, a.id);
+        return s?.status === "ended";
+      });
+      // …and it ended from the process exit, not from anything the hub decided.
+      expect((await getSession(TEST_USER, a.id))?.endedReason).toBe("closed");
+
+      // No live entry leaked either: a fresh session starts (the node still
+      // can't echo, so one at a time).
       const next = await createSession({
         stationId: station.id,
         userId: TEST_USER,
@@ -1369,6 +1385,50 @@ test(
       fake.close();
       await new Promise((r) => setTimeout(r, 100));
     } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "a queued open re-reads the station: the node going offline while it waits is refused, not dialled",
+  async () => {
+    // The first open wedges on the handshake, so the second create sits in the
+    // station's open queue long enough for the fleet to change under it.
+    _setHandshakeTimeoutMsForTest(1500);
+    const { server, fake, station } = await setupRig("acpsess-requeue-host", {
+      stationKey: "acp-requeue-station",
+      hangHandshake: "initialize",
+    });
+    try {
+      // Settle both outcomes as values so neither can become an unhandled
+      // rejection while the other is being asserted.
+      const outcome = (p: Promise<unknown>) =>
+        p.then(
+          () => "resolved",
+          (err) => String(err)
+        );
+      const first = outcome(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      );
+      await new Promise((r) => setTimeout(r, 100));
+      // Passes the fail-fast gates while the node is still online, then queues.
+      const queued = outcome(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      );
+      await new Promise((r) => setTimeout(r, 100));
+      fake.close();
+
+      // The wedged open fails (dropped connection or handshake deadline)…
+      expect(await first).not.toBe("resolved");
+      // …and the queued one re-read the station instead of dialling a node that
+      // is no longer there.
+      expect(await queued).toContain("Node is offline.");
+
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      _setHandshakeTimeoutMsForTest(30_000);
       server.stop(true);
     }
   },

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -67,6 +67,7 @@ import {
   reconcileOnBoot,
   closeOrphanedProcesses,
   _setOfflineGraceMsForTest,
+  _setOpenDbTimeoutMsForTest,
   _setHandshakeTimeoutMsForTest,
 } from "./acp-sessions";
 
@@ -1428,6 +1429,76 @@ test(
 
       await new Promise((r) => setTimeout(r, 100));
     } finally {
+      _setHandshakeTimeoutMsForTest(30_000);
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "a stalled DB write inside the open phase rejects with the database copy and still drains the live map (no 409 lock on the station)",
+  async () => {
+    // The station's transcript table is locked for the duration, so the open
+    // phase's idle state-event insert BLOCKS — a real stalled query, not a mock.
+    _setHandshakeTimeoutMsForTest(2000);
+    _setOpenDbTimeoutMsForTest(300);
+    const { server, fake, station } = await setupRig("acpsess-dbstall-host", {
+      stationKey: "acp-dbstall-station",
+    });
+    let releaseLock!: () => void;
+    const lockHeld = new Promise<void>((r) => {
+      releaseLock = r;
+    });
+    let signalLocked!: () => void;
+    const locked = new Promise<void>((r) => {
+      signalLocked = r;
+    });
+    // EXCLUSIVE conflicts with the INSERT's ROW EXCLUSIVE but not with reads.
+    const lockTx = rawSql.begin(async (tx) => {
+      await tx`LOCK TABLE acp_events IN EXCLUSIVE MODE`;
+      signalLocked();
+      await lockHeld;
+    });
+    try {
+      await locked;
+
+      const attempt = createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      }).then(
+        () => "resolved",
+        (err) => String(err)
+      );
+      // Long enough for the bounded DB step to trip while the table is locked.
+      await new Promise((r) => setTimeout(r, 900));
+      releaseLock();
+      await lockTx;
+
+      // The per-step DB deadline is what fired — not the open-phase backstop.
+      expect(await attempt).toContain("the database didn't respond");
+
+      // The failure exit still ran once the DB freed up: the row is ended and
+      // nothing is left in the live map, so the station is NOT 409-locked.
+      const rows = await listSessions(TEST_USER, station.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.status).toBe("ended");
+      expect(rows[0]!.endedReason).toContain("the database didn't respond");
+
+      const next = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      expect(next.status).toBe("idle");
+
+      await endSession(TEST_USER, next.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      releaseLock();
+      _setOpenDbTimeoutMsForTest(10_000);
       _setHandshakeTimeoutMsForTest(30_000);
       server.stop(true);
     }

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -4,9 +4,9 @@
  * Verifies src/services/acp-sessions.ts against a fake node speaking scripted
  * ACP (tests/helpers/acp-fake-node.ts):
  *
- *   1. createSession → row idle + state event persisted; single live session
- *      per station; capability/ownership/online gates; open-failure marks the
- *      row ended with an error event.
+ *   1. createSession → row idle + state event persisted;
+ *      capability/ownership/online gates; open-failure marks the row ended
+ *      with an error event.
  *   2. promptSession → user-prompt / state working / agent-update / state idle
  *      ordering by seq; audit row (chars only, never text); subscribe fan-out.
  *   3. ask mode parks the permission (status waiting); answerPermission
@@ -18,7 +18,11 @@
  *   7. wrong-user access → null / empty / throws.
  *   8. endSession closes the wire (node sees acp.close) + row ended + event.
  *   9. node offline mid-session → waiting + grace end.
- *  10. reconcileOnBoot marks stale rows ended and best-effort closes orphans.
+ *  10. reconcileOnBoot marks stale rows ended and best-effort closes orphans,
+ *      each row's OWN node_session_id, never one a live session holds.
+ *  11. Slice 4b: several live sessions per station — distinct instances and
+ *      node processes, independent transcripts, independent teardown; a node
+ *      that doesn't echo the instance keeps the one-at-a-time behaviour.
  *
  * Uses the local Docker test-postgres (localhost:5434).
  * DATABASE_URL must be set before any src/ modules are imported.
@@ -61,6 +65,7 @@ import {
   endSession,
   subscribe,
   reconcileOnBoot,
+  closeOrphanedProcesses,
   _setOfflineGraceMsForTest,
   _setHandshakeTimeoutMsForTest,
 } from "./acp-sessions";
@@ -147,9 +152,12 @@ async function eventsFor(sessionId: string) {
     .orderBy(asc(acpEvents.seq));
 }
 
+/** The shape both persisted rows and fanned-out events share. */
+type EventLike = { seq: number; type: string; payload?: unknown };
+
 async function pollForEvent(
   sessionId: string,
-  match: (e: { type: string; payload: unknown }) => boolean,
+  match: (e: EventLike) => boolean,
   timeoutMs = 8000
 ) {
   const deadline = Date.now() + timeoutMs;
@@ -166,13 +174,46 @@ async function pollForEvent(
   }
 }
 
-const stateWith = (status: string) => (e: { type: string; payload: unknown }) =>
-  e.type === "state" && (e.payload as { status?: string }).status === status;
+const stateWith =
+  (status: string) => (e: { type: string; payload?: unknown }) =>
+    e.type === "state" && (e.payload as { status?: string }).status === status;
+
+/** The node process id recorded on a session row. */
+async function nodeSessionIdOf(sessionId: string): Promise<string | null> {
+  const rows = await db
+    .select()
+    .from(acpSessions)
+    .where(eq(acpSessions.id, sessionId));
+  return rows[0]?.nodeSessionId ?? null;
+}
+
+/** acp.open requests the node received, in order. */
+function opensSeenBy(fake: { nodeMsgs: string[] }) {
+  return parsedNodeMsgs(fake.nodeMsgs).filter(
+    (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.open"
+  ) as Array<{ params?: { instance?: string; key?: string } }>;
+}
+
+/** acp.close requests the node received, in order of sessionId. */
+function closesSeenBy(fake: { nodeMsgs: string[] }): string[] {
+  return parsedNodeMsgs(fake.nodeMsgs)
+    .filter(
+      (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+    )
+    .map(
+      (m) => (m as { params?: { sessionId?: string } }).params?.sessionId ?? ""
+    );
+}
+
+const promptTexts = (evts: Array<{ type: string; payload: unknown }>) =>
+  evts
+    .filter((e) => e.type === "user-prompt")
+    .map((e) => (e.payload as { text: string }).text);
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 test(
-  "createSession: row idle + state event; duplicate refused; endSession closes wire (node sees acp.close) + row ended + event",
+  "createSession: row idle + state event; endSession closes its own wire (node sees acp.close) + row ended + event",
   async () => {
     const { server, fake, station } = await setupRig("acpsess-create-host");
     try {
@@ -195,10 +236,16 @@ test(
       expect(evts[0]!.type).toBe("state");
       expect((evts[0]!.payload as { status: string }).status).toBe("idle");
 
-      // Single live session per station.
-      await expect(
-        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
-      ).rejects.toThrow("An active session already exists for this agent.");
+      // A second live session is allowed on a node that echoes the instance
+      // (independence is covered by the multi-session test below).
+      const sibling = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      expect(sibling.id).not.toBe(row.id);
+      expect(sibling.status).toBe("idle");
+      await endSession(TEST_USER, sibling.id, "cleanup");
 
       // getSession / listSessions surface the row.
       const fetched = await getSession(TEST_USER, row.id);
@@ -206,16 +253,19 @@ test(
       const listed = await listSessions(TEST_USER, station.id);
       expect(listed.map((s) => s.id)).toContain(row.id);
 
-      // endSession → node sees acp.close, row ended, state ended event.
+      // endSession → node sees acp.close for THIS session's process id, row
+      // ended, state ended event.
       await endSession(TEST_USER, row.id, "user closed");
       const closeReq = await pollUntil(() =>
         parsedNodeMsgs(fake.nodeMsgs).find(
-          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+          (m) =>
+            m.type === "req" &&
+            (m as { verb?: string }).verb === "acp.close" &&
+            (m as { params?: { sessionId?: string } }).params?.sessionId ===
+              "acp-proc-1"
         )
       );
-      expect((closeReq as { params: { sessionId: string } }).params.sessionId).toBe(
-        "acp-proc-1"
-      );
+      expect(closeReq).toBeTruthy();
 
       const ended = await getSession(TEST_USER, row.id);
       expect(ended?.status).toBe("ended");
@@ -383,7 +433,7 @@ test(
       // Turn ends back at idle (skip seq 1 = the create-time idle event).
       const { all } = await pollForEvent(
         row.id,
-        (e) => stateWith("idle")(e) && (e as { seq: number }).seq > 1,
+        (e) => stateWith("idle")(e) && e.seq > 1,
         8000
       );
 
@@ -770,10 +820,43 @@ test(
 );
 
 test(
-  "concurrent createSession for the same station: exactly one wins, the other gets the active-session error",
+  "concurrent createSession for the same station: a node that echoes instances hosts both; a legacy node lets exactly one win",
   async () => {
     const { server, fake, station } = await setupRig("acpsess-race-host", {
       stationKey: "acp-race-station",
+    });
+    try {
+      const results = await Promise.allSettled([
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" }),
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" }),
+      ]);
+      expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(2);
+      const both = results.map(
+        (r) => (r as PromiseFulfilledResult<{ id: string }>).value
+      );
+      expect(new Set(both.map((s) => s.id)).size).toBe(2);
+      // Distinct agent processes on the node — never one shared process.
+      const procIds = await Promise.all(
+        both.map(async (s) => (await nodeSessionIdOf(s.id))!)
+      );
+      expect(new Set(procIds).size).toBe(2);
+
+      for (const s of both) await endSession(TEST_USER, s.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "concurrent createSession against a legacy node: exactly one wins, the loser gets the active-session error",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-race-legacy-host", {
+      stationKey: "acp-race-legacy-station",
+      legacyOpen: true,
     });
     try {
       const results = await Promise.allSettled([
@@ -787,6 +870,13 @@ test(
       expect(String((lost[0] as PromiseRejectedResult).reason)).toContain(
         "An active session already exists for this agent."
       );
+
+      // Only ONE process was ever opened: the loser never reached the node.
+      expect(
+        parsedNodeMsgs(fake.nodeMsgs).filter(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.open"
+        )
+      ).toHaveLength(1);
 
       const winner = (won[0] as PromiseFulfilledResult<{ id: string }>).value;
       await endSession(TEST_USER, winner.id, "cleanup");
@@ -1001,6 +1091,21 @@ test(
         createdAt: new Date(),
       });
 
+      // A SECOND stale row on the SAME station with its own process id (two
+      // concurrent sessions before the restart) — each must be closed by id.
+      const staleId2 = `acps_${crypto.randomUUID()}`;
+      await db.insert(acpSessions).values({
+        id: staleId2,
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+        status: "idle",
+        endedReason: null,
+        nodeSessionId: "acp-proc-stale-43",
+        createdAt: new Date(),
+        lastEventAt: new Date(),
+      });
+
       // A stale row whose station is gone (transcript survives; no close possible).
       const orphanId = `acps_${crypto.randomUUID()}`;
       await db.insert(acpSessions).values({
@@ -1017,7 +1122,7 @@ test(
 
       await reconcileOnBoot();
 
-      for (const id of [staleId, orphanId]) {
+      for (const id of [staleId, staleId2, orphanId]) {
         const s = await getSession(TEST_USER, id);
         expect(s?.status).toBe("ended");
         expect(s?.endedReason).toBe("hub restarted");
@@ -1028,17 +1133,11 @@ test(
       expect((staleEvts.at(-1)!.payload as { status: string }).status).toBe("ended");
       expect(staleEvts.at(-1)!.seq).toBe(2);
 
-      // Online node got a best-effort acp.close for the orphaned process id.
-      const closeReq = await pollUntil(() =>
-        parsedNodeMsgs(fake.nodeMsgs).find(
-          (m) =>
-            m.type === "req" &&
-            (m as { verb?: string }).verb === "acp.close" &&
-            (m as { params?: { sessionId?: string } }).params?.sessionId ===
-              "acp-proc-stale-42"
-        )
+      // Online node got a best-effort acp.close for EACH row's own process id.
+      await pollUntil(() =>
+        closesSeenBy(fake).includes("acp-proc-stale-42") &&
+        closesSeenBy(fake).includes("acp-proc-stale-43")
       );
-      expect(closeReq).toBeTruthy();
 
       // Boot-time close clears the marker (once-only); the station-less
       // orphan keeps its marker (transcript row survives, nothing to close).
@@ -1047,6 +1146,13 @@ test(
           .select()
           .from(acpSessions)
           .where(eq(acpSessions.id, staleId));
+        return r[0]?.nodeSessionId === null;
+      });
+      await pollUntil(async () => {
+        const r = await db
+          .select()
+          .from(acpSessions)
+          .where(eq(acpSessions.id, staleId2));
         return r[0]?.nodeSessionId === null;
       });
       const orphanRow = await db
@@ -1062,4 +1168,291 @@ test(
     }
   },
   20_000
+);
+
+// ─── Slice 4b: several live sessions per station ───────────────────────────────
+
+test(
+  "two concurrent sessions on one station: each acp.open carries its own instance, transcripts stream independently, ending one leaves the other live",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-multi-host", {
+      stationKey: "acp-multi-station",
+    });
+    try {
+      const a = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+      const b = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+      expect(a.id).not.toBe(b.id);
+      expect(a.status).toBe("idle");
+      expect(b.status).toBe("idle");
+
+      // Each open carried the hub session id as its instance — two distinct ones.
+      const opens = opensSeenBy(fake);
+      expect(opens).toHaveLength(2);
+      expect(opens.map((o) => o.params?.instance)).toEqual([a.id, b.id]);
+
+      // …and the node spawned a distinct process per session, recorded per row.
+      const procA = (await nodeSessionIdOf(a.id))!;
+      const procB = (await nodeSessionIdOf(b.id))!;
+      expect(procA).toBeTruthy();
+      expect(procB).toBeTruthy();
+      expect(procA).not.toBe(procB);
+      expect(fake.processFor(a.id)!.sessionId).toBe(procA);
+      expect(fake.processFor(b.id)!.sessionId).toBe(procB);
+
+      // A prompt in A never appears in B's transcript.
+      await promptSession(TEST_USER, a.id, "hello from A");
+      await pollForEvent(
+        a.id,
+        (e) => stateWith("idle")(e) && e.seq > 1
+      );
+      const aEvents = await eventsFor(a.id);
+      expect(promptTexts(aEvents)).toEqual(["hello from A"]);
+      expect(aEvents.some((e) => e.type === "agent-update")).toBe(true);
+
+      const bEvents = await eventsFor(b.id);
+      expect(bEvents).toHaveLength(1); // only its own create-time idle state
+      expect(promptTexts(bEvents)).toEqual([]);
+      expect(bEvents.some((e) => e.type === "agent-update")).toBe(false);
+
+      // B's own prompt runs on B's process and stays out of A's transcript.
+      await promptSession(TEST_USER, b.id, "hello from B");
+      await pollForEvent(
+        b.id,
+        (e) => stateWith("idle")(e) && e.seq > 1
+      );
+      const bAfter = await eventsFor(b.id);
+      expect(promptTexts(bAfter)).toEqual(["hello from B"]);
+      expect(bAfter.some((e) => e.type === "agent-update")).toBe(true);
+      expect(promptTexts(await eventsFor(a.id))).toEqual(["hello from A"]);
+      expect(
+        fake
+          .processFor(b.id)!
+          .agentReceived.some((m) => m.method === "session/prompt")
+      ).toBe(true);
+
+      // Ending A closes A's process only; B stays live and usable.
+      await endSession(TEST_USER, a.id, "done with A");
+      await pollUntil(() => closesSeenBy(fake).includes(procA));
+      expect(closesSeenBy(fake)).not.toContain(procB);
+      expect((await getSession(TEST_USER, a.id))?.status).toBe("ended");
+      expect((await getSession(TEST_USER, b.id))?.status).toBe("idle");
+
+      await promptSession(TEST_USER, b.id, "still alive");
+      await pollForEvent(
+        b.id,
+        (e) =>
+          e.type === "user-prompt" &&
+          (e.payload as { text: string }).text === "still alive"
+      );
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, b.id);
+        return s?.status === "idle";
+      });
+      expect(closesSeenBy(fake)).not.toContain(procB);
+
+      await endSession(TEST_USER, b.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "legacy node (no instance echo): the second createSession is refused with the pinned error before any second open, leaving no stray row, live entry or wire",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-legacy-host", {
+      stationKey: "acp-legacy-station",
+      legacyOpen: true,
+    });
+    try {
+      const a = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+      expect(a.status).toBe("idle");
+
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("An active session already exists for this agent.");
+
+      // Refused BEFORE touching the node: no second acp.open, no leaked wire.
+      expect(opensSeenBy(fake)).toHaveLength(1);
+      // …and no stray session row for the refused attempt.
+      const rows = await listSessions(TEST_USER, station.id);
+      expect(rows.map((r) => r.id)).toEqual([a.id]);
+
+      // The live session is untouched and still usable.
+      await promptSession(TEST_USER, a.id, "still mine");
+      await pollForEvent(
+        a.id,
+        (e) => stateWith("idle")(e) && e.seq > 1
+      );
+      expect(promptTexts(await eventsFor(a.id))).toEqual(["still mine"]);
+
+      // Ending it releases the station — no 409 lock.
+      await endSession(TEST_USER, a.id, "cleanup");
+      const next = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      expect(next.status).toBe("idle");
+      await endSession(TEST_USER, next.id, "cleanup");
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "a node that stops echoing the instance mid-life: the post-open layer tears the new wire down and refuses, leaving no live entry",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-noecho-host", {
+      stationKey: "acp-noecho-station",
+    });
+    try {
+      const a = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+      expect(a.status).toBe("idle");
+
+      // The node degrades: it still accepts acp.open but stops echoing, so the
+      // process it hands back may be the one session A is already using. Only
+      // the post-open layer can catch that.
+      fake.opts.legacyOpen = true;
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("An active session already exists for this agent.");
+
+      // The refused attempt did reach the node, and its row is ended with the
+      // pinned reason + an error event (the standard failure exit).
+      expect(opensSeenBy(fake)).toHaveLength(2);
+      const rows = await listSessions(TEST_USER, station.id);
+      const refused = rows.find((r) => r.id !== a.id)!;
+      expect(refused.status).toBe("ended");
+      expect(refused.endedReason).toBe(
+        "An active session already exists for this agent."
+      );
+      const refusedEvents = await eventsFor(refused.id);
+      expect(refusedEvents.some((e) => e.type === "error")).toBe(true);
+
+      // A's row is still live, and no live entry leaked: once A ends a fresh
+      // session starts (the node still can't echo, so one at a time).
+      expect((await getSession(TEST_USER, a.id))?.status).toBe("idle");
+      await endSession(TEST_USER, a.id, "cleanup");
+      const next = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      expect(next.status).toBe("idle");
+      await endSession(TEST_USER, next.id, "cleanup");
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "closeOrphanedProcesses: closes each ended row's own node session id, never one a live session is holding",
+  async () => {
+    const { server, nodeId, fake, station } = await setupRig(
+      "acpsess-orphan-multi-host",
+      { stationKey: "acp-orphan-multi-station" }
+    );
+    try {
+      const live = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+      });
+      const liveProc = (await nodeSessionIdOf(live.id))!;
+      expect(liveProc).toBeTruthy();
+
+      // Two orphan markers with their own process ids (two sessions that ended
+      // while the node was away) …
+      const orphanProcs = ["acp-proc-multi-a", "acp-proc-multi-b"];
+      const orphanIds: string[] = [];
+      for (const proc of orphanProcs) {
+        const id = `acps_${crypto.randomUUID()}`;
+        orphanIds.push(id);
+        await db.insert(acpSessions).values({
+          id,
+          stationId: station.id,
+          userId: TEST_USER,
+          mode: "ask",
+          status: "ended",
+          endedReason: "node went away",
+          nodeSessionId: proc,
+          createdAt: new Date(),
+          lastEventAt: new Date(),
+        });
+      }
+      // … and a poisoned marker pointing at the process the LIVE session holds.
+      const poisonedId = `acps_${crypto.randomUUID()}`;
+      await db.insert(acpSessions).values({
+        id: poisonedId,
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "ask",
+        status: "ended",
+        endedReason: "node went away",
+        nodeSessionId: liveProc,
+        createdAt: new Date(),
+        lastEventAt: new Date(),
+      });
+
+      await closeOrphanedProcesses(nodeId);
+
+      // Each orphan closed by its own id, markers cleared.
+      await pollUntil(() =>
+        orphanProcs.every((proc) => closesSeenBy(fake).includes(proc))
+      );
+      for (const id of orphanIds) {
+        const r = await db
+          .select()
+          .from(acpSessions)
+          .where(eq(acpSessions.id, id));
+        expect(r[0]!.nodeSessionId).toBeNull();
+      }
+
+      // The live session's process was never closed and keeps its marker.
+      expect(closesSeenBy(fake)).not.toContain(liveProc);
+      const poisoned = await db
+        .select()
+        .from(acpSessions)
+        .where(eq(acpSessions.id, poisonedId));
+      expect(poisoned[0]!.nodeSessionId).toBe(liveProc);
+      expect((await getSession(TEST_USER, live.id))?.status).toBe("idle");
+
+      await endSession(TEST_USER, live.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
 );

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -451,7 +451,10 @@ export async function createSession(
       lastEventAt: now,
     });
 
-    const wire = await openAcpWire(station.nodeId, station.stationKey);
+    // The hub session id doubles as the ACP instance: stable by construction
+    // across a re-open of this session, and it correlates node-side processes
+    // back to this row in logs.
+    const wire = await openAcpWire(station.nodeId, station.stationKey, id);
     live.wire = wire;
 
     const app = client({ name: "agentpod-hub" })

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -451,15 +451,33 @@ function handlePermissionRequest(
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
- * Serializes the open phase per station.
+ * Serializes the open phase per station — the other half of layer 1.
  *
- * Whether a node can host concurrent sessions is only knowable from a
- * COMPLETED acp.open (the echoed instance). Two opens in flight at once would
- * both pass the pre-open check and — on a node without instance support —
- * commit two hub sessions to ONE agent process before either could refuse.
- * One at a time keeps the refusal in the cheap pre-open layer.
+ * Layer 1 refuses on `instanceEchoed !== true`, and a session's verdict is null
+ * until ITS acp.open completes. So without this lock two simultaneous creates on
+ * a perfectly modern station would race: the second would see the first's null
+ * verdict and 409 a session that is entirely legal. Queueing the open phase
+ * means the second create reads a settled verdict and only refuses for real.
+ *
+ * The strict check and this lock are a PAIR, and dismantling either re-opens
+ * two-hub-sessions-on-one-agent-process for pre-instance nodes:
+ *   - relax layer 1 to `=== false` and two concurrent opens on an old node both
+ *     pass (neither has a verdict yet) and land on the same shared process,
+ *   - drop the lock and layer 1 has to stay strict, which spuriously 409s
+ *     legitimate concurrent creates.
+ * Layer 2 (post-open) is the last resort if both are somehow bypassed.
  */
 const openLocks = new Map<string, Promise<unknown>>();
+
+/**
+ * Ceiling on one queued open, so a stalled open fails instead of wedging the
+ * station: the ACP handshake carries its own deadline but the DB writes around
+ * it do not, and an unbounded open would park every later create behind it
+ * forever. Both handshake steps plus slack for the DB work.
+ */
+const OPEN_PHASE_SLACK_MS = 5_000;
+const OPEN_PHASE_TIMEOUT_MESSAGE =
+  "Couldn't start the agent process — it didn't finish starting in time.";
 
 function withStationOpenLock<T>(
   stationId: string,
@@ -468,7 +486,11 @@ function withStationOpenLock<T>(
   const prev = openLocks.get(stationId);
   const run = (async () => {
     if (prev) await prev.catch(() => {});
-    return fn();
+    return withDeadline(
+      fn(),
+      handshakeTimeoutMs * 2 + OPEN_PHASE_SLACK_MS,
+      OPEN_PHASE_TIMEOUT_MESSAGE
+    );
   })();
   openLocks.set(stationId, run);
   void run.then(
@@ -483,8 +505,10 @@ function withStationOpenLock<T>(
 export async function createSession(
   input: CreateSessionInput
 ): Promise<AcpSessionRow> {
-  const { stationId, userId, mode } = input;
+  const { stationId, userId } = input;
 
+  // Fail fast on the obvious gates before queueing (openSession re-checks them
+  // under the lock, where the answers are current).
   const station = await getStation(userId, stationId);
   if (!station) throw new Error("Station not found.");
   if (!gateCapability(station, "acp")) {
@@ -494,24 +518,33 @@ export async function createSession(
     throw new Error("Node is offline.");
   }
 
-  return withStationOpenLock(stationId, () =>
-    openSession(station.nodeId, station.stationKey, station.workspacePath, input)
-  );
+  return withStationOpenLock(stationId, () => openSession(input));
 }
 
-async function openSession(
-  nodeId: string,
-  stationKey: string,
-  workspacePath: string | null,
-  input: CreateSessionInput
-): Promise<AcpSessionRow> {
+async function openSession(input: CreateSessionInput): Promise<AcpSessionRow> {
   const { stationId, userId, mode } = input;
+
+  // Re-read the station and its node's presence: a queued open can start a
+  // minute after createSession was called, by which time the station may have
+  // been re-adopted onto another node, lost the capability, or gone offline.
+  // The open must target CURRENT routing, never the snapshot from the queue.
+  const station = await getStation(userId, stationId);
+  if (!station) throw new Error("Station not found.");
+  if (!gateCapability(station, "acp")) {
+    throw new Error("This station does not support agent sessions.");
+  }
+  if (!connectionManager.isOnline(station.nodeId)) {
+    throw new Error("Node is offline.");
+  }
+  const { nodeId, stationKey, workspacePath } = station;
 
   // ── Compatibility layer 1 (pre-open) ───────────────────────────────────────
   // A concurrent session is only safe when the node keys its agent processes on
   // (station key, instance). The one signal for that is a live sibling whose
   // acp.open echoed the instance back; anything else (an old node, or a sibling
-  // that never got that far) means one shared process — refuse.
+  // that never got that far) means one shared process — refuse. Runs with no
+  // await between it and addLive below, and under the station open lock, so no
+  // second open can slip past it (see withStationOpenLock).
   for (const sibling of liveByStation.get(stationId) ?? []) {
     if (sibling.instanceEchoed !== true) {
       throw new Error(ACTIVE_SESSION_MESSAGE);

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -81,6 +81,37 @@ export function _setHandshakeTimeoutMsForTest(ms: number): void {
 const HANDSHAKE_TIMEOUT_MESSAGE =
   "Couldn't start the agent process — the agent didn't respond (handshake timed out).";
 
+// Deadline for each DB step of the open phase. Postgres has no statement
+// timeout here (and must not get one — boot migrations share the client), so a
+// blocked query would otherwise hang openSession forever: its live-map entry is
+// already registered, its catch never runs, and layer 1 would refuse every
+// later create for that station until hub restart.
+let openDbTimeoutMs = 10_000;
+
+/** Test hook: shrink the per-step deadline for the open phase's DB writes. */
+export function _setOpenDbTimeoutMsForTest(ms: number): void {
+  openDbTimeoutMs = ms;
+}
+
+const OPEN_DB_TIMEOUT_MESSAGE =
+  "Couldn't start the agent process — the database didn't respond (write timed out).";
+
+/**
+ * Bound one DB step of the open phase so a stall REJECTS into openSession's
+ * catch (error event → finalizeEnd → live-map cleanup) instead of hanging.
+ * `step` names the culprit in the log; the thrown copy stays stable.
+ */
+function boundedDb<T>(promise: Promise<T>, step: string): Promise<T> {
+  return withDeadline(promise, openDbTimeoutMs, OPEN_DB_TIMEOUT_MESSAGE).catch(
+    (err: unknown) => {
+      if (err instanceof Error && err.message === OPEN_DB_TIMEOUT_MESSAGE) {
+        log.error("ACP open: database step timed out", { step });
+      }
+      throw err;
+    }
+  );
+}
+
 /**
  * Reject with `message` if `promise` doesn't settle within `ms`.
  *
@@ -470,14 +501,25 @@ function handlePermissionRequest(
 const openLocks = new Map<string, Promise<unknown>>();
 
 /**
- * Ceiling on one queued open, so a stalled open fails instead of wedging the
- * station: the ACP handshake carries its own deadline but the DB writes around
- * it do not, and an unbounded open would park every later create behind it
- * forever. Both handshake steps plus slack for the DB work.
+ * Backstop ceiling on one queued open, so a stalled open can never park every
+ * later create for that station behind it. Every step INSIDE the open phase has
+ * its own deadline (two handshake requests, four DB steps), and this ceiling is
+ * their sum plus slack — so a single stalled step always trips its own,
+ * attributable deadline first and this one only catches something unbounded
+ * that slipped in.
  */
 const OPEN_PHASE_SLACK_MS = 5_000;
+const OPEN_PHASE_DB_STEPS = 4;
 const OPEN_PHASE_TIMEOUT_MESSAGE =
   "Couldn't start the agent process — it didn't finish starting in time.";
+
+function openPhaseTimeoutMs(): number {
+  return (
+    handshakeTimeoutMs * 2 +
+    openDbTimeoutMs * OPEN_PHASE_DB_STEPS +
+    OPEN_PHASE_SLACK_MS
+  );
+}
 
 function withStationOpenLock<T>(
   stationId: string,
@@ -486,11 +528,7 @@ function withStationOpenLock<T>(
   const prev = openLocks.get(stationId);
   const run = (async () => {
     if (prev) await prev.catch(() => {});
-    return withDeadline(
-      fn(),
-      handshakeTimeoutMs * 2 + OPEN_PHASE_SLACK_MS,
-      OPEN_PHASE_TIMEOUT_MESSAGE
-    );
+    return withDeadline(fn(), openPhaseTimeoutMs(), OPEN_PHASE_TIMEOUT_MESSAGE);
   })();
   openLocks.set(stationId, run);
   void run.then(
@@ -581,17 +619,22 @@ async function openSession(input: CreateSessionInput): Promise<AcpSessionRow> {
   addLive(live);
 
   try {
-    await db.insert(acpSessions).values({
-      id,
-      stationId,
-      userId,
-      mode,
-      status: "starting",
-      endedReason: null,
-      nodeSessionId: null,
-      createdAt: now,
-      lastEventAt: now,
-    });
+    // Every DB step below is bounded (boundedDb): a stalled query must reject
+    // into the catch so the live-map entry is cleaned up, never hang holding it.
+    await boundedDb(
+      db.insert(acpSessions).values({
+        id,
+        stationId,
+        userId,
+        mode,
+        status: "starting",
+        endedReason: null,
+        nodeSessionId: null,
+        createdAt: now,
+        lastEventAt: now,
+      }),
+      "insert session row"
+    );
 
     // The hub session id doubles as the ACP instance: stable by construction
     // across a re-open of this session, and it correlates node-side processes
@@ -651,16 +694,19 @@ async function openSession(input: CreateSessionInput): Promise<AcpSessionRow> {
     );
     live.acpSessionId = created.sessionId;
 
-    await db
-      .update(acpSessions)
-      .set({ nodeSessionId: wire.nodeSessionId })
-      .where(eq(acpSessions.id, id));
-    await setStatus(live, "idle").done;
+    await boundedDb(
+      db
+        .update(acpSessions)
+        .set({ nodeSessionId: wire.nodeSessionId })
+        .where(eq(acpSessions.id, id)),
+      "record node session id"
+    );
+    await boundedDb(setStatus(live, "idle").done, "idle state event");
 
-    const rows = await db
-      .select()
-      .from(acpSessions)
-      .where(eq(acpSessions.id, id));
+    const rows = await boundedDb(
+      db.select().from(acpSessions).where(eq(acpSessions.id, id)),
+      "read back session row"
+    );
     return toContract(rows[0]!);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -15,12 +15,18 @@
  *   - live fan-out to subscribers (replay is the caller's job — read
  *     acp_events).
  *
- * Slice 2 scope: single live session per station, no reattach after node
- * offline (recorded as a slice-3 improvement — on wire eof the session parks
- * at `waiting` and a grace timer ends it).
+ * A station can host SEVERAL live sessions at once (slice 4b): each one opens
+ * its own ACP wire with the hub session id as the `instance`, so the node keys
+ * a separate agent process per session. Nodes that predate the instance
+ * discriminator hand the same process back for every instance — detectable
+ * only from `AcpWire.instanceEchoed` — and those stations stay
+ * one-session-at-a-time (see createSession).
+ *
+ * No reattach after the node goes offline: on wire eof the session parks at
+ * `waiting` and a grace timer ends it.
  */
 
-import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, ne, sql } from "drizzle-orm";
 import {
   client,
   ndJsonStream,
@@ -136,12 +142,66 @@ interface LiveSession {
   agent: ClientContext | null;
   /** ACP protocol session id from session/new (NOT the node process id). */
   acpSessionId: string;
+  /** Node process id from acp.open; null until the wire is open. */
+  nodeSessionId: string | null;
+  /**
+   * Did the node echo our instance on acp.open? null until the wire is open.
+   * `true` is the ONLY evidence that this node keys agent processes on
+   * (station key, instance) and can therefore host a concurrent session.
+   */
+  instanceEchoed: boolean | null;
   graceTimer: ReturnType<typeof setTimeout> | null;
 }
 
-const liveByStation = new Map<string, LiveSession>();
+/** Live sessions per station — one-to-many since slice 4b. */
+const liveByStation = new Map<string, Set<LiveSession>>();
 const liveById = new Map<string, LiveSession>();
 const subscribers = new Map<string, Set<(e: AcpEvent) => void>>();
+
+/** Verbatim copy the routes map to 409 — do not reword (tests pin it). */
+const ACTIVE_SESSION_MESSAGE = "An active session already exists for this agent.";
+
+function addLive(live: LiveSession): void {
+  let set = liveByStation.get(live.stationId);
+  if (!set) {
+    set = new Set();
+    liveByStation.set(live.stationId, set);
+  }
+  set.add(live);
+  liveById.set(live.id, live);
+}
+
+/** Identity-guarded removal; the station key drops when its last one goes. */
+function removeLive(live: LiveSession): void {
+  const set = liveByStation.get(live.stationId);
+  if (set) {
+    set.delete(live);
+    if (set.size === 0) liveByStation.delete(live.stationId);
+  }
+  if (liveById.get(live.id) === live) liveById.delete(live.id);
+}
+
+/** Live sessions on the station other than `self`. */
+function otherLive(stationId: string, self: LiveSession): LiveSession[] {
+  const set = liveByStation.get(stationId);
+  if (!set) return [];
+  return [...set].filter((s) => s !== self);
+}
+
+/**
+ * Is this node process id currently held by a LIVE session? Guards the
+ * orphan-cleanup paths: an ended row may carry the same node_session_id as a
+ * live session (a pre-instance node reuses one process per station key), and
+ * closing it would kill the live session's agent.
+ */
+function isNodeSessionIdLive(nodeId: string, nodeSessionId: string): boolean {
+  for (const live of liveById.values()) {
+    if (live.nodeId === nodeId && live.nodeSessionId === nodeSessionId) {
+      return true;
+    }
+  }
+  return false;
+}
 
 // ─── Row mapping ─────────────────────────────────────────────────────────────
 
@@ -282,10 +342,7 @@ async function finalizeEnd(live: LiveSession, reason: string): Promise<void> {
     endedReason: reason,
     force: true,
   });
-  if (liveByStation.get(live.stationId) === live) {
-    liveByStation.delete(live.stationId);
-  }
-  liveById.delete(live.id);
+  removeLive(live);
   try {
     live.connection?.close();
   } catch {
@@ -393,6 +450,36 @@ function handlePermissionRequest(
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/**
+ * Serializes the open phase per station.
+ *
+ * Whether a node can host concurrent sessions is only knowable from a
+ * COMPLETED acp.open (the echoed instance). Two opens in flight at once would
+ * both pass the pre-open check and — on a node without instance support —
+ * commit two hub sessions to ONE agent process before either could refuse.
+ * One at a time keeps the refusal in the cheap pre-open layer.
+ */
+const openLocks = new Map<string, Promise<unknown>>();
+
+function withStationOpenLock<T>(
+  stationId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const prev = openLocks.get(stationId);
+  const run = (async () => {
+    if (prev) await prev.catch(() => {});
+    return fn();
+  })();
+  openLocks.set(stationId, run);
+  void run.then(
+    () => {},
+    () => {}
+  ).then(() => {
+    if (openLocks.get(stationId) === run) openLocks.delete(stationId);
+  });
+  return run;
+}
+
 export async function createSession(
   input: CreateSessionInput
 ): Promise<AcpSessionRow> {
@@ -406,8 +493,29 @@ export async function createSession(
   if (!connectionManager.isOnline(station.nodeId)) {
     throw new Error("Node is offline.");
   }
-  if (liveByStation.has(stationId)) {
-    throw new Error("An active session already exists for this agent.");
+
+  return withStationOpenLock(stationId, () =>
+    openSession(station.nodeId, station.stationKey, station.workspacePath, input)
+  );
+}
+
+async function openSession(
+  nodeId: string,
+  stationKey: string,
+  workspacePath: string | null,
+  input: CreateSessionInput
+): Promise<AcpSessionRow> {
+  const { stationId, userId, mode } = input;
+
+  // ── Compatibility layer 1 (pre-open) ───────────────────────────────────────
+  // A concurrent session is only safe when the node keys its agent processes on
+  // (station key, instance). The one signal for that is a live sibling whose
+  // acp.open echoed the instance back; anything else (an old node, or a sibling
+  // that never got that far) means one shared process — refuse.
+  for (const sibling of liveByStation.get(stationId) ?? []) {
+    if (sibling.instanceEchoed !== true) {
+      throw new Error(ACTIVE_SESSION_MESSAGE);
+    }
   }
 
   const id = `acps_${crypto.randomUUID()}`;
@@ -416,8 +524,8 @@ export async function createSession(
     id,
     stationId,
     userId,
-    nodeId: station.nodeId,
-    stationKey: station.stationKey,
+    nodeId,
+    stationKey,
     mode,
     status: "starting",
     seq: 0,
@@ -429,14 +537,15 @@ export async function createSession(
     connection: null,
     agent: null,
     acpSessionId: "",
+    nodeSessionId: null,
+    instanceEchoed: null,
     graceTimer: null,
   };
-  // Register before any await so a concurrent createSession is refused
-  // (fresh-process semantics: single session per station in slice 2). Every
-  // failure exit below MUST run finalizeEnd, which removes these entries —
-  // a leaked entry would wedge the station with 409s until restart.
-  liveByStation.set(stationId, live);
-  liveById.set(id, live);
+  // Register before any await so siblings (and the layers above) can see this
+  // session while it is starting. Every failure exit below MUST run
+  // finalizeEnd, which removes these entries — a leaked entry would wedge the
+  // station with 409s until restart.
+  addLive(live);
 
   try {
     await db.insert(acpSessions).values({
@@ -454,8 +563,21 @@ export async function createSession(
     // The hub session id doubles as the ACP instance: stable by construction
     // across a re-open of this session, and it correlates node-side processes
     // back to this row in logs.
-    const wire = await openAcpWire(station.nodeId, station.stationKey, id);
+    const wire = await openAcpWire(nodeId, stationKey, id);
     live.wire = wire;
+    live.nodeSessionId = wire.nodeSessionId;
+    live.instanceEchoed = wire.instanceEchoed;
+
+    // ── Compatibility layer 2 (post-open) ────────────────────────────────────
+    // The node did not echo the instance, so this wire may well be the SAME
+    // agent process a sibling is already talking to — two conversations on one
+    // process and one input-frame key. Refuse rather than risk the bleed; the
+    // catch below tears this wire down (error event + finalizeEnd + node close).
+    // Layer 1 normally catches this first; this is the belt to its braces for
+    // the case where no live sibling had recorded an echo verdict yet.
+    if (!wire.instanceEchoed && otherLive(stationId, live).length > 0) {
+      throw new Error(ACTIVE_SESSION_MESSAGE);
+    }
 
     const app = client({ name: "agentpod-hub" })
       .onNotification("session/update", ({ params }) => {
@@ -488,7 +610,7 @@ export async function createSession(
       connection.agent.request("session/new", {
         // The SDK requires an absolute cwd; the station workspace is the
         // natural one, "/" the fallback for workspace-less stations.
-        cwd: station.workspacePath ?? "/",
+        cwd: workspacePath ?? "/",
         mcpServers: [],
       }),
       handshakeTimeoutMs,
@@ -515,6 +637,11 @@ export async function createSession(
   }
 }
 
+/**
+ * The caller's sessions for a station, newest ACTIVITY first (id desc breaks
+ * same-millisecond ties). Ordered in SQL so the console's session switcher and
+ * the history view share one read — callers must not re-sort.
+ */
 export async function listSessions(
   userId: string,
   stationId: string
@@ -524,7 +651,8 @@ export async function listSessions(
     .from(acpSessions)
     .where(
       and(eq(acpSessions.userId, userId), eq(acpSessions.stationId, stationId))
-    );
+    )
+    .orderBy(desc(acpSessions.lastEventAt), desc(acpSessions.id));
   return rows.map(toContract);
 }
 
@@ -739,7 +867,9 @@ export function subscribe(
 /**
  * Boot reconciliation: mark all non-ended sessions ended("hub restarted");
  * best-effort acp.close each orphaned nodeSessionId whose node is online at
- * boot (log the rest). Call from index.ts boot after initDatabase.
+ * boot (log the rest). Each row's OWN node_session_id is closed — several rows
+ * on one station now mean several distinct agent processes. Call from index.ts
+ * boot after initDatabase.
  */
 export async function reconcileOnBoot(): Promise<void> {
   const stale = await db
@@ -757,6 +887,15 @@ export async function reconcileOnBoot(): Promise<void> {
       .from(stations)
       .where(eq(stations.id, row.stationId));
     const nodeId = stationRows[0]?.nodeId;
+    if (nodeId && isNodeSessionIdLive(nodeId, row.nodeSessionId)) {
+      // A live session holds this process (only possible when a node shares one
+      // process across sessions). Never close it out from under that session.
+      log.info("ACP reconcile: node process held by a live session — not closed", {
+        sessionId: row.id,
+        nodeSessionId: row.nodeSessionId,
+      });
+      continue;
+    }
     if (nodeId && connectionManager.isOnline(nodeId)) {
       // Best-effort: broker.request never rejects; result is ignored.
       void broker.request(nodeId, "acp.close", {
@@ -789,10 +928,13 @@ export async function reconcileOnBoot(): Promise<void> {
  *
  * Orphan marker: an ENDED session row that still carries node_session_id
  * (live/normal ends clear it when the close was deliverable). Fires one
- * best-effort acp.close per orphan and clears the marker so it's once-only.
- * Never touches non-ended rows, so live sessions are safe.
+ * best-effort acp.close per orphan, for that row's OWN node_session_id, and
+ * clears the marker so it's once-only. Never touches non-ended rows, and skips
+ * any process a live session is still holding, so live sessions are safe.
+ *
+ * Exported for tests; production calls it from the node-online hook below.
  */
-async function closeOrphanedProcesses(nodeId: string): Promise<void> {
+export async function closeOrphanedProcesses(nodeId: string): Promise<void> {
   const orphans = await db
     .select({
       id: acpSessions.id,
@@ -808,6 +950,16 @@ async function closeOrphanedProcesses(nodeId: string): Promise<void> {
       )
     );
   for (const orphan of orphans) {
+    if (isNodeSessionIdLive(nodeId, orphan.nodeSessionId!)) {
+      // A live session is talking to this very process (possible when a node
+      // shares one process per station key): leave it — and its marker — alone.
+      log.info("ACP orphan cleanup: process held by a live session — skipped", {
+        sessionId: orphan.id,
+        nodeId,
+        nodeSessionId: orphan.nodeSessionId,
+      });
+      continue;
+    }
     // Best-effort: broker.request never rejects; result is ignored.
     void broker.request(nodeId, "acp.close", {
       sessionId: orphan.nodeSessionId!,

--- a/apps/hub/src/services/acp-transport.test.ts
+++ b/apps/hub/src/services/acp-transport.test.ts
@@ -11,6 +11,9 @@
  *   4. close() sends acp.close {sessionId} + a cancel for the attach stream;
  *      idempotent.
  *   5. acp.open failure → throws Error("Couldn't start the agent process — ...").
+ *   6. The caller's instance rides on acp.open, and `instanceEchoed` reports
+ *      whether the node understood it (an old node echoes nothing but must
+ *      still yield a fully working wire).
  *
  * Uses the local Docker test-postgres (localhost:5434).
  * DATABASE_URL must be set before any src/ modules are imported.
@@ -39,6 +42,8 @@ import { openAcpWire } from "./acp-transport";
 const TEST_USER = "test-user-acpwire-001";
 const STATION_KEY = "acpwire-station";
 const FAKE_SESSION_ID = "acp-session-xyz789";
+/** Stand-in for the hub session id the caller passes as the ACP instance. */
+const HUB_SESSION = "acps_wire-test-session";
 
 const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
 
@@ -73,7 +78,8 @@ afterAll(async () => {
 /**
  * Connect a fake node WS to the gateway and script the ACP verbs.
  *
- * - acp.open  → res {sessionId: FAKE_SESSION_ID} (or {ok:false} when failOpen)
+ * - acp.open  → res {sessionId: FAKE_SESSION_ID, instance: <echoed>} (or
+ *   {ok:false} when failOpen; no instance echo when legacyOpen — an old node)
  * - acp.attach → records the attach id, then emits opts.streamChunks (base64)
  *   followed by eof unless holdStream is set
  * - input frames → echoed back as stream chunks on the attach id
@@ -90,6 +96,7 @@ async function connectFakeNode(
     holdStream?: boolean;
     failOpen?: string; // respond to acp.open with ok:false and this error
     malformedOpen?: boolean; // respond to acp.open with ok:true but no sessionId
+    legacyOpen?: boolean; // old node: return only sessionId, never echo instance
   } = {}
 ): Promise<WebSocket> {
   const ws = new WebSocket(
@@ -172,12 +179,16 @@ async function connectFakeNode(
               })
             );
           } else {
+            const instance = msg.params?.instance as string | undefined;
             ws.send(
               JSON.stringify({
                 type: "res",
                 id: msg.id,
                 ok: true,
-                data: { sessionId: FAKE_SESSION_ID },
+                data:
+                  opts.legacyOpen || instance === undefined
+                    ? { sessionId: FAKE_SESSION_ID }
+                    : { sessionId: FAKE_SESSION_ID, instance },
               })
             );
           }
@@ -306,7 +317,7 @@ test(
         attachIdRef,
       });
 
-      const wire = await openAcpWire(nodeId, STATION_KEY);
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
       expect(wire.nodeSessionId).toBe(FAKE_SESSION_ID);
 
       // acp.open carried the station key; acp.attach carried the session id.
@@ -357,7 +368,7 @@ test(
         attachIdRef,
       });
 
-      const wire = await openAcpWire(nodeId, STATION_KEY);
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
       await pollUntil(() => attachIdRef[0]);
 
       const outbound = '{"jsonrpc":"2.0","id":7,"method":"initialize"}\n';
@@ -410,7 +421,7 @@ test(
         streamChunks: [b64(protocolLine), b64(exitFrame)],
       });
 
-      const wire = await openAcpWire(nodeId, STATION_KEY);
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
 
       const text = await readAllText(wire.readable);
       // Protocol bytes surfaced; the exit frame did NOT leak into readable.
@@ -456,7 +467,7 @@ test(
         streamChunks: [b64(half1), b64(half2)],
       });
 
-      const wire = await openAcpWire(nodeId, STATION_KEY);
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
 
       const text = await readAllText(wire.readable);
       expect(text).toBe(line);
@@ -488,7 +499,7 @@ test(
         attachIdRef,
       });
 
-      const wire = await openAcpWire(nodeId, STATION_KEY);
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
       await pollUntil(() => attachIdRef[0]);
 
       // Consumer-side teardown (what the SDK does on connection close) — must
@@ -547,7 +558,7 @@ test(
         attachIdRef,
       });
 
-      const wire = await openAcpWire(nodeId, STATION_KEY);
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
       await pollUntil(() => attachIdRef[0]);
 
       await wire.close();
@@ -602,13 +613,13 @@ test(
         failOpen: "harness not found",
       });
 
-      await expect(openAcpWire(nodeId, STATION_KEY)).rejects.toThrow(
+      await expect(openAcpWire(nodeId, STATION_KEY, HUB_SESSION)).rejects.toThrow(
         "Couldn't start the agent process — harness not found."
       );
 
       // Offline node (never connected) → broker resolves {ok:false, error:"node offline"}.
       await expect(
-        openAcpWire("00000000-0000-0000-0000-000000000000", STATION_KEY)
+        openAcpWire("00000000-0000-0000-0000-000000000000", STATION_KEY, HUB_SESSION)
       ).rejects.toThrow("Couldn't start the agent process — node offline.");
 
       fakeNode.close();
@@ -623,12 +634,174 @@ test(
         { malformedOpen: true }
       );
       await expect(
-        openAcpWire(malformed.nodeId, STATION_KEY)
+        openAcpWire(malformed.nodeId, STATION_KEY, HUB_SESSION)
       ).rejects.toThrow(
         "Couldn't start the agent process — malformed open response."
       );
 
       malformedNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "acp.open carries a non-empty instance equal to the id passed in; instanceEchoed is true when the node echoes it",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-inst-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        holdStream: true,
+        capturedNodeMsgs,
+        attachIdRef,
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
+
+      const openReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.open"
+        ) as { params: { key: string; instance?: string } } | undefined;
+      });
+      expect(openReq.params.key).toBe(STATION_KEY);
+      expect(openReq.params.instance).toBe(HUB_SESSION);
+      expect(openReq.params.instance!.length).toBeGreaterThan(0);
+
+      // A modern node echoes the instance → the hub knows it was understood.
+      expect(wire.instance).toBe(HUB_SESSION);
+      expect(wire.instanceEchoed).toBe(true);
+      // Existing field meanings are unchanged.
+      expect(wire.nodeSessionId).toBe(FAKE_SESSION_ID);
+
+      await wire.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "two openAcpWire calls for the same station with different ids send different instances",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-two-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        holdStream: true,
+        capturedNodeMsgs,
+        attachIdRef,
+      });
+
+      const wireA = await openAcpWire(nodeId, STATION_KEY, "acps_one");
+      const wireB = await openAcpWire(nodeId, STATION_KEY, "acps_two");
+
+      const opens = await pollUntil(() => {
+        const found = parsedNodeMsgs(capturedNodeMsgs).filter(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.open"
+        ) as Array<{ params: { key: string; instance?: string } }>;
+        return found.length === 2 ? found : undefined;
+      });
+      expect(opens.map((o) => o.params.key)).toEqual([STATION_KEY, STATION_KEY]);
+      expect(opens[0]!.params.instance).toBe("acps_one");
+      expect(opens[1]!.params.instance).toBe("acps_two");
+      expect(opens[0]!.params.instance).not.toBe(opens[1]!.params.instance);
+      expect(wireA.instance).toBe("acps_one");
+      expect(wireB.instance).toBe("acps_two");
+
+      await wireA.close();
+      await wireB.close();
+      fakeNode.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  20_000
+);
+
+test(
+  "legacy node (no instance echo): instanceEchoed is false and readable/writable/closed still work",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+
+    try {
+      const { nodeId, nodeSecret } = await enrollTestNode("acpwire-legacy-host");
+
+      const capturedNodeMsgs: string[] = [];
+      const attachIdRef: [string | null] = [null];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        holdStream: true,
+        capturedNodeMsgs,
+        attachIdRef,
+        legacyOpen: true,
+      });
+
+      const wire = await openAcpWire(nodeId, STATION_KEY, HUB_SESSION);
+      await pollUntil(() => attachIdRef[0]);
+
+      // The hub still sent the instance; the old node just ignored it.
+      const openReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.open"
+        ) as { params: { instance?: string } } | undefined;
+      });
+      expect(openReq.params.instance).toBe(HUB_SESSION);
+      expect(wire.instanceEchoed).toBe(false);
+
+      // …and the wire is fully usable: attach keyed by the node session id,
+      // writable → input frames, echoes back through readable.
+      expect(wire.nodeSessionId).toBe(FAKE_SESSION_ID);
+      const attachReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) =>
+            m.type === "req" && (m as { verb?: string }).verb === "acp.attach"
+        ) as { params: { sessionId: string } } | undefined;
+      });
+      expect(attachReq.params.sessionId).toBe(FAKE_SESSION_ID);
+
+      const outbound = '{"jsonrpc":"2.0","id":9,"method":"initialize"}\n';
+      const writer = wire.writable.getWriter();
+      await writer.write(new TextEncoder().encode(outbound));
+      writer.releaseLock();
+
+      const inputFrame = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "input"
+        ) as { id: string; data: string } | undefined;
+      });
+      expect(inputFrame.id).toBe(FAKE_SESSION_ID);
+
+      const reader = wire.readable.getReader();
+      const { value } = await reader.read();
+      expect(new TextDecoder().decode(value)).toBe(outbound);
+      reader.releaseLock();
+
+      // close() still tears down: acp.close on the node, closed settles.
+      await wire.close();
+      const closeReq = await pollUntil(() => {
+        return parsedNodeMsgs(capturedNodeMsgs).find(
+          (m) => m.type === "req" && (m as { verb?: string }).verb === "acp.close"
+        ) as { params: { sessionId: string } } | undefined;
+      });
+      expect(closeReq.params.sessionId).toBe(FAKE_SESSION_ID);
+      expect(await wire.closed).toBe("eof");
+
+      fakeNode.close();
       await new Promise((r) => setTimeout(r, 100));
     } finally {
       server.stop(true);

--- a/apps/hub/src/services/acp-transport.ts
+++ b/apps/hub/src/services/acp-transport.ts
@@ -6,11 +6,14 @@
  * messages; `ndJsonStream(output, input)` builds one from exactly the pair of
  * Uint8Array streams exposed here:
  *
- *   const wire = await openAcpWire(nodeId, stationKey);
+ *   const wire = await openAcpWire(nodeId, stationKey, hubSessionId);
  *   const stream = ndJsonStream(wire.writable, wire.readable);
  *
  * Wire protocol (node-agent acpHandler):
- *   - `acp.open {key}` starts (or reuses) the agent process → `{sessionId}`.
+ *   - `acp.open {key, instance}` starts (or reuses) the agent process for that
+ *     (key, instance) pair → `{sessionId, instance?}`. A result without the
+ *     echoed instance is an OLDER node that keys processes on the key alone —
+ *     reported as `instanceEchoed: false`, never an error.
  *   - `acp.attach {sessionId}` streams the agent's stdout as base64 chunks.
  *   - Input frames to the node are keyed by the ACP SESSION id — NOT the
  *     attach stream id (that is the terminal PTY convention).
@@ -20,9 +23,14 @@
  */
 
 import { z } from "zod";
+import { VERB_RESULTS } from "@agentpod/contract";
 import * as broker from "./broker";
 
-const OpenResponseSchema = z.object({ sessionId: z.string().min(1) });
+// The contract shape (sessionId + optional echoed instance), tightened so an
+// empty sessionId is still treated as a malformed open response.
+const OpenResponseSchema = VERB_RESULTS["acp.open"].extend({
+  sessionId: z.string().min(1),
+});
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -37,6 +45,12 @@ export interface AcpWire {
   /** Detach + best-effort acp.close on the node. Idempotent. */
   close(): Promise<void>;
   nodeSessionId: string;
+  /** The instance discriminator sent on acp.open (the hub session id). */
+  instance: string;
+  /** True only when the node echoed the instance back — i.e. it keys its ACP
+   *  processes on (key, instance) and can host concurrent sessions. False means
+   *  an older node: one process per station key, whatever instance we asked for. */
+  instanceEchoed: boolean;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -71,14 +85,23 @@ function parseExitReason(bytes: Uint8Array): string | null {
 /**
  * Open an ACP wire to the station's agent process on a node.
  *
+ * `instance` is the caller's discriminator for which process it wants under the
+ * station key; the caller passes its own hub session id, which makes the value
+ * stable across a re-open of the same session and lets node-side logs be
+ * correlated back to a hub session. The transport never invents one.
+ *
  * Throws Error("Couldn't start the agent process — <broker error>.") when
  * acp.open fails or the node is offline.
  */
 export async function openAcpWire(
   nodeId: string,
-  stationKey: string
+  stationKey: string,
+  instance: string
 ): Promise<AcpWire> {
-  const opened = await broker.request(nodeId, "acp.open", { key: stationKey });
+  const opened = await broker.request(nodeId, "acp.open", {
+    key: stationKey,
+    instance,
+  });
   if (!opened.ok) {
     throw new Error(
       `Couldn't start the agent process — ${opened.error ?? "unknown error"}.`
@@ -91,6 +114,9 @@ export async function openAcpWire(
     );
   }
   const { sessionId } = parsedOpen.data;
+  // A missing (or, defensively, mismatched) echo means the node did not honour
+  // the instance — valid, and the caller degrades to one session per station.
+  const instanceEchoed = parsedOpen.data.instance === instance;
 
   let resolveClosed!: (reason: string) => void;
   const closed = new Promise<string>((resolve) => {
@@ -179,5 +205,13 @@ export async function openAcpWire(
     void broker.request(nodeId, "acp.close", { sessionId });
   };
 
-  return { readable, writable, closed, close, nodeSessionId: sessionId };
+  return {
+    readable,
+    writable,
+    closed,
+    close,
+    nodeSessionId: sessionId,
+    instance,
+    instanceEchoed,
+  };
 }

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -45,6 +45,13 @@ export interface FakeAcpNodeOpts {
   /** Respond to acp.open with ok:false and this error. */
   failOpen?: string;
   /**
+   * Behave like a node from before slice 4b: accept acp.open but answer with
+   * only {sessionId} — never echoing the requested instance. That missing echo
+   * is exactly how the hub detects an old node and degrades to one session per
+   * station. Default (false) is a modern node, which echoes the instance.
+   */
+  legacyOpen?: boolean;
+  /**
    * Never answer the named handshake request (wedged-agent simulation).
    * Mutable — clear it between createSession attempts to let one succeed.
    */
@@ -324,12 +331,17 @@ export async function connectFakeAcpNode(
               JSON.stringify({ type: "res", id, ok: false, error: opts.failOpen })
             );
           } else {
+            const params = msg.params as { instance?: string } | undefined;
+            const instance = params?.instance;
+            const echo = !opts.legacyOpen && instance !== undefined;
             ws.send(
               JSON.stringify({
                 type: "res",
                 id,
                 ok: true,
-                data: { sessionId: processSessionId },
+                data: echo
+                  ? { sessionId: processSessionId, instance }
+                  : { sessionId: processSessionId },
               })
             );
           }

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -22,6 +22,11 @@
  *   - `session/cancel`   → resolves the in-flight prompt with
  *                          {stopReason: "cancelled"}.
  *
+ * `acp.close` only DETACHES the process by default — it does not pretend to kill
+ * the agent. Pass `exitOnClose` for the real thing (exit frame + eof on every
+ * attached stream); a test that cares what closing a process does to whoever is
+ * attached to it MUST set that flag, or it is proving nothing.
+ *
  * `opts` is held by reference: tests may mutate `opts.permission` between
  * prompts (e.g. to flip the toolCall kind for accept-edits coverage).
  */
@@ -58,6 +63,14 @@ export interface FakeAcpNodeOpts {
    * station. Default (false) is a modern node, which echoes the instance.
    */
   legacyOpen?: boolean;
+  /**
+   * Model what a real node does on acp.close: the agent process is KILLED, so
+   * every stream attached to it gets the in-band exit frame and then eof —
+   * including a sibling session's stream when the process is shared. Off by
+   * default (close just detaches), because most tests close only their own
+   * process and would otherwise race their own teardown.
+   */
+  exitOnClose?: boolean;
   /**
    * Never answer the named handshake request (wedged-agent simulation).
    * Mutable — clear it between createSession attempts to let one succeed.
@@ -151,7 +164,14 @@ export async function connectFakeAcpNode(
   interface Proc extends FakeAgentProcess {
     /** Set by acp.close: a closed process is never reused by a later open. */
     closed: boolean;
+    /** Stream that carries this process's output (the latest acp.attach). */
     attachId: string | null;
+    /**
+     * EVERY stream ever attached to this process. Normally one — but a shared
+     * (legacy) process can have a sibling session attached too, and killing the
+     * process has to reach all of them.
+     */
+    attachIds: string[];
     streamSeq: number;
     inputBuffer: string;
     pendingPrompts: Array<string | number>;
@@ -175,6 +195,7 @@ export async function connectFakeAcpNode(
       permissionOutcomes: [],
       closed: false,
       attachId: null,
+      attachIds: [],
       streamSeq: 0,
       inputBuffer: "",
       pendingPrompts: [],
@@ -426,6 +447,7 @@ export async function connectFakeAcpNode(
           const proc = processes.find((p) => p.sessionId === String(wanted));
           if (!proc) break;
           proc.attachId = id;
+          proc.attachIds.push(id);
           // Flush agent messages queued before the attach stream existed.
           for (const line of proc.outQueue.splice(0)) {
             ws.send(
@@ -447,6 +469,34 @@ export async function connectFakeAcpNode(
             ?.sessionId;
           const proc = processes.find((p) => p.sessionId === String(wanted));
           if (proc) {
+            if (opts.exitOnClose && !proc.closed) {
+              // The process dies: exit frame then eof on every attached stream,
+              // a sibling's included. This is how closing a SHARED process takes
+              // the other session down with it on a real node.
+              for (const streamId of proc.attachIds) {
+                ws.send(
+                  JSON.stringify({
+                    type: "stream",
+                    id: streamId,
+                    seq: proc.streamSeq++,
+                    chunk: b64encode(
+                      JSON.stringify({ event: "exit", reason: "closed" })
+                    ),
+                    eof: false,
+                    enc: "base64",
+                  })
+                );
+                ws.send(
+                  JSON.stringify({
+                    type: "stream",
+                    id: streamId,
+                    seq: proc.streamSeq++,
+                    chunk: null,
+                    eof: true,
+                  })
+                );
+              }
+            }
             proc.closed = true;
             proc.attachId = null;
           }

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -1,6 +1,13 @@
 /**
- * Fake node with a scripted ACP agent — shared by the ACP session-service
+ * Fake node with scripted ACP agents — shared by the ACP session-service
  * tests (Task 4) and the ACP WS route tests (Task 5).
+ *
+ * Like the real node-agent it keys agent processes on (station key, instance):
+ * each `acp.open` with a fresh instance spawns a new scripted agent with its
+ * OWN process session id, attach stream and prompt state, so concurrent hub
+ * sessions on one station can be verified to stream independently. With
+ * `legacyOpen` it behaves like a pre-slice-4b node instead: one process per
+ * station key, the same `sessionId` for every instance, no echo.
  *
  * Speaks the node-gateway wire protocol (req/res, stream, input, cancel) and,
  * behind `acp.open` / `acp.attach`, scripts a minimal ACP agent:
@@ -58,15 +65,33 @@ export interface FakeAcpNodeOpts {
   hangHandshake?: "initialize" | "session/new";
 }
 
+/** One scripted agent process, as spawned by an `acp.open`. */
+export interface FakeAgentProcess {
+  /** Instance requested on the acp.open that spawned it (null: none sent). */
+  instance: string | null;
+  /** Node-side process session id (what acp.open returned). */
+  sessionId: string;
+  /** ACP protocol session id this process answers session/new with. */
+  agentSessionId: string;
+  /** JSON-RPC messages THIS process received from the hub. */
+  agentReceived: Array<Record<string, unknown>>;
+  /** Permission outcomes THIS process received, in order. */
+  permissionOutcomes: unknown[];
+}
+
 export interface FakeAcpNode {
   ws: WebSocket;
   opts: FakeAcpNodeOpts;
   /** Raw gateway messages received by the node (JSON strings). */
   nodeMsgs: string[];
-  /** Parsed JSON-RPC messages the scripted agent received from the hub. */
+  /** Parsed JSON-RPC messages the scripted agents received, all processes. */
   agentReceived: Array<Record<string, unknown>>;
-  /** Outcomes the agent received for its permission requests, in order. */
+  /** Outcomes the agents received for their permission requests, in order. */
   permissionOutcomes: unknown[];
+  /** Scripted agent processes, in the order acp.open spawned them. */
+  processes: FakeAgentProcess[];
+  /** The process spawned for a given acp.open instance, if any. */
+  processFor(instance: string): FakeAgentProcess | undefined;
   /** Complete the OLDEST still-hanging prompt turn with the given stopReason. */
   releasePrompt(stopReason?: string): void;
   close(): void;
@@ -122,31 +147,57 @@ export async function connectFakeAcpNode(
   const agentReceived: Array<Record<string, unknown>> = [];
   const permissionOutcomes: unknown[] = [];
 
-  // ── Agent-side state ────────────────────────────────────────────────────────
-  let attachId: string | null = null;
-  let streamSeq = 0;
-  let inputBuffer = "";
-  const pendingPrompts: Array<string | number> = [];
-  let permCounter = 0;
-  const outQueue: string[] = [];
-  const pendingAgentRequests = new Map<
-    string,
-    (msg: Record<string, unknown>) => void
-  >();
+  // ── Agent-side state, one record per spawned process ────────────────────────
+  interface Proc extends FakeAgentProcess {
+    /** Set by acp.close: a closed process is never reused by a later open. */
+    closed: boolean;
+    attachId: string | null;
+    streamSeq: number;
+    inputBuffer: string;
+    pendingPrompts: Array<string | number>;
+    permCounter: number;
+    outQueue: string[];
+    pendingAgentRequests: Map<string, (msg: Record<string, unknown>) => void>;
+  }
+
+  const processes: Proc[] = [];
   const decoder = new TextDecoder();
 
-  /** Send one JSON-RPC message from the agent to the hub (as a stream chunk). */
-  const sendAgent = (msg: Record<string, unknown>) => {
+  const spawnProcess = (instance: string | null): Proc => {
+    const n = processes.length;
+    const proc: Proc = {
+      instance,
+      // The first process keeps the configured ids so single-session tests read
+      // exactly as before; later ones are suffixed so they are distinguishable.
+      sessionId: n === 0 ? processSessionId : `${processSessionId}-${n + 1}`,
+      agentSessionId: n === 0 ? agentSessionId : `${agentSessionId}-${n + 1}`,
+      agentReceived: [],
+      permissionOutcomes: [],
+      closed: false,
+      attachId: null,
+      streamSeq: 0,
+      inputBuffer: "",
+      pendingPrompts: [],
+      permCounter: 0,
+      outQueue: [],
+      pendingAgentRequests: new Map(),
+    };
+    processes.push(proc);
+    return proc;
+  };
+
+  /** Send one JSON-RPC message from a process to the hub (as a stream chunk). */
+  const sendAgent = (proc: Proc, msg: Record<string, unknown>) => {
     const line = JSON.stringify(msg) + "\n";
-    if (attachId === null) {
-      outQueue.push(line);
+    if (proc.attachId === null) {
+      proc.outQueue.push(line);
       return;
     }
     ws.send(
       JSON.stringify({
         type: "stream",
-        id: attachId,
-        seq: streamSeq++,
+        id: proc.attachId,
+        seq: proc.streamSeq++,
         chunk: b64encode(line),
         eof: false,
         enc: "base64",
@@ -155,30 +206,34 @@ export async function connectFakeAcpNode(
   };
 
   /** Respond to a SPECIFIC prompt request (the turn's own id). */
-  const respondTo = (id: string | number, result: Record<string, unknown>) => {
-    const i = pendingPrompts.indexOf(id);
+  const respondTo = (
+    proc: Proc,
+    id: string | number,
+    result: Record<string, unknown>
+  ) => {
+    const i = proc.pendingPrompts.indexOf(id);
     if (i === -1) return;
-    pendingPrompts.splice(i, 1);
-    sendAgent({ jsonrpc: "2.0", id, result });
+    proc.pendingPrompts.splice(i, 1);
+    sendAgent(proc, { jsonrpc: "2.0", id, result });
   };
 
-  /** Respond to the OLDEST pending prompt (cancel + releasePrompt semantics). */
-  const respondOldest = (result: Record<string, unknown>) => {
-    const id = pendingPrompts.shift();
+  /** Respond to a process's OLDEST pending prompt (cancel semantics). */
+  const respondOldest = (proc: Proc, result: Record<string, unknown>) => {
+    const id = proc.pendingPrompts.shift();
     if (id === undefined) return;
-    sendAgent({ jsonrpc: "2.0", id, result });
+    sendAgent(proc, { jsonrpc: "2.0", id, result });
   };
 
-  const runPromptTurn = async (msg: {
-    id: string | number;
-    params: { sessionId: string };
-  }) => {
-    pendingPrompts.push(msg.id);
-    sendAgent({
+  const runPromptTurn = async (
+    proc: Proc,
+    msg: { id: string | number; params: { sessionId: string } }
+  ) => {
+    proc.pendingPrompts.push(msg.id);
+    sendAgent(proc, {
       jsonrpc: "2.0",
       method: "session/update",
       params: {
-        sessionId: agentSessionId,
+        sessionId: proc.agentSessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
           content: { type: "text", text: "Working on it" },
@@ -188,19 +243,19 @@ export async function connectFakeAcpNode(
 
     const perm = opts.permission;
     if (perm) {
-      const permId = `perm-${++permCounter}`;
+      const permId = `perm-${proc.sessionId}-${++proc.permCounter}`;
       const options = perm.options ?? [
         { optionId: "allow", name: "Allow", kind: "allow_once" },
         { optionId: "reject", name: "Reject", kind: "reject_once" },
       ];
       const resp = await new Promise<Record<string, unknown>>((resolve) => {
-        pendingAgentRequests.set(permId, resolve);
-        sendAgent({
+        proc.pendingAgentRequests.set(permId, resolve);
+        sendAgent(proc, {
           jsonrpc: "2.0",
           id: permId,
           method: "session/request_permission",
           params: {
-            sessionId: agentSessionId,
+            sessionId: proc.agentSessionId,
             toolCall: {
               toolCallId: "tc-1",
               title: "Do the thing",
@@ -214,61 +269,70 @@ export async function connectFakeAcpNode(
         | { outcome?: { outcome: string; optionId?: string } }
         | undefined;
       const outcome = result?.outcome;
+      proc.permissionOutcomes.push(outcome ?? resp);
       permissionOutcomes.push(outcome ?? resp);
       if (!outcome || outcome.outcome === "cancelled") {
-        respondTo(msg.id, { stopReason: "cancelled" });
+        respondTo(proc, msg.id, { stopReason: "cancelled" });
         return;
       }
       if (
         outcome.outcome === "selected" &&
         String(outcome.optionId).startsWith("reject")
       ) {
-        respondTo(msg.id, { stopReason: "end_turn" });
+        respondTo(proc, msg.id, { stopReason: "end_turn" });
         return;
       }
     }
 
     if (opts.hangPrompt) return; // held open until session/cancel or releasePrompt
 
-    sendAgent({
+    sendAgent(proc, {
       jsonrpc: "2.0",
       method: "session/update",
       params: {
-        sessionId: agentSessionId,
+        sessionId: proc.agentSessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
           content: { type: "text", text: "Done" },
         },
       },
     });
-    respondTo(msg.id, { stopReason: "end_turn" });
+    respondTo(proc, msg.id, { stopReason: "end_turn" });
   };
 
-  const handleAgentMsg = (msg: Record<string, unknown>) => {
+  const handleAgentMsg = (proc: Proc, msg: Record<string, unknown>) => {
+    proc.agentReceived.push(msg);
     agentReceived.push(msg);
     const method = msg.method as string | undefined;
     const id = msg.id as string | number | undefined;
 
     if (method === "initialize") {
       if (opts.hangHandshake === "initialize") return; // wedged agent
-      sendAgent({
+      sendAgent(proc, {
         jsonrpc: "2.0",
         id,
         result: { protocolVersion: 1, agentCapabilities: {} },
       });
     } else if (method === "session/new") {
       if (opts.hangHandshake === "session/new") return; // wedged agent
-      sendAgent({ jsonrpc: "2.0", id, result: { sessionId: agentSessionId } });
+      sendAgent(proc, {
+        jsonrpc: "2.0",
+        id,
+        result: { sessionId: proc.agentSessionId },
+      });
     } else if (method === "session/prompt") {
-      void runPromptTurn(msg as { id: string | number; params: { sessionId: string } });
+      void runPromptTurn(
+        proc,
+        msg as { id: string | number; params: { sessionId: string } }
+      );
     } else if (method === "session/cancel") {
-      if (!opts.ignoreCancel) respondOldest({ stopReason: "cancelled" });
+      if (!opts.ignoreCancel) respondOldest(proc, { stopReason: "cancelled" });
     } else if (method === undefined && id !== undefined) {
       // Response to an agent-initiated request (e.g. request_permission).
-      pendingAgentRequests.get(String(id))?.(msg);
-      pendingAgentRequests.delete(String(id));
+      proc.pendingAgentRequests.get(String(id))?.(msg);
+      proc.pendingAgentRequests.delete(String(id));
     } else if (id !== undefined) {
-      sendAgent({
+      sendAgent(proc, {
         jsonrpc: "2.0",
         id,
         error: { code: -32601, message: `method not found: ${method}` },
@@ -282,17 +346,18 @@ export async function connectFakeAcpNode(
     const msg = JSON.parse(raw) as Record<string, unknown>;
 
     if (msg.type === "input") {
-      // Hub → agent bytes: buffer, split into JSON-RPC lines, dispatch.
-      inputBuffer += decoder.decode(
-        Buffer.from(String(msg.data), "base64")
-      );
+      // Hub → agent bytes, keyed by the PROCESS session id: route to that
+      // process, buffer, split into JSON-RPC lines, dispatch.
+      const proc = processes.find((p) => p.sessionId === String(msg.id));
+      if (!proc) return; // input for an unknown process — drop.
+      proc.inputBuffer += decoder.decode(Buffer.from(String(msg.data), "base64"));
       let nl: number;
-      while ((nl = inputBuffer.indexOf("\n")) !== -1) {
-        const line = inputBuffer.slice(0, nl).trim();
-        inputBuffer = inputBuffer.slice(nl + 1);
+      while ((nl = proc.inputBuffer.indexOf("\n")) !== -1) {
+        const line = proc.inputBuffer.slice(0, nl).trim();
+        proc.inputBuffer = proc.inputBuffer.slice(nl + 1);
         if (!line) continue;
         try {
-          handleAgentMsg(JSON.parse(line) as Record<string, unknown>);
+          handleAgentMsg(proc, JSON.parse(line) as Record<string, unknown>);
         } catch {
           // Not JSON — ignore.
         }
@@ -332,30 +397,42 @@ export async function connectFakeAcpNode(
             );
           } else {
             const params = msg.params as { instance?: string } | undefined;
-            const instance = params?.instance;
-            const echo = !opts.legacyOpen && instance !== undefined;
+            const instance = params?.instance ?? null;
+            const echo = !opts.legacyOpen && instance !== null;
+            // Modern node: (key, instance) → its own process. Legacy node: ONE
+            // process per station key, handed back for every instance — the
+            // shared-process hazard the hub must refuse to build on.
+            const open = processes.filter((p) => !p.closed);
+            const proc = opts.legacyOpen
+              ? open[0] ?? spawnProcess(instance)
+              : open.find((p) => p.instance === instance) ??
+                spawnProcess(instance);
             ws.send(
               JSON.stringify({
                 type: "res",
                 id,
                 ok: true,
                 data: echo
-                  ? { sessionId: processSessionId, instance }
-                  : { sessionId: processSessionId },
+                  ? { sessionId: proc.sessionId, instance }
+                  : { sessionId: proc.sessionId },
               })
             );
           }
           break;
 
-        case "acp.attach":
-          attachId = id;
+        case "acp.attach": {
+          const wanted = (msg.params as { sessionId?: string } | undefined)
+            ?.sessionId;
+          const proc = processes.find((p) => p.sessionId === String(wanted));
+          if (!proc) break;
+          proc.attachId = id;
           // Flush agent messages queued before the attach stream existed.
-          for (const line of outQueue.splice(0)) {
+          for (const line of proc.outQueue.splice(0)) {
             ws.send(
               JSON.stringify({
                 type: "stream",
                 id,
-                seq: streamSeq++,
+                seq: proc.streamSeq++,
                 chunk: b64encode(line),
                 eof: false,
                 enc: "base64",
@@ -363,12 +440,21 @@ export async function connectFakeAcpNode(
             );
           }
           break;
+        }
 
-        case "acp.close":
+        case "acp.close": {
+          const wanted = (msg.params as { sessionId?: string } | undefined)
+            ?.sessionId;
+          const proc = processes.find((p) => p.sessionId === String(wanted));
+          if (proc) {
+            proc.closed = true;
+            proc.attachId = null;
+          }
           ws.send(
             JSON.stringify({ type: "res", id, ok: true, data: { ok: true } })
           );
           break;
+        }
       }
     }
   };
@@ -382,7 +468,14 @@ export async function connectFakeAcpNode(
     nodeMsgs,
     agentReceived,
     permissionOutcomes,
-    releasePrompt: (stopReason = "end_turn") => respondOldest({ stopReason }),
+    processes,
+    processFor: (instance: string) =>
+      processes.find((p) => p.instance === instance),
+    /** Oldest hanging turn across processes, in process-spawn order. */
+    releasePrompt: (stopReason = "end_turn") => {
+      const proc = processes.find((p) => p.pendingPrompts.length > 0);
+      if (proc) respondOldest(proc, { stopReason });
+    },
     close: () => ws.close(),
   };
 }

--- a/apps/node-agent/internal/acp/manager.go
+++ b/apps/node-agent/internal/acp/manager.go
@@ -11,11 +11,22 @@ import (
 var ErrEmptyArgv = errors.New("acp: empty argv")
 
 // Manager owns the set of live ACP sessions keyed both by session ID and by
-// station key. All public methods are safe for concurrent use.
+// the (station key, instance) pair. All public methods are safe for concurrent
+// use.
 type Manager struct {
 	mu    sync.Mutex
 	byID  map[string]*Session
-	byKey map[string]string // station key → session ID
+	byKey map[string]string // instanceKey(key, instance) → session ID
+}
+
+// instanceKey encodes the (station key, instance) pair as one map key. NUL
+// cannot appear in either half (station keys are "harness:id", instances are
+// hub-chosen identifiers), so the pairs can never flatten onto each other the
+// way plain concatenation would collapse ("a","bc") and ("ab","c"). An empty
+// instance is a distinct pair of its own — that is the legacy
+// one-process-per-key slot an older hub keeps re-opening.
+func instanceKey(key, instance string) string {
+	return key + "\x00" + instance
 }
 
 // NewManager allocates an empty Manager.
@@ -34,18 +45,25 @@ func newSessionID() string {
 	return "acp_" + hex.EncodeToString(b[:])
 }
 
-// Open returns the live session for key if one already exists (idempotent),
-// or spawns argv[0] with argv[1:] in dir with env appended to os.Environ().
-// stdout is streamed to subscribers in chunks; stderr is discarded to a
-// bounded ring (last 4 KiB) exposed via s.StderrTail() for exit reasons.
-func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Session, error) {
+// Open returns the live session for the (key, instance) pair if one already
+// exists (idempotent), or spawns argv[0] with argv[1:] in dir with env appended
+// to os.Environ(). stdout is streamed to subscribers in chunks; stderr is
+// discarded to a bounded ring (last 4 KiB) exposed via s.StderrTail() for exit
+// reasons.
+//
+// instance discriminates concurrent sessions on one station: each distinct
+// instance gets its own child, so two hub sessions never read each other's
+// JSON-RPC traffic. An empty instance keeps the pre-instance behaviour
+// (idempotent by station key alone), which is what an older hub sends.
+func (m *Manager) Open(key, instance string, argv []string, dir string, env []string) (*Session, error) {
 	if len(argv) == 0 {
 		return nil, ErrEmptyArgv
 	}
+	ikey := instanceKey(key, instance)
 
 	m.mu.Lock()
-	// Fast path: session already alive for this key.
-	if id, ok := m.byKey[key]; ok {
+	// Fast path: session already alive for this pair.
+	if id, ok := m.byKey[ikey]; ok {
 		if s, ok := m.byID[id]; ok {
 			m.mu.Unlock()
 			return s, nil
@@ -69,8 +87,8 @@ func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Se
 	}
 
 	m.mu.Lock()
-	// Double-check: another goroutine may have won the race for this key.
-	if existingID, ok := m.byKey[key]; ok {
+	// Double-check: another goroutine may have won the race for this pair.
+	if existingID, ok := m.byKey[ikey]; ok {
 		if existing, ok := m.byID[existingID]; ok {
 			m.mu.Unlock()
 			// We lost the race — discard our session.
@@ -79,12 +97,13 @@ func (m *Manager) Open(key string, argv []string, dir string, env []string) (*Se
 		}
 	}
 	m.byID[id] = s
-	m.byKey[key] = id
+	m.byKey[ikey] = id
 	m.mu.Unlock()
 
 	// Drop the session from the registry once the child exits so a later
-	// Open for the same key spawns a fresh process instead of returning a
-	// dead session.
+	// Open for the same pair spawns a fresh process instead of returning a
+	// dead session. Only this pair's entry goes — siblings on the same station
+	// key keep running.
 	s.OnExit(func(string) { m.remove(id) })
 	return s, nil
 }
@@ -97,13 +116,15 @@ func (m *Manager) Get(id string) (*Session, bool) {
 	return s, ok
 }
 
-// remove deletes id from both indexes (no-op if already gone).
+// remove deletes id from both indexes (no-op if already gone). A session ID is
+// mapped from at most one (key, instance) pair, so the reverse scan can stop at
+// the first hit and leaves every sibling pair on the same station key intact.
 func (m *Manager) remove(id string) {
 	m.mu.Lock()
 	delete(m.byID, id)
-	for k, v := range m.byKey {
+	for ikey, v := range m.byKey {
 		if v == id {
-			delete(m.byKey, k)
+			delete(m.byKey, ikey)
 			break
 		}
 	}

--- a/apps/node-agent/internal/acp/manager_test.go
+++ b/apps/node-agent/internal/acp/manager_test.go
@@ -1,0 +1,174 @@
+package acp
+
+import (
+	"testing"
+	"time"
+)
+
+// TestManager_OpenDistinctInstancesAreDistinctSessions pins the multi-session
+// contract: two hub sessions on the SAME station must each get their own ACP
+// child, or they would read each other's JSON-RPC traffic.
+func TestManager_OpenDistinctInstancesAreDistinctSessions(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+
+	a, err := m.Open("opencode:test", "tab-1", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := m.Open("opencode:test", "tab-2", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a == b {
+		t.Fatal("same *Session returned for two different instances")
+	}
+	if a.ID() == b.ID() {
+		t.Fatalf("both instances got session ID %q", a.ID())
+	}
+	if a.cmd.Process.Pid == b.cmd.Process.Pid {
+		t.Fatalf("both instances share process %d", a.cmd.Process.Pid)
+	}
+
+	// Both must be independently addressable by ID.
+	if got, ok := m.Get(a.ID()); !ok || got != a {
+		t.Fatalf("Get(%q) = %v, %v", a.ID(), got, ok)
+	}
+	if got, ok := m.Get(b.ID()); !ok || got != b {
+		t.Fatalf("Get(%q) = %v, %v", b.ID(), got, ok)
+	}
+}
+
+// TestManager_OpenSameInstanceIsIdempotent pins that a re-open of the same
+// (key, instance) pair returns the identical live session rather than spawning
+// a second child.
+func TestManager_OpenSameInstanceIsIdempotent(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+
+	first, err := m.Open("opencode:test", "tab-1", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := m.Open("opencode:test", "tab-1", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first != second {
+		t.Fatalf("re-open of the same instance spawned a new session: %q vs %q", first.ID(), second.ID())
+	}
+}
+
+// TestManager_OpenEmptyInstanceIsIdempotent pins the legacy contract an older
+// hub relies on: no instance means "reuse whatever process this key has".
+func TestManager_OpenEmptyInstanceIsIdempotent(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+
+	first, err := m.Open("opencode:test", "", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := m.Open("opencode:test", "", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first != second {
+		t.Fatalf("legacy re-open (empty instance) spawned a new session: %q vs %q", first.ID(), second.ID())
+	}
+
+	// The legacy entry must not collide with a named instance either.
+	named, err := m.Open("opencode:test", "tab-1", []string{"/bin/cat"}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if named == first {
+		t.Fatal("named instance reused the legacy session for the same key")
+	}
+}
+
+// TestManager_ExitUnregistersOnlyItsInstance is the sibling-isolation
+// regression test: when one instance's child exits, only that (key, instance)
+// entry is dropped — its sibling on the same key stays registered and a later
+// Open for the dead instance spawns a fresh process.
+func TestManager_ExitUnregistersOnlyItsInstance(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+
+	dir := t.TempDir()
+	survivor, err := m.Open("opencode:test", "keep", []string{"/bin/cat"}, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doomed, err := m.Open("opencode:test", "die", []string{"/bin/sh", "-c", "exit 0"}, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exited := make(chan struct{})
+	doomed.OnExit(func(string) { close(exited) })
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("doomed child did not exit")
+	}
+
+	// The manager's own removal hook runs from the same exit fan-out; wait for
+	// the ID index to drop it.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, ok := m.Get(doomed.ID()); !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("exited session still registered by ID")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// The sibling must be untouched: still resolvable by ID, and still the
+	// session a re-open of its own instance hands back.
+	if _, ok := m.Get(survivor.ID()); !ok {
+		t.Fatal("sibling session was unregistered when the other instance exited")
+	}
+	again, err := m.Open("opencode:test", "keep", []string{"/bin/cat"}, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != survivor {
+		t.Fatalf("re-open of the surviving instance spawned a new session: %q vs %q", again.ID(), survivor.ID())
+	}
+
+	// The dead instance's key must be free again, so it spawns a fresh child.
+	fresh, err := m.Open("opencode:test", "die", []string{"/bin/cat"}, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.ID() == doomed.ID() {
+		t.Fatal("re-open of the dead instance returned the dead session")
+	}
+}
+
+// TestManager_OpenInstanceKeysDoNotCollide guards the composite key encoding:
+// distinct (key, instance) pairs must never flatten onto the same map entry
+// through naive concatenation.
+func TestManager_OpenInstanceKeysDoNotCollide(t *testing.T) {
+	m := NewManager()
+	defer m.Shutdown()
+
+	dir := t.TempDir()
+	a, err := m.Open("a", "bc", []string{"/bin/cat"}, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := m.Open("ab", "c", []string{"/bin/cat"}, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal(`("a","bc") and ("ab","c") collapsed onto the same session`)
+	}
+}

--- a/apps/node-agent/internal/acp/session_test.go
+++ b/apps/node-agent/internal/acp/session_test.go
@@ -11,7 +11,7 @@ import (
 func TestSession_EchoRoundTrip(t *testing.T) {
 	m := NewManager()
 	defer m.Shutdown()
-	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	s, err := m.Open("k", "", []string{"/bin/cat"}, t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestSession_EchoRoundTrip(t *testing.T) {
 func TestSession_ExitFiresOnceWithReason(t *testing.T) {
 	m := NewManager()
 	defer m.Shutdown()
-	s, _ := m.Open("k", []string{"/bin/sh", "-c", "echo err >&2; exit 3"}, t.TempDir(), nil)
+	s, _ := m.Open("k", "", []string{"/bin/sh", "-c", "echo err >&2; exit 3"}, t.TempDir(), nil)
 	reasons := make(chan string, 2)
 	s.OnExit(func(r string) { reasons <- r })
 	select {
@@ -55,7 +55,7 @@ func TestSession_ExitFiresOnceWithReason(t *testing.T) {
 func TestSession_CloseFromOnExitDoesNotDeadlock(t *testing.T) {
 	m := NewManager()
 	defer m.Shutdown()
-	s, err := m.Open("k", []string{"/bin/sh", "-c", "exit 0"}, t.TempDir(), nil)
+	s, err := m.Open("k", "", []string{"/bin/sh", "-c", "exit 0"}, t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestSession_CloseFromOnExitDoesNotDeadlock(t *testing.T) {
 
 func TestManager_CloseWithBlockedSubscriber(t *testing.T) {
 	m := NewManager()
-	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	s, err := m.Open("k", "", []string{"/bin/cat"}, t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,8 +131,7 @@ func TestSession_UnsubscribeWaitsForBacklog(t *testing.T) {
 
 	// Child paces its writes so the fast read loop queues ~20 distinct chunks,
 	// then exits immediately after the burst.
-	s, err := m.Open("k",
-		[]string{"/bin/sh", "-c", "i=1; while [ $i -le 20 ]; do echo line$i; sleep 0.01; i=$((i+1)); done"},
+	s, err := m.Open("k", "", []string{"/bin/sh", "-c", "i=1; while [ $i -le 20 ]; do echo line$i; sleep 0.01; i=$((i+1)); done"},
 		t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +173,7 @@ func TestSession_UnsubscribeWaitsForBacklog(t *testing.T) {
 func TestSession_OnExitUnregister(t *testing.T) {
 	m := NewManager()
 	defer m.Shutdown()
-	s, err := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	s, err := m.Open("k", "", []string{"/bin/cat"}, t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,14 +217,14 @@ func TestSession_OnExitUnregister(t *testing.T) {
 func TestManager_OpenEmptyArgv(t *testing.T) {
 	m := NewManager()
 	defer m.Shutdown()
-	if _, err := m.Open("k", nil, t.TempDir(), nil); err == nil {
+	if _, err := m.Open("k", "", nil, t.TempDir(), nil); err == nil {
 		t.Fatal("Open with empty argv should error, not panic")
 	}
 }
 
 func TestManager_CloseKillsProcess(t *testing.T) {
 	m := NewManager()
-	s, _ := m.Open("k", []string{"/bin/cat"}, t.TempDir(), nil)
+	s, _ := m.Open("k", "", []string{"/bin/cat"}, t.TempDir(), nil)
 	done := make(chan string, 1)
 	s.OnExit(func(r string) { done <- r })
 	if err := m.Close(s.ID()); err != nil {

--- a/apps/node-agent/internal/gateway/acp.go
+++ b/apps/node-agent/internal/gateway/acp.go
@@ -121,10 +121,14 @@ func (h *acpHandler) Handle(
 }
 
 // handleOpen resolves the ACP spawn command for key, spawns (or reuses) the
-// session, and returns {sessionId}.
+// session for the (key, instance) pair, and returns {sessionId} — plus the
+// echoed instance when the request carried one. The echo is how the hub tells a
+// node that understands per-instance processes from an older one; omitting the
+// field for an instance-less request keeps the legacy result shape byte-exact.
 func (h *acpHandler) handleOpen(params json.RawMessage) (any, bool, error) {
 	var p struct {
-		Key string `json:"key"`
+		Key      string `json:"key"`
+		Instance string `json:"instance"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, false, fmt.Errorf("acp.open: bad params: %w", err)
@@ -138,12 +142,16 @@ func (h *acpHandler) handleOpen(params json.RawMessage) (any, bool, error) {
 		return nil, false, fmt.Errorf("acp.open: %w", err)
 	}
 
-	sess, err := h.mgr.Open(p.Key, argv, dir, env)
+	sess, err := h.mgr.Open(p.Key, p.Instance, argv, dir, env)
 	if err != nil {
 		return nil, false, fmt.Errorf("acp.open: %w", err)
 	}
 
-	return map[string]any{"sessionId": sess.ID()}, false, nil
+	res := map[string]any{"sessionId": sess.ID()}
+	if p.Instance != "" {
+		res["instance"] = p.Instance
+	}
+	return res, false, nil
 }
 
 // handleAttach subscribes to the session's stdout stream and forwards each

--- a/apps/node-agent/internal/gateway/dispatch_acp_test.go
+++ b/apps/node-agent/internal/gateway/dispatch_acp_test.go
@@ -198,6 +198,70 @@ func TestACPVerbs(t *testing.T) {
 	}
 }
 
+// TestACPOpenEchoesInstance pins the wire contract from the contract package:
+// acp.open echoes the instance it was given (that echo is how the hub detects a
+// node that understands per-instance processes) and omits the field entirely
+// when the request carried none, so an older hub sees exactly today's result.
+func TestACPOpenEchoesInstance(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	h := NewACPHandler(failInner(t), mgr, catCommandFunc(t.TempDir()))
+
+	res, _, err := h.Handle(context.Background(), "acp.open",
+		json.RawMessage(`{"key":"opencode:test","instance":"tab-2"}`), nil)
+	if err != nil {
+		t.Fatalf("acp.open: %v", err)
+	}
+	data := res.(map[string]any)
+	if got := data["instance"]; got != "tab-2" {
+		t.Fatalf(`result["instance"] = %v, want "tab-2"`, got)
+	}
+	if data["sessionId"] == "" || data["sessionId"] == nil {
+		t.Fatal("missing sessionId")
+	}
+
+	legacy, _, err := h.Handle(context.Background(), "acp.open",
+		json.RawMessage(`{"key":"opencode:test"}`), nil)
+	if err != nil {
+		t.Fatalf("legacy acp.open: %v", err)
+	}
+	legacyData := legacy.(map[string]any)
+	if _, present := legacyData["instance"]; present {
+		t.Fatalf(`legacy result carries instance=%v, want the field omitted`, legacyData["instance"])
+	}
+	if legacyData["sessionId"] == data["sessionId"] {
+		t.Fatal("the legacy (instance-less) open reused the named instance's session")
+	}
+}
+
+// TestACPOpenDistinctInstancesGetDistinctSessions pins that two hub sessions on
+// one station key each get their own ACP child through the gateway verb, and
+// that re-opening the same instance is still idempotent.
+func TestACPOpenDistinctInstancesGetDistinctSessions(t *testing.T) {
+	mgr := acp.NewManager()
+	t.Cleanup(mgr.Shutdown)
+
+	h := NewACPHandler(failInner(t), mgr, catCommandFunc(t.TempDir()))
+	open := func(instance string) string {
+		t.Helper()
+		res, _, err := h.Handle(context.Background(), "acp.open",
+			json.RawMessage(fmt.Sprintf(`{"key":"opencode:test","instance":%q}`, instance)), nil)
+		if err != nil {
+			t.Fatalf("acp.open %q: %v", instance, err)
+		}
+		return res.(map[string]any)["sessionId"].(string)
+	}
+
+	one, two := open("tab-1"), open("tab-2")
+	if one == two {
+		t.Fatalf("both instances got sessionId %q", one)
+	}
+	if again := open("tab-1"); again != one {
+		t.Fatalf("re-open of tab-1 = %q, want the existing %q", again, one)
+	}
+}
+
 // TestACPCloseEmitsExitEvent verifies that closing an ACP session delivers a
 // final stream frame whose decoded payload is the {"event":"exit",...} JSON
 // to an attached subscriber.
@@ -404,7 +468,7 @@ func TestACPInputFrameChainPassthrough(t *testing.T) {
 	}
 
 	// A frame for a live ACP session must NOT reach the inner handler.
-	sess, err := mgr.Open("opencode:test", []string{"/bin/cat"}, t.TempDir(), nil)
+	sess, err := mgr.Open("opencode:test", "", []string{"/bin/cat"}, t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/docs/superpowers/plans/2026-08-10-acp-slice4b-multi-session.md
+++ b/docs/superpowers/plans/2026-08-10-acp-slice4b-multi-session.md
@@ -1,0 +1,139 @@
+# ACP Slice 4b — Multiple Sessions Per Station Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A station can host several concurrent ACP sessions, so you can run more than one conversation with the same agent — and the console lets you switch between them.
+
+**Architecture:** The blocker is node-side, not hub-side. The node-agent's ACP manager is idempotent **by station key** (`internal/acp/manager.go`), and stdin/stdout are fanned out per node session id, so two hub sessions on one station today would share one child process and read each other's JSON-RPC traffic. This slice gives `acp.open` an optional **instance discriminator** so each hub session gets its own process, negotiates that capability honestly (an older node that ignores the field must not silently cause cross-talk), relaxes the hub's one-live-session-per-station guard, and adds a session switcher to the chat header.
+
+**Tech Stack:** Go (node-agent), zod contract, Bun/Hono/Drizzle hub, Svelte 5 console.
+
+## Global Constraints
+
+- **Forward/backward compatibility is a correctness requirement, not politeness.** A new hub talking to an old node must NOT open a second session that shares a process — that would cross-wire two conversations. The node signals support by echoing the instance back in the `acp.open` result; when the echo is missing the hub keeps today's single-session behaviour for that station (the existing 409 + copy). Slice-1 already proved the reverse hazard is real: an old hub rejected detect responses carrying an unknown capability.
+- Session identity on the wire stays as it is: input frames are keyed by the **node** session id (`acp.open`'s returned `sessionId`), and the hub's own `acp_sessions.id` is separate. Don't conflate them.
+- The hub's existing safety rails must survive: the 30s handshake deadline, the offline grace park at `waiting`, `reconcileOnBoot`, and `closeOrphanedProcesses` on node reconnect. With unique processes per session, each row's `node_session_id` is now genuinely unique — verify no code still assumes one per station.
+- Console: sessions are hub-owned. Switching sessions must not end any of them; closing the tab still only unsubscribes.
+- Copy grammar `Couldn't <verb> <object>.`; design system only (`<Status>`, type roles, status tokens); keyboard-complete; one status live region (the chat header owns it — a second would double-announce).
+- Keep `busy` exactly equal to `AcpChat.prompt()`'s refusal rule when the controller gains session switching; a refused send must never destroy the draft.
+- Go test hygiene: no unreaped children whose `comm` matches a pgrep target; prefer injectable seams over spawning real processes.
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB`
+
+## File Structure
+
+```
+packages/contract/src/protocol.ts (or wherever VERB_PARAMS/VERB_RESULTS live)  acp.open gains optional instance + echoed instance in the result
+apps/node-agent/internal/acp/manager.go        key on (stationKey, instance); keep no-instance behaviour identical
+apps/node-agent/internal/gateway/acp.go        read instance from params, echo it in the result
+apps/hub/src/services/acp-transport.ts         send a unique instance; surface whether the node echoed it
+apps/hub/src/services/acp-sessions.ts          liveByStation: one → many; guard only when the node lacks instance support
+apps/hub/src/routes/station-acp.ts             409 only in the degraded case
+apps/console/src/lib/api/acp.ts                (only if the session list needs new shapes)
+apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts   attach(sessionId) + explicit create
+apps/console/src/lib/components/stations/chat/ChatHeader.svelte    session switcher
+apps/console/src/lib/components/stations/chat/ChatPanel.svelte     own the selected session id
+```
+
+---
+
+### Task 1: Contract — `acp.open` instance discriminator
+
+**Files:**
+- Modify: the contract module defining the ACP verb params/results (find it: `packages/contract/src/` — the slice-1 verbs `acp.open`/`acp.attach`/`acp.close` live with the other station verbs)
+- Test: the contract's existing verb test file
+
+**Interfaces produced (consumed by Tasks 2–4):**
+- `acp.open` params gain `instance?: string` — an opaque, caller-chosen discriminator. Absent means "legacy: reuse any existing process for this key".
+- `acp.open` result gains `instance?: string` — a node that understands the field **echoes it back**. Absence is the hub's signal that the node is old.
+
+- [ ] **Step 1 (RED):** extend the verb schema tests: params parse with and without `instance`; a result carrying `instance` parses; a result without it still parses (old nodes).
+- [ ] **Step 2:** run the contract suite → FAIL. **Step 3:** implement. **Step 4:** `cd packages/contract && bun test` green.
+- [ ] **Step 5:** Commit `feat(contract): acp.open instance discriminator`.
+
+---
+
+### Task 2: node-agent — per-instance ACP processes
+
+**Files:**
+- Modify: `apps/node-agent/internal/acp/manager.go`, `apps/node-agent/internal/gateway/acp.go`
+- Test: `apps/node-agent/internal/acp/manager_test.go`, `apps/node-agent/internal/gateway/dispatch_acp_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's optional `instance`.
+- Produces: `Manager.Open(key, instance string, argv []string, dir string, env []string) (*Session, error)` — keyed on the pair. `instance == ""` keeps **exactly** today's behaviour (idempotent by key), because that is what an old hub sends. The gateway's `handleOpen` reads `instance` from the params and includes it in the result map alongside `sessionId`.
+
+- [ ] **Step 1 (RED):** tests — two `Open` calls with the same key and *different* instances yield two distinct sessions with distinct ids and distinct processes; same key + same instance is idempotent (returns the identical session); empty instance twice is idempotent (the legacy contract, which `dispatch_acp_test.go`'s `TestACPVerbs` already encodes — extend rather than break it); `handleOpen` echoes the instance it was given and omits it when none was sent; `OnExit` unregisters the right (key, instance) entry and leaves its sibling alive.
+- [ ] **Step 2:** `cd apps/node-agent && go test ./internal/acp/ ./internal/gateway/ -run 'ACP|Manager' -v` → FAIL.
+- [ ] **Step 3:** implement. `byKey map[string]string` becomes keyed by a composite (e.g. `key + "\x00" + instance`) — keep the reverse-scan `remove` correct for the new key shape, and keep the lost-race branch (`manager.go:73-80`) that closes the losing child.
+- [ ] **Step 4:** `go test -race ./...` green.
+- [ ] **Step 5:** Commit `feat(node-agent): one acp process per session instance`.
+
+---
+
+### Task 3: Hub transport — send an instance, report support
+
+**Files:**
+- Modify: `apps/hub/src/services/acp-transport.ts`
+- Test: `apps/hub/tests/` (the acp wire tests + `tests/helpers/acp-fake-node.ts`)
+
+**Interfaces:**
+- `openAcpWire(nodeId, stationKey)` sends a fresh `instance` (a uuid) on `acp.open` and returns it alongside the existing `AcpWire` fields, plus `instanceEchoed: boolean` — `true` only when the node's result echoed the instance. Extend `AcpWire` rather than changing its existing field meanings; `nodeSessionId` still keys input frames.
+- The fake node gains a switch to simulate an **old** node (accepts `acp.open`, returns only `sessionId`), because Task 4's degraded path needs it.
+
+- [ ] **Step 1 (RED):** tests — the open frame carries a non-empty `instance`; two `openAcpWire` calls for one station send different instances; `instanceEchoed` is true against the modern fake and false against the legacy fake.
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** hub suite green (`DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test`).
+- [ ] **Step 5:** Commit `feat(hub): acp wire sends a per-session instance`.
+
+---
+
+### Task 4: Hub service + routes — many live sessions per station
+
+**Files:**
+- Modify: `apps/hub/src/services/acp-sessions.ts`, `apps/hub/src/routes/station-acp.ts`
+- Test: `apps/hub/tests/acp/…` (the service + route suites)
+
+**Interfaces:**
+- `liveByStation` becomes one-to-many (`Map<string, Set<LiveSession>>`). `finalizeEnd`'s delete is already identity-guarded — make it remove from the set and drop the key when empty.
+- `createSession` no longer refuses a second session **when the node echoed the instance**. When it did not (old node), keep today's behaviour verbatim: throw the existing `"An active session already exists for this agent."`, which `station-acp.ts`'s `createErrorStatus` maps to 409. The degraded path must be reached by a real signal from the wire, never by a version guess.
+- `listSessions` gains SQL ordering (`lastEventAt desc, id desc`) so the console's switcher and slice 4c's history share one ordered read; drop the route's JS sort.
+
+- [ ] **Step 1 (RED):** tests — two concurrent sessions on one station both reach `idle` and stream independently (assert with the fake node that each got its own instance and that a prompt in session A never appears in B's transcript); an old node still 409s on the second create; ending one session leaves the other live and its process untouched; `reconcileOnBoot` and `closeOrphanedProcesses` close **each** row's own `node_session_id` and never one that belongs to a live sibling.
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** hub suite green.
+- [ ] **Step 5:** Commit `feat(hub): multiple live acp sessions per station`.
+
+---
+
+### Task 5: Console — session switcher
+
+**Files:**
+- Modify: `apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts`, `ChatHeader.svelte`, `ChatPanel.svelte`; `apps/console/src/lib/api/acp.ts` only if needed
+- Test: the colocated `.svelte.test.ts` files for each
+
+**Interfaces:**
+- `AcpChat` gains `attach(sessionId: string): Promise<void>` (tear down the current socket, reset the transcript, subscribe to the given session) and `sessions: AcpSessionRow[]` (the station's sessions, newest first, refreshed on create/end). `init()` keeps its current behaviour of attaching the newest non-ended session. `newSession()` becomes an explicit create rather than a local reset — but creation stays lazy-on-first-prompt if that is simpler to keep `busy` honest; whichever you choose, document it in the class doc comment.
+- `ChatHeader` gains a session selector (a `<Select>` from `ui/select`, or chips if there are few) listing the station's sessions by relative last-activity with their `<Status>`; picking one calls `onSelectSession(id)`. Keep exactly one status live region.
+- `ChatPanel` owns the selected session id and re-attaches on change. Do NOT remount the whole panel per session (the socket lifecycle is the controller's job) — but DO reset the composer draft state deliberately, and say which way you chose.
+
+- [ ] **Step 1 (RED):** tests — the switcher lists the station's sessions and switching calls `attach` (assert the new socket subscribes to the new id and the old socket closes); switching does NOT DELETE anything (assert zero DELETE fetches); the transcript swaps to the new session's replay; "New session" adds a session and selects it; with one session the switcher stays out of the way (renders nothing or a single inert label — pick and assert).
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** `pnpm check && pnpm test && pnpm build` green.
+- [ ] **Step 5:** Commit `feat(console): switch between an agent's sessions`.
+
+---
+
+### Task 6: Slice gate — suites, PR, CI, live verification (controller-run)
+
+- [ ] All four suites green (contract, hub with the `:5434` DATABASE_URL override, node-agent `-race`, console check+test+build).
+- [ ] Push; PR `feat: ACP slice 4b — multiple sessions per agent`; CI green; merge.
+- [ ] Deploy: hub (`git pull` + `bun x pnpm@10 install --frozen-lockfile --filter @agentpod/hub...` + restart — plain `bun install` is a silent no-op on the box), console (`PUBLIC_HUB_URL=https://hub.agentpod.dev pnpm --filter @agentpod/console build` then `wrangler pages deploy apps/console/build --project-name agentpod-console --branch main`; the Pages git integration does not auto-build), and the node-agent to at least one node.
+- [ ] Live: open two concurrent sessions on one station (opencode-one is the reliable one — hermes works too), confirm each holds its own conversation with no cross-talk, switch between them in the header, end one and confirm the other survives with its process intact, then end the second and confirm no remnants.
+- [ ] Live degraded path: against a node still running an older binary, confirm a second create returns 409 with the existing copy rather than silently sharing a process.
+- [ ] Update the `acp-sessions-program` memory; ledger complete.
+
+## Self-Review Notes
+
+- The instance echo is the whole compatibility story: without it, a new hub plus an old node produces two sessions on one process and two conversations bleeding into each other. That is why Task 3 teaches the fake node to play old.
+- Per-session processes are deliberately chosen over multiplexing several ACP `session/new` ids inside one process. Multiplexing is cheaper and both OpenClaw and the Claude Code adapter support it, but it would require routing every `session/update` by `params.sessionId` (today ignored) and would make one crashed process take out every conversation on that station. Revisit if process count becomes a real cost.
+- The hub's handshake deadline (30s) was added because a hung handshake used to 409-lock a station. With multi-session that pressure drops, but keep the deadline — a wedged process still deserves to fail fast.
+- Slice 4c (history) will reuse `listSessions`' new SQL ordering and the same `Conversation` component in a read-only mode; don't build a second list read path here.

--- a/packages/contract/src/protocol.test.ts
+++ b/packages/contract/src/protocol.test.ts
@@ -24,6 +24,20 @@ it("acp.open params/result schemas round-trip", () => {
   expect(VERB_PARAMS["acp.open"].parse({ key: "opencode:c52ddf65" })).toEqual({ key: "opencode:c52ddf65" });
   expect(VERB_RESULTS["acp.open"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
 });
+it("acp.open params accept an optional instance discriminator", () => {
+  expect(VERB_PARAMS["acp.open"].parse({ key: "opencode:c52ddf65" })).toEqual({ key: "opencode:c52ddf65" });
+  expect(VERB_PARAMS["acp.open"].parse({ key: "opencode:c52ddf65", instance: "tab-2" })).toEqual({
+    key: "opencode:c52ddf65",
+    instance: "tab-2",
+  });
+});
+it("acp.open result echoes instance when the node understands it, and still parses when an old node omits it", () => {
+  expect(VERB_RESULTS["acp.open"].parse({ sessionId: "acp_1", instance: "tab-2" })).toEqual({
+    sessionId: "acp_1",
+    instance: "tab-2",
+  });
+  expect(VERB_RESULTS["acp.open"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
+});
 it("acp.attach takes a sessionId; acp.close returns ok", () => {
   expect(VERB_PARAMS["acp.attach"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });
   expect(VERB_PARAMS["acp.close"].parse({ sessionId: "acp_1" })).toEqual({ sessionId: "acp_1" });

--- a/packages/contract/src/protocol.ts
+++ b/packages/contract/src/protocol.ts
@@ -38,7 +38,10 @@ export const VERB_PARAMS = {
   "term.open":   z.object({ key: z.string(), cols: z.number().int(), rows: z.number().int() }),
   "term.attach": z.object({ sessionId: z.string() }),
   "term.close":  z.object({ sessionId: z.string() }),
-  "acp.open":   z.object({ key: z.string() }),
+  // instance is an opaque, caller-chosen discriminator for a distinct ACP process
+  // under the same station key. Omitted means "legacy: reuse any existing process
+  // for this key".
+  "acp.open":   z.object({ key: z.string(), instance: z.string().optional() }),
   "acp.attach": z.object({ sessionId: z.string() }),
   "acp.close":  z.object({ sessionId: z.string() }),
 } as const;
@@ -61,7 +64,10 @@ export const VERB_RESULTS = {
   "term.open":  z.object({ sessionId: z.string() }),
   "term.close": z.object({ ok: z.boolean() }),
   // term.attach streams; no entry needed.
-  "acp.open":  z.object({ sessionId: z.string() }),
+  // instance echoes the request's instance when the node understands it. A
+  // result missing instance is how the hub detects an older node and degrades
+  // safely (single-process-per-key behavior).
+  "acp.open":  z.object({ sessionId: z.string(), instance: z.string().optional() }),
   "acp.close": z.object({ ok: z.boolean() }),
   // acp.attach streams; no entry needed (same as term.attach).
 } as const;


### PR DESCRIPTION
## Summary

A station can now host **several concurrent ACP sessions**, and the console lets you switch between them. Previously one agent meant one conversation.

The blocker was node-side: the node-agent's ACP manager was idempotent *by station key*, and stdin/stdout are fanned out per node session, so two hub sessions on one station would have shared a child process and read each other's JSON-RPC traffic.

## How it works

- **Contract**: `acp.open` gains an optional `instance` — in the params (an opaque discriminator) and in the result (**echoed back** by a node that understands it).
- **node-agent**: ACP processes are keyed on `(station key, instance)`. An empty instance preserves today's behaviour byte-for-byte, because that's what an older hub sends.
- **Hub**: `openAcpWire` sends the hub's **own session id** as the instance — stable by construction, so no re-open can strand a conversation in an orphaned process, and node processes correlate to session rows in logs. `liveByStation` becomes one-to-many.
- **Console**: a session switcher in the chat header, with per-session drafts.

## Compatibility is a correctness property here, not politeness

A new hub against an **old** node must never open a second session, because that node returns the *same* node session id for both — two conversations bleeding into one process. So the gate has two layers, driven only by the wire's real signal (`instanceEchoed`, a strict value comparison, not mere presence): refuse up front when a live sibling recorded no echo, and if the second open itself comes back without one, tear it down and refuse. The refusal is the existing 409 copy, unchanged. The test fake gained a legacy mode so this path is actually exercised.

## Robustness found and fixed during review

- A per-station open lock was added (correctly: it stops the strict check from spuriously refusing *legitimate* concurrent creates on a modern node — the check and the lock are a pair, now documented as such).
- Every DB write in the open phase is bounded. Without that, a blocking query left a session registered forever and **permanently 409-locked the station** until a hub restart. The regression test holds a real `LOCK TABLE … IN EXCLUSIVE MODE` to prove the station recovers.
- The station is re-read *inside* the lock, so a queued open can't target stale routing after a re-adopt or a node dropping.
- Console: sending into an ended session used to decide its create-branch from a placeholder status, writing the prompt into a socket the hub was about to close. It now decides on real status, with a regression test.
- The test fake's `acp.close` now actually kills the process, which turned one assertion that passed for the wrong reason into an honest one.

## Tests

contract 47 ✅ · hub 364 ✅ · node-agent `-race` + `vet` ✅ · console 649 + `svelte-check` + build ✅

Covers: two sessions streaming independently with cross-talk asserted absent in both directions; the legacy-node 409; ending one session leaving its sibling's process intact; reconcile/orphan-close touching only each row's own node session; per-session drafts including the pre-create slot; and the switcher never issuing a DELETE.

## Live verification

Two concurrent conversations on one station with no cross-talk, header switching, ending one while the other survives, and the degraded 409 against an un-upgraded node — after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB