### PR TITLE
fix(node-agent): resolve the openclaw binary instead of trusting PATH

### DIFF
--- a/apps/node-agent/cmd/agentpod-node/registry.go
+++ b/apps/node-agent/cmd/agentpod-node/registry.go
@@ -14,6 +14,7 @@ func buildRegistry(cfg config.Config) *descriptor.Registry {
 	reg.Register(descriptor.NewHermes("", cfg.HermesStartCmd))
 	reg.Register(descriptor.NewOpenClawFrom(descriptor.OpenClawConfig{
 		StartCmd:     cfg.OpenClawStartCmd,
+		Binary:       cfg.OpenClawBinary,
 		GatewayURL:   cfg.OpenClawGatewayURL,
 		TokenFile:    cfg.OpenClawTokenFile,
 		SessionLabel: cfg.OpenClawSessionLabel,

--- a/apps/node-agent/cmd/agentpod-node/registry_test.go
+++ b/apps/node-agent/cmd/agentpod-node/registry_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/descriptor"
+)
+
+// openclawBinary must reach the descriptor: on a node where openclaw is installed
+// outside the service's PATH (e.g. a pnpm global install under
+// ~/.local/share/pnpm, invisible to a systemd *user* service) it is the
+// operator's escape hatch. A gateway URL is configured so resolving the ACP
+// command skips the local gateway probe.
+func TestBuildRegistry_ThreadsOpenClawBinary(t *testing.T) {
+	reg := buildRegistry(config.Config{
+		OpenClawBinary:     "/opt/custom/bin/openclaw",
+		OpenClawGatewayURL: "wss://gateway.invalid:18789",
+	})
+
+	d, err := reg.For("openclaw")
+	if err != nil {
+		t.Fatalf("registry has no openclaw descriptor: %v", err)
+	}
+	c, ok := d.(descriptor.ACPCommander)
+	if !ok {
+		t.Fatalf("openclaw descriptor must implement ACPCommander, got %T", d)
+	}
+
+	argv, _, _, err := c.ACPCommand("openclaw")
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if argv[0] != "/opt/custom/bin/openclaw" {
+		t.Errorf("argv[0] = %q, want the configured openclawBinary", argv[0])
+	}
+}

--- a/apps/node-agent/internal/config/config.go
+++ b/apps/node-agent/internal/config/config.go
@@ -16,6 +16,12 @@ type Config struct {
   // `openclaw acp` bridge. All optional: with a local Gateway, openclaw resolves
   // its own URL from config. The token is passed as a FILE PATH, never inline —
   // argv is world-readable.
+  // OpenClawBinary is the openclaw executable to spawn (absolute path). Optional:
+  // when empty the node-agent resolves it from PATH, then from well-known install
+  // paths. Set it when openclaw lives somewhere the service's PATH can't see —
+  // e.g. a pnpm global install under ~/.local/share/pnpm, invisible to a systemd
+  // user service.
+  OpenClawBinary       string `json:"openclawBinary,omitempty"`
   OpenClawGatewayURL   string `json:"openclawGatewayUrl,omitempty"`
   OpenClawTokenFile    string `json:"openclawTokenFile,omitempty"`
   OpenClawSessionLabel string `json:"openclawSessionLabel,omitempty"`

--- a/apps/node-agent/internal/descriptor/acp_command_test.go
+++ b/apps/node-agent/internal/descriptor/acp_command_test.go
@@ -112,13 +112,29 @@ func TestHermesACPCommand_BadKey(t *testing.T) {
 
 // --- OpenClaw ---
 //
-// gatewayUp is overridden in every case so no test spawns or pgreps a process
-// (see the Go test hygiene note in CLAUDE.md).
+// Both host-touching seams are overridden in every case so no test spawns or
+// pgreps a process (see the Go test hygiene note in CLAUDE.md) and none depends
+// on openclaw being installed on the machine running the tests.
+
+// stubOpenClawHost replaces the two seams that would otherwise touch the host:
+// the gateway liveness probe (pgrep/systemctl) and the binary resolver
+// (PATH + well-known install paths). It returns the concrete descriptor so a
+// case can refine either seam.
+func stubOpenClawHost(t *testing.T, d Descriptor, gatewayUp bool) *openclawDescriptor {
+	t.Helper()
+	o, ok := d.(*openclawDescriptor)
+	if !ok {
+		t.Fatalf("expected *openclawDescriptor, got %T", d)
+	}
+	o.gatewayUp = func() bool { return gatewayUp }
+	o.resolveBinary = func() (string, error) { return "openclaw", nil }
+	return o
+}
 
 func TestOpenClawACPCommand_RootStation(t *testing.T) {
 	home := testdataOpenClawHome(t)
 	d := NewOpenClawFrom(OpenClawConfig{Home: home})
-	d.(*openclawDescriptor).gatewayUp = func() bool { return true }
+	stubOpenClawHost(t, d, true)
 
 	c, ok := d.(ACPCommander)
 	if !ok {
@@ -143,7 +159,7 @@ func TestOpenClawACPCommand_RootStation(t *testing.T) {
 func TestOpenClawACPCommand_AgentStation(t *testing.T) {
 	home := testdataOpenClawHome(t)
 	d := NewOpenClawFrom(OpenClawConfig{Home: home, SessionLabel: "console"})
-	d.(*openclawDescriptor).gatewayUp = func() bool { return true }
+	stubOpenClawHost(t, d, true)
 
 	argv, dir, _, err := d.(ACPCommander).ACPCommand("openclaw:analyst")
 	if err != nil {
@@ -164,7 +180,7 @@ func TestOpenClawACPCommand_GatewayFlags(t *testing.T) {
 		GatewayURL: "wss://gw.example:18789",
 		TokenFile:  "/etc/agentpod/openclaw.token",
 	})
-	d.(*openclawDescriptor).gatewayUp = func() bool { return false } // a URL makes the local probe irrelevant
+	stubOpenClawHost(t, d, false) // a URL makes the local probe irrelevant
 
 	argv, _, _, err := d.(ACPCommander).ACPCommand("openclaw")
 	if err != nil {
@@ -186,7 +202,7 @@ func TestOpenClawACPCommand_GatewayFlags(t *testing.T) {
 func TestOpenClawACPCommand_NoGatewayNoURL(t *testing.T) {
 	home := testdataOpenClawHome(t)
 	d := NewOpenClawFrom(OpenClawConfig{Home: home})
-	d.(*openclawDescriptor).gatewayUp = func() bool { return false }
+	stubOpenClawHost(t, d, false)
 
 	if _, _, _, err := d.(ACPCommander).ACPCommand("openclaw"); err == nil {
 		t.Fatal("expected an error when no gateway is running and no URL is configured")
@@ -197,7 +213,7 @@ func TestOpenClawACPCommand_NoGatewayNoURL(t *testing.T) {
 
 func TestOpenClawACPCommand_BadKey(t *testing.T) {
 	d := NewOpenClawFrom(OpenClawConfig{Home: testdataOpenClawHome(t)})
-	d.(*openclawDescriptor).gatewayUp = func() bool { return true }
+	stubOpenClawHost(t, d, true)
 
 	if _, _, _, err := d.(ACPCommander).ACPCommand("hermes:main"); err == nil {
 		t.Fatal("expected error for unrecognized key")
@@ -208,7 +224,7 @@ func TestOpenClawACPCommand_BadKey(t *testing.T) {
 // session key is derived, or the bridge would be pointed at "agent::main".
 func TestOpenClawACPCommand_EmptyAgentKey(t *testing.T) {
 	d := NewOpenClawFrom(OpenClawConfig{Home: testdataOpenClawHome(t)})
-	d.(*openclawDescriptor).gatewayUp = func() bool { return true }
+	stubOpenClawHost(t, d, true)
 
 	if _, _, _, err := d.(ACPCommander).ACPCommand("openclaw:"); err == nil {
 		t.Fatal("expected error for a key with an empty agent name")

--- a/apps/node-agent/internal/descriptor/openclaw.go
+++ b/apps/node-agent/internal/descriptor/openclaw.go
@@ -41,6 +41,11 @@ type openclawDescriptor struct {
 	// field so tests can declare the answer without spawning or pgrep-ing a
 	// process; production wiring in NewOpenClawFrom uses openclawGatewayPID.
 	gatewayUp func() bool
+
+	// resolveBinary returns the openclaw executable to spawn. Like gatewayUp it
+	// is a field so tests never depend on the host's PATH or filesystem;
+	// production wiring in NewOpenClawFrom uses resolveOpenClawBinary.
+	resolveBinary func() (string, error)
 }
 
 // OpenClawConfig carries everything the descriptor needs. Zero values are valid:
@@ -49,6 +54,7 @@ type openclawDescriptor struct {
 type OpenClawConfig struct {
 	Home         string // default: <user home>/.openclaw
 	StartCmd     string // lifecycle Start (existing behaviour)
+	Binary       string // openclaw executable; empty = resolve (see resolveOpenClawBinary)
 	GatewayURL   string // → --url
 	TokenFile    string // → --token-file  (never --token)
 	SessionLabel string // session component of agent:<name>:<label>; default "main"
@@ -56,18 +62,21 @@ type OpenClawConfig struct {
 
 // NewOpenClawFrom returns a Descriptor for the OpenClaw harness configured by cfg.
 func NewOpenClawFrom(cfg OpenClawConfig) Descriptor {
+	// userHome is "" when it can't be determined, which resolveOpenClawBinary
+	// reads as "skip the home-relative candidates".
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		userHome = ""
+	}
 	home := cfg.Home
 	if home == "" {
-		userHome, err := os.UserHomeDir()
-		if err != nil {
-			userHome = "."
-		}
 		home = filepath.Join(userHome, ".openclaw")
 	}
 	label := cfg.SessionLabel
 	if label == "" {
 		label = "main"
 	}
+	binary := cfg.Binary
 	return &openclawDescriptor{
 		home:         home,
 		startCmd:     cfg.StartCmd,
@@ -75,7 +84,69 @@ func NewOpenClawFrom(cfg OpenClawConfig) Descriptor {
 		tokenFile:    cfg.TokenFile,
 		sessionLabel: label,
 		gatewayUp:    func() bool { _, err := openclawGatewayPID(); return err == nil },
+		resolveBinary: func() (string, error) {
+			return resolveOpenClawBinary(binary, userHome, exec.LookPath, isExecutableFile)
+		},
 	}
+}
+
+// openclawBinaryName is the executable that hosts the ACP bridge.
+const openclawBinaryName = "openclaw"
+
+// openclawWellKnownBinaries returns the absolute paths probed when openclaw is
+// not on PATH, in priority order. userHome is the OS user's home directory; ""
+// omits the home-relative candidates.
+//
+// This list exists because the node-agent commonly runs as a systemd *user*
+// service, which inherits systemd's minimal default PATH — that excludes
+// ~/.local/share/pnpm and ~/.local/bin, so a pnpm/npm-global install of openclaw
+// is invisible to exec.LookPath even though the shim works in the operator's
+// interactive shell.
+func openclawWellKnownBinaries(userHome string) []string {
+	var paths []string
+	if userHome != "" {
+		paths = append(paths,
+			filepath.Join(userHome, ".local", "share", "pnpm", openclawBinaryName), // pnpm global
+			filepath.Join(userHome, ".local", "bin", openclawBinaryName),           // npm --prefix ~/.local
+		)
+	}
+	return append(paths,
+		"/usr/local/bin/"+openclawBinaryName,
+		"/usr/bin/"+openclawBinaryName,
+		"/opt/homebrew/bin/"+openclawBinaryName, // macOS (Apple silicon Homebrew)
+	)
+}
+
+// resolveOpenClawBinary picks the openclaw executable to spawn, in order:
+// the configured override (used verbatim — the operator knows their layout),
+// then PATH, then the well-known absolute install paths. lookPath and
+// isExecutable are parameters so tests never touch the host's PATH or files.
+//
+// The failure is an actionable lowercase fragment: it composes into the console's
+// "Couldn't start the agent process — <err>".
+func resolveOpenClawBinary(override, userHome string, lookPath func(string) (string, error), isExecutable func(string) bool) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	if abs, err := lookPath(openclawBinaryName); err == nil {
+		return abs, nil
+	}
+	for _, candidate := range openclawWellKnownBinaries(userHome) {
+		if isExecutable(candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("openclaw: couldn't find the openclaw binary on this node — set openclawBinary in the node config")
+}
+
+// isExecutableFile reports whether path is an existing file with an executable
+// bit set. os.Stat follows symlinks, so a pnpm shim (a symlink) resolves.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
 }
 
 // NewOpenClaw returns a Descriptor for the OpenClaw harness.
@@ -196,6 +267,15 @@ func (o *openclawDescriptor) ACPCommand(key string) ([]string, string, []string,
 		return nil, "", nil, err
 	}
 
+	// Resolve the binary before the gateway probe: a bare "openclaw" argv[0] dies
+	// later inside exec with "executable file not found in $PATH", and a node
+	// missing the CLI can't open a session however healthy its gateway is — so
+	// when both are wrong this is the failure worth reporting.
+	binary, err := o.resolveBinary()
+	if err != nil {
+		return nil, "", nil, err
+	}
+
 	// A configured URL points at a remote Gateway, so the local probe says
 	// nothing; without one, a dead local Gateway means the bridge would start,
 	// fail to dial, and leave the user waiting on the hub's handshake deadline.
@@ -216,7 +296,7 @@ func (o *openclawDescriptor) ACPCommand(key string) ([]string, string, []string,
 	// --no-prefix-cwd: the bridge otherwise prefixes every prompt with the
 	// working directory, which is redundant here — the station IS its workspace
 	// and we already set cmd.Dir — and it pollutes the transcript.
-	argv := []string{"openclaw", "acp", "--no-prefix-cwd"}
+	argv := []string{binary, "acp", "--no-prefix-cwd"}
 	if o.gatewayURL != "" {
 		argv = append(argv, "--url", o.gatewayURL)
 	}

--- a/apps/node-agent/internal/descriptor/openclaw_binary_test.go
+++ b/apps/node-agent/internal/descriptor/openclaw_binary_test.go
@@ -1,0 +1,264 @@
+package descriptor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The resolver is exercised entirely through injected lookPath/isExecutable
+// funcs: no case may depend on the host's PATH or on openclaw being installed.
+
+func TestResolveOpenClawBinary_OverrideWinsVerbatim(t *testing.T) {
+	lookPathCalled := false
+	lookPath := func(string) (string, error) {
+		lookPathCalled = true
+		return "/usr/bin/openclaw", nil
+	}
+	got, err := resolveOpenClawBinary("/opt/custom/bin/openclaw", "/home/openclaw", lookPath, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("resolveOpenClawBinary: %v", err)
+	}
+	if got != "/opt/custom/bin/openclaw" {
+		t.Errorf("binary = %q, want the configured override used verbatim", got)
+	}
+	if lookPathCalled {
+		t.Error("an explicit override must not be second-guessed by a PATH lookup")
+	}
+}
+
+func TestResolveOpenClawBinary_UsesPathHit(t *testing.T) {
+	lookPath := func(name string) (string, error) {
+		if name != "openclaw" {
+			t.Errorf("lookPath(%q), want lookPath(\"openclaw\")", name)
+		}
+		return "/usr/bin/openclaw", nil
+	}
+	probed := false
+	got, err := resolveOpenClawBinary("", "/home/openclaw", lookPath, func(string) bool {
+		probed = true
+		return true
+	})
+	if err != nil {
+		t.Fatalf("resolveOpenClawBinary: %v", err)
+	}
+	if got != "/usr/bin/openclaw" {
+		t.Errorf("binary = %q, want the PATH hit /usr/bin/openclaw", got)
+	}
+	if probed {
+		t.Error("well-known paths must only be probed when PATH misses")
+	}
+}
+
+// The bug this fixes: on a node-agent running as a systemd *user* service the
+// inherited PATH excludes ~/.local/share/pnpm, so a pnpm global install of
+// openclaw is invisible to LookPath even though the shim works in a shell.
+func TestResolveOpenClawBinary_FallsBackToPnpmShim(t *testing.T) {
+	shim := filepath.Join("/home/openclaw", ".local", "share", "pnpm", "openclaw")
+	lookPath := func(string) (string, error) { return "", fmt.Errorf("not found in $PATH") }
+	isExecutable := func(path string) bool { return path == shim || path == "/usr/bin/openclaw" }
+
+	got, err := resolveOpenClawBinary("", "/home/openclaw", lookPath, isExecutable)
+	if err != nil {
+		t.Fatalf("resolveOpenClawBinary: %v", err)
+	}
+	if got != shim {
+		t.Errorf("binary = %q, want the pnpm shim %q (probed before /usr/bin)", got, shim)
+	}
+}
+
+func TestResolveOpenClawBinary_ProbesWellKnownPathsInOrder(t *testing.T) {
+	home := "/home/openclaw"
+	want := []string{
+		filepath.Join(home, ".local", "share", "pnpm", "openclaw"),
+		filepath.Join(home, ".local", "bin", "openclaw"),
+		"/usr/local/bin/openclaw",
+		"/usr/bin/openclaw",
+		"/opt/homebrew/bin/openclaw",
+	}
+	for _, only := range want {
+		lookPath := func(string) (string, error) { return "", fmt.Errorf("not found in $PATH") }
+		got, err := resolveOpenClawBinary("", home, lookPath, func(path string) bool { return path == only })
+		if err != nil {
+			t.Fatalf("resolveOpenClawBinary with only %q installed: %v", only, err)
+		}
+		if got != only {
+			t.Errorf("binary = %q, want %q", got, only)
+		}
+	}
+
+	var probed []string
+	lookPath := func(string) (string, error) { return "", fmt.Errorf("not found in $PATH") }
+	if _, err := resolveOpenClawBinary("", home, lookPath, func(path string) bool {
+		probed = append(probed, path)
+		return false
+	}); err == nil {
+		t.Fatal("expected an error when nothing is installed")
+	}
+	if len(probed) != len(want) {
+		t.Fatalf("probed %v, want the %d well-known paths %v", probed, len(want), want)
+	}
+	for i := range want {
+		if probed[i] != want[i] {
+			t.Errorf("probe %d = %q, want %q", i, probed[i], want[i])
+		}
+	}
+}
+
+// No home directory (os.UserHomeDir failed) must not produce relative garbage
+// candidates like ".local/share/pnpm/openclaw".
+func TestResolveOpenClawBinary_SkipsHomeCandidatesWithoutHome(t *testing.T) {
+	lookPath := func(string) (string, error) { return "", fmt.Errorf("not found in $PATH") }
+	_, err := resolveOpenClawBinary("", "", lookPath, func(path string) bool {
+		if !filepath.IsAbs(path) {
+			t.Errorf("probed relative candidate %q", path)
+		}
+		return false
+	})
+	if err == nil {
+		t.Fatal("expected an error when nothing is installed")
+	}
+}
+
+func TestResolveOpenClawBinary_ActionableErrorNamesConfigKey(t *testing.T) {
+	lookPath := func(string) (string, error) { return "", fmt.Errorf("not found in $PATH") }
+	_, err := resolveOpenClawBinary("", "/home/openclaw", lookPath, func(string) bool { return false })
+	if err == nil {
+		t.Fatal("expected an error when openclaw resolves nowhere")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "openclawBinary") {
+		t.Errorf("error %q must name the openclawBinary config key so the operator knows the fix", msg)
+	}
+	// The message composes into "Couldn't start the agent process — <err>".
+	if strings.HasPrefix(msg, "Openclaw") || strings.HasSuffix(msg, ".") {
+		t.Errorf("error %q must stay a lowercase sentence fragment", msg)
+	}
+}
+
+func TestIsExecutableFile(t *testing.T) {
+	dir := t.TempDir()
+
+	plain := filepath.Join(dir, "openclaw-plain")
+	if err := os.WriteFile(plain, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isExecutableFile(plain) {
+		t.Error("a non-executable file must not resolve as the binary")
+	}
+	if err := os.Chmod(plain, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !isExecutableFile(plain) {
+		t.Error("an executable file must resolve as the binary")
+	}
+	if isExecutableFile(filepath.Join(dir, "missing")) {
+		t.Error("a missing path must not resolve as the binary")
+	}
+	if isExecutableFile(dir) {
+		t.Error("a directory must not resolve as the binary")
+	}
+
+	// pnpm installs a symlink shim; resolution must follow it.
+	link := filepath.Join(dir, "openclaw-shim")
+	if err := os.Symlink(plain, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if !isExecutableFile(link) {
+		t.Error("a symlink to an executable (the pnpm shim shape) must resolve")
+	}
+}
+
+// --- ACPCommand integration ---
+
+func TestOpenClawACPCommand_UsesResolvedBinary(t *testing.T) {
+	home := testdataOpenClawHome(t)
+	d := NewOpenClawFrom(OpenClawConfig{Home: home})
+	o := stubOpenClawHost(t, d, true)
+	shim := "/home/openclaw/.local/share/pnpm/openclaw"
+	o.resolveBinary = func() (string, error) { return shim, nil }
+
+	argv, _, _, err := d.(ACPCommander).ACPCommand("openclaw")
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if argv[0] != shim {
+		t.Errorf("argv[0] = %q, want the resolved binary %q — a bare name relies on PATH", argv[0], shim)
+	}
+}
+
+// The config override goes through the production resolver wiring (no seam
+// injection), which is the whole point of the escape hatch.
+func TestOpenClawACPCommand_ConfigBinaryOverride(t *testing.T) {
+	home := testdataOpenClawHome(t)
+	d := NewOpenClawFrom(OpenClawConfig{
+		Home:   home,
+		Binary: "/opt/custom/bin/openclaw",
+		// A gateway URL keeps the local gateway probe out of this test.
+		GatewayURL: "wss://gateway.invalid:18789",
+	})
+
+	argv, _, _, err := d.(ACPCommander).ACPCommand("openclaw")
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if argv[0] != "/opt/custom/bin/openclaw" {
+		t.Errorf("argv[0] = %q, want the configured openclawBinary", argv[0])
+	}
+}
+
+func TestOpenClawACPCommand_UnresolvableBinary(t *testing.T) {
+	home := testdataOpenClawHome(t)
+	d := NewOpenClawFrom(OpenClawConfig{Home: home})
+	o := stubOpenClawHost(t, d, true)
+	o.resolveBinary = func() (string, error) {
+		return "", fmt.Errorf("openclaw: couldn't find the openclaw binary on this node — set openclawBinary in the node config")
+	}
+
+	_, _, _, err := d.(ACPCommander).ACPCommand("openclaw")
+	if err == nil {
+		t.Fatal("expected an error rather than argv that exec would fail on later")
+	}
+	if !strings.Contains(err.Error(), "openclawBinary") {
+		t.Errorf("error %q must name the openclawBinary config key", err)
+	}
+}
+
+// A node with neither the binary nor a gateway reports the missing binary: it is
+// the more fundamental failure (a running gateway is useless without the CLI)
+// and its fix is a config key, not "start the gateway".
+func TestOpenClawACPCommand_NoBinaryNoGatewayReportsBinary(t *testing.T) {
+	home := testdataOpenClawHome(t)
+	d := NewOpenClawFrom(OpenClawConfig{Home: home})
+	o := stubOpenClawHost(t, d, false)
+	o.resolveBinary = func() (string, error) {
+		return "", fmt.Errorf("openclaw: couldn't find the openclaw binary on this node — set openclawBinary in the node config")
+	}
+
+	_, _, _, err := d.(ACPCommander).ACPCommand("openclaw")
+	if err == nil {
+		t.Fatal("expected an error when neither the binary nor the gateway is present")
+	}
+	if !strings.Contains(err.Error(), "openclawBinary") {
+		t.Errorf("error %q should report the missing binary first", err)
+	}
+	if strings.Contains(err.Error(), "gateway isn't running") {
+		t.Errorf("error %q reports the gateway, but the binary is the blocking problem", err)
+	}
+}
+
+// An unrecognized key is still rejected before any host probing.
+func TestOpenClawACPCommand_BadKeySkipsBinaryResolution(t *testing.T) {
+	d := NewOpenClawFrom(OpenClawConfig{Home: testdataOpenClawHome(t)})
+	o := stubOpenClawHost(t, d, true)
+	o.resolveBinary = func() (string, error) {
+		t.Error("binary resolution must not run for an unrecognized station key")
+		return "openclaw", nil
+	}
+
+	if _, _, _, err := d.(ACPCommander).ACPCommand("hermes:main"); err == nil {
+		t.Fatal("expected error for unrecognized key")
+	}
+}

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -173,12 +173,16 @@ Stations advertising the `acp` capability get a **Chat** tab — a real conversa
 Prerequisites:
 
 - **OpenClaw ≥ 2026.1.20** on the node (that release added the `acp` subcommand).
-- **The OpenClaw Gateway must be running.** The bridge dials it over WebSocket. If no Gateway is running on the node and no remote URL is configured, opening a session fails immediately with `Couldn't start the agent process — openclaw: the OpenClaw gateway isn't running on this node — start it before opening a session` rather than hanging until the handshake times out.
+- **The `openclaw` binary must be findable.** The node-agent resolves it, in order: the `openclawBinary` config key (used verbatim) → `PATH` → the well-known install paths `~/.local/share/pnpm/openclaw`, `~/.local/bin/openclaw`, `/usr/local/bin/openclaw`, `/usr/bin/openclaw`, `/opt/homebrew/bin/openclaw` (first one that exists and is executable; symlink shims are followed). If none resolves, opening a session fails immediately with `Couldn't start the agent process — openclaw: couldn't find the openclaw binary on this node — set openclawBinary in the node config`.
+- **The OpenClaw Gateway must be running.** The bridge dials it over WebSocket. If no Gateway is running on the node and no remote URL is configured, opening a session fails immediately with `Couldn't start the agent process — openclaw: the OpenClaw gateway isn't running on this node — start it before opening a session` rather than hanging until the handshake times out. (When both the binary and the Gateway are missing, the binary is reported first — nothing can start without it.)
 
-A default local install needs **no configuration** — openclaw resolves the Gateway URL and credentials from its own config. Three optional node config keys override that (`~/.config/agentpod-node/config.json`, or `~/Library/Application Support/agentpod-node/config.json` on macOS):
+> **PATH gotcha — systemd user service.** The node-agent usually runs as a `systemctl --user` unit whose `Environment=` is empty, so it inherits systemd's minimal default `PATH` (`/usr/local/bin:/usr/bin:/bin` and friends). A **pnpm or npm-global install** of openclaw lives under `~/.local/share/pnpm` or `~/.local/bin` — invisible to that `PATH`, even though `openclaw` works fine in your interactive shell. That is why the well-known paths are probed; if your install is somewhere else again, set `openclawBinary` to the absolute path (`which openclaw` in a login shell tells you which) and `apn restart`.
+
+A default local install needs **no configuration** — openclaw resolves the Gateway URL and credentials from its own config. Four optional node config keys override that (`~/.config/agentpod-node/config.json`, or `~/Library/Application Support/agentpod-node/config.json` on macOS):
 
 ```json
 {
+  "openclawBinary": "/home/openclaw/.local/share/pnpm/openclaw",
   "openclawGatewayUrl": "wss://gateway.internal:18789",
   "openclawTokenFile": "/etc/agentpod/openclaw.token",
   "openclawSessionLabel": "console"
@@ -187,6 +191,7 @@ A default local install needs **no configuration** — openclaw resolves the Gat
 
 | Key | Flag | Meaning |
 |-----|------|---------|
+| `openclawBinary` | `argv[0]` | Absolute path to the `openclaw` executable. Used verbatim, skipping `PATH` and the well-known-path probe. |
 | `openclawGatewayUrl` | `--url` | Point at a remote Gateway. When set, the local Gateway check is skipped. |
 | `openclawTokenFile` | `--token-file` | **Path to a file** containing the Gateway token. |
 | `openclawSessionLabel` | `--session` | Session component of the OpenClaw session key; default `main`. |


### PR DESCRIPTION
## Why

Found live minutes after v0.1.14 shipped. On the `superchotu` node, opening a chat session on an OpenClaw station failed with:

> Couldn't start the agent process — acp.open: exec: "openclaw": executable file not found in $PATH.

Slice 4a's `ACPCommand` returned a bare `openclaw` and trusted PATH. That worked on the other node only because OpenClaw happens to live in `/usr/bin` there. On superchotu it's a **pnpm global install** — the working shim is `~/.local/share/pnpm/openclaw` — and the node-agent runs as a **systemd user service**, which inherits systemd's minimal default PATH. That PATH excludes both `~/.local/share/pnpm` and `~/.local/bin`, so a perfectly good install is invisible to `exec.LookPath` even though the operator's interactive shell finds it fine.

## Fix

Resolve the executable instead of assuming, in order:

1. `openclawBinary` from the node config — used verbatim, because the operator knows their layout
2. `exec.LookPath("openclaw")`
3. Well-known absolute paths, in priority order: `~/.local/share/pnpm/openclaw` (pnpm global), `~/.local/bin/openclaw`, `/usr/local/bin`, `/usr/bin`, `/opt/homebrew/bin` (Apple-silicon Homebrew)

If none resolve, fail with an actionable fragment — `couldn't find the openclaw binary on this node — set openclawBinary in the node config` — which composes into the console's "Couldn't start the agent process — …" rather than leaking a raw exec error.

Resolution runs **before** the gateway probe: a node without the CLI can't open a session however healthy its Gateway is, so that's the failure worth reporting when both are wrong.

Both host-touching seams (the gateway probe and the resolver) are injectable, so no test depends on the host's PATH, filesystem, or on OpenClaw being installed — and none spawns or pgreps anything, per the repo's Go test-hygiene rule.

## Tests

node-agent `go test -race ./...` all packages ✅ · `go vet` ✅ — 13 new cases: override used verbatim, PATH hit, pnpm-shim fallback, exact probe order, the actionable error naming `openclawBinary`, binary-before-gateway precedence, and config→registry threading.

`docs/OPERATING.md` documents the resolution order, the new key, and the systemd-user-PATH gotcha.

## Known gaps (deliberate)

Only the ACP spawn path is fixed. OpenClaw's lifecycle `Start`/`Stop` and the gateway probe still shell out to `systemctl`/`pgrep` with the same minimal-PATH exposure. The well-known list is a heuristic — nvm/volta or `node_modules/.bin` installs still need `openclawBinary`, which is why the error names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB