### PR TITLE
feat: ACP slice 4c — session history

### DIFF
--- a/apps/console/src/lib/api/acp.test.ts
+++ b/apps/console/src/lib/api/acp.test.ts
@@ -260,6 +260,35 @@ test("listAcpSessions GETs /api/stations/:id/acp/sessions", async () => {
   expect(rows).toEqual([sessionRow]);
 });
 
+test("listAcpSessions passes limit + the compound cursor through as query params", async () => {
+  // The history surface pages with a compound cursor (lastEventAt + id), so the
+  // timestamp MUST be url-encoded — a raw ISO string carries colons the hub
+  // would have to guess at — and `beforeId` must go with it, or a group of tied
+  // timestamps straddling a page boundary drops rows from history for good.
+  const fetchSpy = vi.fn().mockResolvedValue(jsonResponse([sessionRow]));
+  vi.stubGlobal("fetch", fetchSpy);
+
+  await listAcpSessions("st1", {
+    limit: 20,
+    before: "2026-08-09T00:00:00.000Z",
+    beforeId: "s1",
+  });
+
+  const [url] = fetchSpy.mock.calls[0];
+  expect(url).toBe(
+    "http://hub.test:3001/api/stations/st1/acp/sessions?limit=20&before=2026-08-09T00%3A00%3A00.000Z&beforeId=s1",
+  );
+});
+
+test("listAcpSessions with no cursor GETs the bare path (hub's own default page)", async () => {
+  const fetchSpy = vi.fn().mockResolvedValue(jsonResponse([sessionRow]));
+  vi.stubGlobal("fetch", fetchSpy);
+
+  await listAcpSessions("st1", {});
+
+  expect(fetchSpy.mock.calls[0][0]).toBe("http://hub.test:3001/api/stations/st1/acp/sessions");
+});
+
 test("endAcpSession DELETEs /api/acp/sessions/:sessionId and resolves on 204", async () => {
   const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
   vi.stubGlobal("fetch", fetchSpy);

--- a/apps/console/src/lib/api/acp.ts
+++ b/apps/console/src/lib/api/acp.ts
@@ -4,9 +4,9 @@
  * Thin client for the hub's ACP session API.
  *
  * REST (via client.ts `http`):
- *   POST   /api/stations/:id/acp/sessions {mode} → 201 AcpSessionRow
- *   GET    /api/stations/:id/acp/sessions        → AcpSessionRow[]
- *   DELETE /api/acp/sessions/:sessionId          → 204
+ *   POST   /api/stations/:id/acp/sessions {mode}          → 201 AcpSessionRow
+ *   GET    /api/stations/:id/acp/sessions[?limit&before]  → AcpSessionRow[]
+ *   DELETE /api/acp/sessions/:sessionId                   → 204
  *
  * WS (mirrors terminal.ts):
  *   /api/acp/sessions/:sessionId/ws speaking AcpClientMsg / AcpServerMsg
@@ -39,8 +39,40 @@ export const createAcpSession = (stationId: string, mode: AcpSessionMode) =>
     body: JSON.stringify({ mode }),
   });
 
-export const listAcpSessions = (stationId: string) =>
-  http<AcpSessionRow[]>(`/api/stations/${stationId}/acp/sessions`);
+/**
+ * The station's sessions, newest ACTIVITY first (hub SQL order — never
+ * re-sorted by callers).
+ *
+ * Paging options exist for the history surface, which lists sessions a station
+ * accumulated over weeks: `limit` (hub default 20, clamped to 100) and a
+ * COMPOUND cursor, `before` (a `lastEventAt` ISO string) plus `beforeId` — the
+ * hub reads them as `lastEventAt < before OR (lastEventAt = before AND id <
+ * beforeId)`. Both come from the LAST row of the page just received, and both
+ * must be sent: `lastEventAt` is only millisecond-resolution, so a page boundary
+ * landing inside a group of tied timestamps drops the tied rows that missed the
+ * earlier page out of every later page too — they vanish from history rather
+ * than merely repeating. `before` alone still works (the hub falls back to a
+ * strict `<`); it is just lossy.
+ *
+ * Omitting all three leaves the page size to the hub, which is what the
+ * switcher wants.
+ */
+export const listAcpSessions = (
+  stationId: string,
+  opts: { limit?: number; before?: string; beforeId?: string } = {},
+) => {
+  const params = new URLSearchParams();
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  // The cursor is an ISO timestamp — colons and '+' MUST be encoded, which is
+  // exactly what URLSearchParams does (hand-built query strings have shipped
+  // half-parsed cursors before).
+  if (opts.before !== undefined) params.set("before", opts.before);
+  if (opts.beforeId !== undefined) params.set("beforeId", opts.beforeId);
+  const query = params.toString();
+  return http<AcpSessionRow[]>(
+    `/api/stations/${stationId}/acp/sessions${query ? `?${query}` : ""}`,
+  );
+};
 
 export const endAcpSession = (sessionId: string) =>
   http<void>(`/api/acp/sessions/${sessionId}`, { method: "DELETE" });

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -17,8 +17,14 @@
    * one there is nothing to switch to, and an inert control beside the status
    * line would be noise. Rows are rendered in the order the hub gave them
    * (newest-activity-first) — never re-sorted here, or the list would reshuffle
-   * under the pointer. Each row is numbered by creation order so two sessions
-   * that happen to share a status and a rounded age are still tellable apart.
+   * under the pointer. A row is named by its TITLE (the session's first prompt)
+   * and falls back to "Session N" numbered by creation order, so two untitled
+   * sessions sharing a status and a rounded age are still tellable apart.
+   *
+   * The switcher is a shortcut, not an archive: it shows at most SWITCHER_LIMIT
+   * sessions and, when the station has more, ends with an "All sessions…" row
+   * that opens the history dialog. An uncapped dropdown of every session a
+   * station ever hosted is unusable, and history is the surface built for scale.
    *
    * "New session" is offered whatever the current session's status: a station
    * can host several at once, so starting another is not something to wait for
@@ -41,6 +47,7 @@
   import { Status } from "$lib/components/ui/status";
   import { chipClass } from "$lib/utils/toggle-chip";
   import { relativeTime } from "$lib/utils/relative-time";
+  import { ACP_STATUS_TOKEN, sessionName } from "./session-status";
 
   interface Props {
     session: AcpSessionRow | null;
@@ -57,6 +64,8 @@
     onEnd: () => void;
     onNew: () => void;
     onSelectSession: (sessionId: string) => void;
+    /** Opens the full (paginated) session history — the switcher's escape hatch. */
+    onOpenHistory: () => void;
   }
 
   let {
@@ -71,15 +80,11 @@
     onEnd,
     onNew,
     onSelectSession,
+    onOpenHistory,
   }: Props = $props();
 
-  const STATUS_DOT: Record<AcpSessionStatus, string> = {
-    starting: "starting",
-    working: "starting",
-    idle: "running",
-    waiting: "degraded",
-    ended: "stopped",
-  };
+  /** Shared with the history dialog, so a session is never two colours at once. */
+  const STATUS_DOT = ACP_STATUS_TOKEN;
   const STATUS_LABEL: Record<AcpSessionStatus, string> = {
     starting: "Starting…",
     working: "Working…",
@@ -129,12 +134,67 @@
     return new Map(byAge.map((s, i) => [s.id, i + 1]));
   });
 
-  /** "Session 2 · working · 5m ago" — status stays lowercase (agent-reported data). */
+  /** A session's title, or "Session N" until its first prompt gives it one. */
+  function nameOf(s: AcpSessionRow): string {
+    return sessionName(s, `Session ${sessionNumber.get(s.id) ?? "?"}`);
+  }
+
+  /** The row's meta half: "· working · 5m ago" (status is agent data → lowercase). */
+  function metaOf(s: AcpSessionRow): string {
+    return `· ${s.status} · ${relativeTime(s.lastEventAt)}`;
+  }
+
+  /**
+   * "Fix the flaky test · working · 5m ago" — the row's whole accessible name.
+   * Set explicitly (aria-label) because the visible row is split into a
+   * truncating name and a meta span, and an accessible name assembled from
+   * separate elements is at the mercy of how the browser joins them.
+   */
   function sessionLabel(s: AcpSessionRow): string {
-    return `Session ${sessionNumber.get(s.id) ?? "?"} · ${s.status} · ${relativeTime(s.lastEventAt)}`;
+    return `${nameOf(s)} ${metaOf(s)}`;
   }
 
   const selectedRow = $derived(sessions.find((s) => s.id === selectedId) ?? session);
+
+  /** How many sessions the dropdown itself will show. Beyond it: history. */
+  const SWITCHER_LIMIT = 8;
+  /** Sentinel value for the "All sessions…" row — never a real session id. */
+  const ALL_SESSIONS = "__all-sessions__";
+
+  const visibleSessions = $derived.by(() => {
+    const head = sessions.slice(0, SWITCHER_LIMIT);
+    // The session ON SCREEN is always in the list, even when its activity has
+    // sunk past the cap (opening an old one from history does exactly that) — a
+    // switcher that can't show what you are reading looks like a lost pick.
+    const current = selectedRow;
+    return current && !head.some((s) => s.id === current.id) ? [...head, current] : head;
+  });
+  const hasMoreSessions = $derived(sessions.length > SWITCHER_LIMIT);
+
+  /**
+   * The value bits-ui holds. Mirrors the pick, but it is local state because
+   * "All sessions…" is a COMMAND, not a value: it is reverted the moment it
+   * fires, or the checkmark would sit next to it instead of the session that is
+   * actually on screen.
+   */
+  let selectValue = $state("");
+  $effect(() => {
+    // The panel's pick is authoritative — including when a switch was refused
+    // and `selectedId` stayed where it was. (Seeded here rather than at
+    // declaration so the prop is tracked, not captured once.)
+    selectValue = selectedId ?? "";
+  });
+
+  function handleValueChange(v: string): void {
+    if (v === ALL_SESSIONS) {
+      selectValue = selectedId ?? "";
+      onOpenHistory();
+      return;
+    }
+    // bits-ui re-fires for the value already selected; re-attaching there
+    // would tear down the socket the user is looking at.
+    if (v && v !== selectedId) onSelectSession(v);
+  }
 
   let confirmEndOpen = $state(false);
 </script>
@@ -150,15 +210,7 @@
   </div>
 
   {#if sessions.length > 1}
-    <Select.Root
-      type="single"
-      value={selectedId ?? ""}
-      onValueChange={(v) => {
-        // bits-ui re-fires for the value already selected; re-attaching there
-        // would tear down the socket the user is looking at.
-        if (v && v !== selectedId) onSelectSession(v);
-      }}
-    >
+    <Select.Root type="single" bind:value={selectValue} onValueChange={handleValueChange}>
       <Select.Trigger
         size="sm"
         class="min-w-0 max-w-56"
@@ -177,15 +229,29 @@
           <span class="truncate">Sessions</span>
         {/if}
       </Select.Trigger>
-      <Select.Content>
-        {#each sessions as s (s.id)}
-          <Select.Item value={s.id}>
+      <Select.Content class="max-w-[calc(100vw-2rem)]">
+        {#each visibleSessions as s (s.id)}
+          <!-- aria-label: the row is two spans (a truncating name + its meta), so
+               the accessible name is stated once, verbatim, instead of being
+               reassembled from them. -->
+          <Select.Item value={s.id} aria-label={sessionLabel(s)}>
             <span aria-hidden="true" class="flex">
               <Status form="dot" status={STATUS_DOT[s.status]} />
             </span>
-            <span>{sessionLabel(s)}</span>
+            <!-- min-w-0 + truncate: a title is up to 80 chars of the user's own
+                 prose and must not stretch the dropdown across the viewport. -->
+            <span class="min-w-0 max-w-64 truncate">{nameOf(s)}</span>
+            <span class="shrink-0 text-muted-foreground">{metaOf(s)}</span>
           </Select.Item>
         {/each}
+        {#if hasMoreSessions}
+          <!-- Not a session: picking it opens history (handleValueChange reverts
+               the value straight away). It lives INSIDE the listbox so it is
+               reachable by keyboard like every other row. -->
+          <Select.Item value={ALL_SESSIONS} aria-label="All sessions…">
+            <span class="truncate">All sessions…</span>
+          </Select.Item>
+        {/if}
       </Select.Content>
     </Select.Root>
   {/if}

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
@@ -44,6 +44,7 @@ function setup(props: Partial<ComponentProps<typeof ChatHeader>> = {}) {
   const onEnd = vi.fn();
   const onNew = vi.fn();
   const onSelectSession = vi.fn();
+  const onOpenHistory = vi.fn();
   const utils = render(ChatHeader, {
     props: {
       session: row,
@@ -56,10 +57,11 @@ function setup(props: Partial<ComponentProps<typeof ChatHeader>> = {}) {
       onEnd,
       onNew,
       onSelectSession,
+      onOpenHistory,
       ...props,
     },
   });
-  return { ...utils, onModeChange, onEnd, onNew, onSelectSession };
+  return { ...utils, onModeChange, onEnd, onNew, onSelectSession, onOpenHistory };
 }
 
 test("mode chips call onModeChange and mark the active mode pressed", async () => {
@@ -267,4 +269,154 @@ test("an ended session is still listed, and reads as ended", async () => {
 
   const option = await waitFor(() => getByRole("option", { name: /^Session 1 · ended · 2h ago$/ }));
   expect(option).toBeTruthy();
+});
+
+// ─── Titles ─────────────────────────────────────────────────────────────────
+
+/** Opens the switcher (bits-ui: pointerdown) and waits for the listbox. */
+async function openSwitcher(u: ReturnType<typeof setup>): Promise<void> {
+  const trigger = u.getByRole("button", { name: /^Switch session/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await waitFor(() => u.getAllByRole("option"));
+}
+
+test("a titled session is named by its title, not by its number", async () => {
+  // "Session 3 · ended · 2h ago" tells the user nothing about which conversation
+  // it was; the first prompt does.
+  const titled: AcpSessionRow = { ...sessionA, title: "Fix the flaky terminal test" };
+  const u = setup({
+    sessions: [sessionB, titled],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  await openSwitcher(u);
+
+  expect(
+    u.getByRole("option", { name: /^Fix the flaky terminal test · idle · 1h ago$/ }),
+  ).toBeTruthy();
+});
+
+test("the trigger names the attached session by its title too", async () => {
+  const titled: AcpSessionRow = { ...sessionA, title: "Fix the flaky terminal test" };
+  const u = setup({
+    sessions: [titled, sessionB],
+    session: titled,
+    selectedId: titled.id,
+    status: "idle",
+  });
+
+  expect(
+    u.getByRole("button", {
+      name: /^Switch session — currently Fix the flaky terminal test · idle · 1h ago$/,
+    }),
+  ).toBeTruthy();
+});
+
+test("a session with no (or blank) title falls back to its number", async () => {
+  // A session has no title until its first prompt lands, and the hub trims — a
+  // whitespace-only title must not render as a nameless row.
+  const blank: AcpSessionRow = { ...sessionA, title: "   " };
+  const u = setup({
+    sessions: [sessionB, blank],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  await openSwitcher(u);
+
+  expect(u.getByRole("option", { name: /^Session 1 · idle · 1h ago$/ })).toBeTruthy();
+  expect(u.getByRole("option", { name: /^Session 2 · working · 5m ago$/ })).toBeTruthy();
+});
+
+test("a title is rendered as text, never as markup", async () => {
+  // Titles are the user's / the agent's own words — untrusted text.
+  const nasty: AcpSessionRow = {
+    ...sessionA,
+    title: "<img src=x onerror=alert(1)> & <b>bold</b>",
+  };
+  const u = setup({
+    sessions: [sessionB, nasty],
+    session: sessionB,
+    selectedId: sessionB.id,
+    status: "working",
+  });
+
+  await openSwitcher(u);
+
+  const option = u.getByRole("option", { name: /onerror=alert\(1\)/ });
+  expect(option.querySelector("img")).toBeNull();
+  expect(option.querySelector("b")).toBeNull();
+  expect(option.textContent).toContain("<img src=x onerror=alert(1)> & <b>bold</b>");
+});
+
+// ─── Cap + history escape hatch ─────────────────────────────────────────────
+
+/** `n` sessions, newest activity first, created oldest-first. */
+function manySessions(n: number): AcpSessionRow[] {
+  return Array.from({ length: n }, (_, i) => ({
+    ...row,
+    id: `ses_${i + 1}`,
+    createdAt: new Date(Date.UTC(2026, 7, 1, i)).toISOString(),
+    lastEventAt: minutesAgo(i),
+  }));
+}
+
+test("the switcher lists every session while there are 8 or fewer", async () => {
+  const sessions = manySessions(8);
+  const u = setup({ sessions, session: sessions[0], selectedId: sessions[0].id });
+
+  await openSwitcher(u);
+
+  expect(u.getAllByRole("option")).toHaveLength(8);
+  expect(u.queryByRole("option", { name: /All sessions/ })).toBeNull();
+});
+
+test("past 8 sessions the switcher caps at 8 and offers All sessions…", async () => {
+  // A switcher is a shortcut, not an archive: an uncapped dropdown of every
+  // session a station has ever hosted is unusable, and the history surface is
+  // what handles scale.
+  const sessions = manySessions(9);
+  const u = setup({ sessions, session: sessions[0], selectedId: sessions[0].id });
+
+  await openSwitcher(u);
+
+  const options = u.getAllByRole("option");
+  expect(options).toHaveLength(9); // 8 sessions + the escape hatch
+  expect(options.at(-1)!.textContent).toContain("All sessions");
+  // The 9th row (oldest ACTIVITY, so last in the hub's order) is not in the
+  // dropdown — the cap keeps the hub's own front of the list.
+  expect(u.queryByRole("option", { name: /^Session 9 ·/ })).toBeNull();
+  expect(u.getByRole("option", { name: /^Session 1 ·/ })).toBeTruthy();
+
+  // …and the escape hatch opens history rather than attaching anything.
+  const all = u.getByRole("option", { name: /All sessions/ });
+  await fireEvent.pointerUp(all, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await waitFor(() => expect(u.onOpenHistory).toHaveBeenCalledTimes(1));
+  expect(u.onSelectSession).not.toHaveBeenCalled();
+});
+
+test("the session on screen is listed even when it has sunk past the cap", async () => {
+  // Opening an old session from history does exactly this: it is attached while
+  // its activity leaves it at the bottom of the hub's order.
+  const sessions = manySessions(12);
+  const oldest = sessions.at(-1)!;
+  const u = setup({ sessions, session: oldest, selectedId: oldest.id });
+
+  await openSwitcher(u);
+
+  const options = u.getAllByRole("option");
+  expect(options).toHaveLength(10); // 8 + the attached one + All sessions…
+  expect(u.getByRole("option", { name: new RegExp(`^Session 12 ·`) })).toBeTruthy();
+});
+
+test("the capped switcher still adds no second live region", async () => {
+  const sessions = manySessions(12);
+  const u = setup({ sessions, session: sessions[0], selectedId: sessions[0].id });
+
+  await openSwitcher(u);
+
+  expect(u.getAllByRole("status")).toHaveLength(1);
 });

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
@@ -37,6 +37,7 @@
   import ChatHeader from "./ChatHeader.svelte";
   import Conversation from "./Conversation.svelte";
   import PromptInput from "./PromptInput.svelte";
+  import SessionHistory from "./SessionHistory.svelte";
 
   interface Props {
     stationId: string;
@@ -65,6 +66,12 @@
    * there has no session id to be filed under. It is parked all the same, and the
    * next session CREATED inherits it — that text was written for whichever
    * session came next, and creating one is what makes it exist.
+   *
+   * Text typed while an ENDED session is attached lands in that same slot: the
+   * composer there is ALREADY a new-session composer (the notice below says so,
+   * and `prompt()` creates), so its words belong to the next session, not to the
+   * dead one. Filing them under the ended session's own id is how "New session"
+   * used to lose them — the pruning effect below garbage-collects that slot.
    */
   const drafts = new Map<string, string>();
 
@@ -81,6 +88,13 @@
    * in the handler for the thing the user actually clicked.
    */
   let selectedId = $state<string | null>(null);
+
+  /**
+   * The full session history (a dialog, so this panel stays mounted behind it —
+   * the socket, the transcript and the draft all survive browsing). Owned here
+   * because the pick it produces belongs to `selectSession`, not to the header.
+   */
+  let historyOpen = $state(false);
 
   // Plain (non-reactive) ref: the controller holds its own $state internally,
   // so the template stays reactive while the instance itself is stable for the
@@ -105,18 +119,27 @@
   /**
    * Park the on-screen draft under the slot being left and load the slot being
    * landed on. A no-op when nothing moved, so a refused switch (a session that is
-   * gone) leaves the composer exactly as the user left it.
+   * gone) or a failed create leaves the composer exactly as the user left it.
    *
    * `created` marks the landing session as brand new, which is the one case that
    * inherits the pre-session draft — see NEW_SESSION_SLOT.
+   *
+   * `fromEnded` says the session being left had ENDED, which redirects the park
+   * to NEW_SESSION_SLOT: nothing can be sent into that session again, so text
+   * written there is destined for the next one (and the pruning effect below
+   * would otherwise collect it).
    */
-  function swapDraft(from: string | null, to: string | null, created = false) {
-    const fromSlot = draftSlot(from);
+  function swapDraft(from: string | null, to: string | null, created = false, fromEnded = false) {
+    if (from === to) return; // nothing moved — don't touch the composer
+    const fromSlot = fromEnded ? NEW_SESSION_SLOT : draftSlot(from);
     const toSlot = draftSlot(to);
     if (fromSlot === toSlot) return;
 
     if (draft.length > 0) drafts.set(fromSlot, draft);
-    else drafts.delete(fromSlot);
+    // Never leave a stale entry under the slot we actually left: an empty
+    // composer parks nothing, and a redirected park must not also keep a copy
+    // filed under the ended session's own id.
+    if (draft.length === 0 || fromSlot !== draftSlot(from)) drafts.delete(draftSlot(from));
 
     if (created && !drafts.has(toSlot)) {
       const preSession = drafts.get(NEW_SESSION_SLOT);
@@ -128,28 +151,34 @@
     draft = drafts.get(toSlot) ?? "";
   }
 
-  /** Point the header and the drafts at whatever the controller actually attached. */
-  function settleOn(from: string | null, created: boolean) {
+  /**
+   * Point the header and the drafts at whatever the controller actually attached.
+   * `fromEnded` must be read BEFORE the attach/create — by the time this runs,
+   * `chat.status` describes the session just landed on.
+   */
+  function settleOn(from: string | null, created: boolean, fromEnded = false) {
     const landed = chat.session?.id ?? null;
     selectedId = landed;
-    swapDraft(from, landed, created);
+    swapDraft(from, landed, created, fromEnded);
     return landed;
   }
 
   async function selectSession(id: string) {
     const from = chat.session?.id ?? null;
     if (id === from) return; // already on it — don't touch the socket or the draft
+    const fromEnded = chat.status === "ended";
     selectedId = id;
     await chat.attach(id);
     // A refused switch leaves the previous session attached, so the header must
     // fall back to what is really on screen.
-    settleOn(from, false);
+    settleOn(from, false, fromEnded);
   }
 
   async function startSession() {
     const from = chat.session?.id ?? null;
+    const fromEnded = chat.status === "ended";
     await chat.newSession();
-    const landed = settleOn(from, true);
+    const landed = settleOn(from, true, fromEnded);
     // Same reasoning as a failed first prompt: the strip shows it, but a toast is
     // what gets noticed when the transcript below hasn't changed.
     if (chat.error !== null && landed === from) {
@@ -192,7 +221,7 @@
     // has to follow, or the header names the session the user was reading while
     // the transcript below it belongs to a different one — and the stale pick then
     // swallows the next click on either of them.
-    const landed = settleOn(beforeId, needsCreate);
+    const landed = settleOn(beforeId, needsCreate, beforeId !== null && needsCreate);
 
     // A create that failed leaves the session unchanged and the message in
     // `chat.error` — the strip shows it, but a toast is what gets noticed when
@@ -222,6 +251,7 @@
       }}
       onNew={() => void startSession()}
       onSelectSession={(id) => void selectSession(id)}
+      onOpenHistory={() => (historyOpen = true)}
     />
   </div>
 
@@ -259,3 +289,17 @@
     />
   </div>
 </div>
+
+<!-- Mounted only while open, so its list is re-read (and starts at page 1) each
+     time — a station's sessions move while the dialog is shut. Selecting there
+     goes through the SAME selectSession/settleOn path as the switcher: a second
+     attach path is exactly what left the header naming a session the user
+     wasn't in. -->
+{#if historyOpen}
+  <SessionHistory
+    {stationId}
+    currentSessionId={chat.session?.id ?? null}
+    onSelect={(id) => void selectSession(id)}
+    onClose={() => (historyOpen = false)}
+  />
+{/if}

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -135,7 +135,7 @@ function ev(seq: number, type: AcpEvent["type"], payload: unknown): AcpEvent {
 async function renderIdle() {
   vi.spyOn(api, "listAcpSessions").mockResolvedValue([]);
   const utils = render(ChatPanel, { props: { stationId: "st1" } });
-  await waitFor(() => expect(api.listAcpSessions).toHaveBeenCalledWith("st1"));
+  await waitFor(() => expect(api.listAcpSessions).toHaveBeenCalledWith("st1", { limit: 100 }));
   await tick();
   return utils;
 }
@@ -709,7 +709,7 @@ test("a draft typed with no session survives switching away to read one", async 
   const endedB = { ...sessionB, status: "ended" as const };
   vi.spyOn(api, "listAcpSessions").mockResolvedValue([endedB, endedA]);
   const u = render(ChatPanel, { props: { stationId: "st1" } });
-  await waitFor(() => expect(api.listAcpSessions).toHaveBeenCalledWith("st1"));
+  await waitFor(() => expect(api.listAcpSessions).toHaveBeenCalledWith("st1", { limit: 100 }));
   await tick();
   expect(MockWebSocket.instances).toHaveLength(0); // nothing live to attach
   const box = composer(u);

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -733,6 +733,149 @@ test("a draft typed with no session survives switching away to read one", async 
   expect(box.value).toBe("typed before any session");
 });
 
+test("a draft typed into an ENDED session survives New session", async () => {
+  // Regression (4b review): the draft was parked under the ended session's own
+  // slot, which the pruning effect then garbage-collected — the text the user
+  // had just typed vanished on the click that was supposed to carry it forward.
+  const u = await renderWithEnded();
+  await readEndedSession(u);
+  expect(u.getByText("This session has ended — sending starts a new one.")).toBeTruthy();
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "carry me into the next one" } });
+
+  const created = row({
+    id: "sc",
+    createdAt: "2026-08-09T12:00:00.000Z",
+    lastEventAt: minutesAgo(0),
+  });
+  vi.spyOn(api, "createAcpSession").mockResolvedValue(created);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([created, sessionB, endedA]);
+
+  await fireEvent.click(u.getByRole("button", { name: "New session" }));
+  await waitFor(() => expect(api.createAcpSession).toHaveBeenCalledWith("st1", "ask"));
+  await tick();
+
+  // The new session is attached AND the words are still in the composer.
+  expect(MockWebSocket.latest()!.url).toContain("/api/acp/sessions/sc/ws");
+  expect(box.value).toBe("carry me into the next one");
+});
+
+test("a failed create from an ended session keeps the draft on screen", async () => {
+  // The draft is only ever MOVED when the pick actually moves: a create that
+  // failed leaves the same (ended) session attached, so the text stays put.
+  const u = await renderWithEnded();
+  await readEndedSession(u);
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "still here" } });
+
+  vi.spyOn(api, "createAcpSession").mockRejectedValue(new Error("Couldn't start a session."));
+  await fireEvent.click(u.getByRole("button", { name: "New session" }));
+  await waitFor(() => expect(api.createAcpSession).toHaveBeenCalled());
+  await tick();
+
+  expect(box.value).toBe("still here");
+});
+
+// ─── Session history ────────────────────────────────────────────────────────
+
+/** `n` sessions, newest activity first (created oldest-first), each titled. */
+function manySessions(n: number): AcpSessionRow[] {
+  return Array.from({ length: n }, (_, i) => {
+    const age = n - 1 - i; // index 0 = newest activity
+    return row({
+      id: `sh${age}`,
+      title: `Task ${age}`,
+      createdAt: new Date(Date.UTC(2026, 7, 1, age)).toISOString(),
+      lastEventAt: minutesAgo(age),
+      lastSeq: age + 1,
+    });
+  });
+}
+
+test("past 8 sessions the switcher hands off to the history dialog", async () => {
+  const endSpy = vi.spyOn(api, "endAcpSession");
+  const sessions = manySessions(9);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue(sessions);
+  const u = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await tick();
+
+  // The oldest session is past the switcher's cap — history is the way to it.
+  const trigger = u.getByRole("button", { name: /^Switch session/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const all = await waitFor(() => u.getByRole("option", { name: /All sessions/ }));
+  await fireEvent.pointerUp(all, { pointerId: 1, button: 0, pointerType: "mouse" });
+
+  const dialog = await waitFor(() => {
+    const found = u.getAllByRole("dialog").find((d) => d.textContent?.includes("All sessions"));
+    if (!found) throw new Error("history dialog not open yet");
+    return found;
+  });
+  const oldest = await waitFor(() => {
+    const found = u.getAllByRole("button").find((b) => b.textContent?.includes("Task 0"));
+    if (!found) throw new Error("history rows not rendered yet");
+    return found;
+  });
+  expect(dialog.textContent).toContain("Task 0");
+
+  // Selecting there goes through the SAME attach path the switcher uses: the old
+  // socket is dropped, a new one subscribes, and the header names what it landed on.
+  await fireEvent.click(oldest);
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2));
+  const ws2 = MockWebSocket.latest()!;
+  expect(ws2.url).toContain("/api/acp/sessions/sh0/ws");
+  expect(ws.readyState).toBe(3);
+  ws2.open();
+  expect(ws2.frames()).toEqual([{ t: "subscribe", sinceSeq: 0 }]);
+  await waitFor(() =>
+    expect(u.getByRole("button", { name: /^Switch session — currently Task 0 ·/ })).toBeTruthy(),
+  );
+
+  // The dialog got out of the way, and history ended nothing.
+  await waitFor(() =>
+    expect(u.queryAllByRole("dialog").some((d) => d.textContent?.includes("All sessions"))).toBe(
+      false,
+    ),
+  );
+  expect(endSpy).not.toHaveBeenCalled();
+});
+
+test("switching from history parks the draft exactly like the switcher does", async () => {
+  const sessions = manySessions(9);
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue(sessions);
+  const u = render(ChatPanel, { props: { stationId: "st1" } });
+  await waitFor(() => expect(MockWebSocket.latest()).toBeTruthy());
+  MockWebSocket.latest()!.open();
+  MockWebSocket.latest()!.fireMessage({ t: "replay-done", lastSeq: 0 });
+  await tick();
+
+  const box = composer(u);
+  await fireEvent.input(box, { target: { value: "written for Task 8" } });
+
+  const trigger = u.getByRole("button", { name: /^Switch session/ });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const all = await waitFor(() => u.getByRole("option", { name: /All sessions/ }));
+  await fireEvent.pointerUp(all, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const oldest = await waitFor(() => {
+    const found = u.getAllByRole("button").find((b) => b.textContent?.includes("Task 0"));
+    if (!found) throw new Error("history rows not rendered yet");
+    return found;
+  });
+  await fireEvent.click(oldest);
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2));
+  await tick();
+
+  expect(box.value).toBe(""); // Task 0 has no draft of its own
+
+  // …and the parked one comes back on the way home.
+  await switchTo(u, /^Task 8 ·/);
+  await waitFor(() => expect(box.value).toBe("written for Task 8"));
+});
+
 // ─── Connection failures ────────────────────────────────────────────────────
 
 test("an exhausted reconnect budget shows the offline strip with a working Retry", async () => {

--- a/apps/console/src/lib/components/stations/chat/SessionHistory.svelte
+++ b/apps/console/src/lib/components/stations/chat/SessionHistory.svelte
@@ -142,7 +142,14 @@
     {#if rows.length === 0}
       {#if loading}
         <p class="t-label text-muted-foreground">Loading sessions…</p>
-      {:else if error === null}
+      {:else if error !== null}
+        <!-- A failed FIRST page leaves nothing to page from, so "Load older"
+             below is out of reach: without this the only way out of a blank
+             dialog is closing and reopening it. -->
+        <div>
+          <Button variant="outline" size="sm" onclick={() => void loadPage()}>Try again</Button>
+        </div>
+      {:else}
         <Empty
           title="No sessions yet"
           description="Send a message in the composer and the session will show up here."

--- a/apps/console/src/lib/components/stations/chat/SessionHistory.svelte
+++ b/apps/console/src/lib/components/stations/chat/SessionHistory.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  /**
+   * SessionHistory — every ACP session on a station, paginated, read-only.
+   *
+   * A DIALOG, deliberately: the chat panel behind it stays MOUNTED, so the live
+   * socket, the transcript and the per-session draft all survive browsing the
+   * history (the repo's usual list→detail idiom is routing, which would tear the
+   * panel down and re-attach on the way back — for a picker that is pure loss).
+   * `ui/sheet` is also in the kit but is used nowhere in this console; a second
+   * overlay idiom for one list isn't worth introducing, and every other overlay
+   * here (ConfirmDialog, NewRuntimeDialog, …) is a Dialog.
+   *
+   * Read-only by construction: a row ATTACHES (through the panel's one
+   * `selectSession` path — this component only reports the id it was given), and
+   * there is no end/delete action anywhere on the surface. Sessions are
+   * hub-owned; browsing history must never stop an agent process.
+   *
+   * It adds NO live region: the chat header owns the ONE status region in the
+   * panel, and a second one would announce every session flip twice. The load
+   * error is therefore plain text next to the control that triggered it, not an
+   * alert.
+   *
+   * Paging is cursor-based, not offset-based: an offset would skip or repeat rows
+   * as sessions keep streaming and the top of the list moves. The cursor is the
+   * last row's `lastEventAt` AND its id (`before` + `beforeId`) — the timestamp
+   * alone is only millisecond-resolution, so a boundary inside a group of tied
+   * timestamps would drop the tied rows that missed the earlier page out of every
+   * later page too, losing them from history entirely.
+   *
+   * The hub answers with a BARE array: no `hasMore`, no `nextCursor`, so a page
+   * shorter than PAGE_SIZE is what "last page" means. Pages are still merged BY
+   * ID — a session whose activity bumps between requests can arrive twice, and a
+   * duplicate would break the keyed list.
+   */
+  import { onMount } from "svelte";
+  import { listAcpSessions, type AcpSessionRow } from "$lib/api/acp";
+  import { Button } from "$lib/components/ui/button";
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Empty } from "$lib/components/ui/empty";
+  import { Status } from "$lib/components/ui/status";
+  import { relativeTime } from "$lib/utils/relative-time";
+  import { ACP_STATUS_TOKEN, sessionName } from "./session-status";
+
+  interface Props {
+    stationId: string;
+    /** The session the panel has attached — marked, never treated specially. */
+    currentSessionId: string | null;
+    /** Attach this session. The panel routes it through its own switcher path. */
+    onSelect: (sessionId: string) => void;
+    onClose: () => void;
+  }
+
+  let { stationId, currentSessionId, onSelect, onClose }: Props = $props();
+
+  /** Page size. The hub clamps at 100; 20 is one screenful of scrolling. */
+  const PAGE_SIZE = 20;
+
+  let rows = $state<AcpSessionRow[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  /** True once a page came back short — the hub has nothing older to give. */
+  let exhausted = $state(false);
+
+  /** The compound cursor for "everything older than this row". */
+  type Cursor = { before: string; beforeId: string };
+
+  async function loadPage(cursor?: Cursor): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const page = await listAcpSessions(
+        stationId,
+        cursor === undefined ? { limit: PAGE_SIZE } : { limit: PAGE_SIZE, ...cursor },
+      );
+      // Append, never replace: the user keeps their place in the list. Rows
+      // already on screen win — a bumped session must not jump to the bottom.
+      rows =
+        cursor === undefined
+          ? page
+          : [...rows, ...page.filter((s) => !rows.some((seen) => seen.id === s.id))];
+      // No `hasMore` from the hub: a short page is the end of the list. Measured
+      // on the PAGE, not on the merged rows — de-duplication can shorten it.
+      if (page.length < PAGE_SIZE) exhausted = true;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void loadPage();
+  });
+
+  /** The oldest row on screen is the cursor for the next (older) page. */
+  const olderCursor = $derived.by((): Cursor | undefined => {
+    const last = rows.at(-1);
+    return last === undefined ? undefined : { before: last.lastEventAt, beforeId: last.id };
+  });
+
+  /**
+   * Untitled rows can't borrow the header's "Session N": that number comes from
+   * the whole list's creation order, which a paginated view doesn't have.
+   */
+  const nameOf = (s: AcpSessionRow) => sessionName(s, "Untitled session");
+
+  /**
+   * "12 events" — `lastSeq` is the session's highest event seq, so it doubles as
+   * its size. Omitted entirely (rather than shown as 0) when an older hub didn't
+   * send it: an invented count is worse than no count.
+   */
+  function eventCount(s: AcpSessionRow): string | null {
+    if (s.lastSeq === undefined) return null;
+    if (s.lastSeq === 0) return "no events";
+    return s.lastSeq === 1 ? "1 event" : `${s.lastSeq} events`;
+  }
+
+  function choose(sessionId: string): void {
+    // Attach first, then get out of the way — closing first would leave the
+    // panel's focus moving while an attach is still in flight.
+    onSelect(sessionId);
+    onClose();
+  }
+</script>
+
+<Dialog.Root open onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+  <Dialog.Content class="sm:max-w-lg">
+    <Dialog.Header>
+      <Dialog.Title>All sessions</Dialog.Title>
+      <Dialog.Description>
+        Every chat session on this station, newest activity first. Opening one is read-only
+        until you send a message.
+      </Dialog.Description>
+    </Dialog.Header>
+
+    {#if error}
+      <!-- Not a live region (the header owns the panel's only one) — it sits
+           beside the control that failed, where focus already is. -->
+      <p class="t-label text-status-error">{error}</p>
+    {/if}
+
+    {#if rows.length === 0}
+      {#if loading}
+        <p class="t-label text-muted-foreground">Loading sessions…</p>
+      {:else if error === null}
+        <Empty
+          title="No sessions yet"
+          description="Send a message in the composer and the session will show up here."
+        />
+      {/if}
+    {:else}
+      <ul class="-mx-1 max-h-[55vh] min-w-0 overflow-y-auto">
+        {#each rows as s (s.id)}
+          <li class="min-w-0">
+            <button
+              type="button"
+              class="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+              aria-current={s.id === currentSessionId ? "true" : undefined}
+              onclick={() => choose(s.id)}
+            >
+              <!-- The badge carries the status word itself, so the token is only
+                   there for colour — hence the label override. -->
+              <span class="shrink-0">
+                <Status form="badge" status={ACP_STATUS_TOKEN[s.status]} label={s.status} />
+              </span>
+              <span class="min-w-0 flex-1">
+                <!-- min-w-0 + truncate: titles are up to 80 chars of prose. -->
+                <span class="block truncate text-sm text-foreground">{nameOf(s)}</span>
+                <span class="t-label block truncate">
+                  {relativeTime(s.lastEventAt)}{eventCount(s) ? ` · ${eventCount(s)}` : ""}
+                </span>
+              </span>
+              {#if s.id === currentSessionId}
+                <span class="t-label shrink-0">on screen</span>
+              {/if}
+            </button>
+          </li>
+        {/each}
+      </ul>
+
+      {#if !exhausted}
+        <div class="flex items-center gap-2">
+          <Button variant="outline" size="sm" disabled={loading} onclick={() => void loadPage(olderCursor)}>
+            Load older
+          </Button>
+          {#if loading}
+            <span class="t-label text-muted-foreground">Loading…</span>
+          {/if}
+        </div>
+      {/if}
+    {/if}
+  </Dialog.Content>
+</Dialog.Root>

--- a/apps/console/src/lib/components/stations/chat/SessionHistory.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/SessionHistory.svelte.test.ts
@@ -1,0 +1,295 @@
+/**
+ * SessionHistory.svelte.test.ts
+ *
+ * The station's full session history: a paginated, read-only list in a dialog.
+ * The api layer is mocked (spies on $lib/api/acp) — no network is touched.
+ *
+ * Run: cd apps/console && pnpm test src/lib/components/stations/chat/SessionHistory
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, fireEvent, waitFor, within } from "@testing-library/svelte";
+import type { AcpSessionRow } from "@agentpod/contract";
+import * as api from "$lib/api/acp";
+
+import SessionHistory from "./SessionHistory.svelte";
+
+/** Matches the component's page size — the cue that a page was the last one. */
+const PAGE_SIZE = 20;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+/** ISO timestamp `minutes` ago — keeps relative labels deterministic. */
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+function row(over: Partial<AcpSessionRow> = {}): AcpSessionRow {
+  return {
+    id: "s1",
+    stationId: "st1",
+    userId: "u1",
+    mode: "ask",
+    status: "idle",
+    endedReason: null,
+    createdAt: "2026-08-09T00:00:00.000Z",
+    lastEventAt: minutesAgo(5),
+    title: null,
+    lastSeq: 0,
+    ...over,
+  };
+}
+
+/** A full page (so the component keeps offering "Load older"). */
+function fullPage(prefix: string, ageOffset = 0): AcpSessionRow[] {
+  return Array.from({ length: PAGE_SIZE }, (_, i) =>
+    row({
+      id: `${prefix}${i}`,
+      title: `${prefix} session ${i}`,
+      lastEventAt: minutesAgo(ageOffset + i),
+      lastSeq: i,
+    }),
+  );
+}
+
+function setup(rows: AcpSessionRow[], props: { currentSessionId?: string | null } = {}) {
+  const list = vi.spyOn(api, "listAcpSessions").mockResolvedValue(rows);
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const utils = render(SessionHistory, {
+    props: {
+      stationId: "st1",
+      currentSessionId: props.currentSessionId ?? null,
+      onSelect,
+      onClose,
+    },
+  });
+  return { ...utils, list, onSelect, onClose };
+}
+
+/** The dialog element, once its first page has landed. */
+async function dialogOf(u: { getByRole: (r: string) => HTMLElement }): Promise<HTMLElement> {
+  return await waitFor(() => u.getByRole("dialog"));
+}
+
+// ─── Listing ────────────────────────────────────────────────────────────────
+
+test("lists the station's sessions with title, status, activity and event count", async () => {
+  const rows = [
+    row({ id: "sa", title: "Fix the flaky terminal test", status: "idle", lastEventAt: minutesAgo(65), lastSeq: 12 }),
+    row({ id: "sb", title: "Bump the node-agent version", status: "ended", lastEventAt: minutesAgo(150), lastSeq: 1 }),
+  ];
+  const u = setup(rows);
+
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(u.list).toHaveBeenCalledWith("st1", { limit: PAGE_SIZE }));
+
+  const buttons = await waitFor(() => {
+    const found = within(dialog)
+      .getAllByRole("button")
+      .filter((b) => b.textContent?.includes("session") || b.textContent?.includes("Fix") || b.textContent?.includes("Bump"));
+    if (found.length < 2) throw new Error("rows not rendered yet");
+    return found;
+  });
+
+  const first = buttons.find((b) => b.textContent?.includes("Fix the flaky terminal test"))!;
+  expect(first.textContent).toContain("idle");
+  expect(first.textContent).toContain("1h ago");
+  expect(first.textContent).toContain("12 events");
+
+  const second = buttons.find((b) => b.textContent?.includes("Bump the node-agent version"))!;
+  expect(second.textContent).toContain("ended");
+  expect(second.textContent).toContain("2h ago");
+  expect(second.textContent).toContain("1 event");
+  expect(second.textContent).not.toContain("1 events");
+});
+
+test("an untitled session falls back to a plain name, and titles are text only", async () => {
+  const rows = [
+    row({ id: "sa", title: null }),
+    row({ id: "sb", title: "   " }),
+    row({ id: "sc", title: "<img src=x onerror=alert(1)> & <b>bold</b>" }),
+  ];
+  const u = setup(rows);
+  const dialog = await dialogOf(u);
+
+  const untitled = await waitFor(() => within(dialog).getAllByText("Untitled session"));
+  expect(untitled).toHaveLength(2); // null and whitespace-only both fall back
+
+  // Untrusted text: the agent's / the user's own words never become markup.
+  const nasty = within(dialog).getByText("<img src=x onerror=alert(1)> & <b>bold</b>");
+  expect(nasty.querySelector("img")).toBeNull();
+  expect(nasty.querySelector("b")).toBeNull();
+});
+
+test("a station with no sessions shows the empty state, not an empty list", async () => {
+  const u = setup([]);
+  const dialog = await dialogOf(u);
+
+  await waitFor(() => expect(within(dialog).getByText("No sessions yet")).toBeTruthy());
+  expect(within(dialog).queryByRole("button", { name: "Load older" })).toBeNull();
+});
+
+test("a failed load says so instead of looking empty", async () => {
+  vi.spyOn(api, "listAcpSessions").mockRejectedValue(new Error("Couldn't reach the hub."));
+  const u = render(SessionHistory, {
+    props: { stationId: "st1", currentSessionId: null, onSelect: vi.fn(), onClose: vi.fn() },
+  });
+
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(within(dialog).getByText("Couldn't reach the hub.")).toBeTruthy());
+  expect(within(dialog).queryByText("No sessions yet")).toBeNull();
+});
+
+// ─── Pagination ─────────────────────────────────────────────────────────────
+
+test("Load older requests the next page with the compound cursor and appends it", async () => {
+  const first = fullPage("first", 0);
+  const u = setup(first);
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(within(dialog).getByText("first session 19")).toBeTruthy());
+
+  const older = [row({ id: "old1", title: "ancient session", lastEventAt: minutesAgo(9000), lastSeq: 3 })];
+  u.list.mockResolvedValue(older);
+
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Load older" }));
+
+  // The cursor is the OLDEST row on screen — its timestamp AND its id, so a
+  // group of sessions sharing a millisecond can't fall through the boundary.
+  await waitFor(() =>
+    expect(u.list).toHaveBeenLastCalledWith("st1", {
+      limit: PAGE_SIZE,
+      before: first.at(-1)!.lastEventAt,
+      beforeId: first.at(-1)!.id,
+    }),
+  );
+  await waitFor(() => expect(within(dialog).getByText("ancient session")).toBeTruthy());
+  // Appended, not replaced — the user keeps their place in the list.
+  expect(within(dialog).getByText("first session 0")).toBeTruthy();
+});
+
+test("a row that arrives twice is listed once (the cursor is timestamp-only)", async () => {
+  // `before` is a lastEventAt cursor, so a session written in the same
+  // millisecond as the boundary — or one whose activity bumped between
+  // requests — can come back in the next page too. A duplicate would break the
+  // keyed list, so pages are merged by id.
+  const first = fullPage("first", 0);
+  const u = setup(first);
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(within(dialog).getByText("first session 19")).toBeTruthy());
+
+  u.list.mockResolvedValue([first.at(-1)!, row({ id: "old1", title: "genuinely older" })]);
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Load older" }));
+
+  await waitFor(() => expect(within(dialog).getByText("genuinely older")).toBeTruthy());
+  expect(within(dialog).getAllByText("first session 19")).toHaveLength(1);
+});
+
+test("a short page is the last page: Load older goes away", async () => {
+  const u = setup([row({ id: "sa", title: "only session" })]);
+  const dialog = await dialogOf(u);
+
+  await waitFor(() => expect(within(dialog).getByText("only session")).toBeTruthy());
+  expect(within(dialog).queryByRole("button", { name: "Load older" })).toBeNull();
+});
+
+test("Load older disappears once the hub runs out of older sessions", async () => {
+  const u = setup(fullPage("first", 0));
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(within(dialog).getByRole("button", { name: "Load older" })).toBeTruthy());
+
+  u.list.mockResolvedValue([]);
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Load older" }));
+
+  await waitFor(() => expect(within(dialog).queryByRole("button", { name: "Load older" })).toBeNull());
+  expect(within(dialog).getByText("first session 0")).toBeTruthy(); // nothing was dropped
+});
+
+// ─── Selecting ──────────────────────────────────────────────────────────────
+
+test("picking a session hands its id up and closes", async () => {
+  const u = setup([row({ id: "sa", title: "the one I want" }), row({ id: "sb", title: "not this" })]);
+  const dialog = await dialogOf(u);
+
+  const target = await waitFor(() => {
+    const found = within(dialog)
+      .getAllByRole("button")
+      .find((b) => b.textContent?.includes("the one I want"));
+    if (!found) throw new Error("row not rendered yet");
+    return found;
+  });
+  await fireEvent.click(target);
+
+  expect(u.onSelect).toHaveBeenCalledWith("sa");
+  expect(u.onClose).toHaveBeenCalledTimes(1);
+  // Order matters: the panel attaches, then the dialog gets out of the way.
+  expect(u.onSelect.mock.invocationCallOrder[0]).toBeLessThan(
+    u.onClose.mock.invocationCallOrder[0],
+  );
+});
+
+test("the attached session is marked as the current one", async () => {
+  const u = setup([row({ id: "sa", title: "on screen" }), row({ id: "sb", title: "not on screen" })], {
+    currentSessionId: "sa",
+  });
+  const dialog = await dialogOf(u);
+
+  const current = await waitFor(() => {
+    const found = within(dialog)
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("aria-current") === "true");
+    if (!found) throw new Error("current row not marked yet");
+    return found;
+  });
+  expect(current.textContent).toContain("on screen");
+});
+
+// ─── Invariants ─────────────────────────────────────────────────────────────
+
+test("nothing in history ends a session", async () => {
+  // Sessions are hub-owned and this surface is read-only: browsing history must
+  // never stop an agent process.
+  const end = vi.spyOn(api, "endAcpSession");
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const u = setup(fullPage("first", 0));
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(within(dialog).getByText("first session 0")).toBeTruthy());
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Load older" }));
+  const target = within(dialog)
+    .getAllByRole("button")
+    .find((b) => b.textContent?.includes("first session 0"))!;
+  await fireEvent.click(target);
+
+  expect(end).not.toHaveBeenCalled();
+  expect(fetchSpy.mock.calls).toEqual([]);
+});
+
+test("the history dialog adds no live region", async () => {
+  // The chat header owns the ONE status region in the panel; a second one here
+  // would announce every session flip twice.
+  const u = setup([row({ id: "sa", title: "a session" })]);
+  const dialog = await dialogOf(u);
+  await waitFor(() => expect(within(dialog).getByText("a session")).toBeTruthy());
+
+  expect(within(dialog).queryAllByRole("status")).toHaveLength(0);
+  expect(within(dialog).queryAllByRole("alert")).toHaveLength(0);
+});
+
+test("closing the dialog reports it up (Escape, backdrop, close button)", async () => {
+  const u = setup([row({ id: "sa", title: "a session" })]);
+  const dialog = await dialogOf(u);
+
+  await fireEvent.keyDown(dialog, { key: "Escape" });
+
+  await waitFor(() => expect(u.onClose).toHaveBeenCalled());
+  expect(u.onSelect).not.toHaveBeenCalled();
+});

--- a/apps/console/src/lib/components/stations/chat/SessionHistory.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/SessionHistory.svelte.test.ts
@@ -137,8 +137,13 @@ test("a station with no sessions shows the empty state, not an empty list", asyn
   expect(within(dialog).queryByRole("button", { name: "Load older" })).toBeNull();
 });
 
-test("a failed load says so instead of looking empty", async () => {
-  vi.spyOn(api, "listAcpSessions").mockRejectedValue(new Error("Couldn't reach the hub."));
+test("a failed load says so instead of looking empty, and can be retried", async () => {
+  // A failed FIRST page has nothing to page from, so the "Load older" control
+  // isn't rendered — without a retry here the only way out is closing and
+  // reopening the dialog.
+  const list = vi
+    .spyOn(api, "listAcpSessions")
+    .mockRejectedValue(new Error("Couldn't reach the hub."));
   const u = render(SessionHistory, {
     props: { stationId: "st1", currentSessionId: null, onSelect: vi.fn(), onClose: vi.fn() },
   });
@@ -146,6 +151,14 @@ test("a failed load says so instead of looking empty", async () => {
   const dialog = await dialogOf(u);
   await waitFor(() => expect(within(dialog).getByText("Couldn't reach the hub.")).toBeTruthy());
   expect(within(dialog).queryByText("No sessions yet")).toBeNull();
+
+  list.mockResolvedValue([row({ id: "sa", title: "back from the dead" })]);
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Try again" }));
+
+  await waitFor(() => expect(within(dialog).getByText("back from the dead")).toBeTruthy());
+  // The stale error goes with the successful retry.
+  expect(within(dialog).queryByText("Couldn't reach the hub.")).toBeNull();
+  expect(list).toHaveBeenLastCalledWith("st1", { limit: PAGE_SIZE });
 });
 
 // ─── Pagination ─────────────────────────────────────────────────────────────

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -140,7 +140,7 @@ test("init attaches to the newest non-ended session and replays to connected", a
   const chat = new AcpChat("st1");
   await chat.init();
 
-  expect(api.listAcpSessions).toHaveBeenCalledWith("st1");
+  expect(api.listAcpSessions).toHaveBeenCalledWith("st1", { limit: 100 });
   const ws = MockWebSocket.latest();
   expect(ws).toBeTruthy();
   expect(ws!.url).toContain("/api/acp/sessions/s1/ws");
@@ -160,6 +160,29 @@ test("init attaches to the newest non-ended session and replays to connected", a
   expect(chat.mode).toBe("accept-edits"); // synced from the session row
   expect(chat.transcript.lastSeq).toBe(2);
   expect(chat.transcript.items.map((it) => it.kind)).toEqual(["user", "assistant"]);
+});
+
+test("init attaches a live session that sits past the hub's default page", async () => {
+  // Regression: the hub's session list is paginated (default 20). A station where
+  // an idle live session was left running while a dozen short-lived ones were
+  // created and ended has it far down the ACTIVITY order — on the default page it
+  // isn't in the response at all, so `init` found no live row and the panel
+  // opened on "No session" with an empty transcript while the agent was running.
+  const rows = [
+    ...Array.from({ length: 21 }, (_, i) =>
+      row({ id: `dead${i}`, status: "ended", lastEventAt: `2026-08-09T10:${String(i).padStart(2, "0")}:00.000Z` }),
+    ),
+    row({ id: "alive", status: "idle", lastEventAt: "2026-08-01T00:00:00.000Z" }),
+  ];
+  const list = vi.spyOn(api, "listAcpSessions").mockResolvedValue(rows);
+
+  const chat = new AcpChat("st1");
+  await chat.init();
+
+  // Asking for the deepest page is what makes the 22nd row visible at all.
+  expect(list).toHaveBeenCalledWith("st1", { limit: 100 });
+  expect(chat.session?.id).toBe("alive");
+  expect(MockWebSocket.latest()!.url).toContain("/api/acp/sessions/alive/ws");
 });
 
 // ─── (b) init: only ended sessions → idle, no socket ─────────────────────────

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -1055,6 +1055,26 @@ test("attach to an id that is gone re-reads the list and keeps the live session"
   expect(chat.error).toBe("Couldn't open that session — it's no longer there.");
 });
 
+test("attach resolves a session the first page never had, via a deep re-read", async () => {
+  // The history dialog pages far deeper than the switcher, so a legitimate pick
+  // can be a session this controller has never seen. The re-read asks for the
+  // hub's maximum page rather than its default, or that pick would be reported
+  // as "no longer there".
+  const list = vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ id: "sa" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  MockWebSocket.latest()!.open();
+
+  const ancient = row({ id: "s99", createdAt: "2026-01-01T00:00:00.000Z" });
+  list.mockResolvedValue([row({ id: "sa" }), ancient]);
+  await chat.attach("s99");
+
+  expect(list).toHaveBeenLastCalledWith("st1", { limit: 100 });
+  expect(chat.session?.id).toBe("s99");
+  expect(chat.error).toBeNull();
+  expect(MockWebSocket.latest()!.url).toContain("/api/acp/sessions/s99/ws");
+});
+
 test("attach after destroy dials nothing", async () => {
   vi.spyOn(api, "listAcpSessions").mockResolvedValue([row({ id: "sa" }), row({ id: "sb" })]);
   const chat = new AcpChat("st1");

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -103,11 +103,13 @@ const GONE_SESSION_COPY = "Couldn't open that session — it's no longer there."
 export const ECHO_DEADLINE_MS = 20_000;
 
 /**
- * Page size for the session re-read behind create/end/attach. The hub clamps
- * `limit` at 100; asking for the maximum keeps `attach` able to resolve a
- * session the switcher never showed (the history dialog lists far deeper than
- * the switcher's 8), which is the difference between opening an old session and
- * being told it is "no longer there".
+ * Page size for every session list this controller reads (`init` and the re-read
+ * behind create/end/attach). The hub clamps `limit` at 100; asking for the
+ * maximum is what keeps `init` able to FIND a live session that has drifted down
+ * the activity order, and `attach` able to resolve a session the switcher never
+ * showed (the history dialog lists far deeper than the switcher's 8) — the
+ * difference between opening an old session and being told it is "no longer
+ * there". The hub's own default page is 20.
  */
 const SESSION_LIST_LIMIT = 100;
 
@@ -282,11 +284,18 @@ export class AcpChat {
    * List the station's sessions and attach the first live one. Only ended
    * sessions (or none at all) → stay idle with the empty state, but the list is
    * still published so the switcher can offer their transcripts.
+   *
+   * Asks for the DEEPEST page, like `refreshSessions` — the live session is not
+   * necessarily near the top. A station where an idle live session was left
+   * running while a dozen short-lived ones were created and ended has it far
+   * down the activity order, and on the hub's default page it wouldn't be in the
+   * response at all: the panel would open on "No session" with an empty
+   * transcript while the agent is actually running.
    */
   async init(): Promise<void> {
     let rows: AcpSessionRow[];
     try {
-      rows = await listAcpSessions(this.stationId);
+      rows = await listAcpSessions(this.stationId, { limit: SESSION_LIST_LIMIT });
     } catch (err) {
       this.#error = errMessage(err);
       return;

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -102,6 +102,15 @@ const GONE_SESSION_COPY = "Couldn't open that session — it's no longer there."
  */
 export const ECHO_DEADLINE_MS = 20_000;
 
+/**
+ * Page size for the session re-read behind create/end/attach. The hub clamps
+ * `limit` at 100; asking for the maximum keeps `attach` able to resolve a
+ * session the switcher never showed (the history dialog lists far deeper than
+ * the switcher's 8), which is the difference between opening an old session and
+ * being told it is "no longer there".
+ */
+const SESSION_LIST_LIMIT = 100;
+
 let echoDeadlineMs: number = ECHO_DEADLINE_MS;
 
 /** Test hook: shrink the echo deadline (mirrors the hub's `_set…ForTest` hooks). */
@@ -451,7 +460,11 @@ export class AcpChat {
    */
   private async refreshSessions(): Promise<void> {
     try {
-      const rows = await listAcpSessions(this.stationId);
+      // Deepest page the hub allows. This re-read is also `attach`'s last
+      // resort before it calls a session gone, and the history dialog can offer
+      // rows far older than the hub's default page — asking for the default
+      // here would make a legitimate pick from history unattachable.
+      const rows = await listAcpSessions(this.stationId, { limit: SESSION_LIST_LIMIT });
       if (this.destroyed) return;
       this.#sessions = rows;
     } catch {

--- a/apps/console/src/lib/components/stations/chat/session-status.ts
+++ b/apps/console/src/lib/components/stations/chat/session-status.ts
@@ -1,0 +1,44 @@
+/**
+ * session-status.ts
+ *
+ * ACP session vocab → the console's six shared status tokens.
+ *
+ * `tokenFor` (status-badge.ts) knows the fleet vocab, not this one: "idle"
+ * means *ready* for an ACP session but falls through to "stopped" there, and
+ * "working"/"waiting" have no fleet equivalent at all. Both the chat header and
+ * the session-history dialog render the same rows, so the mapping lives here
+ * rather than being copied — two maps drifting apart would colour the same
+ * session differently in two surfaces on the same screen.
+ *
+ * Pair it with `label` when rendering `<Status>`, so the visible word stays the
+ * session's own status ("idle") rather than the token it maps to ("running").
+ */
+
+import type { AcpSessionStatus } from "@agentpod/contract";
+
+export const ACP_STATUS_TOKEN: Record<AcpSessionStatus, string> = {
+  starting: "starting",
+  working: "starting",
+  idle: "running",
+  waiting: "degraded",
+  ended: "stopped",
+};
+
+/**
+ * A session's display name: its title (the first prompt, trimmed + truncated by
+ * the hub) when it has one, else the caller's fallback.
+ *
+ * Titles are UNTRUSTED text — user- or agent-authored — so they are only ever
+ * interpolated as text, never as markup, and a whitespace-only title counts as
+ * no title at all (the hub trims, but an older hub might not). No ellipsis is
+ * appended: the hub truncates without one and there is no way to tell a title
+ * that was cut from one that happened to be 80 chars long, so overflow is CSS's
+ * job (`truncate`).
+ */
+export function sessionName(
+  session: { title?: string | null },
+  fallback: string,
+): string {
+  const title = session.title?.trim();
+  return title !== undefined && title.length > 0 ? title : fallback;
+}

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
@@ -143,7 +143,7 @@ test("an acp station gets Chat first and selected by default, with the panel mou
   });
   // The panel is really there (not just the tab), and it booted the controller.
   expect(getByPlaceholderText("Message the agent…")).toBeTruthy();
-  expect(acpApi.listAcpSessions).toHaveBeenCalledWith("station_1");
+  expect(acpApi.listAcpSessions).toHaveBeenCalledWith("station_1", { limit: 100 });
 });
 
 test("switching away from Chat keeps the panel mounted so its socket survives", async () => {

--- a/apps/hub/src/db/drizzle-migrations/0026_modern_colleen_wing.sql
+++ b/apps/hub/src/db/drizzle-migrations/0026_modern_colleen_wing.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "acp_sessions" ADD COLUMN "title" text;--> statement-breakpoint
+ALTER TABLE "acp_sessions" ADD COLUMN "last_seq" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX "acp_sessions_station_activity_idx" ON "acp_sessions" USING btree ("station_id","last_event_at" DESC NULLS LAST);

--- a/apps/hub/src/db/drizzle-migrations/meta/0026_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0026_snapshot.json
@@ -1,0 +1,1842 @@
+{
+  "id": "ae573edb-6076-410b-9f37-b2f630e5c2ef",
+  "prevId": "30e24d8f-1262-4c23-ad94-34de7bf40522",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "online",
+        "stopped",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1786267145481,
       "tag": "0025_striped_demogoblin",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1786354141066,
+      "tag": "0026_modern_colleen_wing",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/acp.ts
+++ b/apps/hub/src/db/schema/acp.ts
@@ -24,9 +24,15 @@ export const acpSessions = pgTable("acp_sessions", {
   status: text("status").notNull(),                                   // starting|idle|working|waiting|ended
   endedReason: text("ended_reason"),
   nodeSessionId: text("node_session_id"),                             // the node-side acp_* id, for reconciliation acp.close
+  title: text("title"),                                               // first prompt, truncated; null until the first prompt
+  lastSeq: integer("last_seq").notNull().default(0),                  // highest event seq persisted for this session
   createdAt: timestamp("created_at").notNull(),
   lastEventAt: timestamp("last_event_at").notNull(),
-}, (t) => [index("acp_sessions_station_id_idx").on(t.stationId)]);
+}, (t) => [
+  index("acp_sessions_station_id_idx").on(t.stationId),
+  // Ordering index for the paginated per-station history list (newest first).
+  index("acp_sessions_station_activity_idx").on(t.stationId, t.lastEventAt.desc()),
+]);
 
 export const acpEvents = pgTable("acp_events", {
   sessionId: text("session_id").notNull().references(() => acpSessions.id, { onDelete: "cascade" }),

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -384,7 +384,7 @@ test(
 );
 
 test(
-  "GET paging: ?limit= caps the page (out-of-range numbers clamp), ?before= returns strictly older rows, nonsense limit/cursor → 400; rows carry title + lastSeq",
+  "GET paging: ?limit= caps the page (out-of-range numbers clamp), ?before=&beforeId= page strictly older rows and tile a same-millisecond tie group, nonsense/half a cursor → 400; rows carry title + lastSeq",
   async () => {
     const { server, fake, station, baseUrl } = await setupRig(
       "acproute-page-host",
@@ -400,10 +400,27 @@ test(
         rows: res.status === 200 ? ((await res.json()) as AcpSessionRow[]) : [],
       };
     };
+    /** Follow the cursor to the end, `limit` rows at a time. */
+    const walk = async (limit: number, total: number) => {
+      const seen: string[] = [];
+      let cursor: AcpSessionRow | null = null;
+      for (let guard = 0; guard <= total; guard++) {
+        const q = cursor
+          ? `?limit=${limit}&before=${encodeURIComponent(cursor.lastEventAt)}&beforeId=${encodeURIComponent(cursor.id)}`
+          : `?limit=${limit}`;
+        const { status, rows } = await list(q);
+        expect(status).toBe(200);
+        if (rows.length === 0) break;
+        seen.push(...rows.map((r) => r.id));
+        cursor = rows[rows.length - 1]!;
+      }
+      return seen;
+    };
     try {
-      // Three sessions, ended as we go so each lastEventAt is settled and
-      // strictly increasing in creation order. The first one gets a prompt so
-      // the listing has a titled row to prove title/lastSeq reach the client.
+      // Three ended sessions; the first gets a prompt so the listing has a
+      // titled row to prove title/lastSeq reach the client. lastEventAt is
+      // stamped explicitly below so ordering never rides on wall-clock gaps —
+      // and so the same-millisecond tie case can be tested rather than dodged.
       const ids: string[] = [];
       for (let i = 0; i < 3; i++) {
         const res = await createSessionReq(baseUrl, station.id, { mode: "full-auto" });
@@ -418,8 +435,21 @@ test(
         }
         await endSession(TEST_USER, row.id, "test done");
         ids.push(row.id);
-        await new Promise((r) => setTimeout(r, 15));
       }
+      const stampAll = async (at: (i: number) => Date) => {
+        for (const [i, id] of ids.entries()) {
+          // Written as a literal wall-clock timestamp (the column has no time
+          // zone), so what goes in is exactly what comes back out.
+          const stamp = at(i).toISOString().replace("Z", "");
+          await rawSql`
+            UPDATE acp_sessions SET last_event_at = ${stamp}::timestamp
+            WHERE id = ${id}`;
+        }
+      };
+
+      // ── Distinct timestamps ────────────────────────────────────────────────
+      const base = new Date("2026-08-10T00:00:00.000Z");
+      await stampAll((i) => new Date(base.getTime() + i * 1000));
       const newestFirst = [...ids].reverse();
 
       // No query → the whole (short) history, newest activity first.
@@ -437,22 +467,47 @@ test(
       expect(page1.status).toBe(200);
       expect(page1.rows.map((r) => r.id)).toEqual(newestFirst.slice(0, 2));
 
-      // ?before= pages strictly older, with no duplicates and no gaps.
-      const cursor = page1.rows[1]!.lastEventAt;
-      const page2 = await list(`?limit=2&before=${encodeURIComponent(cursor)}`);
+      // ?before=&beforeId= page strictly older, with no duplicates and no gaps.
+      const cursor = page1.rows[1]!;
+      const page2 = await list(
+        `?limit=2&before=${encodeURIComponent(cursor.lastEventAt)}&beforeId=${encodeURIComponent(cursor.id)}`
+      );
       expect(page2.status).toBe(200);
       expect(page2.rows.map((r) => r.id)).toEqual(newestFirst.slice(2));
       expect([...page1.rows, ...page2.rows].map((r) => r.id)).toEqual(newestFirst);
+      expect(await walk(2, ids.length)).toEqual(newestFirst);
+
+      // ?before= alone still works while timestamps differ (old-console path).
+      expect(
+        (await list(`?limit=2&before=${encodeURIComponent(cursor.lastEventAt)}`)).rows.map(
+          (r) => r.id
+        )
+      ).toEqual(newestFirst.slice(2));
+
+      // ── All three tied on ONE millisecond ─────────────────────────────────
+      await stampAll(() => base);
+      const tiedOrder = (await list()).rows.map((r) => r.id);
+      expect([...tiedOrder].sort()).toEqual([...ids].sort());
+      // The full keyset tiles the tie group: every session once, in order.
+      expect(await walk(2, ids.length)).toEqual(tiedOrder);
+      expect(await walk(1, ids.length)).toEqual(tiedOrder);
+      // Without beforeId the tie group is excluded wholesale — the silent
+      // history loss beforeId exists to prevent.
+      const tiedFirst = (await list("?limit=2")).rows;
+      const lossy = await list(
+        `?limit=2&before=${encodeURIComponent(tiedFirst[1]!.lastEventAt)}`
+      );
+      expect(lossy.rows).toHaveLength(0);
 
       // An out-of-range NUMBER is clamped, not rejected.
       expect((await list("?limit=1000")).status).toBe(200);
-      expect((await list("?limit=0")).rows.map((r) => r.id)).toEqual([
-        newestFirst[0]!,
-      ]);
+      expect((await list("?limit=0")).rows).toHaveLength(1);
 
       // Nonsense is a client bug: 400 rather than a silent default page.
       expect((await list("?limit=abc")).status).toBe(400);
       expect((await list("?before=yesterday")).status).toBe(400);
+      // Half a cursor is a broken paging loop, not a fresh page.
+      expect((await list(`?beforeId=${ids[0]}`)).status).toBe(400);
 
       fake.close();
       await new Promise((r) => setTimeout(r, 100));

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -8,7 +8,9 @@
  *        capability, 404 unknown station, 409 the node can't host a second
  *        session, 502 node offline / acp.open failure.
  *     2. GET /api/stations/:id/acp/sessions → rows newest ACTIVITY first,
- *        straight from the service's SQL ordering (the route never re-sorts).
+ *        straight from the service's SQL ordering (the route never re-sorts),
+ *        with ?limit= / ?before= paging (slice 4c) — out-of-range numbers are
+ *        clamped, nonsense is 400.
  *   WS (GET /api/acp/sessions/:sessionId/ws):
  *     3. subscribe → session row, replay of persisted events (seq order),
  *        replay-done, then live events stream; prompt over the WS produces
@@ -379,6 +381,86 @@ test(
     }
   },
   20_000
+);
+
+test(
+  "GET paging: ?limit= caps the page (out-of-range numbers clamp), ?before= returns strictly older rows, nonsense limit/cursor → 400; rows carry title + lastSeq",
+  async () => {
+    const { server, fake, station, baseUrl } = await setupRig(
+      "acproute-page-host",
+      { stationKey: "acproute-page" }
+    );
+    const list = async (query = "") => {
+      const res = await fetch(
+        `${baseUrl}/api/stations/${station.id}/acp/sessions${query}`,
+        { headers: { "X-Test-User-Id": TEST_USER } }
+      );
+      return {
+        status: res.status,
+        rows: res.status === 200 ? ((await res.json()) as AcpSessionRow[]) : [],
+      };
+    };
+    try {
+      // Three sessions, ended as we go so each lastEventAt is settled and
+      // strictly increasing in creation order. The first one gets a prompt so
+      // the listing has a titled row to prove title/lastSeq reach the client.
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const res = await createSessionReq(baseUrl, station.id, { mode: "full-auto" });
+        expect(res.status).toBe(201);
+        const row = (await res.json()) as AcpSessionRow;
+        if (i === 0) {
+          await promptSession(TEST_USER, row.id, "  name this conversation  ");
+          await pollUntil(async () => {
+            const s = await getSession(TEST_USER, row.id);
+            return s?.status === "idle" && s.title !== null;
+          });
+        }
+        await endSession(TEST_USER, row.id, "test done");
+        ids.push(row.id);
+        await new Promise((r) => setTimeout(r, 15));
+      }
+      const newestFirst = [...ids].reverse();
+
+      // No query → the whole (short) history, newest activity first.
+      const all = await list();
+      expect(all.status).toBe(200);
+      expect(all.rows.map((r) => r.id)).toEqual(newestFirst);
+
+      // toContract exposes the slice-4c fields over the wire.
+      const titled = all.rows.find((r) => r.id === ids[0]);
+      expect(titled?.title).toBe("name this conversation");
+      expect(titled?.lastSeq).toBeGreaterThan(1);
+
+      // ?limit= caps the page.
+      const page1 = await list("?limit=2");
+      expect(page1.status).toBe(200);
+      expect(page1.rows.map((r) => r.id)).toEqual(newestFirst.slice(0, 2));
+
+      // ?before= pages strictly older, with no duplicates and no gaps.
+      const cursor = page1.rows[1]!.lastEventAt;
+      const page2 = await list(`?limit=2&before=${encodeURIComponent(cursor)}`);
+      expect(page2.status).toBe(200);
+      expect(page2.rows.map((r) => r.id)).toEqual(newestFirst.slice(2));
+      expect([...page1.rows, ...page2.rows].map((r) => r.id)).toEqual(newestFirst);
+
+      // An out-of-range NUMBER is clamped, not rejected.
+      expect((await list("?limit=1000")).status).toBe(200);
+      expect((await list("?limit=0")).rows.map((r) => r.id)).toEqual([
+        newestFirst[0]!,
+      ]);
+
+      // Nonsense is a client bug: 400 rather than a silent default page.
+      expect((await list("?limit=abc")).status).toBe(400);
+      expect((await list("?before=yesterday")).status).toBe(400);
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
 );
 
 test(

--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -70,6 +70,25 @@ function createErrorStatus(message: string): 403 | 404 | 409 | 502 {
 
 const CreateBody = z.object({ mode: AcpSessionMode });
 
+/** Treat `?limit=` / `?before=` with an empty value as absent, not as junk. */
+const blankToUndefined = (v: unknown) => (v === "" ? undefined : v);
+
+/**
+ * Paging for the session list.
+ *
+ * An out-of-RANGE limit is clamped by the service (1000 → 100): asking for too
+ * much is not a bug. A limit that isn't a number, or a cursor no Date can parse,
+ * IS a client bug — 400 it, because silently serving the default page would
+ * hide a broken paging loop and look like "history stops here".
+ */
+const ListQuery = z.object({
+  limit: z.preprocess(blankToUndefined, z.coerce.number().finite().optional()),
+  before: z.preprocess(
+    blankToUndefined,
+    z.string().datetime({ offset: true }).optional()
+  ),
+});
+
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
 export const stationAcpRoutes = new Hono()
@@ -104,12 +123,14 @@ export const stationAcpRoutes = new Hono()
   )
 
   /**
-   * GET /api/stations/:id/acp/sessions
+   * GET /api/stations/:id/acp/sessions?limit=&before=
    *
-   * Lists the caller's sessions for the station, newest ACTIVITY first (the
-   * service orders in SQL by last_event_at desc, id desc).
+   * One page of the caller's sessions for the station, newest ACTIVITY first
+   * (the service orders in SQL by last_event_at desc, id desc). `before` is the
+   * previous page's last `lastEventAt` — keyset paging, so rows arriving
+   * meanwhile can't shift the page.
    */
-  .get("/stations/:id/acp/sessions", async (c) => {
+  .get("/stations/:id/acp/sessions", zValidator("query", ListQuery), async (c) => {
     const user = c.get("user") as AuthUser | undefined;
     if (!user || user.id === "anonymous") {
       return c.json({ error: "Unauthorized" }, 401);
@@ -121,8 +142,10 @@ export const stationAcpRoutes = new Hono()
       return c.json({ error: "Not Found" }, 404);
     }
 
-    // Already ordered newest-activity-first in SQL — never re-sort here.
-    const rows = await acp.listSessions(user.id, stationId);
+    const { limit, before } = c.req.valid("query");
+    // Already ordered newest-activity-first and limited in SQL — never re-sort
+    // or re-slice here.
+    const rows = await acp.listSessions(user.id, stationId, { limit, before });
     return c.json(rows);
   })
 

--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -74,20 +74,28 @@ const CreateBody = z.object({ mode: AcpSessionMode });
 const blankToUndefined = (v: unknown) => (v === "" ? undefined : v);
 
 /**
- * Paging for the session list.
+ * Paging for the session list. The cursor is the previous page's last row:
+ * `before` its lastEventAt, `beforeId` its id — both halves, or rows tied on
+ * the timestamp fall out of history entirely (see listSessions).
  *
  * An out-of-RANGE limit is clamped by the service (1000 → 100): asking for too
- * much is not a bug. A limit that isn't a number, or a cursor no Date can parse,
- * IS a client bug — 400 it, because silently serving the default page would
- * hide a broken paging loop and look like "history stops here".
+ * much is not a bug. A limit that isn't a number, a cursor no Date can parse, or
+ * half a cursor IS a client bug — 400 it, because silently serving the default
+ * page would hide a broken paging loop and look like "history stops here".
  */
-const ListQuery = z.object({
-  limit: z.preprocess(blankToUndefined, z.coerce.number().finite().optional()),
-  before: z.preprocess(
-    blankToUndefined,
-    z.string().datetime({ offset: true }).optional()
-  ),
-});
+const ListQuery = z
+  .object({
+    limit: z.preprocess(blankToUndefined, z.coerce.number().finite().optional()),
+    before: z.preprocess(
+      blankToUndefined,
+      z.string().datetime({ offset: true }).optional()
+    ),
+    beforeId: z.preprocess(blankToUndefined, z.string().min(1).optional()),
+  })
+  .refine((q) => q.beforeId === undefined || q.before !== undefined, {
+    message: "beforeId requires before",
+    path: ["beforeId"],
+  });
 
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
@@ -123,12 +131,12 @@ export const stationAcpRoutes = new Hono()
   )
 
   /**
-   * GET /api/stations/:id/acp/sessions?limit=&before=
+   * GET /api/stations/:id/acp/sessions?limit=&before=&beforeId=
    *
    * One page of the caller's sessions for the station, newest ACTIVITY first
-   * (the service orders in SQL by last_event_at desc, id desc). `before` is the
-   * previous page's last `lastEventAt` — keyset paging, so rows arriving
-   * meanwhile can't shift the page.
+   * (the service orders in SQL by last_event_at desc, id desc). `before` +
+   * `beforeId` are the previous page's last row — keyset paging, so rows
+   * arriving meanwhile can't shift the page.
    */
   .get("/stations/:id/acp/sessions", zValidator("query", ListQuery), async (c) => {
     const user = c.get("user") as AuthUser | undefined;
@@ -142,10 +150,14 @@ export const stationAcpRoutes = new Hono()
       return c.json({ error: "Not Found" }, 404);
     }
 
-    const { limit, before } = c.req.valid("query");
+    const { limit, before, beforeId } = c.req.valid("query");
     // Already ordered newest-activity-first and limited in SQL — never re-sort
     // or re-slice here.
-    const rows = await acp.listSessions(user.id, stationId, { limit, before });
+    const rows = await acp.listSessions(user.id, stationId, {
+      limit,
+      before,
+      beforeId,
+    });
     return c.json(rows);
   })
 

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -24,8 +24,10 @@
  *      node processes, independent transcripts, independent teardown; a node
  *      that doesn't echo the instance keeps the one-at-a-time behaviour.
  *  12. Slice 4c (history): the first prompt titles the session (and nothing
- *      later renames it), last_seq tracks the transcript's highest seq, and
- *      listSessions pages with limit + a lastEventAt cursor.
+ *      later renames it), the 80-char cut is code-point safe through Postgres,
+ *      last_seq tracks the transcript's highest seq, and listSessions pages on
+ *      the (lastEventAt, id) keyset — including inside a same-millisecond tie
+ *      group, where a timestamp-only cursor would lose rows for good.
  *
  * Uses the local Docker test-postgres (localhost:5434).
  * DATABASE_URL must be set before any src/ modules are imported.
@@ -70,6 +72,7 @@ import {
   reconcileOnBoot,
   closeOrphanedProcesses,
   clampSessionLimit,
+  deriveSessionTitle,
   _setOfflineGraceMsForTest,
   _setOpenDbTimeoutMsForTest,
   _setHandshakeTimeoutMsForTest,
@@ -1687,14 +1690,102 @@ test(
 );
 
 test(
-  "listSessions pagination: limit caps the page and clamps out-of-range values; before returns strictly older rows; two pages tile the history with no duplicates and no gaps",
+  "deriveSessionTitle: the 80-char cut is code-point safe — an emoji on the boundary is kept whole or dropped whole, never left as a lone surrogate",
+  () => {
+    // A string survives a UTF-8 round trip iff it holds no lone surrogate —
+    // exactly the check postgres.js applies on the way into the DB.
+    const wellFormed = (s: string) =>
+      new TextDecoder().decode(new TextEncoder().encode(s)) === s;
+
+    expect(deriveSessionTitle("  hello  ")).toBe("hello");
+    expect(deriveSessionTitle("   \n\t ")).toBeNull();
+
+    // 80 code points whose last is astral: 81 UTF-16 code units, so a
+    // slice(0, 80) would keep the high surrogate alone and postgres would then
+    // silently swallow the emoji. Kept whole instead.
+    const exactly80 = `${"a".repeat(79)}😀`;
+    expect(Array.from(exactly80)).toHaveLength(80);
+    const kept = deriveSessionTitle(exactly80)!;
+    expect(kept).toBe(exactly80);
+    expect(Array.from(kept)).toHaveLength(80);
+    expect(wellFormed(kept)).toBe(true);
+
+    // 81 code points: the emoji is past the budget and is dropped WHOLE.
+    const past = `${"a".repeat(80)}😀`;
+    const cut = deriveSessionTitle(past)!;
+    expect(cut).toBe("a".repeat(80));
+    expect(cut.includes("\uD83D")).toBe(false); // no orphaned high surrogate
+    expect(wellFormed(cut)).toBe(true);
+
+    // An emoji sitting on the boundary of a longer prompt is kept intact and
+    // the code-point budget still holds.
+    const straddling = `${"a".repeat(79)}😀${"b".repeat(20)}`;
+    const clipped = deriveSessionTitle(straddling)!;
+    expect(clipped).toBe(exactly80);
+    expect(Array.from(clipped)).toHaveLength(80);
+    expect(wellFormed(clipped)).toBe(true);
+  }
+);
+
+test(
+  "session titles round-trip through Postgres unchanged: an emoji on the 80-char boundary is stored whole (never a lone surrogate), and one past it is dropped whole",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-title-utf8-host", {
+      stationKey: "acp-title-utf8-station",
+    });
+    const wellFormed = (s: string) =>
+      new TextDecoder().decode(new TextEncoder().encode(s)) === s;
+    try {
+      /** Title a fresh session with `text` and read back what Postgres stored. */
+      const titleFromPrompt = async (text: string) => {
+        const row = await createSession({
+          stationId: station.id,
+          userId: TEST_USER,
+          mode: "full-auto",
+        });
+        await promptSession(TEST_USER, row.id, text);
+        const stored = await pollUntil(async () => {
+          const s = await getSession(TEST_USER, row.id);
+          return s?.title ?? false;
+        });
+        await endSession(TEST_USER, row.id, "cleanup");
+        return stored;
+      };
+
+      // Exactly 80 code points ending in an emoji (81 UTF-16 code units): the
+      // emoji is intact, not swallowed by a broken surrogate pair.
+      const onBoundary = `${"a".repeat(79)}😀`;
+      const stored = await titleFromPrompt(onBoundary);
+      expect(stored).toBe(onBoundary);
+      expect(stored.endsWith("😀")).toBe(true);
+      expect(Array.from(stored)).toHaveLength(80);
+      expect(wellFormed(stored)).toBe(true);
+
+      // One code point past the budget: dropped whole, nothing corrupt stored.
+      const pastBoundary = `${"a".repeat(80)}😀`;
+      const clipped = await titleFromPrompt(pastBoundary);
+      expect(clipped).toBe("a".repeat(80));
+      expect(wellFormed(clipped)).toBe(true);
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "listSessions pagination: limit caps and clamps; the (before, beforeId) keyset pages strictly older rows and resumes INSIDE a same-millisecond tie group without losing or repeating a session",
   async () => {
     const { server, fake, station } = await setupRig("acpsess-page-host", {
       stationKey: "acp-page-station",
     });
     try {
-      // Five sessions, ended as we go so each row's lastEventAt is settled and
-      // strictly increasing in creation order.
+      // Five ended sessions. Their lastEventAt is stamped explicitly below, so
+      // ordering is deterministic — and so the same-millisecond tie case (which
+      // wall-clock gaps would only hide) can be tested head-on.
       const ids: string[] = [];
       for (let i = 0; i < 5; i++) {
         const s = await createSession({
@@ -1704,8 +1795,38 @@ test(
         });
         await endSession(TEST_USER, s.id, "cleanup");
         ids.push(s.id);
-        await new Promise((r) => setTimeout(r, 15)); // distinct lastEventAt
       }
+
+      const stamp = async (at: (i: number) => Date) => {
+        for (const [i, id] of ids.entries()) {
+          await db
+            .update(acpSessions)
+            .set({ lastEventAt: at(i) })
+            .where(eq(acpSessions.id, id));
+        }
+      };
+      /** Walk the whole history `limit` rows at a time with the full keyset. */
+      const walk = async (limit: number) => {
+        const seen: string[] = [];
+        let cursor: { lastEventAt: string; id: string } | null = null;
+        for (let guard = 0; guard <= ids.length; guard++) {
+          const p = await listSessions(TEST_USER, station.id, {
+            limit,
+            ...(cursor
+              ? { before: cursor.lastEventAt, beforeId: cursor.id }
+              : {}),
+          });
+          if (p.length === 0) break;
+          seen.push(...p.map((s) => s.id));
+          const last = p[p.length - 1]!;
+          cursor = { lastEventAt: last.lastEventAt, id: last.id };
+        }
+        return seen;
+      };
+
+      // ── Distinct timestamps ────────────────────────────────────────────────
+      const base = new Date("2026-08-10T00:00:00.000Z");
+      await stamp((i) => new Date(base.getTime() + i * 1000));
       const newestFirst = [...ids].reverse();
 
       // Default limit (20) covers all five, newest activity first.
@@ -1725,30 +1846,59 @@ test(
         (await listSessions(TEST_USER, station.id, { limit: 0 })).map((s) => s.id)
       ).toEqual([newestFirst[0]!]);
 
-      // before = the last row of page 1 → strictly older rows only.
-      const cursor = page1[page1.length - 1]!.lastEventAt;
+      // before + beforeId = the last row of page 1 → strictly older rows.
+      const cursorRow = page1[page1.length - 1]!;
       const page2 = await listSessions(TEST_USER, station.id, {
         limit: 2,
-        before: cursor,
+        before: cursorRow.lastEventAt,
+        beforeId: cursorRow.id,
       });
       expect(page2.map((s) => s.id)).toEqual(newestFirst.slice(2, 4));
       for (const s of page2) {
         expect(new Date(s.lastEventAt).getTime()).toBeLessThan(
-          new Date(cursor).getTime()
+          new Date(cursorRow.lastEventAt).getTime()
         );
       }
-
       // The two pages tile the history: no duplicates, no gaps.
       expect([...page1, ...page2].map((s) => s.id)).toEqual(
         newestFirst.slice(0, 4)
       );
+      // Paging the whole history two at a time reproduces it exactly.
+      expect(await walk(2)).toEqual(newestFirst);
 
-      // The tail page runs out cleanly.
-      const page3 = await listSessions(TEST_USER, station.id, {
+      // A console still sending `before` alone (no beforeId) keeps working while
+      // timestamps differ — the compatibility path.
+      expect(
+        (
+          await listSessions(TEST_USER, station.id, {
+            limit: 2,
+            before: cursorRow.lastEventAt,
+          })
+        ).map((s) => s.id)
+      ).toEqual(newestFirst.slice(2, 4));
+
+      // ── All five tied on ONE millisecond ──────────────────────────────────
+      await stamp(() => base);
+      // The unpaged read is the reference ordering (lastEventAt equal → id desc).
+      const tiedOrder = (await listSessions(TEST_USER, station.id)).map(
+        (s) => s.id
+      );
+      expect([...tiedOrder].sort()).toEqual([...ids].sort());
+
+      // Every session exactly once, in order: the keyset resumes inside the tie
+      // group instead of skipping past it.
+      expect(await walk(2)).toEqual(tiedOrder);
+      expect(await walk(1)).toEqual(tiedOrder);
+
+      // Why beforeId exists: the timestamp-only cursor excludes the ENTIRE tie
+      // group — those three sessions would be missing from every later page,
+      // gone from history with no error at all.
+      const tiedPage1 = await listSessions(TEST_USER, station.id, { limit: 2 });
+      const lossy = await listSessions(TEST_USER, station.id, {
         limit: 2,
-        before: page2[page2.length - 1]!.lastEventAt,
+        before: tiedPage1[tiedPage1.length - 1]!.lastEventAt,
       });
-      expect(page3.map((s) => s.id)).toEqual([newestFirst[4]!]);
+      expect(lossy).toHaveLength(0);
 
       fake.close();
       await new Promise((r) => setTimeout(r, 100));

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -23,6 +23,9 @@
  *  11. Slice 4b: several live sessions per station — distinct instances and
  *      node processes, independent transcripts, independent teardown; a node
  *      that doesn't echo the instance keeps the one-at-a-time behaviour.
+ *  12. Slice 4c (history): the first prompt titles the session (and nothing
+ *      later renames it), last_seq tracks the transcript's highest seq, and
+ *      listSessions pages with limit + a lastEventAt cursor.
  *
  * Uses the local Docker test-postgres (localhost:5434).
  * DATABASE_URL must be set before any src/ modules are imported.
@@ -66,6 +69,7 @@ import {
   subscribe,
   reconcileOnBoot,
   closeOrphanedProcesses,
+  clampSessionLimit,
   _setOfflineGraceMsForTest,
   _setOpenDbTimeoutMsForTest,
   _setHandshakeTimeoutMsForTest,
@@ -1587,6 +1591,165 @@ test(
       expect((await getSession(TEST_USER, live.id))?.status).toBe("idle");
 
       await endSession(TEST_USER, live.id, "cleanup");
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+// ─── Slice 4c: titles, lastSeq, paginated history ─────────────────────────────
+
+test("clampSessionLimit: defaults to 20, floors, and clamps into [1, 100]", () => {
+  expect(clampSessionLimit(undefined)).toBe(20);
+  expect(clampSessionLimit(7)).toBe(7);
+  expect(clampSessionLimit(100)).toBe(100);
+  // Out-of-range values are CLAMPED, never rejected — the route 400s only on
+  // input that isn't a number at all.
+  expect(clampSessionLimit(0)).toBe(1);
+  expect(clampSessionLimit(-5)).toBe(1);
+  expect(clampSessionLimit(500)).toBe(100);
+  expect(clampSessionLimit(2.9)).toBe(2);
+  expect(clampSessionLimit(Number.NaN)).toBe(20);
+});
+
+test(
+  "title + lastSeq: the first real prompt names the session (trimmed, 80 chars, no ellipsis), later prompts never rename it, whitespace leaves it null; lastSeq tracks the highest seq and still does after the end",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-title-host", {
+      stationKey: "acp-title-station",
+    });
+    try {
+      const row = await createSession({
+        stationId: station.id,
+        userId: TEST_USER,
+        mode: "full-auto",
+      });
+      // Fresh session: unnamed, and lastSeq is the create-time idle event.
+      expect(row.title).toBeNull();
+      expect(row.lastSeq).toBe(1);
+
+      /** Prompt, then wait for that turn to land back at idle. */
+      const promptAndSettle = async (text: string) => {
+        const before = (await eventsFor(row.id)).length;
+        await promptSession(TEST_USER, row.id, text);
+        // before+1 is the user-prompt and before+2 the `working` state, so any
+        // idle beyond before+1 is this turn's completion.
+        await pollForEvent(
+          row.id,
+          (e) => stateWith("idle")(e) && e.seq > before + 1
+        );
+      };
+
+      // A whitespace-only prompt is no title at all.
+      await promptAndSettle("   \n\t ");
+      expect((await getSession(TEST_USER, row.id))?.title).toBeNull();
+
+      // The first real prompt names it: trimmed, truncated to 80 chars, stored
+      // truncated with NO ellipsis (presentation is the console's job).
+      const long = `  ${"a".repeat(60)} ${"b".repeat(60)}  `;
+      await promptAndSettle(long);
+      const titled = await getSession(TEST_USER, row.id);
+      expect(titled?.title).toBe(long.trim().slice(0, 80));
+      expect(titled?.title).toHaveLength(80);
+      expect(titled!.title!.includes("…")).toBe(false);
+
+      // A long conversation keeps the label the user recognises.
+      await promptAndSettle("a completely different question");
+      expect((await getSession(TEST_USER, row.id))?.title).toBe(titled!.title);
+
+      // lastSeq === the highest persisted seq across prompts, agent updates and
+      // state events.
+      const evts = await eventsFor(row.id);
+      const maxSeq = Math.max(...evts.map((e) => e.seq));
+      expect(maxSeq).toBeGreaterThan(1);
+      expect((await getSession(TEST_USER, row.id))?.lastSeq).toBe(maxSeq);
+
+      // … and it still reflects the FINAL event once the session has ended.
+      await endSession(TEST_USER, row.id, "cleanup");
+      const ended = await getSession(TEST_USER, row.id);
+      const finalMax = Math.max(
+        ...(await eventsFor(row.id)).map((e) => e.seq)
+      );
+      expect(finalMax).toBe(maxSeq + 1); // the state-ended event
+      expect(ended?.lastSeq).toBe(finalMax);
+      expect(ended?.title).toBe(titled!.title);
+
+      fake.close();
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+test(
+  "listSessions pagination: limit caps the page and clamps out-of-range values; before returns strictly older rows; two pages tile the history with no duplicates and no gaps",
+  async () => {
+    const { server, fake, station } = await setupRig("acpsess-page-host", {
+      stationKey: "acp-page-station",
+    });
+    try {
+      // Five sessions, ended as we go so each row's lastEventAt is settled and
+      // strictly increasing in creation order.
+      const ids: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        const s = await createSession({
+          stationId: station.id,
+          userId: TEST_USER,
+          mode: "ask",
+        });
+        await endSession(TEST_USER, s.id, "cleanup");
+        ids.push(s.id);
+        await new Promise((r) => setTimeout(r, 15)); // distinct lastEventAt
+      }
+      const newestFirst = [...ids].reverse();
+
+      // Default limit (20) covers all five, newest activity first.
+      expect((await listSessions(TEST_USER, station.id)).map((s) => s.id)).toEqual(
+        newestFirst
+      );
+
+      // limit caps the page.
+      const page1 = await listSessions(TEST_USER, station.id, { limit: 2 });
+      expect(page1.map((s) => s.id)).toEqual(newestFirst.slice(0, 2));
+
+      // Out-of-range limits clamp instead of throwing.
+      expect(
+        (await listSessions(TEST_USER, station.id, { limit: 500 })).map((s) => s.id)
+      ).toEqual(newestFirst);
+      expect(
+        (await listSessions(TEST_USER, station.id, { limit: 0 })).map((s) => s.id)
+      ).toEqual([newestFirst[0]!]);
+
+      // before = the last row of page 1 → strictly older rows only.
+      const cursor = page1[page1.length - 1]!.lastEventAt;
+      const page2 = await listSessions(TEST_USER, station.id, {
+        limit: 2,
+        before: cursor,
+      });
+      expect(page2.map((s) => s.id)).toEqual(newestFirst.slice(2, 4));
+      for (const s of page2) {
+        expect(new Date(s.lastEventAt).getTime()).toBeLessThan(
+          new Date(cursor).getTime()
+        );
+      }
+
+      // The two pages tile the history: no duplicates, no gaps.
+      expect([...page1, ...page2].map((s) => s.id)).toEqual(
+        newestFirst.slice(0, 4)
+      );
+
+      // The tail page runs out cleanly.
+      const page3 = await listSessions(TEST_USER, station.id, {
+        limit: 2,
+        before: page2[page2.length - 1]!.lastEventAt,
+      });
+      expect(page3.map((s) => s.id)).toEqual([newestFirst[4]!]);
+
       fake.close();
       await new Promise((r) => setTimeout(r, 100));
     } finally {

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -26,7 +26,8 @@
  * `waiting` and a grace timer ends it.
  */
 
-import { and, desc, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, lt, ne, sql } from "drizzle-orm";
+import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import {
   client,
   ndJsonStream,
@@ -238,6 +239,9 @@ function isNodeSessionIdLive(nodeId: string, nodeSessionId: string): boolean {
 
 type DbRow = typeof acpSessions.$inferSelect;
 
+/** Columns a row write may set alongside the ones persistEvent owns. */
+type SessionRowPatch = PgUpdateSetSource<typeof acpSessions>;
+
 function toContract(r: DbRow): AcpSessionRow {
   return {
     id: r.id,
@@ -248,7 +252,32 @@ function toContract(r: DbRow): AcpSessionRow {
     endedReason: r.endedReason,
     createdAt: r.createdAt.toISOString(),
     lastEventAt: r.lastEventAt.toISOString(),
+    // Slice 4c (history): the console's session list renders the title and
+    // sizes the transcript from lastSeq — a row that omitted them would leave
+    // every session labelled "Session" no matter what was persisted.
+    title: r.title,
+    lastSeq: r.lastSeq,
   };
+}
+
+// ─── Session titles ───────────────────────────────────────────────────────────
+
+/**
+ * Stored title length. Truncation is stored as-is with NO ellipsis: how a
+ * clipped title is presented (…, fade, tooltip) is the console's choice, and
+ * baking a glyph in here would corrupt the data for every other reader.
+ */
+const TITLE_MAX_CHARS = 80;
+
+/**
+ * The title a prompt would give a session: trimmed, clipped to 80 chars.
+ * Whitespace-only prompts name nothing (null) — the next real prompt titles
+ * the session instead.
+ */
+export function deriveSessionTitle(text: string): string | null {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(0, TITLE_MAX_CHARS);
 }
 
 // ─── Event persistence ────────────────────────────────────────────────────────
@@ -279,13 +308,20 @@ function enqueue(live: LiveSession, fn: () => Promise<void>): Promise<void> {
 
 /**
  * Persist the next event: assign seq synchronously, then (serialized) insert
- * into acp_events, bump last_event_at (+ any extra row columns), and fan out.
+ * into acp_events, bump last_event_at + last_seq (+ any extra row columns), and
+ * fan out.
+ *
+ * last_seq rides along in the SAME update as last_event_at — a second round
+ * trip would double every event's write cost and could be observed half-applied
+ * (a row whose activity moved but whose transcript size didn't). Plain
+ * assignment is safe because the writes are serialized per session (enqueue)
+ * in seq order, so the last write always carries the highest seq.
  */
 function persistEvent(
   live: LiveSession,
   type: AcpEventType,
   payload: unknown,
-  rowSet: Partial<typeof acpSessions.$inferInsert> = {}
+  rowSet: SessionRowPatch = {}
 ): { seq: number; done: Promise<void> } {
   const seq = ++live.seq;
   const createdAt = new Date();
@@ -299,7 +335,7 @@ function persistEvent(
     });
     await db
       .update(acpSessions)
-      .set({ lastEventAt: createdAt, ...rowSet })
+      .set({ lastEventAt: createdAt, lastSeq: seq, ...rowSet })
       .where(eq(acpSessions.id, live.id));
     fanOut(live.id, {
       sessionId: live.id,
@@ -716,22 +752,72 @@ async function openSession(input: CreateSessionInput): Promise<AcpSessionRow> {
   }
 }
 
+// ─── Session listing ─────────────────────────────────────────────────────────
+
+/** Page size when the caller doesn't say. */
+const SESSION_PAGE_DEFAULT_LIMIT = 20;
+/** Hard ceiling on one page — a station can accumulate thousands of sessions. */
+const SESSION_PAGE_MAX_LIMIT = 100;
+
+export interface ListSessionsOptions {
+  /** Page size; defaults to 20 and is clamped into [1, 100]. */
+  limit?: number;
+  /**
+   * `lastEventAt` cursor (ISO): return only rows STRICTLY older than this.
+   * Pass the last row of the previous page.
+   */
+  before?: string;
+}
+
 /**
- * The caller's sessions for a station, newest ACTIVITY first (id desc breaks
- * same-millisecond ties). Ordered in SQL so the console's session switcher and
- * the history view share one read — callers must not re-sort.
+ * The page size to use for `limit`: default when absent or not a number,
+ * otherwise floored into [1, 100].
+ *
+ * Out-of-range numbers are clamped rather than refused — a client asking for
+ * 1000 rows gets 100, not an error. Deciding that a *non-numeric* limit is a
+ * client bug worth a 400 is the route's job (it can't be told apart from a
+ * default down here).
+ */
+export function clampSessionLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return SESSION_PAGE_DEFAULT_LIMIT;
+  }
+  return Math.min(SESSION_PAGE_MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+/**
+ * One page of the caller's sessions for a station, newest ACTIVITY first (id
+ * desc breaks same-millisecond ties). Ordered and limited in SQL — backed by
+ * acp_sessions_station_activity_idx — so the console's session switcher and the
+ * history view share one read; callers must not re-sort.
+ *
+ * Paging is keyset, not offset: pass the last row's `lastEventAt` as `before`
+ * and rows inserted meanwhile can't shift the page under the caller. The cursor
+ * is the timestamp alone, so two rows sharing one millisecond exactly at a page
+ * boundary can straddle it; the tie-break inside a page is id desc.
  */
 export async function listSessions(
   userId: string,
-  stationId: string
+  stationId: string,
+  opts: ListSessionsOptions = {}
 ): Promise<AcpSessionRow[]> {
+  const filters = [
+    eq(acpSessions.userId, userId),
+    eq(acpSessions.stationId, stationId),
+  ];
+  if (opts.before !== undefined) {
+    const cursor = new Date(opts.before);
+    if (Number.isNaN(cursor.getTime())) {
+      throw new Error("Invalid page cursor.");
+    }
+    filters.push(lt(acpSessions.lastEventAt, cursor));
+  }
   const rows = await db
     .select()
     .from(acpSessions)
-    .where(
-      and(eq(acpSessions.userId, userId), eq(acpSessions.stationId, stationId))
-    )
-    .orderBy(desc(acpSessions.lastEventAt), desc(acpSessions.id));
+    .where(and(...filters))
+    .orderBy(desc(acpSessions.lastEventAt), desc(acpSessions.id))
+    .limit(clampSessionLimit(opts.limit));
   return rows.map(toContract);
 }
 
@@ -758,7 +844,17 @@ export async function promptSession(
   const agent = live.agent;
   if (!agent) throw new Error("Session is still starting.");
 
-  const { done: promptWritten } = persistEvent(live, "user-prompt", { text });
+  // The first real prompt names the session, in the user-prompt's own write.
+  // COALESCE is what makes "first" mean first: an existing title always wins,
+  // so a long conversation keeps the label the user recognises no matter how
+  // many prompts follow (and a whitespace-only prompt sets nothing at all).
+  const title = deriveSessionTitle(text);
+  const { done: promptWritten } = persistEvent(
+    live,
+    "user-prompt",
+    { text },
+    title === null ? {} : { title: sql`COALESCE(${acpSessions.title}, ${title})` }
+  );
   const { done: statusWritten } = setStatus(live, "working");
   await Promise.all([promptWritten, statusWritten]);
 
@@ -908,7 +1004,14 @@ async function appendEndedState(sessionId: string, reason: string): Promise<void
   });
   await db
     .update(acpSessions)
-    .set({ status: "ended", endedReason: reason, lastEventAt: createdAt })
+    .set({
+      status: "ended",
+      endedReason: reason,
+      lastEventAt: createdAt,
+      // This row is not live, so seq came from MAX(seq)+1 — the same
+      // last_seq invariant persistEvent maintains for live sessions.
+      lastSeq: seq,
+    })
     .where(eq(acpSessions.id, sessionId));
   fanOut(sessionId, {
     sessionId,

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -26,7 +26,7 @@
  * `waiting` and a grace timer ends it.
  */
 
-import { and, desc, eq, isNotNull, lt, ne, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, lt, ne, or, sql } from "drizzle-orm";
 import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import {
   client,
@@ -263,21 +263,34 @@ function toContract(r: DbRow): AcpSessionRow {
 // ─── Session titles ───────────────────────────────────────────────────────────
 
 /**
- * Stored title length. Truncation is stored as-is with NO ellipsis: how a
- * clipped title is presented (…, fade, tooltip) is the console's choice, and
- * baking a glyph in here would corrupt the data for every other reader.
+ * Stored title length, counted in CODE POINTS. Truncation is stored as-is with
+ * NO ellipsis: how a clipped title is presented (…, fade, tooltip) is the
+ * console's choice, and baking a glyph in here would corrupt the data for every
+ * other reader.
  */
 const TITLE_MAX_CHARS = 80;
 
 /**
- * The title a prompt would give a session: trimmed, clipped to 80 chars.
+ * The title a prompt would give a session: trimmed, clipped to 80 code points.
  * Whitespace-only prompts name nothing (null) — the next real prompt titles
  * the session instead.
+ *
+ * The cut is code-point-safe (Array.from, not slice): `"a".repeat(79) + "😀"`
+ * has 81 UTF-16 code units, and a plain `slice(0, 80)` would keep the emoji's
+ * HIGH SURROGATE only. That lone surrogate is not valid UTF-8, so postgres.js
+ * drops it on the way in — the emoji vanishes and the stored title is 79 chars,
+ * silently, with no error anywhere. Code points, not grapheme clusters
+ * (Intl.Segmenter): the contract is a character budget, and a grapheme-limited
+ * cut could store far more than 80 characters. A multi-code-point emoji
+ * sequence (ZWJ family, flag) can still be split at the boundary, but every
+ * piece stays well-formed text — which is the invariant that matters here.
  */
 export function deriveSessionTitle(text: string): string | null {
   const trimmed = text.trim();
   if (trimmed.length === 0) return null;
-  return trimmed.slice(0, TITLE_MAX_CHARS);
+  const points = Array.from(trimmed);
+  if (points.length <= TITLE_MAX_CHARS) return trimmed;
+  return points.slice(0, TITLE_MAX_CHARS).join("");
 }
 
 // ─── Event persistence ────────────────────────────────────────────────────────
@@ -763,10 +776,17 @@ export interface ListSessionsOptions {
   /** Page size; defaults to 20 and is clamped into [1, 100]. */
   limit?: number;
   /**
-   * `lastEventAt` cursor (ISO): return only rows STRICTLY older than this.
-   * Pass the last row of the previous page.
+   * `lastEventAt` cursor (ISO) from the last row of the previous page: return
+   * only rows older than this. Pair it with `beforeId` — on its own it can only
+   * express "strictly older", which LOSES rows tied on the timestamp.
    */
   before?: string;
+  /**
+   * `id` of the same cursor row, completing the keyset. With it the predicate
+   * becomes (lastEventAt, id) < (before, beforeId) in the list's own ordering,
+   * so rows sharing `before` resume exactly where the page stopped.
+   */
+  beforeId?: string;
 }
 
 /**
@@ -791,10 +811,18 @@ export function clampSessionLimit(limit?: number): number {
  * acp_sessions_station_activity_idx — so the console's session switcher and the
  * history view share one read; callers must not re-sort.
  *
- * Paging is keyset, not offset: pass the last row's `lastEventAt` as `before`
- * and rows inserted meanwhile can't shift the page under the caller. The cursor
- * is the timestamp alone, so two rows sharing one millisecond exactly at a page
- * boundary can straddle it; the tie-break inside a page is id desc.
+ * Paging is keyset, not offset: pass the last row of the previous page back as
+ * `before` (its lastEventAt) AND `beforeId` (its id), and rows arriving
+ * meanwhile can't shift the page under the caller.
+ *
+ * Both halves matter. lastEventAt comes from `new Date()`, so several rows
+ * sharing one millisecond is ordinary — and a timestamp-only cursor with
+ * `lastEventAt < before` excludes every tied row from EVERY later page, not
+ * just this one. A session tied with the page boundary would disappear from
+ * history for good, silently. `beforeId` closes that hole by resuming inside
+ * the tie group. It stays optional only for cross-version tolerance: a console
+ * that sends `before` alone gets the old strict-older behaviour rather than an
+ * error.
  */
 export async function listSessions(
   userId: string,
@@ -810,7 +838,18 @@ export async function listSessions(
     if (Number.isNaN(cursor.getTime())) {
       throw new Error("Invalid page cursor.");
     }
-    filters.push(lt(acpSessions.lastEventAt, cursor));
+    filters.push(
+      opts.beforeId === undefined
+        ? lt(acpSessions.lastEventAt, cursor)
+        : // (lastEventAt, id) < (before, beforeId) — the list's own ordering.
+          or(
+            lt(acpSessions.lastEventAt, cursor),
+            and(
+              eq(acpSessions.lastEventAt, cursor),
+              lt(acpSessions.id, opts.beforeId)
+            )
+          )!
+    );
   }
   const rows = await db
     .select()

--- a/apps/hub/tests/unit/acp.schema.test.ts
+++ b/apps/hub/tests/unit/acp.schema.test.ts
@@ -63,6 +63,29 @@ test("acpSessions has an index on station_id", () => {
   expect(idx).toBeDefined();
 });
 
+test("acpSessions.title is a nullable text column", () => {
+  const config = getTableConfig(acpSessions);
+  const col = config.columns.find((c) => c.name === "title");
+  expect(col).toBeDefined();
+  expect(col?.notNull).toBe(false);
+});
+
+test("acpSessions.last_seq is NOT NULL with a default of 0", () => {
+  const config = getTableConfig(acpSessions);
+  const col = config.columns.find((c) => c.name === "last_seq");
+  expect(col).toBeDefined();
+  expect(col?.notNull).toBe(true);
+  expect(col?.default).toBe(0);
+});
+
+test("acpSessions has a (station_id, last_event_at desc) activity index", () => {
+  const config = getTableConfig(acpSessions);
+  const idx = config.indexes.find((i) => i.config.name === "acp_sessions_station_activity_idx");
+  expect(idx).toBeDefined();
+  const cols = idx!.config.columns.map((c: any) => c.name ?? c.column?.name);
+  expect(cols).toEqual(["station_id", "last_event_at"]);
+});
+
 test("acpEvents.sessionId still has a foreign key to acpSessions.id ON DELETE CASCADE", () => {
   const config = getTableConfig(acpEvents);
   expect(config.foreignKeys.length).toBe(1);

--- a/docs/superpowers/plans/2026-08-10-acp-slice4c-history.md
+++ b/docs/superpowers/plans/2026-08-10-acp-slice4c-history.md
@@ -1,0 +1,113 @@
+# ACP Slice 4c — Session History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Past conversations with an agent are findable and readable — labelled by what they were about, not just when they happened.
+
+**Architecture:** Slice 4b already gives every station many sessions, a SQL-ordered list, and a switcher that can attach an ended session read-only. What's missing is meaning and scale: rows say "Session 3 · ended · 2h ago", the list is uncapped, and the transcript read path is the live WebSocket. This slice denormalizes a `title` from each session's first prompt, tracks `lastSeq` so a row can show its size, caps and paginates the list, and gives the console a proper history surface. No new read path: the existing WS `subscribe` already replays ended sessions correctly, and reusing it keeps one code path.
+
+**Tech Stack:** zod contract, Drizzle/Postgres migration, Bun/Hono hub, Svelte 5 console.
+
+## Global Constraints
+
+- **Additive contract only.** `AcpSessionRow` gains optional fields; a console built before this slice must still parse rows from the new hub, and the new console must tolerate a row without them (the hub and console deploy separately — the Pages build is a manual step).
+- The migration is `0026_*` (latest on disk is `0025_striped_demogoblin.sql`). Generate it with drizzle-kit (`generate`, then the SQL + meta snapshot land together) — never hand-write the journal.
+- **Title is derived, never authoritative.** It's a denormalized convenience: set it once from the first `user-prompt` of a session and never rewrite it. Truncate at a fixed width, store the truncation, and don't try to summarize.
+- Titles are **untrusted user/agent text**: the console must render them as text (no HTML), truncate visually, and handle empty/whitespace-only.
+- Keep every invariant earlier slices paid for: `busy` is exactly `prompt()`'s refusal rule; switching/reading never ends a session (zero DELETEs); exactly one status live region (the chat header); pending optimistic prompts resolved on every path; kind-prefixed keyed lists with unique negative seqs for synthetic items.
+- Copy grammar `Couldn't <verb> <object>.`; design-system components only; keyboard-complete; reduced-motion respected.
+- Hub tests need the explicit override: `DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test`.
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB`
+
+## File Structure
+
+```
+packages/contract/src/acp-session.ts              AcpSessionRow += title?, lastSeq?
+apps/hub/src/db/schema/acp.ts                     acp_sessions += title, lastSeq; index (stationId, lastEventAt desc)
+apps/hub/src/db/drizzle-migrations/0026_*.sql      generated
+apps/hub/src/services/acp-sessions.ts             set title on first prompt; maintain lastSeq; listSessions limit/cursor
+apps/hub/src/routes/station-acp.ts                list route takes ?limit=&before=
+apps/console/src/lib/api/acp.ts                   listAcpSessions gains paging args
+apps/console/src/lib/components/stations/chat/ChatHeader.svelte    titled rows, capped switcher + "All sessions…"
+apps/console/src/lib/components/stations/chat/SessionHistory.svelte  NEW: full list surface
+apps/console/src/lib/components/stations/chat/ChatPanel.svelte     history wiring + the draft-prune fix
+```
+
+---
+
+### Task 1: Contract + schema + migration
+
+**Files:**
+- Modify: `packages/contract/src/acp-session.ts`, `apps/hub/src/db/schema/acp.ts`
+- Create: `apps/hub/src/db/drizzle-migrations/0026_*.sql` (+ meta snapshot, via drizzle-kit)
+- Test: the contract's acp-session test file; `apps/hub/tests/unit/acp.schema.test.ts` if it asserts row shape
+
+**Interfaces produced (consumed by Tasks 2–3):**
+```ts
+// AcpSessionRow gains, both optional for cross-version tolerance:
+title: z.string().nullable().optional()   // first prompt, truncated; null until the first prompt
+lastSeq: z.number().int().optional()      // highest event seq persisted for the session
+```
+DB: `acp_sessions.title text` (nullable), `acp_sessions.last_seq integer NOT NULL DEFAULT 0`, plus `index acp_sessions_station_activity_idx on (station_id, last_event_at desc)`.
+
+- [ ] **Step 1 (RED):** contract tests — a row WITH title/lastSeq parses; a row WITHOUT them parses (old hub); `title: null` parses; a non-integer lastSeq is rejected.
+- [ ] **Step 2:** `cd packages/contract && bun test` → FAIL. **Step 3:** implement schema + contract, then generate the migration with drizzle-kit and verify `0026_*.sql` contains exactly the two columns and the index (no unrelated churn — if drizzle wants to emit anything else, stop and report it).
+- [ ] **Step 4:** contract green; `DATABASE_URL=… bun test` in apps/hub green (migrations auto-apply on boot, so the suite exercises the new migration).
+- [ ] **Step 5:** Commit `feat(contract): acp session title + lastSeq`.
+
+---
+
+### Task 2: Hub — title, lastSeq, paginated list
+
+**Files:**
+- Modify: `apps/hub/src/services/acp-sessions.ts`, `apps/hub/src/routes/station-acp.ts`
+- Test: the acp service + route suites
+
+**Interfaces:**
+- `persistEvent` maintains `last_seq` on the session row in the same write it already does for `last_event_at` — one statement, not a second round trip.
+- On the FIRST `user-prompt` of a session (title still null), set `title` to that prompt trimmed and truncated to **80 characters** (store the truncation; append no ellipsis — that's the console's presentation choice). Whitespace-only prompts leave it null.
+- `listSessions(userId, stationId, opts?: { limit?: number; before?: string })` — `limit` defaults to 20 and is clamped to 100; `before` is a `lastEventAt` ISO cursor for "older than". Ordering stays `lastEventAt desc, id desc`. Returns rows plus enough to page.
+- The list route accepts `?limit=` and `?before=`, validated with zod, and rejects nonsense with 400 rather than silently clamping to a default (clamping the *value* is fine; a non-numeric limit is a client bug worth surfacing).
+
+- [ ] **Step 1 (RED):** tests — first prompt sets the title, a second prompt does NOT rewrite it; an 81+ char prompt is stored truncated to 80; a whitespace-only prompt leaves title null; `lastSeq` tracks the highest seq across prompts/updates/state and survives an end; `limit` caps and clamps; `before` returns strictly older rows and paginates without duplicates or gaps across two pages; a bad `limit` is 400.
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** hub suite green.
+- [ ] **Step 5:** Commit `feat(hub): session titles, lastSeq, paginated session list`.
+
+---
+
+### Task 3: Console — titled switcher, history surface, draft fix
+
+**Files:**
+- Modify: `apps/console/src/lib/api/acp.ts`, `chat/ChatHeader.svelte`, `chat/ChatPanel.svelte`
+- Create: `chat/SessionHistory.svelte`
+- Test: colocated `.svelte.test.ts` for the new component and the two modified ones
+
+**Interfaces:**
+- `listAcpSessions(stationId, opts?: { limit?: number; before?: string })`.
+- `ChatHeader`: rows read `title` when present (falling back to today's "Session N"), truncated with `line-clamp`/`truncate` and `min-w-0`, status and relative activity kept. The switcher lists at most **8** sessions; when more exist it ends with an "All sessions…" item that calls `onOpenHistory()`.
+- `SessionHistory.svelte`: props `{ stationId, currentSessionId, onSelect(id), onClose }`. A `Dialog` (the repo's established list→detail idiom is routing, but a dialog keeps the chat mounted and is the smaller change — `ui/sheet` exists unused; pick Dialog and say why in a comment). Shows the paginated list with title, `<Status>`, relative last activity and event count from `lastSeq`; a "Load older" control drives the `before` cursor; `<Empty>` when a station has no sessions; selecting a row calls `onSelect` and closes.
+- `ChatPanel`: owns history open/closed, passes `onOpenHistory`, and routes `onSelect` through the SAME `selectSession`/`settleOn` path the switcher uses (do not add a second attach path — that's how the header went stale in 4b).
+- **Fix carried from 4b's review:** typing into an already-ended session and then clicking "New session" parks the draft under the ended session's slot, which the pruning effect garbage-collects — the text is lost. Park it under the `NEW_SESSION_SLOT` sentinel instead whenever the session being left is ended, so it survives into the next created session. Regression test required.
+
+- [ ] **Step 1 (RED):** tests — a titled session renders its title, an untitled one falls back; a 9th session collapses the switcher to 8 + "All sessions…"; opening history lists rows and "Load older" requests the next page with a `before` cursor; selecting from history attaches via the shared path (assert the new socket subscribes and the header names the selected session); history issues ZERO DELETEs; the ended-session draft survives "New session".
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** `pnpm check && pnpm test && pnpm build` green.
+- [ ] **Step 5:** Commit `feat(console): session history with titles`.
+
+---
+
+### Task 4: Slice gate — suites, PR, CI, live verification (controller-run)
+
+- [ ] Four suites green (contract; hub with the `:5434` override; node-agent `-race`; console check+test+build).
+- [ ] Push; PR `feat: ACP slice 4c — session history`; CI green; merge.
+- [ ] Deploy: hub (`git pull` + `bun x pnpm@10 install --frozen-lockfile --filter @agentpod/hub...` + restart — plain `bun install` is a silent no-op on the box) and console (`PUBLIC_HUB_URL=https://hub.agentpod.dev pnpm --filter @agentpod/console build`, then `wrangler pages deploy apps/console/build --project-name agentpod-console --branch main`; the Pages git integration does not auto-build). No node-agent change in this slice.
+- [ ] Live: on a station with several sessions (hermes:buddhimaan or openclaw:hanuman, both known good), confirm new prompts produce titled rows, older sessions keep their titles, the switcher caps and "All sessions…" opens the history list, "Load older" pages, and selecting an ended session opens it read-only with the ended notice. Verify the migration applied by reading a row's title/last_seq on the box.
+- [ ] Update the `acp-sessions-program` memory; ledger complete.
+
+## Self-Review Notes
+
+- No new transcript read path: the WS `subscribe` already replays an ended session then sends `bye`, and it is ownership-checked. A REST events endpoint would be a second thing to secure and keep consistent for no gain here.
+- `lastSeq` is maintained in the write that already touches the row, so history can show size without a `COUNT(*)` per session — the reason the schema review flagged it in the first place.
+- Titles are set once and never rewritten, so a long conversation keeps the label the user recognizes rather than drifting to whatever was said last.
+- Pagination uses a `lastEventAt` cursor rather than OFFSET because the ordering key changes as sessions stream — OFFSET would skip or repeat rows mid-scroll.

--- a/packages/contract/src/acp-session.test.ts
+++ b/packages/contract/src/acp-session.test.ts
@@ -18,6 +18,33 @@ it("AcpSessionRow round-trips a full row", () => {
   expect(AcpSessionRow.parse(row)).toEqual(row);
 });
 
+describe("AcpSessionRow title + lastSeq (slice 4c) are cross-version tolerant", () => {
+  const base = {
+    id: "acp_1", stationId: "station_1", userId: "user_1",
+    mode: "ask", status: "idle", endedReason: null,
+    createdAt: "2026-08-09T00:00:00.000Z", lastEventAt: "2026-08-09T00:00:01.000Z",
+  };
+
+  it("parses a row WITH title and lastSeq", () => {
+    const row = { ...base, title: "Fix the flaky gateway test", lastSeq: 42 };
+    expect(AcpSessionRow.parse(row)).toEqual(row);
+  });
+
+  it("parses a row WITHOUT title or lastSeq (rows from an older hub)", () => {
+    expect(AcpSessionRow.parse(base)).toEqual(base);
+  });
+
+  it("parses title: null (no prompt sent yet)", () => {
+    const row = { ...base, title: null, lastSeq: 0 };
+    expect(AcpSessionRow.parse(row)).toEqual(row);
+  });
+
+  it("rejects a non-integer lastSeq", () => {
+    expect(() => AcpSessionRow.parse({ ...base, lastSeq: 1.5 })).toThrow();
+    expect(() => AcpSessionRow.parse({ ...base, lastSeq: "7" })).toThrow();
+  });
+});
+
 it("AcpSessionMode and AcpSessionStatus reject unknown values", () => {
   expect(() => AcpSessionMode.parse("yolo")).toThrow();
   expect(() => AcpSessionStatus.parse("bogus")).toThrow();

--- a/packages/contract/src/acp-session.ts
+++ b/packages/contract/src/acp-session.ts
@@ -13,6 +13,11 @@ export const AcpSessionRow = z.object({
   mode: AcpSessionMode, status: AcpSessionStatus,
   endedReason: z.string().nullable(),
   createdAt: z.string(), lastEventAt: z.string(),
+  // Slice 4c (history). Both optional so hub and console can deploy
+  // independently: a console built before this slice still parses new rows,
+  // and a new console tolerates rows from an older hub.
+  title: z.string().nullable().optional(),   // first prompt, truncated; null until the first prompt
+  lastSeq: z.number().int().optional(),      // highest event seq persisted for the session
 });
 export type AcpSessionRow = z.infer<typeof AcpSessionRow>;
 


### PR DESCRIPTION
## Summary

Past conversations with an agent are now findable and readable — labelled by what they were about, not just when they happened.

- **Titles.** Each session takes its label from its first prompt (trimmed, capped at 80 **code points**, set once and never rewritten, so a long conversation keeps the label the user recognises).
- **Size.** `last_seq` is maintained in the write that already touches the row, so history can show a conversation's length without a `COUNT(*)` per session.
- **Scale.** The session list is paginated with a keyset cursor; the switcher caps at 8 and overflows into an "All sessions…" history dialog with "Load older".
- Migration `0026` adds the two columns plus an index on `(station_id, last_event_at desc)`. Contract fields are optional, since the hub and console deploy separately.

Also fixes a bug carried from 4b's review: typing into an ended session and then clicking "New session" used to park the draft in a slot the pruning effect garbage-collected, losing the text.

## Two silent-data-loss bugs review caught

Both were on the exact boundaries this slice was asked to scrutinise, and both were reproduced rather than reasoned about:

1. **Emoji-splitting titles.** Truncation used a UTF-16 slice, so an astral character straddling character 80 was cut in half; the lone surrogate is then *silently dropped* by the Postgres driver — the title came back one character short with the emoji gone and no error. Now cut on code points, with an end-to-end round trip asserting the stored value is byte-identical. Code points rather than graphemes is deliberate: a grapheme-limited cut could store far more than 80 characters, and a split ZWJ sequence still leaves every piece well-formed text.
2. **Pagination that lost sessions permanently.** The cursor filtered on `last_event_at` alone, so when a page boundary fell inside a group of rows sharing a millisecond, the tied row that missed the earlier page was excluded from *every* later page — absent from history entirely, not merely duplicated. The tell was that the original tests had to sleep 15ms between session creations to dodge it. The cursor is now compound (`before` + `beforeId`, tie-breaking on the same column the ordering uses), added additively so `before` alone still works; the tests now write identical timestamps directly to force real ties, and a companion assertion reproduces the old bug on demand.

A third, subtler one: the console raised its session refresh to 100 rows for deep reads but left `init()` on the hub's new default of 20 — a station whose *live* session had sunk past the 20 most-recently-active would open on "No session" with an empty transcript while the agent was still running.

## Tests

contract 51 ✅ · hub 373 ✅ · node-agent `-race` ✅ · console 678 + `svelte-check` + build ✅

## Live verification

Titles on new prompts, capped switcher, "All sessions…" paging, and an ended session opening read-only — after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB