### PR TITLE
test(hub): de-flake the stale-turn epoch test

### DIFF
--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -785,11 +785,19 @@ test(
         return s?.status === "idle";
       });
 
-      // Turn #2 starts.
+      // Turn #2 starts. Wait for its "working" state EVENT, not just the row:
+      // the row update and the event insert land in separate statements, so a
+      // poll on the row can win the race and `before` would miss an event that
+      // shows up a beat later — the count below then reads 8 instead of 7. That
+      // flaked on CI (run 31370830538) before this poll watched the events.
       await promptSession(TEST_USER, row.id, "task two");
       await pollUntil(async () => {
-        const s = await getSession(TEST_USER, row.id);
-        return s?.status === "working";
+        const working = (await eventsFor(row.id)).filter(
+          (e) =>
+            e.type === "state" &&
+            (e.payload as { status?: string } | null)?.status === "working"
+        );
+        return working.length === 2; // turn #1's and turn #2's
       });
       const before = (await eventsFor(row.id)).length;
 


### PR DESCRIPTION
## Why

CI failed on `main` in [run 31370830538](https://github.com/rakeshgangwar/agentpod/actions/runs/31370830538/job/93399195279): `Expected: 7, Received: 8` at `acp-sessions.test.ts:804`.

Not a defect in the code under test. The test polled the **session row** until status was `working`, then counted **events**. The row update and the event insert are separate statements, so the poll could win the race — the captured baseline missed an event that landed a beat later, and the strict count assertion then read 8 instead of 7.

## Fix

Poll for turn #2's own `working` **state event** (two `working` state events total: turn #1's and turn #2's) before capturing the baseline, so both reads see the same committed history. The strict `after.length === before` assertion is kept — it's the one that proves no spurious state event came from the stale completion — it just no longer races the write it depends on.

## Note on local verification

My machine was at load average 34 while verifying (a lot of concurrent work), which made the fake-node WebSocket rigs time out across unrelated tests, so local runs weren't trustworthy for this. The epoch test itself passed under that load — which is precisely the flake's condition — and CI here is the clean adjudicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB