### PR TITLE
feat: ACP slice 4d — Claude Code sessions

### DIFF
--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -47,7 +47,7 @@
   import { Status } from "$lib/components/ui/status";
   import { chipClass } from "$lib/utils/toggle-chip";
   import { relativeTime } from "$lib/utils/relative-time";
-  import { ACP_STATUS_TOKEN, sessionName } from "./session-status";
+  import { ACP_STATUS_TOKEN, sessionName, untitledSessionLabel } from "./session-status";
 
   interface Props {
     session: AcpSessionRow | null;
@@ -121,22 +121,13 @@
   );
 
   /**
-   * id → "Session N", numbered by creation order. Computed from a SORTED COPY:
-   * the rendered list keeps the hub's activity order, only the numbers come from
-   * createdAt, so a session's name never changes as it streams.
+   * A session's title, or "Session N" (numbered by creation order across
+   * `sessions`) until its first prompt gives it one — the shared fallback
+   * from session-status.ts, so the history dialog names the same row the
+   * same way.
    */
-  const sessionNumber = $derived.by(() => {
-    const byAge = [...sessions].sort((a, b) =>
-      a.createdAt === b.createdAt
-        ? a.id.localeCompare(b.id)
-        : a.createdAt.localeCompare(b.createdAt),
-    );
-    return new Map(byAge.map((s, i) => [s.id, i + 1]));
-  });
-
-  /** A session's title, or "Session N" until its first prompt gives it one. */
   function nameOf(s: AcpSessionRow): string {
-    return sessionName(s, `Session ${sessionNumber.get(s.id) ?? "?"}`);
+    return sessionName(s, untitledSessionLabel(sessions, s.id));
   }
 
   /** The row's meta half: "· working · 5m ago" (status is agent data → lowercase). */

--- a/apps/console/src/lib/components/stations/chat/SessionHistory.svelte
+++ b/apps/console/src/lib/components/stations/chat/SessionHistory.svelte
@@ -39,7 +39,7 @@
   import { Empty } from "$lib/components/ui/empty";
   import { Status } from "$lib/components/ui/status";
   import { relativeTime } from "$lib/utils/relative-time";
-  import { ACP_STATUS_TOKEN, sessionName } from "./session-status";
+  import { ACP_STATUS_TOKEN, sessionName, untitledSessionLabel } from "./session-status";
 
   interface Props {
     stationId: string;
@@ -99,10 +99,15 @@
   });
 
   /**
-   * Untitled rows can't borrow the header's "Session N": that number comes from
-   * the whole list's creation order, which a paginated view doesn't have.
+   * A session's title, or "Session N" — the same shared fallback the chat
+   * header's switcher uses (session-status.ts), so an untitled row never
+   * wears two different words on the two surfaces a user is most likely to
+   * compare side by side. The number is scoped to whatever page(s) of `rows`
+   * this dialog has loaded so far — a paginated view doesn't have the whole
+   * station's session list to number against, only the header's switcher
+   * does — but the FORMAT is unified.
    */
-  const nameOf = (s: AcpSessionRow) => sessionName(s, "Untitled session");
+  const nameOf = (s: AcpSessionRow) => sessionName(s, untitledSessionLabel(rows, s.id));
 
   /**
    * "12 events" — `lastSeq` is the session's highest event seq, so it doubles as

--- a/apps/console/src/lib/components/stations/chat/SessionHistory.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/SessionHistory.svelte.test.ts
@@ -111,7 +111,9 @@ test("lists the station's sessions with title, status, activity and event count"
   expect(second.textContent).not.toContain("1 events");
 });
 
-test("an untitled session falls back to a plain name, and titles are text only", async () => {
+test("an untitled session falls back to 'Session N' — the same word the switcher uses — and titles are text only", async () => {
+  // Same createdAt on sa/sb: the ordinal ties break on id, so sa=1, sb=2
+  // regardless of sc (titled, and sorted between them by id) being present.
   const rows = [
     row({ id: "sa", title: null }),
     row({ id: "sb", title: "   " }),
@@ -120,8 +122,11 @@ test("an untitled session falls back to a plain name, and titles are text only",
   const u = setup(rows);
   const dialog = await dialogOf(u);
 
-  const untitled = await waitFor(() => within(dialog).getAllByText("Untitled session"));
-  expect(untitled).toHaveLength(2); // null and whitespace-only both fall back
+  // Not "Untitled session" — the history dialog and the chat header's
+  // switcher must agree on the fallback word for the same kind of row.
+  expect(await waitFor(() => within(dialog).getByText("Session 1"))).toBeTruthy();
+  expect(within(dialog).getByText("Session 2")).toBeTruthy(); // null and whitespace-only both fall back
+  expect(within(dialog).queryByText("Untitled session")).toBeNull();
 
   // Untrusted text: the agent's / the user's own words never become markup.
   const nasty = within(dialog).getByText("<img src=x onerror=alert(1)> & <b>bold</b>");

--- a/apps/console/src/lib/components/stations/chat/session-status.ts
+++ b/apps/console/src/lib/components/stations/chat/session-status.ts
@@ -1,7 +1,8 @@
 /**
  * session-status.ts
  *
- * ACP session vocab → the console's six shared status tokens.
+ * ACP session vocab → the console's six shared status tokens, plus the ONE
+ * place that decides how to name a session row.
  *
  * `tokenFor` (status-badge.ts) knows the fleet vocab, not this one: "idle"
  * means *ready* for an ACP session but falls through to "stopped" there, and
@@ -12,6 +13,10 @@
  *
  * Pair it with `label` when rendering `<Status>`, so the visible word stays the
  * session's own status ("idle") rather than the token it maps to ("running").
+ *
+ * `sessionName` + `untitledSessionLabel` are shared for the same reason: both
+ * surfaces must render the identical fallback ("Session N") for the same
+ * untitled row, not two different words for the same absence of a title.
  */
 
 import type { AcpSessionStatus } from "@agentpod/contract";
@@ -41,4 +46,38 @@ export function sessionName(
 ): string {
   const title = session.title?.trim();
   return title !== undefined && title.length > 0 ? title : fallback;
+}
+
+/**
+ * id → ordinal ("Session N"), numbered by creation order across whatever
+ * slice of sessions the caller can see. Computed from a SORTED COPY: the
+ * caller's own list order (e.g. the hub's newest-activity-first order) is
+ * left alone, only the numbers come from `createdAt` — so a session's
+ * number never changes as it streams. Ties (same millisecond) break on id
+ * for a stable order.
+ */
+export function sessionOrdinals(
+  sessions: { id: string; createdAt: string }[],
+): Map<string, number> {
+  const byAge = [...sessions].sort((a, b) =>
+    a.createdAt === b.createdAt
+      ? a.id.localeCompare(b.id)
+      : a.createdAt.localeCompare(b.createdAt),
+  );
+  return new Map(byAge.map((s, i) => [s.id, i + 1]));
+}
+
+/**
+ * The ONE fallback name for a session with no title: "Session N", numbered
+ * by creation order within `sessions`. Both the chat header's switcher and
+ * the history dialog call this — before this helper existed they disagreed
+ * ("Session 9" vs. "Untitled session") for the very same row, which is
+ * confusing in the two surfaces a user is most likely to compare side by
+ * side.
+ */
+export function untitledSessionLabel(
+  sessions: { id: string; createdAt: string }[],
+  id: string,
+): string {
+  return `Session ${sessionOrdinals(sessions).get(id) ?? "?"}`;
 }

--- a/apps/console/src/lib/components/stations/chat/untitled-session-label.test.ts
+++ b/apps/console/src/lib/components/stations/chat/untitled-session-label.test.ts
@@ -1,0 +1,121 @@
+/**
+ * untitled-session-label.test.ts
+ *
+ * Regression for the 4d live-verification blemish: the chat header's
+ * switcher rendered "Session N" for an untitled row while the history
+ * dialog rendered "Untitled session" for the SAME row — two different words
+ * for the same absence of a title, in two surfaces a user is likely to
+ * compare side by side.
+ *
+ * Both surfaces must render the identical fallback text, via the ONE shared
+ * helper in session-status.ts (`untitledSessionLabel`).
+ */
+
+import { test, expect, vi } from "vitest";
+import { render, waitFor, within, fireEvent } from "@testing-library/svelte";
+import type { AcpSessionRow } from "$lib/api/acp";
+import * as api from "$lib/api/acp";
+
+import ChatHeader from "./ChatHeader.svelte";
+import SessionHistory from "./SessionHistory.svelte";
+import { sessionOrdinals, untitledSessionLabel } from "./session-status";
+
+// bits-ui's Select opens on `pointerdown` and touches capture APIs jsdom
+// lacks — same polyfill as ChatHeader.svelte.test.ts.
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  // @ts-expect-error jsdom has no native PointerEvent
+  window.PointerEvent = PointerEventPolyfill;
+}
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+
+const titled: AcpSessionRow = {
+  id: "ses_titled",
+  stationId: "st_1",
+  userId: "u_1",
+  mode: "ask",
+  status: "idle",
+  endedReason: null,
+  createdAt: "2026-08-09T10:00:00.000Z",
+  lastEventAt: "2026-08-09T10:00:00.000Z",
+  title: "Fix the flaky test",
+  lastSeq: 4,
+};
+
+const untitled: AcpSessionRow = {
+  id: "ses_untitled",
+  stationId: "st_1",
+  userId: "u_1",
+  mode: "ask",
+  status: "working",
+  endedReason: null,
+  createdAt: "2026-08-09T11:00:00.000Z",
+  lastEventAt: "2026-08-09T11:05:00.000Z",
+  title: null,
+  lastSeq: 2,
+};
+
+const sessions = [untitled, titled]; // hub's newest-activity-first order
+
+test("untitledSessionLabel / sessionOrdinals: numbers by creation order, ties break on id", () => {
+  const ordinals = sessionOrdinals(sessions);
+  // Sorted by createdAt: titled (10:00) is older than untitled (11:00).
+  expect(ordinals.get(titled.id)).toBe(1);
+  expect(ordinals.get(untitled.id)).toBe(2);
+  expect(untitledSessionLabel(sessions, untitled.id)).toBe("Session 2");
+});
+
+test("the chat header's switcher and the history dialog render the SAME fallback for the same untitled row", async () => {
+  // ── Chat header ──
+  const header = render(ChatHeader, {
+    props: {
+      session: untitled,
+      sessions,
+      selectedId: untitled.id,
+      status: "working",
+      connection: "connected",
+      mode: "ask",
+      onModeChange: vi.fn(),
+      onEnd: vi.fn(),
+      onNew: vi.fn(),
+      onSelectSession: vi.fn(),
+      onOpenHistory: vi.fn(),
+    },
+  });
+  await fireEvent.pointerDown(
+    header.getByRole("button", { name: /^Switch session/ }),
+    { pointerId: 1, button: 0, pointerType: "mouse" },
+  );
+  const headerOption = await waitFor(() =>
+    header.getByRole("option", { name: /^Session 2 ·/ }),
+  );
+  expect(headerOption).toBeTruthy();
+  header.unmount();
+
+  // ── History dialog ──
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue(sessions);
+  const history = render(SessionHistory, {
+    props: {
+      stationId: "st_1",
+      currentSessionId: null,
+      onSelect: vi.fn(),
+      onClose: vi.fn(),
+    },
+  });
+  const dialog = await waitFor(() => history.getByRole("dialog"));
+
+  // Same word, same number, for the same row — not "Untitled session".
+  expect(await waitFor(() => within(dialog).getByText("Session 2"))).toBeTruthy();
+  expect(within(dialog).queryByText("Untitled session")).toBeNull();
+  history.unmount();
+});

--- a/apps/hub/src/db/drizzle-migrations/0027_backfill_last_seq.sql
+++ b/apps/hub/src/db/drizzle-migrations/0027_backfill_last_seq.sql
@@ -1,0 +1,11 @@
+-- Custom SQL migration file, put your code below! -----
+-- Backfill last_seq for acp_sessions rows created before slice 4c added the
+-- column (they default to 0), so the history dialog stops reporting
+-- "no events" for sessions that have a real transcript.
+UPDATE "acp_sessions"
+SET "last_seq" = (
+  SELECT COALESCE(MAX("seq"), 0)
+  FROM "acp_events" e
+  WHERE e."session_id" = "acp_sessions"."id"
+)
+WHERE "last_seq" = 0;

--- a/apps/hub/src/db/drizzle-migrations/meta/0027_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0027_snapshot.json
@@ -1,0 +1,1842 @@
+{
+  "id": "8ce14435-0d23-42a6-912c-8ddd6c4a0306",
+  "prevId": "ae573edb-6076-410b-9f37-b2f630e5c2ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "tableTo": "provisioned_runtimes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "tableTo": "stations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "acp_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "online",
+        "stopped",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1786354141066,
       "tag": "0026_modern_colleen_wing",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1786358074831,
+      "tag": "0027_backfill_last_seq",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -474,7 +474,13 @@ test(
       expect(update.sessionUpdate).toBe("agent_message_chunk");
       expect(update.content.text).toBe("Working on it");
 
-      // Session row is idle again.
+      // Session row is idle again. Poll rather than read once: the idle state
+      // event is persisted before the row update settles, so a bare read races
+      // the transition on a loaded CI runner (observed failing "working").
+      await pollUntil(async () => {
+        const s = await getSession(TEST_USER, row.id);
+        return s?.status === "idle";
+      });
       const after = await getSession(TEST_USER, row.id);
       expect(after?.status).toBe("idle");
 
@@ -806,7 +812,19 @@ test(
         );
         return working.length === 2; // turn #1's and turn #2's
       });
-      const before = (await eventsFor(row.id)).length;
+      // Count only STATE events. A stale completion's symptom is a spurious
+      // `state` transition, and turn #2 is legitimately live — it may emit its
+      // own agent-updates inside the window below, so counting every event
+      // makes this assertion a race (it flaked on CI twice: 7 vs 8).
+      const stateEvents = async () =>
+        (await eventsFor(row.id)).filter((e) => e.type === "state");
+      const idleCount = (evs: Awaited<ReturnType<typeof stateEvents>>) =>
+        evs.filter(
+          (e) => (e.payload as { status?: string } | null)?.status === "idle"
+        ).length;
+      const before = await stateEvents();
+      const statesBefore = before.length;
+      const idlesBefore = idleCount(before); // create's idle + turn #1's cancel
 
       // NOW turn #1's late response arrives (oldest pending prompt).
       fake.releasePrompt("end_turn");
@@ -815,8 +833,10 @@ test(
       // Status must stay working and no spurious state event may appear.
       const mid = await getSession(TEST_USER, row.id);
       expect(mid?.status).toBe("working");
-      const after = await eventsFor(row.id);
-      expect(after.length).toBe(before);
+      const statesAfter = await stateEvents();
+      expect(statesAfter.length).toBe(statesBefore);
+      // …and no NEW idle in particular: that is what clobbering looks like.
+      expect(idleCount(statesAfter)).toBe(idlesBefore);
 
       // Turn #2's own completion still lands normally.
       fake.releasePrompt("end_turn");

--- a/apps/hub/tests/integration/backfill-last-seq.test.ts
+++ b/apps/hub/tests/integration/backfill-last-seq.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration Test: 0027_backfill_last_seq migration
+ *
+ * Slice 4c added acp_sessions.last_seq with a NOT NULL DEFAULT 0. Rows
+ * created before that migration are therefore stuck at last_seq = 0 even
+ * though acp_events plainly has a transcript for them — the history dialog
+ * then reports "no events" for a session that has plenty.
+ *
+ * The 0027 migration backfills those rows:
+ *   UPDATE acp_sessions SET last_seq = MAX(acp_events.seq) WHERE last_seq = 0
+ *
+ * By the time this suite runs, drizzle's migrate() (via ensurePgMigrations)
+ * has already applied 0027 once against the test DB — drizzle tracks applied
+ * migrations and never re-runs them. To exercise 0027's SQL directly (and
+ * prove it is idempotent) this test re-executes the migration file's own
+ * UPDATE statement against rows it sets up itself, the same statement
+ * drizzle ran at boot.
+ *
+ * DATABASE_URL must point to the local Docker test-postgres on localhost:5434.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { eq } from "drizzle-orm";
+
+import { db, rawSql } from "../../src/db/drizzle";
+import { acpSessions, acpEvents } from "../../src/db/schema/acp";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+
+const STATION_ID = "backfill-test-station";
+const USER_ID = "backfill-test-user";
+
+/**
+ * The 0027 migration file is a single UPDATE statement (plus the drizzle
+ * "custom migration" header comment). Strip the header and hand the bare
+ * SQL to postgres.js — this is exactly the statement drizzle's migrate()
+ * executed at boot, re-run here against rows this test controls.
+ */
+function loadBackfillSql(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const migrationPath = join(
+    here,
+    "../../src/db/drizzle-migrations/0027_backfill_last_seq.sql"
+  );
+  const raw = readFileSync(migrationPath, "utf-8");
+  return raw
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n")
+    .trim();
+}
+
+async function insertSession(id: string, lastSeq: number): Promise<void> {
+  const now = new Date();
+  await db.insert(acpSessions).values({
+    id,
+    stationId: STATION_ID,
+    userId: USER_ID,
+    mode: "full-auto",
+    status: "ended",
+    endedReason: "cleanup",
+    nodeSessionId: null,
+    title: null,
+    lastSeq,
+    createdAt: now,
+    lastEventAt: now,
+  });
+}
+
+async function insertEvent(sessionId: string, seq: number): Promise<void> {
+  await db.insert(acpEvents).values({
+    sessionId,
+    seq,
+    type: "state",
+    payload: { status: "idle" },
+    createdAt: new Date(),
+  });
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
+
+afterAll(async () => {
+  await rawSql`DELETE FROM acp_events WHERE session_id LIKE ${STATION_ID + "%"}`;
+  await rawSql`DELETE FROM acp_sessions WHERE station_id = ${STATION_ID}`;
+});
+
+test(
+  "0027_backfill_last_seq: sets last_seq to MAX(seq) for pre-4c rows stuck at 0, leaves already-populated rows alone, and is idempotent",
+  async () => {
+    const staleId = `${STATION_ID}-stale`; // pre-4c row: last_seq=0 despite events
+    const freshId = `${STATION_ID}-fresh`; // post-4c row: last_seq already correct
+    const emptyId = `${STATION_ID}-empty`; // last_seq=0 AND genuinely no events
+
+    await insertSession(staleId, 0);
+    await insertEvent(staleId, 1);
+    await insertEvent(staleId, 2);
+    await insertEvent(staleId, 5); // out-of-order insert; MAX must still find it
+
+    await insertSession(freshId, 3);
+    await insertEvent(freshId, 1);
+    await insertEvent(freshId, 3);
+
+    await insertSession(emptyId, 0);
+
+    const backfillSql = loadBackfillSql();
+    await rawSql.unsafe(backfillSql);
+
+    const rows = await db
+      .select()
+      .from(acpSessions)
+      .where(eq(acpSessions.stationId, STATION_ID));
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+
+    expect(byId[staleId]!.lastSeq).toBe(5);
+    expect(byId[freshId]!.lastSeq).toBe(3); // untouched — WHERE last_seq = 0 excluded it
+    expect(byId[emptyId]!.lastSeq).toBe(0); // COALESCE(MAX(...), 0) — no events, no change
+
+    // Idempotent: running it again changes nothing further.
+    await rawSql.unsafe(backfillSql);
+    const rowsAgain = await db
+      .select()
+      .from(acpSessions)
+      .where(eq(acpSessions.stationId, STATION_ID));
+    const byIdAgain = Object.fromEntries(rowsAgain.map((r) => [r.id, r]));
+
+    expect(byIdAgain[staleId]!.lastSeq).toBe(5);
+    expect(byIdAgain[freshId]!.lastSeq).toBe(3);
+    expect(byIdAgain[emptyId]!.lastSeq).toBe(0);
+  }
+);

--- a/apps/node-agent/cmd/agentpod-node/registry.go
+++ b/apps/node-agent/cmd/agentpod-node/registry.go
@@ -7,8 +7,9 @@ import (
 
 // buildRegistry constructs the descriptor registry from the node config.
 // Every field it reads is optional: the zero Config yields the same registry as
-// an unconfigured host (detection works, lifecycle start and the openclaw ACP
-// gateway overrides simply stay unset).
+// an unconfigured host (detection works; lifecycle start, the openclaw ACP
+// gateway overrides and the claude-code adapter/runtime overrides simply stay
+// unset, and each descriptor resolves what it can from the host).
 func buildRegistry(cfg config.Config) *descriptor.Registry {
 	reg := descriptor.NewRegistry()
 	reg.Register(descriptor.NewHermes("", cfg.HermesStartCmd))
@@ -19,7 +20,11 @@ func buildRegistry(cfg config.Config) *descriptor.Registry {
 		TokenFile:    cfg.OpenClawTokenFile,
 		SessionLabel: cfg.OpenClawSessionLabel,
 	}))
-	reg.Register(descriptor.NewClaudeCode(""))
+	reg.Register(descriptor.NewClaudeCodeFrom(descriptor.ClaudeCodeConfig{
+		AcpBinary:    cfg.ClaudeCodeAcpBinary,
+		ClaudeBinary: cfg.ClaudeCodeBinary,
+		NodeBinary:   cfg.NodeBinary,
+	}))
 	reg.Register(descriptor.NewOpenCode(""))
 	reg.Register(descriptor.NewCodex(""))
 	return reg

--- a/apps/node-agent/cmd/agentpod-node/registry_test.go
+++ b/apps/node-agent/cmd/agentpod-node/registry_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
@@ -33,5 +37,65 @@ func TestBuildRegistry_ThreadsOpenClawBinary(t *testing.T) {
 	}
 	if argv[0] != "/opt/custom/bin/openclaw" {
 		t.Errorf("argv[0] = %q, want the configured openclawBinary", argv[0])
+	}
+}
+
+// The claude-code ACP keys are the same kind of escape hatch: claude-agent-acp
+// is a Node program that a fleet host may have anywhere. A HOME fixture keeps
+// station detection off the real machine, and nodeBinary points at a path that
+// can't report a version — which both neutralises the Node gate for this test
+// and proves the key is threaded.
+func TestBuildRegistry_ThreadsClaudeCodeACPKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	proj := filepath.Join(home, "work", "repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := json.Marshal(map[string]any{"projects": map[string]any{proj: map[string]any{}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), doc, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := buildRegistry(config.Config{
+		ClaudeCodeAcpBinary: "/opt/custom/bin/claude-agent-acp",
+		ClaudeCodeBinary:    "/opt/custom/bin/claude",
+		NodeBinary:          "/nonexistent/node",
+	})
+
+	var key string
+	for _, s := range reg.DetectAll() {
+		if s.Harness == "claude-code" {
+			key = s.Key
+		}
+	}
+	if key == "" {
+		t.Fatal("no claude-code station detected from the HOME fixture")
+	}
+
+	d, err := reg.For(key)
+	if err != nil {
+		t.Fatalf("registry has no claude-code descriptor: %v", err)
+	}
+	c, ok := d.(descriptor.ACPCommander)
+	if !ok {
+		t.Fatalf("claude-code descriptor must implement ACPCommander, got %T", d)
+	}
+
+	argv, dir, env, err := c.ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if argv[0] != "/opt/custom/bin/claude-agent-acp" {
+		t.Errorf("argv[0] = %q, want the configured claudeCodeAcpBinary", argv[0])
+	}
+	if dir != proj {
+		t.Errorf("dir = %q, want the station's project path %q", dir, proj)
+	}
+	if want := "CLAUDE_CODE_EXECUTABLE=/opt/custom/bin/claude"; !strings.Contains(strings.Join(env, " "), want) {
+		t.Errorf("env = %v, want the configured claudeCodeBinary as %q", env, want)
 	}
 }

--- a/apps/node-agent/cmd/agentpod-node/registry_test.go
+++ b/apps/node-agent/cmd/agentpod-node/registry_test.go
@@ -41,15 +41,24 @@ func TestBuildRegistry_ThreadsOpenClawBinary(t *testing.T) {
 }
 
 // The claude-code ACP keys are the same kind of escape hatch: claude-agent-acp
-// is a Node program that a fleet host may have anywhere. A HOME fixture keeps
-// station detection off the real machine, and nodeBinary points at a path that
-// can't report a version — which both neutralises the Node gate for this test
-// and proves the key is threaded.
+// is a Node program that a fleet host may have anywhere. This goes through the
+// production seams (real LookPath, real `node --version`, real os.Getenv), so it
+// is kept off the host's own installs: a HOME fixture supplies the station, and
+// nodeBinary points at a stub that reports v22 — which is also what proves the
+// key is threaded, since only a configured runtime is prepended to PATH.
 func TestBuildRegistry_ThreadsClaudeCodeACPKeys(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	proj := filepath.Join(home, "work", "repo")
 	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodeDir := filepath.Join(home, "runtime", "bin")
+	if err := os.MkdirAll(nodeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodeStub := filepath.Join(nodeDir, "node")
+	if err := os.WriteFile(nodeStub, []byte("#!/bin/sh\necho v22.14.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	doc, err := json.Marshal(map[string]any{"projects": map[string]any{proj: map[string]any{}}})
@@ -63,7 +72,7 @@ func TestBuildRegistry_ThreadsClaudeCodeACPKeys(t *testing.T) {
 	reg := buildRegistry(config.Config{
 		ClaudeCodeAcpBinary: "/opt/custom/bin/claude-agent-acp",
 		ClaudeCodeBinary:    "/opt/custom/bin/claude",
-		NodeBinary:          "/nonexistent/node",
+		NodeBinary:          nodeStub,
 	})
 
 	var key string
@@ -97,5 +106,14 @@ func TestBuildRegistry_ThreadsClaudeCodeACPKeys(t *testing.T) {
 	}
 	if want := "CLAUDE_CODE_EXECUTABLE=/opt/custom/bin/claude"; !strings.Contains(strings.Join(env, " "), want) {
 		t.Errorf("env = %v, want the configured claudeCodeBinary as %q", env, want)
+	}
+	var pathEntry string
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			pathEntry = strings.TrimPrefix(e, "PATH=")
+		}
+	}
+	if !strings.HasPrefix(pathEntry, nodeDir+string(os.PathListSeparator)) {
+		t.Errorf("PATH = %q, want the configured nodeBinary's dir %q first", pathEntry, nodeDir)
 	}
 }

--- a/apps/node-agent/internal/config/config.go
+++ b/apps/node-agent/internal/config/config.go
@@ -25,6 +25,20 @@ type Config struct {
   OpenClawGatewayURL   string `json:"openclawGatewayUrl,omitempty"`
   OpenClawTokenFile    string `json:"openclawTokenFile,omitempty"`
   OpenClawSessionLabel string `json:"openclawSessionLabel,omitempty"`
+  // Claude Code has no native ACP mode: sessions run through the external
+  // claude-agent-acp adapter (a Node program). All three keys are optional —
+  // with the adapter or npx on PATH, a node needs no configuration.
+  //
+  // ClaudeCodeAcpBinary is a claude-agent-acp executable, used verbatim as
+  // argv[0]; when empty the node-agent resolves it from PATH, then from
+  // well-known install paths, then falls back to a version-pinned `npx -y`.
+  // ClaudeCodeBinary is the claude CLI exported as CLAUDE_CODE_EXECUTABLE, so
+  // the ACP session drives the same install the Health tab reports on.
+  // NodeBinary is the node runtime (its directory also supplies npx) for hosts
+  // where node isn't on the service's PATH.
+  ClaudeCodeAcpBinary string `json:"claudeCodeAcpBinary,omitempty"`
+  ClaudeCodeBinary    string `json:"claudeCodeBinary,omitempty"`
+  NodeBinary          string `json:"nodeBinary,omitempty"`
 }
 
 func DefaultPath() string {

--- a/apps/node-agent/internal/config/config_test.go
+++ b/apps/node-agent/internal/config/config_test.go
@@ -10,6 +10,9 @@ func TestSaveLoadRoundTrip(t *testing.T) {
     OpenClawGatewayURL: "wss://gw.example:18789",
     OpenClawTokenFile: "/etc/agentpod/openclaw.token",
     OpenClawSessionLabel: "console",
+    ClaudeCodeAcpBinary: "/opt/bin/claude-agent-acp",
+    ClaudeCodeBinary: "/usr/local/bin/claude",
+    NodeBinary: "/opt/node-22/bin/node",
   }
   if err := Save(p, want); err != nil { t.Fatal(err) }
   got, err := Load(p)

--- a/apps/node-agent/internal/descriptor/acp_command_test.go
+++ b/apps/node-agent/internal/descriptor/acp_command_test.go
@@ -244,6 +244,10 @@ func TestCapabilitiesIncludeACP(t *testing.T) {
 	t.Run("openclaw", func(t *testing.T) {
 		assertAllStationsHaveACP(t, NewOpenClaw(testdataOpenClawHome(t)))
 	})
+	t.Run("claude-code", func(t *testing.T) {
+		home, _, _, _ := buildClaudeCodeFixture(t)
+		assertAllStationsHaveACP(t, NewClaudeCode(home))
+	})
 }
 
 func assertAllStationsHaveACP(t *testing.T, d Descriptor) {
@@ -291,12 +295,15 @@ func TestHandlerACPCommand_ResolvesOpenCode(t *testing.T) {
 	}
 }
 
+// Codex is the last harness without an ACP mode; every other registered
+// descriptor implements ACPCommander, so it is what "unsupported" looks like
+// until Codex gains a bridge of its own.
 func TestHandlerACPCommand_UnsupportedHarness(t *testing.T) {
 	reg := NewRegistry()
-	reg.Register(NewClaudeCode("/nonexistent/claude/home"))
+	reg.Register(NewCodex("/nonexistent/codex/home"))
 	h := NewCapabilityHandler(reg)
 
-	_, _, _, err := h.ACPCommand("claude-code:abcd1234")
+	_, _, _, err := h.ACPCommand("codex:abcd1234")
 	if err == nil {
 		t.Fatal("expected error for harness without ACP support")
 	}

--- a/apps/node-agent/internal/descriptor/binary.go
+++ b/apps/node-agent/internal/descriptor/binary.go
@@ -2,7 +2,6 @@ package descriptor
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -39,41 +38,35 @@ func wellKnownBinaryDirs(userHome string) []string {
 type binaryLocator struct {
 	// userHome is the OS user's home directory, or "" when undeterminable.
 	userHome string
-	// extraDirs are probed before the well-known directories. Used for dirs
-	// derived from configuration, e.g. the bin dir of a configured runtime.
-	extraDirs []string
+	// preferDirs are probed BEFORE PATH. They exist for the case where a
+	// configured runtime must beat whatever PATH offers — e.g. the npx beside a
+	// configured node, when PATH's npx belongs to an older one.
+	preferDirs []string
 	// lookPath is exec.LookPath in production.
 	lookPath func(string) (string, error)
 	// isExecutable is isExecutableFile in production.
 	isExecutable func(string) bool
 }
 
-// newBinaryLocator returns a locator wired to the real host.
-func newBinaryLocator(userHome string, extraDirs ...string) binaryLocator {
-	return binaryLocator{
-		userHome:     userHome,
-		extraDirs:    extraDirs,
-		lookPath:     exec.LookPath,
-		isExecutable: isExecutableFile,
-	}
-}
-
 // locate resolves the executable named name, in order: the configured override
 // (used verbatim — the operator knows their layout, and second-guessing it with
-// a PATH lookup would defeat the escape hatch), then PATH, then extraDirs, then
+// a PATH lookup would defeat the escape hatch), then preferDirs, then PATH, then
 // the well-known install directories. The second return value reports whether
 // anything was found; callers own the (harness-specific, actionable) error.
 func (l binaryLocator) locate(name, override string) (string, bool) {
 	if override != "" {
 		return override, true
 	}
+	for _, dir := range l.preferDirs {
+		if candidate := filepath.Join(dir, name); l.isExecutable(candidate) {
+			return candidate, true
+		}
+	}
 	if abs, err := l.lookPath(name); err == nil {
 		return abs, true
 	}
-	dirs := append(append([]string{}, l.extraDirs...), wellKnownBinaryDirs(l.userHome)...)
-	for _, dir := range dirs {
-		candidate := filepath.Join(dir, name)
-		if l.isExecutable(candidate) {
+	for _, dir := range wellKnownBinaryDirs(l.userHome) {
+		if candidate := filepath.Join(dir, name); l.isExecutable(candidate) {
 			return candidate, true
 		}
 	}

--- a/apps/node-agent/internal/descriptor/binary.go
+++ b/apps/node-agent/internal/descriptor/binary.go
@@ -1,0 +1,91 @@
+package descriptor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// This file holds the one way descriptors find an executable on a node.
+//
+// Every harness bridge has the same problem: the node-agent commonly runs as a
+// systemd *user* service, which inherits systemd's minimal default PATH — that
+// excludes ~/.local/share/pnpm and ~/.local/bin, so a pnpm/npm-global install
+// is invisible to exec.LookPath even though the shim works fine in the
+// operator's interactive shell. Hence: config override → PATH → well-known
+// absolute paths.
+
+// wellKnownBinaryDirs returns the directories probed when a binary is not on
+// PATH, in priority order. userHome is the OS user's home directory; "" omits
+// the home-relative candidates (a relative ".local/share/pnpm/x" candidate
+// would be garbage).
+func wellKnownBinaryDirs(userHome string) []string {
+	var dirs []string
+	if userHome != "" {
+		dirs = append(dirs,
+			filepath.Join(userHome, ".local", "share", "pnpm"), // pnpm global
+			filepath.Join(userHome, ".local", "bin"),           // npm --prefix ~/.local
+		)
+	}
+	return append(dirs,
+		"/usr/local/bin",
+		"/usr/bin",
+		"/opt/homebrew/bin", // macOS (Apple silicon Homebrew)
+	)
+}
+
+// binaryLocator resolves executable names to absolute paths. lookPath and
+// isExecutable are fields so tests never touch the host's PATH or filesystem.
+type binaryLocator struct {
+	// userHome is the OS user's home directory, or "" when undeterminable.
+	userHome string
+	// extraDirs are probed before the well-known directories. Used for dirs
+	// derived from configuration, e.g. the bin dir of a configured runtime.
+	extraDirs []string
+	// lookPath is exec.LookPath in production.
+	lookPath func(string) (string, error)
+	// isExecutable is isExecutableFile in production.
+	isExecutable func(string) bool
+}
+
+// newBinaryLocator returns a locator wired to the real host.
+func newBinaryLocator(userHome string, extraDirs ...string) binaryLocator {
+	return binaryLocator{
+		userHome:     userHome,
+		extraDirs:    extraDirs,
+		lookPath:     exec.LookPath,
+		isExecutable: isExecutableFile,
+	}
+}
+
+// locate resolves the executable named name, in order: the configured override
+// (used verbatim — the operator knows their layout, and second-guessing it with
+// a PATH lookup would defeat the escape hatch), then PATH, then extraDirs, then
+// the well-known install directories. The second return value reports whether
+// anything was found; callers own the (harness-specific, actionable) error.
+func (l binaryLocator) locate(name, override string) (string, bool) {
+	if override != "" {
+		return override, true
+	}
+	if abs, err := l.lookPath(name); err == nil {
+		return abs, true
+	}
+	dirs := append(append([]string{}, l.extraDirs...), wellKnownBinaryDirs(l.userHome)...)
+	for _, dir := range dirs {
+		candidate := filepath.Join(dir, name)
+		if l.isExecutable(candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// isExecutableFile reports whether path is an existing file with an executable
+// bit set. os.Stat follows symlinks, so a pnpm shim (a symlink) resolves.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}

--- a/apps/node-agent/internal/descriptor/claudecode.go
+++ b/apps/node-agent/internal/descriptor/claudecode.go
@@ -32,22 +32,65 @@ import (
 type claudeCodeDescriptor struct {
 	home    string // absolute path to ~/.claude
 	jsonDir string // absolute path to ~/ (parent of home; .claude.json lives here)
+
+	// ACP adapter settings — see ClaudeCodeConfig. All optional.
+	acpBinary    string
+	claudeBinary string
+	nodeBinary   string
+
+	// Host seams. These are fields so no test needs node, npx or claude
+	// installed and none touches the host's PATH or filesystem; production
+	// wiring in NewClaudeCodeFrom uses the real host.
+	userHome     string                                // OS user home; "" omits home-relative candidates
+	lookPath     func(string) (string, error)          // exec.LookPath
+	isExecutable func(string) bool                     // isExecutableFile
+	nodeVersion  func(nodePath string) (string, error) // `node --version`
+}
+
+// ClaudeCodeConfig carries everything the descriptor needs. Zero values are
+// valid: an unconfigured host still detects stations, and an ACP session still
+// starts as long as the adapter (or npx) is reachable on PATH.
+type ClaudeCodeConfig struct {
+	Home         string // path to the ~/.claude directory; default <user home>/.claude
+	AcpBinary    string // a claude-agent-acp executable; empty = resolve it
+	ClaudeBinary string // the claude CLI, for CLAUDE_CODE_EXECUTABLE; empty = resolve it
+	NodeBinary   string // the node runtime, when it isn't on the service's PATH
 }
 
 // NewClaudeCode returns a Descriptor for the Claude Code harness.
 // home is the path to the ~/.claude directory. If empty it defaults to
 // $HOME/.claude. The .claude.json file is read from filepath.Dir(home).
 func NewClaudeCode(home string) Descriptor {
+	return NewClaudeCodeFrom(ClaudeCodeConfig{Home: home})
+}
+
+// NewClaudeCodeFrom returns a Descriptor for the Claude Code harness configured
+// by cfg.
+func NewClaudeCodeFrom(cfg ClaudeCodeConfig) Descriptor {
+	// userHome is "" when it can't be determined, which the binary locator
+	// reads as "skip the home-relative candidates".
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		userHome = ""
+	}
+	home := cfg.Home
 	if home == "" {
-		userHome, err := os.UserHomeDir()
-		if err != nil {
-			userHome = "."
+		base := userHome
+		if base == "" {
+			base = "."
 		}
-		home = filepath.Join(userHome, ".claude")
+		home = filepath.Join(base, ".claude")
 	}
 	return &claudeCodeDescriptor{
-		home:    home,
-		jsonDir: filepath.Dir(home),
+		home:         home,
+		jsonDir:      filepath.Dir(home),
+		acpBinary:    cfg.AcpBinary,
+		claudeBinary: cfg.ClaudeBinary,
+		nodeBinary:   cfg.NodeBinary,
+		userHome:     userHome,
+		lookPath:     exec.LookPath,
+		isExecutable: isExecutableFile,
+		nodeVersion:  nodeVersionOutput,
 	}
 }
 
@@ -83,7 +126,9 @@ func (c *claudeCodeDescriptor) Detect() ([]Station, error) {
 		return nil, err
 	}
 
-	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup"}
+	// "acp" is advertised because *claudeCodeDescriptor implements ACPCommander
+	// (via the external claude-agent-acp adapter — see ACPCommand).
+	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup", "acp"}
 	var stations []Station
 
 	for _, projPath := range paths {
@@ -187,6 +232,128 @@ func (c *claudeCodeDescriptor) projectPathForKey(key string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("claude-code: station not found: %q", key)
+}
+
+// Claude Code has no ACP mode of its own: sessions run through the external
+// claude-agent-acp adapter, a Node program that speaks ACP on stdio and drives
+// Claude Code underneath.
+const (
+	// claudeACPBinaryName is the adapter's executable name once installed.
+	claudeACPBinaryName = "claude-agent-acp"
+	// claudeACPPackage is the npx fallback, VERSION-PINNED on purpose: an
+	// unpinned `npx -y <pkg>` would silently change every node's adapter the
+	// moment a new version is published, mid-flight, with no way to tell which
+	// version a session actually ran.
+	claudeACPPackage = "@agentclientprotocol/claude-agent-acp@0.66.0"
+	// claudeACPMinNodeMajor is the adapter's minimum Node major version.
+	claudeACPMinNodeMajor = 22
+)
+
+// locator returns the executable resolver for this node. A configured node
+// runtime contributes its own directory: the npx that ships with a hand-placed
+// node lives beside it, not on PATH.
+func (c *claudeCodeDescriptor) locator() binaryLocator {
+	var extraDirs []string
+	if c.nodeBinary != "" {
+		extraDirs = append(extraDirs, filepath.Dir(c.nodeBinary))
+	}
+	return binaryLocator{
+		userHome:     c.userHome,
+		extraDirs:    extraDirs,
+		lookPath:     c.lookPath,
+		isExecutable: c.isExecutable,
+	}
+}
+
+// nodeVersionOutput runs `node --version` and returns its raw output.
+func nodeVersionOutput(nodePath string) (string, error) {
+	out, err := exec.Command(nodePath, "--version").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// parseNodeMajor extracts the major version from `node --version` output
+// ("v22.14.0\n" → 22). ok is false when the string isn't a version at all.
+func parseNodeMajor(out string) (int, bool) {
+	s := strings.TrimSpace(out)
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexByte(s, '.'); i != -1 {
+		s = s[:i]
+	}
+	major, err := strconv.Atoi(s)
+	if err != nil || major <= 0 {
+		return 0, false
+	}
+	return major, true
+}
+
+// checkNodeVersion fails when the node on this host is too old for the adapter.
+// A node that can't be found, or won't report a version, is NOT a failure: an
+// adapter may ship its own runtime, and the npx path fails on npx anyway.
+func (c *claudeCodeDescriptor) checkNodeVersion() error {
+	nodePath, ok := c.locator().locate("node", c.nodeBinary)
+	if !ok {
+		return nil
+	}
+	out, err := c.nodeVersion(nodePath)
+	if err != nil {
+		return nil
+	}
+	major, parsed := parseNodeMajor(out)
+	if !parsed {
+		return nil
+	}
+	if major < claudeACPMinNodeMajor {
+		return fmt.Errorf("claude-code: node %d+ is required by claude-agent-acp (found %s)",
+			claudeACPMinNodeMajor, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+// ACPCommand implements ACPCommander. Unlike the other harnesses there is no
+// `claude acp`: the command spawned is the claude-agent-acp adapter, resolved
+// in order — the claudeCodeAcpBinary override, an installed adapter (PATH then
+// the well-known install dirs), then a version-pinned `npx -y`.
+//
+// No credential is ever put in argv (world-readable via ps) or env: the adapter
+// drives the host's own Claude Code install, which is already authenticated.
+// The one variable set is CLAUDE_CODE_EXECUTABLE — without it the adapter uses
+// the Claude Code build bundled with its SDK, so a chat session and the
+// station's Health tab would be reporting two different installs.
+func (c *claudeCodeDescriptor) ACPCommand(key string) ([]string, string, []string, error) {
+	// The station must exist before anything is probed on the host: an unknown
+	// key has no project directory to run in.
+	projPath, err := c.projectPathForKey(key)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	// Node is checked up front for every path: a too-old runtime otherwise
+	// fails cryptically inside the adapter, after the hub opened a session.
+	if err := c.checkNodeVersion(); err != nil {
+		return nil, "", nil, err
+	}
+
+	locator := c.locator()
+
+	var env []string
+	if claudePath, ok := locator.locate("claude", c.claudeBinary); ok {
+		env = append(env, "CLAUDE_CODE_EXECUTABLE="+claudePath)
+	}
+
+	// An installed adapter beats npx: it starts immediately and can't change
+	// under us between two sessions.
+	if adapter, ok := locator.locate(claudeACPBinaryName, c.acpBinary); ok {
+		return []string{adapter}, projPath, env, nil
+	}
+
+	npx, ok := locator.locate("npx", "")
+	if !ok {
+		return nil, "", nil, fmt.Errorf("claude-code: couldn't find claude-agent-acp or npx on this node — set claudeCodeAcpBinary in the node config")
+	}
+	return []string{npx, "-y", claudeACPPackage}, projPath, env, nil
 }
 
 // Health returns a best-effort liveness/resource snapshot for a leaf station.

--- a/apps/node-agent/internal/descriptor/claudecode.go
+++ b/apps/node-agent/internal/descriptor/claudecode.go
@@ -45,6 +45,7 @@ type claudeCodeDescriptor struct {
 	lookPath     func(string) (string, error)          // exec.LookPath
 	isExecutable func(string) bool                     // isExecutableFile
 	nodeVersion  func(nodePath string) (string, error) // `node --version`
+	getenv       func(string) string                   // os.Getenv
 }
 
 // ClaudeCodeConfig carries everything the descriptor needs. Zero values are
@@ -91,6 +92,7 @@ func NewClaudeCodeFrom(cfg ClaudeCodeConfig) Descriptor {
 		lookPath:     exec.LookPath,
 		isExecutable: isExecutableFile,
 		nodeVersion:  nodeVersionOutput,
+		getenv:       os.Getenv,
 	}
 }
 
@@ -249,17 +251,17 @@ const (
 	claudeACPMinNodeMajor = 22
 )
 
-// locator returns the executable resolver for this node. A configured node
-// runtime contributes its own directory: the npx that ships with a hand-placed
-// node lives beside it, not on PATH.
-func (c *claudeCodeDescriptor) locator() binaryLocator {
-	var extraDirs []string
-	if c.nodeBinary != "" {
-		extraDirs = append(extraDirs, filepath.Dir(c.nodeBinary))
-	}
+// nodeVersionTimeout bounds `node --version`. It runs on the gateway's
+// acp.open path, so a node binary on a stalled network mount would otherwise
+// wedge session opening with no error at all.
+const nodeVersionTimeout = 2 * time.Second
+
+// locator returns the executable resolver for this node. preferDirs (when any)
+// are probed ahead of PATH — see nodeRuntimeDir.
+func (c *claudeCodeDescriptor) locator(preferDirs ...string) binaryLocator {
 	return binaryLocator{
 		userHome:     c.userHome,
-		extraDirs:    extraDirs,
+		preferDirs:   preferDirs,
 		lookPath:     c.lookPath,
 		isExecutable: c.isExecutable,
 	}
@@ -267,7 +269,15 @@ func (c *claudeCodeDescriptor) locator() binaryLocator {
 
 // nodeVersionOutput runs `node --version` and returns its raw output.
 func nodeVersionOutput(nodePath string) (string, error) {
-	out, err := exec.Command(nodePath, "--version").Output()
+	return nodeVersionOutputWithin(nodeVersionTimeout, nodePath)
+}
+
+// nodeVersionOutputWithin is nodeVersionOutput with an explicit deadline. A
+// timeout surfaces as an error, which callers treat as "version unknown".
+func nodeVersionOutputWithin(timeout time.Duration, nodePath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, nodePath, "--version").Output()
 	if err != nil {
 		return "", err
 	}
@@ -289,27 +299,67 @@ func parseNodeMajor(out string) (int, bool) {
 	return major, true
 }
 
-// checkNodeVersion fails when the node on this host is too old for the adapter.
-// A node that can't be found, or won't report a version, is NOT a failure: an
-// adapter may ship its own runtime, and the npx path fails on npx anyway.
-func (c *claudeCodeDescriptor) checkNodeVersion() error {
-	nodePath, ok := c.locator().locate("node", c.nodeBinary)
-	if !ok {
-		return nil
+// nodeRuntimeDir decides which node the adapter will run under, and refuses the
+// session when that node is too old for it.
+//
+// Candidates are the configured nodeBinary (when set) and then whatever PATH or
+// the well-known dirs offer. The FIRST candidate new enough for the adapter
+// wins; a configured node that is too old is stepped over rather than enforced,
+// because nodeBinary exists to supply a good runtime, never to downgrade a
+// working one. A configured override that can't report a version at all (a typo,
+// say) also falls through to PATH, so a mistyped key degrades to a check rather
+// than to no check.
+//
+// The returned dir is non-empty only when the winner is the CONFIGURED node:
+// that one needs help to actually be used (see ACPCommand), whereas a node found
+// on PATH is what the adapter and npx would pick by themselves.
+//
+// No node at all, and no readable version from any candidate, is NOT a failure:
+// an adapter may ship its own runtime, and the npx path fails on npx anyway.
+func (c *claudeCodeDescriptor) nodeRuntimeDir() (string, error) {
+	var candidates []string
+	if c.nodeBinary != "" {
+		candidates = append(candidates, c.nodeBinary)
 	}
-	out, err := c.nodeVersion(nodePath)
-	if err != nil {
-		return nil
+	if resolved, ok := c.locator().locate("node", ""); ok {
+		candidates = append(candidates, resolved)
 	}
-	major, parsed := parseNodeMajor(out)
-	if !parsed {
-		return nil
+
+	tooOld := "" // first readable version that falls short
+	for _, nodePath := range candidates {
+		out, err := c.nodeVersion(nodePath)
+		if err != nil {
+			continue // unreachable, stalled, or not a node at all
+		}
+		major, parsed := parseNodeMajor(out)
+		if !parsed {
+			continue
+		}
+		if major < claudeACPMinNodeMajor {
+			if tooOld == "" {
+				tooOld = strings.TrimSpace(out)
+			}
+			continue
+		}
+		if nodePath == c.nodeBinary {
+			return filepath.Dir(nodePath), nil
+		}
+		return "", nil
 	}
-	if major < claudeACPMinNodeMajor {
-		return fmt.Errorf("claude-code: node %d+ is required by claude-agent-acp (found %s)",
-			claudeACPMinNodeMajor, strings.TrimSpace(out))
+
+	if tooOld != "" {
+		return "", fmt.Errorf("claude-code: node %d+ is required by claude-agent-acp (found %s)",
+			claudeACPMinNodeMajor, tooOld)
 	}
-	return nil
+	return "", nil
+}
+
+// pathWithDirFirst puts dir at the front of a PATH value.
+func pathWithDirFirst(dir, path string) string {
+	if path == "" {
+		return dir
+	}
+	return dir + string(os.PathListSeparator) + path
 }
 
 // ACPCommand implements ACPCommander. Unlike the other harnesses there is no
@@ -319,9 +369,10 @@ func (c *claudeCodeDescriptor) checkNodeVersion() error {
 //
 // No credential is ever put in argv (world-readable via ps) or env: the adapter
 // drives the host's own Claude Code install, which is already authenticated.
-// The one variable set is CLAUDE_CODE_EXECUTABLE — without it the adapter uses
-// the Claude Code build bundled with its SDK, so a chat session and the
-// station's Health tab would be reporting two different installs.
+// Only two variables are set: CLAUDE_CODE_EXECUTABLE — without it the adapter
+// uses the Claude Code build bundled with its SDK, so a chat session and the
+// station's Health tab would be reporting two different installs — and, when a
+// configured node runtime is in play, PATH.
 func (c *claudeCodeDescriptor) ACPCommand(key string) ([]string, string, []string, error) {
 	// The station must exist before anything is probed on the host: an unknown
 	// key has no project directory to run in.
@@ -330,26 +381,44 @@ func (c *claudeCodeDescriptor) ACPCommand(key string) ([]string, string, []strin
 		return nil, "", nil, err
 	}
 
-	// Node is checked up front for every path: a too-old runtime otherwise
-	// fails cryptically inside the adapter, after the hub opened a session.
-	if err := c.checkNodeVersion(); err != nil {
-		return nil, "", nil, err
+	// Node is settled up front: a too-old runtime otherwise fails cryptically
+	// inside the adapter, after the hub opened a session. The refusal is skipped
+	// for an explicit claudeCodeAcpBinary — that adapter may be a wrapper that
+	// execs a runtime of its own, and naming it is the operator taking
+	// responsibility for it. Its outcome is still used for PATH below, and the
+	// check runs before adapter resolution, so on a host with neither a new
+	// enough node nor an adapter the runtime is what gets reported: it is the
+	// more fundamental problem, and installing an adapter wouldn't fix it.
+	nodeDir, nodeErr := c.nodeRuntimeDir()
+	if nodeErr != nil && c.acpBinary == "" {
+		return nil, "", nil, nodeErr
 	}
 
-	locator := c.locator()
-
 	var env []string
-	if claudePath, ok := locator.locate("claude", c.claudeBinary); ok {
+	// A configured node only genuinely wins if the adapter's own child processes
+	// see it first — npx resolves `node` through PATH, so gating on one runtime
+	// and spawning under another is exactly the crash the gate exists to
+	// prevent. Prepending makes the gate's verdict the truth at spawn time.
+	if nodeDir != "" {
+		env = append(env, "PATH="+pathWithDirFirst(nodeDir, c.getenv("PATH")))
+	}
+	if claudePath, ok := c.locator().locate("claude", c.claudeBinary); ok {
 		env = append(env, "CLAUDE_CODE_EXECUTABLE="+claudePath)
 	}
 
 	// An installed adapter beats npx: it starts immediately and can't change
 	// under us between two sessions.
-	if adapter, ok := locator.locate(claudeACPBinaryName, c.acpBinary); ok {
+	if adapter, ok := c.locator().locate(claudeACPBinaryName, c.acpBinary); ok {
 		return []string{adapter}, projPath, env, nil
 	}
 
-	npx, ok := locator.locate("npx", "")
+	// npx is resolved from the configured runtime's directory first: PATH's npx
+	// belongs to PATH's node, which is the one we just stepped over.
+	var preferDirs []string
+	if nodeDir != "" {
+		preferDirs = append(preferDirs, nodeDir)
+	}
+	npx, ok := c.locator(preferDirs...).locate("npx", "")
 	if !ok {
 		return nil, "", nil, fmt.Errorf("claude-code: couldn't find claude-agent-acp or npx on this node — set claudeCodeAcpBinary in the node config")
 	}

--- a/apps/node-agent/internal/descriptor/claudecode_acp_test.go
+++ b/apps/node-agent/internal/descriptor/claudecode_acp_test.go
@@ -2,10 +2,12 @@ package descriptor
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Claude Code has no native ACP mode: sessions run through the external
@@ -14,12 +16,17 @@ import (
 // needs node, npx or claude installed and none spawns a process (see the Go
 // test hygiene note in CLAUDE.md).
 
-const testStubHome = "/home/pod"
+const (
+	testStubHome = "/home/pod"
+	testStubPath = "/usr/local/bin:/usr/bin:/bin"
+)
 
 // stubClaudeCodeHost replaces the descriptor's host seams. installed maps an
 // executable name to the absolute path PATH would report for it; anything
 // absent from the map is "not on PATH". No well-known path exists unless a
-// case overrides isExecutable. nodeVersion is what `node --version` prints.
+// case overrides isExecutable. nodeVersion is what `node --version` prints, for
+// every candidate — a case that needs one answer per node path replaces the
+// seam itself.
 func stubClaudeCodeHost(t *testing.T, d Descriptor, installed map[string]string, nodeVersion string) *claudeCodeDescriptor {
 	t.Helper()
 	c, ok := d.(*claudeCodeDescriptor)
@@ -35,7 +42,34 @@ func stubClaudeCodeHost(t *testing.T, d Descriptor, installed map[string]string,
 	}
 	c.isExecutable = func(string) bool { return false }
 	c.nodeVersion = func(string) (string, error) { return nodeVersion, nil }
+	c.getenv = func(name string) string {
+		if name == "PATH" {
+			return testStubPath
+		}
+		return ""
+	}
 	return c
+}
+
+// nodeVersions builds a nodeVersion seam that answers per node path; a path
+// absent from the map behaves like a binary that can't be run.
+func nodeVersions(versions map[string]string) func(string) (string, error) {
+	return func(nodePath string) (string, error) {
+		if v, ok := versions[nodePath]; ok {
+			return v, nil
+		}
+		return "", fmt.Errorf("fork/exec %s: no such file or directory", nodePath)
+	}
+}
+
+// pathEntry returns the PATH= entry from env, or "".
+func pathEntry(env []string) string {
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			return strings.TrimPrefix(e, "PATH=")
+		}
+	}
+	return ""
 }
 
 // claudeCodeACP builds a descriptor over the standard fixture and returns it
@@ -177,6 +211,174 @@ func TestClaudeCodeACPCommand_NpxBesideConfiguredNode(t *testing.T) {
 	}
 	if argv[0] != npx {
 		t.Errorf("argv[0] = %q, want the npx beside the configured node %q", argv[0], npx)
+	}
+}
+
+// The gate must judge the runtime the adapter will ACTUALLY run under. On the
+// host nodeBinary exists for — an old node first on the service's PATH, a good
+// one installed out of the way — a PATH-first npx lookup would green-light v22
+// and then start the adapter under v18: the exact crash the gate prevents, now
+// with a passing pre-check.
+func TestClaudeCodeACPCommand_ConfiguredNodeBeatsOlderPathNode(t *testing.T) {
+	const (
+		configuredDir = "/opt/node-22/bin"
+		configured    = configuredDir + "/node"
+	)
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{NodeBinary: configured})
+	c := stubClaudeCodeHost(t, d, map[string]string{
+		"node": "/usr/bin/node",
+		"npx":  "/usr/bin/npx", // node 18's npx
+	}, "")
+	c.nodeVersion = nodeVersions(map[string]string{
+		configured:      "v22.14.0",
+		"/usr/bin/node": "v18.19.0",
+	})
+	c.isExecutable = func(path string) bool { return path == configuredDir+"/npx" }
+
+	argv, _, env, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := configuredDir + "/npx"; argv[0] != want {
+		t.Errorf("argv[0] = %q, want the configured runtime's npx %q — PATH's npx belongs to node 18", argv[0], want)
+	}
+	// Belt and braces: npx execs `node` through PATH, so the configured runtime
+	// must also come first there.
+	if got := pathEntry(env); !strings.HasPrefix(got, configuredDir+string(os.PathListSeparator)) {
+		t.Errorf("PATH = %q, want the configured runtime's dir %q first", got, configuredDir)
+	}
+	if got := pathEntry(env); !strings.HasSuffix(got, testStubPath) {
+		t.Errorf("PATH = %q must PREPEND to the inherited PATH %q, not replace it", got, testStubPath)
+	}
+}
+
+// The mirror case must not refuse: nodeBinary exists to supply a good runtime,
+// never to downgrade a working one. A stale override with node 22 on PATH is an
+// operator's leftover config, not a reason to refuse a session that works.
+func TestClaudeCodeACPCommand_StaleConfiguredNodeDoesNotRefuse(t *testing.T) {
+	const configured = "/opt/node-18/bin/node"
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{NodeBinary: configured})
+	c := stubClaudeCodeHost(t, d, map[string]string{
+		"node":             "/usr/bin/node",
+		"npx":              "/usr/bin/npx",
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+	}, "")
+	c.nodeVersion = nodeVersions(map[string]string{
+		configured:      "v18.19.0",
+		"/usr/bin/node": "v22.14.0",
+	})
+
+	argv, _, env, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("a node 22 on PATH must carry the session: %v", err)
+	}
+	if want := []string{"/usr/local/bin/claude-agent-acp"}; !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if got := pathEntry(env); strings.Contains(got, "/opt/node-18/bin") {
+		t.Errorf("PATH = %q must not put the stale configured runtime ahead of the node 22 being used", got)
+	}
+}
+
+// A mistyped nodeBinary must degrade to a check, not to no check: `locate`
+// returns an override unexamined, so without a fallback the version probe fails
+// and the gate silently passes whatever is really on the host.
+func TestClaudeCodeACPCommand_UnusableNodeBinaryFallsBackToPath(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{NodeBinary: "/opt/node-22/bni/node"})
+	c := stubClaudeCodeHost(t, d, map[string]string{
+		"node":             "/usr/bin/node",
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+	}, "")
+	c.nodeVersion = nodeVersions(map[string]string{"/usr/bin/node": "v20.11.1"})
+
+	_, _, _, err := acpCommander(t, d).ACPCommand(key)
+	if err == nil {
+		t.Fatal("a typo'd nodeBinary must not disable the version gate")
+	}
+	if !strings.Contains(err.Error(), "v20.11.1") {
+		t.Errorf("error %q should report the node actually found on PATH", err)
+	}
+}
+
+// An explicitly configured adapter takes responsibility for its own runtime: it
+// may be a wrapper that execs a bundled node, in which case the host's node is
+// irrelevant. Refusing there would contradict the same rule that lets a host
+// with NO node through.
+func TestClaudeCodeACPCommand_NodeGateAppliesPerAdapterSource(t *testing.T) {
+	t.Run("explicit adapter override is exempt", func(t *testing.T) {
+		d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{AcpBinary: "/opt/wrapper/claude-agent-acp"})
+		stubClaudeCodeHost(t, d, map[string]string{"node": "/usr/bin/node"}, "v18.19.0")
+
+		argv, _, _, err := acpCommander(t, d).ACPCommand(key)
+		if err != nil {
+			t.Fatalf("a configured adapter must not be gated on the host's node: %v", err)
+		}
+		if want := []string{"/opt/wrapper/claude-agent-acp"}; !reflect.DeepEqual(argv, want) {
+			t.Errorf("argv = %v, want %v", argv, want)
+		}
+	})
+
+	t.Run("resolved adapter is gated", func(t *testing.T) {
+		d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+		stubClaudeCodeHost(t, d, map[string]string{
+			"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+			"node":             "/usr/bin/node",
+		}, "v18.19.0")
+
+		if _, _, _, err := acpCommander(t, d).ACPCommand(key); err == nil {
+			t.Fatal("an adapter we chose ourselves runs under the host's node, so it must be gated")
+		}
+	})
+
+	t.Run("npx fallback is gated", func(t *testing.T) {
+		d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+		stubClaudeCodeHost(t, d, map[string]string{
+			"npx":  "/usr/bin/npx",
+			"node": "/usr/bin/node",
+		}, "v18.19.0")
+
+		if _, _, _, err := acpCommander(t, d).ACPCommand(key); err == nil {
+			t.Fatal("the npx fallback runs under the host's node, so it must be gated")
+		}
+	})
+}
+
+// Both problems at once: the runtime is reported, because it is the more
+// fundamental one — installing an adapter wouldn't make node 20 work.
+func TestClaudeCodeACPCommand_OldNodeReportedBeforeMissingAdapter(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, map[string]string{"node": "/usr/bin/node"}, "v20.11.1")
+
+	_, _, _, err := acpCommander(t, d).ACPCommand(key)
+	if err == nil {
+		t.Fatal("expected an error when the node is too old and no adapter resolves")
+	}
+	if !strings.Contains(err.Error(), "node 22+") {
+		t.Errorf("error %q should report the runtime, not the missing adapter", err)
+	}
+	if strings.Contains(err.Error(), "claudeCodeAcpBinary") {
+		t.Errorf("error %q points at the adapter key, but the runtime is the blocking problem", err)
+	}
+}
+
+// A node on a stalled network mount must not wedge acp.open with no error.
+func TestNodeVersionOutputWithin_Timeout(t *testing.T) {
+	stub := filepath.Join(t.TempDir(), "node")
+	// exec, so the process that hangs IS the child the deadline kills — a
+	// wrapping shell would leave `sleep` behind unreaped.
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	out, err := nodeVersionOutputWithin(50*time.Millisecond, stub)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected an error from a node that never answers, got %q", out)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("took %s: `node --version` must be bounded, it runs on the acp.open path", elapsed)
 	}
 }
 

--- a/apps/node-agent/internal/descriptor/claudecode_acp_test.go
+++ b/apps/node-agent/internal/descriptor/claudecode_acp_test.go
@@ -1,0 +1,402 @@
+package descriptor
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Claude Code has no native ACP mode: sessions run through the external
+// claude-agent-acp adapter. Every host-touching seam (PATH lookup, well-known
+// path probing, `node --version`) is injected in every case below, so no test
+// needs node, npx or claude installed and none spawns a process (see the Go
+// test hygiene note in CLAUDE.md).
+
+const testStubHome = "/home/pod"
+
+// stubClaudeCodeHost replaces the descriptor's host seams. installed maps an
+// executable name to the absolute path PATH would report for it; anything
+// absent from the map is "not on PATH". No well-known path exists unless a
+// case overrides isExecutable. nodeVersion is what `node --version` prints.
+func stubClaudeCodeHost(t *testing.T, d Descriptor, installed map[string]string, nodeVersion string) *claudeCodeDescriptor {
+	t.Helper()
+	c, ok := d.(*claudeCodeDescriptor)
+	if !ok {
+		t.Fatalf("expected *claudeCodeDescriptor, got %T", d)
+	}
+	c.userHome = testStubHome
+	c.lookPath = func(name string) (string, error) {
+		if p, ok := installed[name]; ok {
+			return p, nil
+		}
+		return "", fmt.Errorf("%s: not found in $PATH", name)
+	}
+	c.isExecutable = func(string) bool { return false }
+	c.nodeVersion = func(string) (string, error) { return nodeVersion, nil }
+	return c
+}
+
+// claudeCodeACP builds a descriptor over the standard fixture and returns it
+// alongside the station key and workspace of project A.
+func claudeCodeACP(t *testing.T, cfg ClaudeCodeConfig) (Descriptor, string, string) {
+	t.Helper()
+	home, _, projA, _ := buildClaudeCodeFixture(t)
+	cfg.Home = home
+	d := NewClaudeCodeFrom(cfg)
+	return d, expectedClaudeKey(projA), projA
+}
+
+func acpCommander(t *testing.T, d Descriptor) ACPCommander {
+	t.Helper()
+	c, ok := d.(ACPCommander)
+	if !ok {
+		t.Fatal("claude-code descriptor must implement ACPCommander")
+	}
+	return c
+}
+
+// The operator's override is the escape hatch: it is used verbatim, without a
+// PATH lookup that might second-guess it.
+func TestClaudeCodeACPCommand_ConfigAdapterOverrideWinsVerbatim(t *testing.T) {
+	d, key, projA := claudeCodeACP(t, ClaudeCodeConfig{AcpBinary: "/opt/custom/bin/claude-agent-acp"})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"npx":              "/usr/bin/npx",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+
+	argv, dir, _, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{"/opt/custom/bin/claude-agent-acp"}; !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if dir != projA {
+		t.Errorf("dir = %q, want the station's project path %q", dir, projA)
+	}
+}
+
+// An installed adapter is preferred over npx: it starts instantly and can't be
+// changed under us by a registry publish.
+func TestClaudeCodeACPCommand_InstalledAdapterBeatsNpx(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"npx":              "/usr/bin/npx",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+
+	argv, _, _, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{"/usr/local/bin/claude-agent-acp"}; !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want the PATH-resolved adapter %v", argv, want)
+	}
+}
+
+// A pnpm/npm-global install is invisible to a systemd user service's PATH, so
+// the well-known directories are probed in the documented order.
+func TestClaudeCodeACPCommand_AdapterFromWellKnownPath(t *testing.T) {
+	shim := filepath.Join(testStubHome, ".local", "share", "pnpm", "claude-agent-acp")
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	c := stubClaudeCodeHost(t, d, map[string]string{"node": "/usr/bin/node"}, "v22.14.0")
+	c.isExecutable = func(path string) bool { return path == shim }
+
+	argv, _, _, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{shim}; !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want the pnpm shim %v", argv, want)
+	}
+}
+
+func TestClaudeCodeACPCommand_ProbesWellKnownPathsInOrder(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	c := stubClaudeCodeHost(t, d, nil, "v22.14.0")
+	var probed []string
+	c.isExecutable = func(path string) bool {
+		if filepath.Base(path) == "claude-agent-acp" {
+			probed = append(probed, path)
+		}
+		return false
+	}
+
+	if _, _, _, err := acpCommander(t, d).ACPCommand(key); err == nil {
+		t.Fatal("expected an error when nothing resolves")
+	}
+
+	want := []string{
+		filepath.Join(testStubHome, ".local", "share", "pnpm", "claude-agent-acp"),
+		filepath.Join(testStubHome, ".local", "bin", "claude-agent-acp"),
+		"/usr/local/bin/claude-agent-acp",
+		"/usr/bin/claude-agent-acp",
+		"/opt/homebrew/bin/claude-agent-acp",
+	}
+	if !reflect.DeepEqual(probed, want) {
+		t.Errorf("probed %v, want %v", probed, want)
+	}
+}
+
+// The npx fallback MUST pin the version. An unpinned `npx -y <pkg>` would let
+// the whole fleet's adapter change silently between two sessions.
+func TestClaudeCodeACPCommand_NpxFallbackIsPinned(t *testing.T) {
+	d, key, projA := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"npx":  "/usr/bin/npx",
+		"node": "/usr/bin/node",
+	}, "v22.14.0")
+
+	argv, dir, _, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	want := []string{"/usr/bin/npx", "-y", "@agentclientprotocol/claude-agent-acp@0.66.0"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+	if dir != projA {
+		t.Errorf("dir = %q, want %q", dir, projA)
+	}
+}
+
+// The npx shipped with a hand-installed node lives beside it, not on PATH.
+func TestClaudeCodeACPCommand_NpxBesideConfiguredNode(t *testing.T) {
+	npx := "/opt/node-22/bin/npx"
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{NodeBinary: "/opt/node-22/bin/node"})
+	c := stubClaudeCodeHost(t, d, nil, "v22.14.0")
+	c.isExecutable = func(path string) bool { return path == npx }
+
+	argv, _, _, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if argv[0] != npx {
+		t.Errorf("argv[0] = %q, want the npx beside the configured node %q", argv[0], npx)
+	}
+}
+
+func TestClaudeCodeACPCommand_NothingResolvable(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, nil, "v22.14.0")
+
+	_, _, _, err := acpCommander(t, d).ACPCommand(key)
+	if err == nil {
+		t.Fatal("expected an error rather than argv that exec would fail on later")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "claudeCodeAcpBinary") {
+		t.Errorf("error %q must name the claudeCodeAcpBinary config key so the operator knows the fix", msg)
+	}
+	// The message composes into "Couldn't start the agent process — <err>".
+	if strings.HasPrefix(msg, "Claude") || strings.HasSuffix(msg, ".") {
+		t.Errorf("error %q must stay a lowercase sentence fragment", msg)
+	}
+}
+
+// claude-agent-acp requires Node >= 22. Saying so up front beats a cryptic
+// crash inside the adapter after the hub has already opened a session.
+func TestClaudeCodeACPCommand_NodeVersionGate(t *testing.T) {
+	cases := []struct {
+		version string
+		ok      bool
+	}{
+		{"v20.11.1", false},
+		{"v21.7.3", false},
+		{"v22.0.0", true},
+		{"v22.14.0", true},
+		{"v24.4.1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.version, func(t *testing.T) {
+			d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+			stubClaudeCodeHost(t, d, map[string]string{
+				"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+				"node":             "/usr/bin/node",
+			}, tc.version)
+
+			_, _, _, err := acpCommander(t, d).ACPCommand(key)
+			if tc.ok {
+				if err != nil {
+					t.Fatalf("ACPCommand with node %s: %v", tc.version, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error for node %s", tc.version)
+			}
+			if !strings.Contains(err.Error(), "node 22+") || !strings.Contains(err.Error(), tc.version) {
+				t.Errorf("error %q should name the requirement and the version found", err)
+			}
+		})
+	}
+}
+
+// A node that can't be found (or won't report a version) is not a reason to
+// block: an adapter may ship its own runtime. The npx path fails on npx.
+func TestClaudeCodeACPCommand_UnknownNodeVersionDoesNotBlock(t *testing.T) {
+	t.Run("node not installed", func(t *testing.T) {
+		d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+		c := stubClaudeCodeHost(t, d, map[string]string{
+			"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		}, "v22.14.0")
+		c.nodeVersion = func(string) (string, error) {
+			t.Error("node --version must not run when node resolves nowhere")
+			return "", nil
+		}
+
+		if _, _, _, err := acpCommander(t, d).ACPCommand(key); err != nil {
+			t.Fatalf("ACPCommand: %v", err)
+		}
+	})
+
+	t.Run("version unreadable", func(t *testing.T) {
+		d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+		c := stubClaudeCodeHost(t, d, map[string]string{
+			"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+			"node":             "/usr/bin/node",
+		}, "")
+		c.nodeVersion = func(string) (string, error) { return "", fmt.Errorf("exec: killed") }
+
+		if _, _, _, err := acpCommander(t, d).ACPCommand(key); err != nil {
+			t.Fatalf("ACPCommand: %v", err)
+		}
+	})
+}
+
+// Without CLAUDE_CODE_EXECUTABLE the adapter drives the Claude Code build
+// bundled with its own SDK — so the chat session and the station's Health tab
+// would be reporting two different installs.
+func TestClaudeCodeACPCommand_SetsClaudeCodeExecutable(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"claude":           "/usr/local/bin/claude",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+
+	_, _, env, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{"CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude"}; !reflect.DeepEqual(env, want) {
+		t.Errorf("env = %v, want %v", env, want)
+	}
+}
+
+func TestClaudeCodeACPCommand_ClaudeBinaryOverride(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{ClaudeBinary: "/opt/claude/bin/claude"})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"claude":           "/usr/local/bin/claude",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+
+	_, _, env, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	if want := []string{"CLAUDE_CODE_EXECUTABLE=/opt/claude/bin/claude"}; !reflect.DeepEqual(env, want) {
+		t.Errorf("env = %v, want the configured claudeCodeBinary %v", env, want)
+	}
+}
+
+// No claude on the node: the variable is left unset rather than set to a path
+// that doesn't exist, which the adapter would fail on immediately.
+func TestClaudeCodeACPCommand_NoClaudeLeavesEnvUnset(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+
+	_, _, env, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	for _, e := range env {
+		if strings.HasPrefix(e, "CLAUDE_CODE_EXECUTABLE=") {
+			t.Errorf("env %v must not set CLAUDE_CODE_EXECUTABLE when no claude was found", env)
+		}
+	}
+}
+
+// Nothing about the session may leak into argv or env: argv is world-readable
+// via ps, and Claude Code's credentials already live on the host.
+func TestClaudeCodeACPCommand_NoSecretsInCommand(t *testing.T) {
+	d, key, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"claude":           "/usr/local/bin/claude",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+
+	argv, _, env, err := acpCommander(t, d).ACPCommand(key)
+	if err != nil {
+		t.Fatalf("ACPCommand: %v", err)
+	}
+	for _, s := range append(append([]string{}, argv...), env...) {
+		lower := strings.ToLower(s)
+		for _, banned := range []string{"api_key", "apikey", "token", "secret"} {
+			if strings.Contains(lower, banned) {
+				t.Errorf("command carries a credential-shaped value %q", s)
+			}
+		}
+	}
+}
+
+// An unknown station has no project path, so there is nothing to resolve for.
+func TestClaudeCodeACPCommand_BadKeySkipsResolution(t *testing.T) {
+	d, _, _ := claudeCodeACP(t, ClaudeCodeConfig{})
+	c := stubClaudeCodeHost(t, d, map[string]string{
+		"claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+		"node":             "/usr/bin/node",
+	}, "v22.14.0")
+	c.lookPath = func(name string) (string, error) {
+		t.Errorf("PATH lookup for %q must not run for an unknown station key", name)
+		return "", fmt.Errorf("not found")
+	}
+	c.nodeVersion = func(string) (string, error) {
+		t.Error("node --version must not run for an unknown station key")
+		return "v22.14.0", nil
+	}
+
+	if _, _, _, err := acpCommander(t, d).ACPCommand("claude-code:deadbeef"); err == nil {
+		t.Fatal("expected an error for an unknown station key")
+	}
+}
+
+// NewClaudeCode (the plain constructor used by older call sites) must still
+// produce a working, production-wired descriptor.
+func TestNewClaudeCodeStillImplementsACPCommander(t *testing.T) {
+	home, _, _, _ := buildClaudeCodeFixture(t)
+	if _, ok := NewClaudeCode(home).(ACPCommander); !ok {
+		t.Fatal("NewClaudeCode must return a descriptor implementing ACPCommander")
+	}
+}
+
+func TestParseNodeMajor(t *testing.T) {
+	cases := []struct {
+		in    string
+		major int
+		ok    bool
+	}{
+		{"v22.14.0", 22, true},
+		{"v22.14.0\n", 22, true},
+		{" v24.0.1 ", 24, true},
+		{"20.11.1", 20, true},
+		{"", 0, false},
+		{"vX.Y.Z", 0, false},
+		{"node", 0, false},
+	}
+	for _, tc := range cases {
+		major, ok := parseNodeMajor(tc.in)
+		if ok != tc.ok || major != tc.major {
+			t.Errorf("parseNodeMajor(%q) = (%d, %v), want (%d, %v)", tc.in, major, ok, tc.major, tc.ok)
+		}
+	}
+}

--- a/apps/node-agent/internal/descriptor/openclaw.go
+++ b/apps/node-agent/internal/descriptor/openclaw.go
@@ -93,60 +93,19 @@ func NewOpenClawFrom(cfg OpenClawConfig) Descriptor {
 // openclawBinaryName is the executable that hosts the ACP bridge.
 const openclawBinaryName = "openclaw"
 
-// openclawWellKnownBinaries returns the absolute paths probed when openclaw is
-// not on PATH, in priority order. userHome is the OS user's home directory; ""
-// omits the home-relative candidates.
-//
-// This list exists because the node-agent commonly runs as a systemd *user*
-// service, which inherits systemd's minimal default PATH — that excludes
-// ~/.local/share/pnpm and ~/.local/bin, so a pnpm/npm-global install of openclaw
-// is invisible to exec.LookPath even though the shim works in the operator's
-// interactive shell.
-func openclawWellKnownBinaries(userHome string) []string {
-	var paths []string
-	if userHome != "" {
-		paths = append(paths,
-			filepath.Join(userHome, ".local", "share", "pnpm", openclawBinaryName), // pnpm global
-			filepath.Join(userHome, ".local", "bin", openclawBinaryName),           // npm --prefix ~/.local
-		)
-	}
-	return append(paths,
-		"/usr/local/bin/"+openclawBinaryName,
-		"/usr/bin/"+openclawBinaryName,
-		"/opt/homebrew/bin/"+openclawBinaryName, // macOS (Apple silicon Homebrew)
-	)
-}
-
-// resolveOpenClawBinary picks the openclaw executable to spawn, in order:
-// the configured override (used verbatim — the operator knows their layout),
-// then PATH, then the well-known absolute install paths. lookPath and
-// isExecutable are parameters so tests never touch the host's PATH or files.
+// resolveOpenClawBinary picks the openclaw executable to spawn via the shared
+// resolution order (config override → PATH → well-known install dirs; see
+// binaryLocator). lookPath and isExecutable are parameters so tests never touch
+// the host's PATH or files.
 //
 // The failure is an actionable lowercase fragment: it composes into the console's
 // "Couldn't start the agent process — <err>".
 func resolveOpenClawBinary(override, userHome string, lookPath func(string) (string, error), isExecutable func(string) bool) (string, error) {
-	if override != "" {
-		return override, nil
-	}
-	if abs, err := lookPath(openclawBinaryName); err == nil {
-		return abs, nil
-	}
-	for _, candidate := range openclawWellKnownBinaries(userHome) {
-		if isExecutable(candidate) {
-			return candidate, nil
-		}
+	locator := binaryLocator{userHome: userHome, lookPath: lookPath, isExecutable: isExecutable}
+	if binary, ok := locator.locate(openclawBinaryName, override); ok {
+		return binary, nil
 	}
 	return "", fmt.Errorf("openclaw: couldn't find the openclaw binary on this node — set openclawBinary in the node config")
-}
-
-// isExecutableFile reports whether path is an existing file with an executable
-// bit set. os.Stat follows symlinks, so a pnpm shim (a symlink) resolves.
-func isExecutableFile(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return false
-	}
-	return info.Mode()&0o111 != 0
 }
 
 // NewOpenClaw returns a Descriptor for the OpenClaw harness.

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -206,7 +206,7 @@ Claude Code has **no ACP mode of its own**. Its stations get a **Chat** tab via 
 
 Prerequisites:
 
-- **Node 22 or newer** on the node. The adapter requires it. The node-agent reads `node --version` before spawning and fails fast with `Couldn't start the agent process — claude-code: node 22+ is required by claude-agent-acp (found v20.11.1)` rather than letting the adapter crash after the session is open. A node it can't find (or that won't report a version) is not treated as a failure — an adapter may ship its own runtime.
+- **Node 22 or newer** on the node. The adapter requires it. The node-agent reads `node --version` (bounded, 2s) before spawning and fails fast with `Couldn't start the agent process — claude-code: node 22+ is required by claude-agent-acp (found v20.11.1)` rather than letting the adapter crash after the session is open. Two deliberate exemptions: a node it can't find, or that won't report a version, is **not** a failure (an adapter may ship its own runtime), and the check is **skipped entirely when you set `claudeCodeAcpBinary`** — naming your own adapter means taking responsibility for the runtime it uses, which may be one it execs itself.
 - **The adapter must be reachable.** Resolution order: the `claudeCodeAcpBinary` config key (used verbatim) → a `claude-agent-acp` on `PATH` → the well-known install paths `~/.local/share/pnpm/`, `~/.local/bin/`, `/usr/local/bin/`, `/usr/bin/`, `/opt/homebrew/bin/` → a version-pinned `npx -y @agentclientprotocol/claude-agent-acp@0.66.0`. If not even `npx` resolves, opening a session fails immediately with `Couldn't start the agent process — claude-code: couldn't find claude-agent-acp or npx on this node — set claudeCodeAcpBinary in the node config`.
 - **Credentials come from the host.** The adapter uses the Claude Code install already on the node and whatever it is already authenticated with — the node-agent passes no API key, token or secret in argv (world-readable via `ps`) or in the environment. If `claude` isn't logged in on that host, the session won't be either.
 
@@ -228,7 +228,12 @@ A host with node and `claude` on the service's `PATH` needs **no configuration**
 |-----|--------|
 | `claudeCodeAcpBinary` | `argv[0]`: absolute path to a `claude-agent-acp` executable. Used verbatim, skipping `PATH`, the well-known-path probe and the npx fallback. |
 | `claudeCodeBinary` | Absolute path to the `claude` CLI, exported as `CLAUDE_CODE_EXECUTABLE`. |
-| `nodeBinary` | Absolute path to the `node` runtime used for the version check. Its directory is also probed for `npx`, which is where a hand-installed node keeps it. |
+| `nodeBinary` | Absolute path to a `node` runtime to use **instead of** the one on the service's `PATH`. When it satisfies Node 22 it becomes the runtime the adapter actually runs under: its directory is prepended to the session's `PATH` and its `npx` is preferred over `PATH`'s. |
+
+**How `nodeBinary` is chosen.** It is an escape hatch for supplying a *good* runtime, never for downgrading a working one, so the node-agent uses the first of `nodeBinary` then `PATH` that satisfies Node 22:
+
+- apt node 18 on `PATH`, `nodeBinary` → node 22: the configured one wins **for the spawn as well as the check** — `PATH`'s `npx` belongs to node 18, and `npx` finds `node` through `PATH`, so gating on one runtime and spawning under another would produce exactly the crash the gate exists to prevent.
+- `PATH` → node 22, `nodeBinary` → something older or mistyped: the session runs on `PATH`'s node 22 and is **not** refused. A stale key in a config file shouldn't cost you a session that works. (A `nodeBinary` that can't report a version at all falls through to `PATH` for the same reason — a typo degrades to a check against the real runtime, not to no check.)
 
 The same **PATH gotcha as OpenClaw** applies, and bites harder here: under a `systemctl --user` unit, an nvm- or fnm-managed node is invisible (those live under `~/.nvm/versions/...`, which is not probed) — set `nodeBinary` to the absolute path from `which node` in a login shell. Restart the node-agent (`apn restart`) after changing any of these keys.
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -200,6 +200,38 @@ The token is always passed as a **file path, never inline** — argv is world-re
 
 Work is addressed by OpenClaw session key `agent:<name>:<label>`: the root `openclaw` station maps to `agent:main:<label>`, and a subagent station `openclaw:<agent>` maps to `agent:<agent>:<label>`. Restart the node-agent (`apn restart`) after changing any of these keys.
 
+### Claude Code agent sessions (ACP)
+
+Claude Code has **no ACP mode of its own**. Its stations get a **Chat** tab via an external adapter, [`@agentclientprotocol/claude-agent-acp`](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp) — a Node program that speaks ACP on stdio and drives Claude Code underneath. The node-agent runs it in the station's **project directory**, the same path the Files, Health and Cleanup tabs use.
+
+Prerequisites:
+
+- **Node 22 or newer** on the node. The adapter requires it. The node-agent reads `node --version` before spawning and fails fast with `Couldn't start the agent process — claude-code: node 22+ is required by claude-agent-acp (found v20.11.1)` rather than letting the adapter crash after the session is open. A node it can't find (or that won't report a version) is not treated as a failure — an adapter may ship its own runtime.
+- **The adapter must be reachable.** Resolution order: the `claudeCodeAcpBinary` config key (used verbatim) → a `claude-agent-acp` on `PATH` → the well-known install paths `~/.local/share/pnpm/`, `~/.local/bin/`, `/usr/local/bin/`, `/usr/bin/`, `/opt/homebrew/bin/` → a version-pinned `npx -y @agentclientprotocol/claude-agent-acp@0.66.0`. If not even `npx` resolves, opening a session fails immediately with `Couldn't start the agent process — claude-code: couldn't find claude-agent-acp or npx on this node — set claudeCodeAcpBinary in the node config`.
+- **Credentials come from the host.** The adapter uses the Claude Code install already on the node and whatever it is already authenticated with — the node-agent passes no API key, token or secret in argv (world-readable via `ps`) or in the environment. If `claude` isn't logged in on that host, the session won't be either.
+
+> **The npx version is pinned on purpose.** A bare `npx -y @agentclientprotocol/claude-agent-acp` would change every node's adapter the moment a new version is published — mid-flight, with no record of which version a session ran. Installing the adapter properly (`pnpm add -g @agentclientprotocol/claude-agent-acp`) is faster to start and is preferred on a node that hosts sessions regularly; bumping the pinned fallback is a node-agent release.
+
+> **Install skew.** The node-agent sets `CLAUDE_CODE_EXECUTABLE` to the `claude` it resolves on the node (same order: `claudeCodeBinary` → `PATH` → well-known paths). Without it the adapter drives the Claude Code build bundled with its own SDK, so the Chat tab and the Health tab would be reporting two different installs — different version, different config, different session history. When no `claude` resolves at all, the variable is left unset rather than pointed at a path that doesn't exist.
+
+A host with node and `claude` on the service's `PATH` needs **no configuration**. Three optional keys cover the rest (`~/.config/agentpod-node/config.json`, or `~/Library/Application Support/agentpod-node/config.json` on macOS):
+
+```json
+{
+  "claudeCodeAcpBinary": "/home/pod/.local/share/pnpm/claude-agent-acp",
+  "claudeCodeBinary": "/home/pod/.local/bin/claude",
+  "nodeBinary": "/opt/node-22/bin/node"
+}
+```
+
+| Key | Effect |
+|-----|--------|
+| `claudeCodeAcpBinary` | `argv[0]`: absolute path to a `claude-agent-acp` executable. Used verbatim, skipping `PATH`, the well-known-path probe and the npx fallback. |
+| `claudeCodeBinary` | Absolute path to the `claude` CLI, exported as `CLAUDE_CODE_EXECUTABLE`. |
+| `nodeBinary` | Absolute path to the `node` runtime used for the version check. Its directory is also probed for `npx`, which is where a hand-installed node keeps it. |
+
+The same **PATH gotcha as OpenClaw** applies, and bites harder here: under a `systemctl --user` unit, an nvm- or fnm-managed node is invisible (those live under `~/.nvm/versions/...`, which is not probed) — set `nodeBinary` to the absolute path from `which node` in a login shell. Restart the node-agent (`apn restart`) after changing any of these keys.
+
 ### Cleanup
 
 Disk usage summary for the station's workspace. Actions: prune caches · rotate logs · reclaim space. Each cleanup action shows the bytes to be freed before applying.

--- a/docs/superpowers/plans/2026-08-10-acp-slice4d-claude-code.md
+++ b/docs/superpowers/plans/2026-08-10-acp-slice4d-claude-code.md
@@ -1,0 +1,108 @@
+# ACP Slice 4d — Claude Code Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Claude Code stations become conversable from the console Chat tab, and two blemishes 4c's live verification exposed get cleaned up.
+
+**Architecture:** Claude Code has **no native ACP** (verified against the CLI: no `acp` subcommand). The official-lineage adapter is `@agentclientprotocol/claude-agent-acp` — a Node program that speaks ACP over stdio and drives Claude Code underneath. So unlike OpenClaw (native) and unlike a Gateway bridge, this needs an *external program* present on the node. The whole slice is therefore: a node-agent descriptor change that resolves and runs that adapter, plus the small hub/console cleanups.
+
+**Tech Stack:** Go (node-agent), Drizzle migration (backfill), Svelte (one copy fix).
+
+## Global Constraints
+
+- **Verified adapter facts (2026-08-10 — do not re-derive, and do NOT use the `@zed-industries/*` names, which are deprecated):**
+  - Package `@agentclientprotocol/claude-agent-acp`, version **0.66.0**, bin `claude-agent-acp`, `engines: node >= 22`.
+  - Canonical invocation: `npx -y @agentclientprotocol/claude-agent-acp`.
+  - It speaks JSON-RPC on stdout and deliberately redirects `console.log/warn/debug` to **stderr**, so stdout stays clean framing. It exits on stdin EOF / SIGTERM / SIGINT.
+  - Auth: **no API key needed when the host already has Claude Code credentials** (a live `initialize` returned `authMethods: []`). Relevant env: `CLAUDE_CODE_EXECUTABLE`, `CLAUDE_CONFIG_DIR`, `ANTHROPIC_MODEL`.
+  - It advertises `loadSession: true`, supports `session/request_permission`, `session/cancel`, `agent_thought_chunk`, tool-call updates, and multiple concurrent sessions per process.
+  - **Version-skew trap:** it resolves a Claude Code binary shipped as an optional dependency of its own SDK — NOT the node's installed `claude` — unless `CLAUDE_CODE_EXECUTABLE` points at one. Set it when we can find the node's `claude`, so the chat session and what the Health tab reports are the same install.
+- **Prefer a pre-installed adapter over `npx`-at-spawn.** `npx -y` resolves ~100 packages on first use: slow first session and it needs network on every node. Resolution order mirrors the OpenClaw work: explicit config override → a resolved `claude-agent-acp` binary on PATH/well-known paths → `npx -y <pkg>@<pinned version>` as the last resort. Failing that, an actionable error naming the config key.
+- Node >= 22 is a hard requirement of the adapter. Detect it and fail with an actionable message rather than letting the adapter die with a syntax error.
+- The `acp` capability may only be advertised by a descriptor implementing `ACPCommander` (contract at `apps/node-agent/internal/descriptor/descriptor.go:178`).
+- Descriptor errors compose into the console's `Couldn't start the agent process — <err>`: lowercase fragments.
+- Go test hygiene (root `CLAUDE.md`): never leave unreaped children whose `comm` matches a pgrep target; macOS SIGKILLs copied system binaries. Keep every host-touching probe behind an injectable seam, as `openclaw.go` now does — no test may depend on node/npx/claude being installed.
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB`
+
+## File Structure
+
+```
+apps/node-agent/internal/descriptor/claudecode.go        ACPCommand, "acp" capability, adapter+runtime resolution
+apps/node-agent/internal/descriptor/claudecode_acp_test.go   NEW: resolution + argv tests
+apps/node-agent/internal/descriptor/acp_command_test.go  retarget the negative case, add the capability subtest
+apps/node-agent/internal/config/config.go                claudeCodeAcpBinary, claudeCodeBinary, nodeBinary
+apps/node-agent/cmd/agentpod-node/registry.go            thread the config through
+docs/OPERATING.md                                        Claude Code ACP prerequisites
+apps/hub/src/db/drizzle-migrations/0027_*.sql            last_seq backfill
+apps/console/src/lib/components/stations/chat/…          one untitled-fallback copy fix
+```
+
+---
+
+### Task 1: Claude Code `ACPCommander`
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/claudecode.go`, `internal/config/config.go`, `cmd/agentpod-node/registry.go`, `docs/OPERATING.md`
+- Modify: `internal/descriptor/acp_command_test.go` — `TestHandlerACPCommand_UnsupportedHarness` currently asserts **claude-code** returns "acp not supported"; retarget it at **openclaw**… no: openclaw now supports ACP too. Retarget at **codex** (still unsupported until 4e), and add a `claude-code` subtest to `TestCapabilitiesIncludeACP`.
+- Test: `internal/descriptor/claudecode_acp_test.go`
+
+**Interfaces:**
+- Reuse the existing shape: `ACPCommand(key string) (argv []string, dir string, env []string, err error)`. The claude-code descriptor already resolves a station's project path (`projectPathForKey`, used by Health/ListDir/ReadFile) — that is `dir`.
+- New config keys (all optional), threaded through `buildRegistry(config.Config)`:
+  ```go
+  ClaudeCodeAcpBinary string `json:"claudeCodeAcpBinary,omitempty"` // a claude-agent-acp executable
+  ClaudeCodeBinary    string `json:"claudeCodeBinary,omitempty"`    // the claude CLI, for CLAUDE_CODE_EXECUTABLE
+  NodeBinary          string `json:"nodeBinary,omitempty"`          // node/npx runtime, when not on PATH
+  ```
+- Resolution, behind injectable seams:
+  1. `ClaudeCodeAcpBinary` if set → argv `[that]`.
+  2. else a `claude-agent-acp` on PATH or well-known paths (reuse/generalise the openclaw well-known list: `$HOME/.local/share/pnpm`, `$HOME/.local/bin`, `/usr/local/bin`, `/usr/bin`, `/opt/homebrew/bin`) → argv `[that]`.
+  3. else `npx` (resolved the same way) → argv `[npx, -y, @agentclientprotocol/claude-agent-acp@0.66.0]` — pin the version; an unpinned `npx -y` silently upgrades the fleet mid-flight.
+  4. else error: `claude-code: couldn't find claude-agent-acp or npx on this node — set claudeCodeAcpBinary in the node config`.
+- Node runtime check: resolve `node` (config override → PATH → well-known) and read `node --version`; if < 22, error `claude-code: node 22+ is required by claude-agent-acp (found <v>)`. Behind a seam so tests inject the version string.
+- `env`: set `CLAUDE_CODE_EXECUTABLE=<resolved claude>` when a claude CLI is found (config override → PATH → well-known), so the ACP session and the Health tab agree on one install. Set nothing else. Never put a secret in argv or env here — Claude Code's own credentials are already on the host.
+- Advertise `"acp"` in the caps slice (`claudecode.go:86`).
+
+- [ ] **Step 1 (RED):** tests in `claudecode_acp_test.go`, all seams injected: config override wins verbatim; a resolved `claude-agent-acp` beats npx; npx fallback produces the pinned `@0.66.0` argv; nothing resolvable → the actionable error naming `claudeCodeAcpBinary`; node 21 → the version error, node 22 and 24 → fine; `CLAUDE_CODE_EXECUTABLE` present when a claude is found and absent when not; `dir` is the station's project path; a bad key errors before anything is resolved. Plus the two edits in `acp_command_test.go`.
+- [ ] **Step 2:** `cd apps/node-agent && go test ./internal/descriptor/ -run 'ClaudeCode|Capabilities|Unsupported' -v` → FAIL.
+- [ ] **Step 3:** implement. Factor the shared "resolve a binary: override → PATH → well-known" helper out of `openclaw.go` rather than copying it, keeping openclaw's behaviour identical (its tests must stay green untouched).
+- [ ] **Step 4:** `go test -race ./... && go vet ./...` green.
+- [ ] **Step 5:** Document in `docs/OPERATING.md`: the adapter, the three config keys, the Node 22 requirement, that credentials come from the host's Claude Code install, and the `CLAUDE_CODE_EXECUTABLE` skew note. Commit `feat(node-agent): claude code acp sessions`.
+
+---
+
+### Task 2: Cleanups from 4c's live verification
+
+**Files:**
+- Create: `apps/hub/src/db/drizzle-migrations/0027_*.sql` (via drizzle-kit or a hand-written data migration — see below)
+- Modify: one console chat component (the untitled-session fallback)
+- Test: hub migration behaviour if practical; console copy test
+
+**Two independent fixes, both found live:**
+1. **`last_seq` backfill.** Sessions created before 4c have `last_seq = 0`, so history shows "no events" for conversations that plainly have events. Add a data migration: `UPDATE acp_sessions SET last_seq = (SELECT COALESCE(MAX(seq), 0) FROM acp_events e WHERE e.session_id = acp_sessions.id) WHERE last_seq = 0;`. This is a data-only migration — drizzle-kit generates schema diffs, so it may need to be hand-added as `0027_*.sql` **with** its journal entry written the way drizzle expects; check how the repo's existing migrations are registered and follow it exactly rather than inventing a format.
+2. **Inconsistent untitled fallback.** The switcher renders "Session 9" while the history dialog renders "Untitled session" for the same row. Pick ONE (the 4c plan specified "Session N") and use it in both surfaces, via the existing shared label helper.
+
+- [ ] **Step 1 (RED):** a console test asserting both surfaces render the same fallback for an untitled row.
+- [ ] **Step 2:** FAIL. **Step 3:** implement both. **Step 4:** hub suite + `pnpm check && pnpm test` green. Verify the migration applies cleanly against the test DB and is idempotent (running it twice changes nothing further).
+- [ ] **Step 5:** Commit `fix: backfill last_seq and unify the untitled-session label`.
+
+---
+
+### Task 3: Slice gate — suites, PR, CI, live verification (controller-run)
+
+- [ ] Four suites green.
+- [ ] Push; PR `feat: ACP slice 4d — Claude Code sessions`; CI green; merge.
+- [ ] Release + deploy: cut the next `v0.1.x` tag (the fleet self-updates with `apn update`, and **verify the release is complete** — 4 binaries + `install.sh` + service unit + SHA256SUMS covering all, since an incomplete release bricks self-update). Deploy the hub (`bun x pnpm@10 install --frozen-lockfile --filter @agentpod/hub...`, restart) and the console (build with `PUBLIC_HUB_URL`, then `wrangler pages deploy`).
+- [ ] **Find a node with claude-code stations first** — check each node's `/detected` for `claude-code:*` keys; the Mac (`Rakeshs-MacBook-Pro.local`) is the likely host. Re-adopt after upgrading, since capabilities only refresh on re-adoption.
+- [ ] Live: open Chat on a claude-code station, send a real prompt, confirm streamed output and a permission request if one arises (Claude Code's adapter *does* implement `session/request_permission`, so `ask` mode should finally exercise the PermissionCard that neither OpenCode nor Hermes triggered). End the session; confirm no adapter process remains.
+- [ ] Verify the backfill: a pre-4c session now shows a real event count in history.
+- [ ] Update the `acp-sessions-program` memory; ledger complete.
+
+## Self-Review Notes
+
+- The version pin on the npx fallback is deliberate: `npx -y <pkg>` with no version would let a fleet-wide adapter upgrade land silently between two sessions, which is exactly the kind of drift the v0.1.14/15 releases were cut to end.
+- `CLAUDE_CODE_EXECUTABLE` is the one env var worth setting: without it the adapter talks to a *different* Claude Code build than the station's Health tab reports, which would make a version-dependent bug impossible to reason about.
+- Claude Code's adapter is the first one that reliably asks for permission, so this slice is also the first honest live test of the PermissionCard shipped in slice 3.
+- Multiple ACP sessions per adapter process are supported, but this slice keeps one process per session (slice 4b's instance keying) — uniform across harnesses, and a crash can't take out a sibling conversation.

--- a/docs/superpowers/plans/2026-08-10-acp-slice4e-codex.md
+++ b/docs/superpowers/plans/2026-08-10-acp-slice4e-codex.md
@@ -1,0 +1,100 @@
+# ACP Slice 4e — Codex Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codex projects appear as stations and become conversable from the console Chat tab.
+
+**Architecture:** Codex is the last and least-finished harness. Its descriptor currently detects **nothing** — `Detect()` returns an empty slice and its comments assume a station-declaration API that does not exist — so unlike every other slice this one starts by making the harness visible at all. Then it gets ACP through the `@agentclientprotocol/codex-acp` adapter (Codex has no native ACP; the adapter wraps `codex app-server`), reusing the binary/runtime resolution the OpenClaw and Claude Code slices built.
+
+**Tech Stack:** Go (node-agent) only. The hub and console are harness-agnostic and need no changes.
+
+## Global Constraints
+
+- **Verified facts (2026-08-10 — do not re-derive; the `@zed-industries/codex-acp` name in `docs/archive` is DEPRECATED):**
+  - Adapter package `@agentclientprotocol/codex-acp`, version **1.1.14**, bin `codex-acp`, invoked `npx -y @agentclientprotocol/codex-acp`. Verify the exact version against the registry before pinning (the controller confirmed 0.66.0 for the Claude Code adapter this way; do the same here and report what you find).
+  - It bundles its own Codex build; `CODEX_PATH` points it at a different Codex binary. Set it to the node's own `codex` when one resolves, for the same reason `CLAUDE_CODE_EXECUTABLE` exists in slice 4d: otherwise the chat session and the station's Health tab describe different installs.
+  - Auth: ChatGPT login (browser) **or** `CODEX_API_KEY` / `OPENAI_API_KEY` (`CODEX_API_KEY` wins). **`NO_BROWSER=1` matters for a fleet** — it stops the adapter trying to open a browser on a headless node.
+  - It advertises `loadSession: true` and session capabilities resume/list/close/delete/additionalDirectories (no `fork`), `agent_thought_chunk`, permission requests, plan and token-usage events.
+  - Local ground truth on the Mac (the only host with Codex today): `codex-cli 0.36.0` at `/opt/homebrew/bin/codex`; `~/.codex/config.toml` contains `[projects."<absolute path>"]` tables with `trust_level`; `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-*.jsonl` holds 12 session files.
+- **Detection source: `~/.codex/config.toml`'s `[projects."<path>"]` table keys.** That is authoritative, cheap and stable. Do NOT parse session rollout JSONL for paths in this slice — it's a fallback at best, and the config gives us the same answer without a format dependency.
+- Station keys follow the established scheme for path-derived harnesses: `codex:<first 8 hex of sha256(absolute project path)>`, exactly as `claudecode.go` and `opencode.go` do. Filter out paths that no longer exist, as claude-code does.
+- The `acp` capability may only be advertised by a descriptor implementing `ACPCommander` (`descriptor.go:178`), and only advertise the other capabilities the descriptor can actually serve.
+- Descriptor errors compose into `Couldn't start the agent process — <err>`: lowercase fragments naming the config key that fixes them.
+- Reuse the shared `binaryLocator` and the Node-runtime gate from slice 4d rather than copying them; whatever 4d settled about `nodeBinary` governing the spawn applies here unchanged.
+- Go test hygiene (root `CLAUDE.md`): no test may depend on codex/node/npx being installed; every host-touching probe stays behind an injectable seam; never leave unreaped children whose `comm` matches a pgrep target; macOS SIGKILLs copied system binaries.
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB`
+
+## File Structure
+
+```
+apps/node-agent/internal/descriptor/codex.go                 Detect from config.toml, real Health/fs, ACPCommand
+apps/node-agent/internal/descriptor/codex_test.go            NEW: detection + capability tests
+apps/node-agent/internal/descriptor/codex_acp_test.go        NEW: adapter resolution + argv/env tests
+apps/node-agent/internal/descriptor/acp_command_test.go      retarget the negative case again; add the codex capability subtest
+apps/node-agent/internal/config/config.go                    codexAcpBinary, codexBinary
+apps/node-agent/cmd/agentpod-node/registry.go                thread the config through
+docs/OPERATING.md                                            Codex ACP prerequisites + auth on headless nodes
+```
+
+---
+
+### Task 1: Make Codex stations exist
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/codex.go`
+- Test: `apps/node-agent/internal/descriptor/codex_test.go` (new)
+
+**Interfaces produced (consumed by Task 2):**
+- `Detect()` returns one leaf station per existing `[projects."<path>"]` entry in `<home>/.codex/config.toml`, with `key: "codex:<8 hex>"`, `workspacePath` the absolute project path, `displayName` the path's base name, `kind: "leaf"`, `parentKey: nil`.
+- `projectPathForKey(key)` mirroring `claudecode.go`'s helper, so every other method can resolve a station's directory.
+- Capabilities: `health, logs, fs.read, fs.write, terminal, cleanup` — the same set `claude-code` advertises. **`acp` is added in Task 2, not here** (the contract ties it to `ACPCommander`).
+
+Implementation notes:
+- Parse the TOML by hand or with whatever TOML library is already in `go.mod`; check first — do NOT add a dependency for this if a simple scan of `[projects."..."]` lines suffices. Handle quoted paths containing spaces, and ignore every other table.
+- If `~/.codex` or the config is missing, return an empty slice (nil-safe), exactly as the other descriptors do for a missing home.
+- Replace the current placeholder behaviour: `Health` should follow `claudecode.go`'s shape (disk usage of the project, plus a best-effort "is a codex process working in this directory" check), and `ListDir`/`ReadFile` must serve the project path instead of returning errors. `TailLogs` already walks `~/.codex/sessions/` — keep it, but make it station-scoped if that's cheap; if not, leave it and say so.
+
+- [ ] **Step 1 (RED):** `codex_test.go` with a fixture `~/.codex` — a `config.toml` containing three `[projects."…"]` entries (one with a space in the path, one that does not exist on disk) plus unrelated tables and top-level keys. Assert: two stations detected (the missing path filtered), keys are `codex:` + 8 hex and stable across calls, `workspacePath`/`displayName` correct, the unrelated tables ignored, capabilities exactly the expected set with **no `acp` yet**, a missing `~/.codex` yields an empty slice, and `ListDir`/`ReadFile` now serve files under the project path.
+- [ ] **Step 2:** `cd apps/node-agent && go test ./internal/descriptor/ -run Codex -v` → FAIL.
+- [ ] **Step 3:** implement. **Step 4:** `go test -race ./... && go vet ./...` green.
+- [ ] **Step 5:** Commit `feat(node-agent): detect codex projects as stations`.
+
+---
+
+### Task 2: Codex `ACPCommander`
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/codex.go`, `internal/config/config.go`, `cmd/agentpod-node/registry.go`, `internal/descriptor/acp_command_test.go`, `docs/OPERATING.md`
+- Test: `apps/node-agent/internal/descriptor/codex_acp_test.go` (new)
+
+**Interfaces:**
+- New optional config keys threaded through `buildRegistry(config.Config)`: `CodexAcpBinary` (`codexAcpBinary`) and `CodexBinary` (`codexBinary`).
+- Resolution, via the shared `binaryLocator`: `codexAcpBinary` override → a `codex-acp` on PATH/well-known paths → `npx -y @agentclientprotocol/codex-acp@<pinned>` → else `codex: couldn't find codex-acp or npx on this node — set codexAcpBinary in the node config`.
+- Node-runtime gate: reuse slice 4d's helper and whatever it concluded about which node actually runs the adapter.
+- `env`: `NO_BROWSER=1` always (a fleet node must never try to open a browser), plus `CODEX_PATH=<resolved codex>` when the node's own codex resolves. **Do NOT put `CODEX_API_KEY`/`OPENAI_API_KEY` in argv or env from config** — that would place a secret in a process listing; if a node needs key auth, it belongs in the node-agent service's own environment, and OPERATING.md should say exactly that.
+- `dir` is the station's project path. Add `"acp"` to the caps slice. Retarget `TestHandlerACPCommand_UnsupportedHarness` once more — after this slice every registered descriptor supports ACP, so either point it at a synthetic descriptor that doesn't implement `ACPCommander` or assert the handler's error path directly; do not delete the test.
+
+- [ ] **Step 1 (RED):** `codex_acp_test.go`, all seams injected: override wins verbatim; a resolved `codex-acp` beats npx; the npx fallback carries the pinned version and `-y`; nothing resolvable → the actionable error naming `codexAcpBinary`; `NO_BROWSER=1` always present; `CODEX_PATH` present when a codex resolves and absent when not; no `*_API_KEY` ever appears in argv or env; `dir` is the project path; a bad key errors before any host probe. Plus the `acp_command_test.go` edits and a `codex` subtest in `TestCapabilitiesIncludeACP`.
+- [ ] **Step 2:** FAIL. **Step 3:** implement. **Step 4:** `go test -race ./... && go vet ./...` green.
+- [ ] **Step 5:** Document in `docs/OPERATING.md`: the adapter and its pin, the two config keys, `NO_BROWSER=1`, that ChatGPT-login auth needs a one-time interactive `codex login` on the node (or an API key in the service environment, never in node config), and the `CODEX_PATH` skew note. Commit `feat(node-agent): codex acp sessions`.
+
+---
+
+### Task 3: Slice gate — suites, PR, CI, live verification (controller-run)
+
+- [ ] Four suites green (contract; hub with the `:5434` override; node-agent `-race` + `vet`; console check+test+build) — the last three should be untouched by this slice; confirm rather than assume.
+- [ ] Push; PR `feat: ACP slice 4e — Codex sessions`; CI green; merge.
+- [ ] Release: cut the next `v0.1.x` tag and **verify completeness** (4 binaries + `install.sh` + service unit + SHA256SUMS covering every asset — an incomplete release bricks fleet self-update). Then `apn update` the Mac.
+- [ ] Live verification runs on **the Mac** — it is the only host with Codex (`codex-cli 0.36.0`, `~/.codex/config.toml` with several trusted projects; no other node has a `~/.codex`). Confirm codex stations now appear in `/detected`, adopt one (capabilities only refresh on adoption), and check its Health/Files tabs work rather than erroring as they did before this slice.
+- [ ] Live chat: open Chat on a codex station and send a real prompt. If auth is unresolved the adapter will say so — surface whatever it reports rather than guessing; a `codex login` on the Mac is acceptable setup, but note it in the PR as an operator step.
+- [ ] End the session and confirm no `codex-acp` or `codex app-server` process remains.
+- [ ] Update the `acp-sessions-program` memory (the ACP program is complete at this point — record the final harness matrix); ledger complete.
+
+## Self-Review Notes
+
+- Detection from `config.toml` rather than session files is the load-bearing choice: it is the only source that says "this is a project the user works in" rather than "a conversation happened here once", and it needs no JSONL format dependency.
+- This slice deliberately fixes Codex's degraded `Health`/`ListDir`/`ReadFile` alongside detection. Shipping detection alone would create stations whose other tabs error — visible breakage that would read as a regression even though it predates the slice.
+- No hub or console work: the Chat tab keys off the `acp` capability, and the transcript fold ignores unknown `sessionUpdate` values, so Codex's plan/token-usage events degrade rather than break.
+- After this slice every harness in the registry speaks ACP, which retires the "unsupported harness" test's original subject — hence the note to re-point it at a synthetic descriptor rather than delete the coverage.


### PR DESCRIPTION
## Summary

Claude Code stations become conversable from the console Chat tab. This is the first harness needing an **external adapter program** on the node: Claude Code has no native ACP (verified against the CLI — no `acp` subcommand), so the descriptor resolves and runs `@agentclientprotocol/claude-agent-acp`.

Also cleans up two blemishes 4c's live verification exposed: pre-4c sessions showed "no events" in history because `last_seq` was never backfilled, and the untitled-session fallback disagreed between surfaces ("Session 9" in the switcher vs "Untitled session" in the history dialog).

## How the adapter is found and run

Resolution order, reusing the locator built for the OpenClaw fix: `claudeCodeAcpBinary` override → a `claude-agent-acp` on PATH or well-known install paths → `npx -y @agentclientprotocol/claude-agent-acp@0.66.0` → otherwise an actionable error naming the config key.

The npx version is **pinned deliberately**. An unpinned `npx -y` would let every node's adapter change silently between two sessions — the exact drift the v0.1.14/15 releases were cut to end. Package name, version, bin name and the `node >= 22` engine were all verified against the npm registry rather than taken from the plan.

`CLAUDE_CODE_EXECUTABLE` is set to the node's own resolved `claude` when one is found, so the chat session and the station's Health tab describe the same install — the adapter otherwise uses a Claude Code binary bundled with its own SDK.

## The Node-runtime gate, and what review changed about it

The adapter requires Node 22+, so the descriptor checks before spawning rather than letting it die on a syntax error. Review found the first cut had it backwards in an important way: `nodeBinary` governed the *check* but not the *spawn* — `npx` still resolved PATH-first and nothing altered PATH. On exactly the hosts that setting exists for (nvm, tarball installs), the gate could approve a runtime the adapter would never use, or refuse one that would have worked.

It now **selects rather than enforces**: it takes the first of `{nodeBinary, PATH}` that satisfies Node 22, and prepends that directory to PATH *only* when the configured runtime is the winner (so ordinary hosts get no PATH changes leaking into everything the adapter spawns). The reviewer traced all twelve runtime-combination cells: no cell refuses when a working runtime exists, and none allows when none does.

Three smaller fixes from the same review: the gate no longer applies when the operator names their own adapter (which may bring its own runtime — a documented transfer of responsibility); `node --version` is bounded, so a binary on a stalled network mount can't wedge session opening; and a typo'd `nodeBinary` now falls back to a real PATH check instead of silently disabling the gate.

`binaryLocator` was factored out of the OpenClaw descriptor for reuse — verified byte-equivalent, with OpenClaw's tests untouched and green.

## Tests

contract 51 ✅ · hub 374 ✅ · node-agent `-race` + `vet` ✅ · console 680 + `svelte-check` + build ✅

## Live verification

The Mac has 26 Claude Code projects detected, so verification happens there after a release. Claude Code's adapter **does** implement `session/request_permission`, making this the first honest live test of the PermissionCard shipped in slice 3 — neither OpenCode nor Hermes ever asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB