### PR TITLE
fix(node-agent): CODEX_PATH is opt-in, never auto-discovered

### DIFF
--- a/apps/node-agent/internal/config/config.go
+++ b/apps/node-agent/internal/config/config.go
@@ -44,8 +44,11 @@ type Config struct {
   // CodexAcpBinary is a codex-acp executable, used verbatim as argv[0]; when
   // empty the node-agent resolves it from PATH, then from well-known install
   // paths, then falls back to a version-pinned `npx -y`.
-  // CodexBinary is the codex CLI exported as CODEX_PATH, so the ACP session
-  // drives the same install the Health tab reports on.
+  // CodexBinary is an OPT-IN codex CLI exported as CODEX_PATH. Leave it empty
+  // unless the node's codex is new enough to expose `app-server` (the interface
+  // codex-acp drives): empty means the adapter uses its own bundled, known-
+  // compatible Codex, and an older CLI dies with "Device not configured
+  // (os error 6)". It is never auto-discovered for exactly that reason.
   //
   // There is deliberately NO key for CODEX_API_KEY/OPENAI_API_KEY: a key in this
   // file would end up in argv or in a child's environment, i.e. readable via

--- a/apps/node-agent/internal/descriptor/codex.go
+++ b/apps/node-agent/internal/descriptor/codex.go
@@ -352,11 +352,12 @@ func (c *codexDescriptor) locator(preferDirs ...string) binaryLocator {
 //
 //   - NO_BROWSER=1 always: it hides the browser-based ChatGPT login, which is
 //     meaningless on a headless fleet node and would otherwise be offered (and
-//     attempted) with no one there to complete it. ChatGPT-login auth comes from
-//     a prior interactive `codex login` on the node instead.
-//   - CODEX_PATH when a codex resolves on the node: without it the adapter runs
-//     the Codex build bundled with its own npm dependency, so a chat session and
-//     the station's Health tab would be reporting two different installs.
+//     attempted) with no one there to complete it. With it set the adapter
+//     advertises only api-key auth, so a fleet node needs CODEX_API_KEY (or
+//     OPENAI_API_KEY) in the SERVICE environment, or a prior interactive
+//     `codex login` on the node.
+//   - INITIAL_AGENT_MODE=agent always: see the env literal below.
+//   - CODEX_PATH only when codexBinary is configured — never from discovery.
 //   - PATH when, and only when, a configured node runtime is in play.
 func (c *codexDescriptor) ACPCommand(key string) ([]string, string, []string, error) {
 	// The station must exist before anything is probed on the host: an unknown
@@ -401,8 +402,20 @@ func (c *codexDescriptor) ACPCommand(key string) ([]string, string, []string, er
 	if nodeDir != "" {
 		env = append(env, "PATH="+pathWithDirFirst(nodeDir, c.getenv("PATH")))
 	}
-	if codexPath, ok := c.locator().locate("codex", c.codexBinary); ok {
-		env = append(env, "CODEX_PATH="+codexPath)
+	// OPT-IN ONLY, and never auto-discovered — the opposite of what
+	// CLAUDE_CODE_EXECUTABLE does, on purpose. The adapter ships a Codex it is
+	// known to work with; pointing it at the node's own CLI instead is only safe
+	// if that CLI exposes `app-server`, which is the single interface codex-acp
+	// drives. A Codex predating it (0.36.0, say) falls into interactive mode and
+	// dies immediately on a TTY a fleet node does not have:
+	//
+	//	Codex process has exited with code 1: Error: Device not configured (os error 6)
+	//
+	// Discovery cannot tell those apart — so it isn't attempted. An operator who
+	// names codexBinary is asserting their install is new enough, and that
+	// assertion is used verbatim.
+	if c.codexBinary != "" {
+		env = append(env, "CODEX_PATH="+c.codexBinary)
 	}
 
 	// An installed adapter beats npx: it starts immediately and can't change

--- a/apps/node-agent/internal/descriptor/codex.go
+++ b/apps/node-agent/internal/descriptor/codex.go
@@ -56,7 +56,12 @@ type codexDescriptor struct {
 type CodexConfig struct {
 	Home        string // path to the ~/.codex directory; default <user home>/.codex
 	AcpBinary   string // a codex-acp executable; empty = resolve it
-	CodexBinary string // the codex CLI, for CODEX_PATH; empty = resolve it
+	// CodexBinary is opt-in: naming a codex CLI here sets CODEX_PATH, which
+	// overrides the Codex the adapter bundles. Empty means "don't set it" —
+	// never "discover one". Discovery would find CLIs older than the
+	// `app-server` interface codex-acp drives, which fail with
+	// "Device not configured (os error 6)".
+	CodexBinary string
 	NodeBinary  string // the node runtime, when it isn't on the service's PATH
 }
 

--- a/apps/node-agent/internal/descriptor/codex_acp_test.go
+++ b/apps/node-agent/internal/descriptor/codex_acp_test.go
@@ -297,26 +297,86 @@ func TestCodexACPCommand_NeverOptsIntoFullAccess(t *testing.T) {
 	}
 }
 
-// Without CODEX_PATH the adapter drives the Codex build bundled with its own npm
-// dependency — so the Chat tab and the station's Health tab would be reporting
-// two different installs.
-func TestCodexACPCommand_SetsCodexPath(t *testing.T) {
-	d, key, _ := codexACP(t, CodexConfig{})
-	stubCodexHost(t, d, map[string]string{
-		"codex-acp": "/usr/local/bin/codex-acp",
-		"codex":     "/usr/local/bin/codex",
-		"node":      "/usr/bin/node",
-	}, "v22.14.0")
+// CODEX_PATH is OPT-IN ONLY. This is the regression test for a real live
+// failure: auto-discovery pointed the adapter at the node's own
+// /opt/homebrew/bin/codex (v0.36.0), which has no `app-server` subcommand at
+// all — codex-acp drives exactly that interface, so the old CLI fell into
+// interactive mode and died on a TTY it does not have:
+//
+//	Codex process has exited with code 1: Error: Device not configured (os error 6)
+//
+// With no CODEX_PATH the adapter uses its own bundled Codex (v0.147.0) and the
+// ACP handshake succeeds. So a discoverable codex must NEVER be volunteered: the
+// CLAUDE_CODE_EXECUTABLE analogy does not transfer, because Claude Code's adapter
+// tolerates the CLI it drives while codex-acp requires a specific interface from
+// it. Guessing is strictly worse than the known-good default.
+func TestCodexACPCommand_NeverAutoDiscoversCodexPath(t *testing.T) {
+	t.Run("codex on PATH", func(t *testing.T) {
+		d, key, _ := codexACP(t, CodexConfig{})
+		stubCodexHost(t, d, map[string]string{
+			"codex-acp": "/usr/local/bin/codex-acp",
+			"codex":     "/opt/homebrew/bin/codex", // the v0.36.0 that broke the live node
+			"node":      "/usr/bin/node",
+		}, "v22.14.0")
 
-	_, _, env, err := codexACPCommander(t, d).ACPCommand(key)
-	if err != nil {
-		t.Fatalf("ACPCommand: %v", err)
-	}
-	if got, ok := envValue(env, "CODEX_PATH"); !ok || got != "/usr/local/bin/codex" {
-		t.Errorf("env = %v, want CODEX_PATH=/usr/local/bin/codex", env)
-	}
+		_, _, env, err := codexACPCommander(t, d).ACPCommand(key)
+		if err != nil {
+			t.Fatalf("ACPCommand: %v", err)
+		}
+		if got, ok := envValue(env, "CODEX_PATH"); ok {
+			t.Errorf("env volunteered CODEX_PATH=%q from PATH discovery: an un-vetted codex may predate `app-server` and kill the session", got)
+		}
+	})
+
+	t.Run("codex in a well-known dir", func(t *testing.T) {
+		shim := filepath.Join(testStubHome, ".local", "bin", "codex")
+		d, key, _ := codexACP(t, CodexConfig{})
+		c := stubCodexHost(t, d, map[string]string{
+			"codex-acp": "/usr/local/bin/codex-acp",
+			"node":      "/usr/bin/node",
+		}, "v22.14.0")
+		c.isExecutable = func(path string) bool { return path == shim }
+
+		_, _, env, err := codexACPCommander(t, d).ACPCommand(key)
+		if err != nil {
+			t.Fatalf("ACPCommand: %v", err)
+		}
+		if got, ok := envValue(env, "CODEX_PATH"); ok {
+			t.Errorf("env volunteered CODEX_PATH=%q from the well-known-path probe", got)
+		}
+	})
+
+	// Belt and braces: the probe must not even be ATTEMPTED, so re-adding
+	// discovery can't sneak back in behind a resolver that happens to find
+	// nothing on this particular host.
+	t.Run("no codex lookup happens at all", func(t *testing.T) {
+		d, key, _ := codexACP(t, CodexConfig{})
+		c := stubCodexHost(t, d, map[string]string{
+			"codex-acp": "/usr/local/bin/codex-acp",
+			"node":      "/usr/bin/node",
+		}, "v22.14.0")
+		inner := c.lookPath
+		c.lookPath = func(name string) (string, error) {
+			if name == "codex" {
+				t.Error("looked up `codex` on PATH: CODEX_PATH is opt-in via codexBinary only")
+			}
+			return inner(name)
+		}
+		c.isExecutable = func(path string) bool {
+			if filepath.Base(path) == "codex" {
+				t.Errorf("probed %q for a codex: CODEX_PATH is opt-in via codexBinary only", path)
+			}
+			return false
+		}
+
+		if _, _, _, err := codexACPCommander(t, d).ACPCommand(key); err != nil {
+			t.Fatalf("ACPCommand: %v", err)
+		}
+	})
 }
 
+// The escape hatch: an operator whose codex is new enough to expose `app-server`
+// names it, and takes responsibility for that. Used verbatim.
 func TestCodexACPCommand_CodexBinaryOverride(t *testing.T) {
 	d, key, _ := codexACP(t, CodexConfig{CodexBinary: "/opt/codex/bin/codex"})
 	stubCodexHost(t, d, map[string]string{
@@ -334,9 +394,9 @@ func TestCodexACPCommand_CodexBinaryOverride(t *testing.T) {
 	}
 }
 
-// No codex on the node: the variable is left unset rather than set to a path
-// that doesn't exist, which would break a session the bundled Codex could have
-// carried.
+// The default configuration, and the one the live probe proved works: nothing
+// configured, nothing volunteered, the adapter's own bundled Codex carries the
+// session.
 func TestCodexACPCommand_NoCodexLeavesCodexPathUnset(t *testing.T) {
 	d, key, _ := codexACP(t, CodexConfig{})
 	stubCodexHost(t, d, map[string]string{

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -243,13 +243,12 @@ Codex has **no ACP mode of its own** either. Its stations get a **Chat** tab via
 
 - **The adapter must be reachable.** Resolution order: the `codexAcpBinary` config key (used verbatim) → a `codex-acp` on `PATH` → the well-known install paths `~/.local/share/pnpm/`, `~/.local/bin/`, `/usr/local/bin/`, `/usr/bin/`, `/opt/homebrew/bin/` → a version-pinned `npx -y @agentclientprotocol/codex-acp@1.1.14`. If not even `npx` resolves, opening a session fails immediately with `Couldn't start the agent process — codex: couldn't find codex-acp or npx on this node — set codexAcpBinary in the node config`. The pin exists for the same reason as claude-code's, and bumping it is a node-agent release.
 - **No Node version gate.** Unlike `claude-agent-acp` (which declares `node >= 22`), `codex-acp` declares **no `engines` field at all** — so the node-agent selects a runtime but never refuses a session over its version: inventing a floor the package never asked for would cost sessions on hosts it actually supports. `nodeBinary` still works exactly as it does for claude-code, with one difference that follows from the missing requirement: since there is no minimum to judge an "old" runtime against, a configured `nodeBinary` always wins the spawn (its directory is prepended to the session's `PATH` and its `npx` is preferred over `PATH`'s) rather than being stepped over in favour of a newer `PATH` node. A `nodeBinary` that can't report a version at all — a typo — still falls through to `PATH` untouched. With **no** `nodeBinary` set, no `node --version` runs at all on the Codex path: with nothing to enforce and nothing to prefer, the result couldn't change the command, and a node on a stalled mount would otherwise cost every session opening the full 2s probe timeout.
-- **`NO_BROWSER=1` is always set.** It hides the browser-based ChatGPT login, which is meaningless on a headless fleet node: nobody is sitting at that host to complete an OAuth round trip, and offering the method only produces a session that hangs on auth.
+- **`NO_BROWSER=1` is always set.** It hides the browser-based ChatGPT login, which is meaningless on a headless fleet node: nobody is sitting at that host to complete an OAuth round trip, and offering the method only produces a session that hangs on auth. A live handshake against the adapter confirms the consequence — with it set, the only auth method advertised is `api-key` (`initialize` → `protocolVersion: 1`, `authMethods: ["api-key"]`, `loadSession: true`), which is what makes the service-environment key below the practical route on a fleet node.
 - **`INITIAL_AGENT_MODE=agent` is always set** — the approval-seeking mode, chosen by us and never inherited from the adapter's default. This matters more than it looks: the console gives a station its **Chat** tab based on the `acp` capability alone, so every Codex project on a node gains one as soon as that node updates, and the hub's `ask` / `accept-edits` / `full-auto` modes are only a safety net *if the agent actually sends a permission request*. AgentPod **never** opts a fleet node into Codex's `agent-full-access` mode, and there is no config key to do so: an unattended host is the worst place to hand an agent unprompted write-and-execute. If you want a Codex station to act without asking, that is a decision to make per turn in the console, not a default baked into the node.
 
-**Authentication is the node's, not AgentPod's.** Pick one, per node:
+**Authentication is the node's, not AgentPod's.**
 
-1. **ChatGPT login (recommended).** A **one-time interactive** `codex login` on the node itself — over SSH, or via the station's own Terminal tab. It writes credentials under `~/.codex/`, and every later ACP session reuses them silently. Do this once and Chat just works.
-2. **API key in the SERVICE environment.** `codex-acp` reads `CODEX_API_KEY` (preferred) or `OPENAI_API_KEY` from the environment it **inherits** from the node-agent — so put the key in the service unit, not anywhere AgentPod reads:
+1. **API key in the SERVICE environment — the route to use.** With `NO_BROWSER=1` the adapter advertises `api-key` and nothing else, so this is what a fleet node actually authenticates with. `codex-acp` reads `CODEX_API_KEY` (preferred) or `OPENAI_API_KEY` from the environment it **inherits** from the node-agent — so put the key in the service unit, not anywhere AgentPod reads:
 
    ```ini
    # systemd: ~/.config/systemd/user/agentpod-node.service.d/codex.conf
@@ -257,13 +256,23 @@ Codex has **no ACP mode of its own** either. Its stations get a **Chat** tab via
    EnvironmentFile=/home/pod/.config/agentpod-node/codex.env   # chmod 0600, contains CODEX_API_KEY=sk-...
    ```
 
-   On macOS, the equivalent is an `EnvironmentVariables` entry in the LaunchAgent plist — or, better, keep the key in a `0600` file referenced from a wrapper, never inline in a world-readable plist.
+   On macOS, the equivalent is an `EnvironmentVariables` entry in the LaunchAgent plist — or, better, keep the key in a `0600` file referenced from a wrapper, never inline in a world-readable plist. Restart the node-agent (`apn restart`) so the new environment is inherited; a key added without a restart changes nothing.
+
+2. **ChatGPT login.** A one-time interactive `codex login` on the node (over SSH, or via the station's own Terminal tab) writes credentials under `~/.codex/`. Note that this is *not* the method the adapter advertises under `NO_BROWSER=1`, so treat it as unproven for Chat until a live session says otherwise — and note that stored credentials belong to the node's own `codex`, which by default is **not** the Codex the adapter runs (see below).
 
 > **There is deliberately no `codexApiKey` config key, and there never will be.** The node config feeds argv and child environments, and argv is world-readable via `ps` — a key there would be visible to every process on the host. The node-agent passes **no** key, token or secret in argv or in the environment it adds; it only ever lets the service's own environment through.
 
-> **Install skew.** The node-agent sets `CODEX_PATH` to the `codex` it resolves on the node (order: `codexBinary` → `PATH` → well-known paths). Without it the adapter runs the Codex build bundled with its own npm dependency, so the Chat tab and the Health tab would be reporting two different installs — different version, different config, different auth. When no `codex` resolves at all, the variable is left unset so the adapter's bundled Codex can still carry the session.
+> **The adapter brings its own Codex, and by default we let it.** `codex-acp` bundles a Codex build it is known to work with (1.1.14 ships 0.147.0), and AgentPod deliberately does **not** point it at the node's own `codex` CLI. That is the reverse of the claude-code case, for a concrete reason: `codex-acp` drives one specific interface, `codex app-server`, and a CLI that predates it has no such subcommand — it falls into interactive mode and dies instantly on a TTY a fleet node doesn't have. The symptom, if you ever see it:
+>
+> ```
+> Codex process has exited with code 1: Error: Device not configured (os error 6)
+> ```
+>
+> That is a Codex older than `app-server` (confirmed on Homebrew's `codex 0.36.0`, where `codex --help` lists no `app-server`). Check with `codex app-server --help` on the node.
+>
+> `codexBinary` is the **opt-in** escape hatch for the opposite case — your `codex` is recent enough, and you want the session on the same install the Health tab reports on. Set it and it is used verbatim; leave it unset and nothing is volunteered, because auto-discovery cannot tell a new CLI from one that will kill every session. There is no version probe: naming the key is the assertion.
 
-A host with node and `codex` on the service's `PATH` needs **no configuration**. The optional keys:
+A host with node (or just `npx`) on the service's `PATH` needs **no configuration** — and note that a node's own `codex` install is not required at all, since the adapter brings its own. The optional keys:
 
 ```json
 {
@@ -276,7 +285,7 @@ A host with node and `codex` on the service's `PATH` needs **no configuration**.
 | Key | Effect |
 |-----|--------|
 | `codexAcpBinary` | `argv[0]`: absolute path to a `codex-acp` executable. Used verbatim, skipping `PATH`, the well-known-path probe and the npx fallback. |
-| `codexBinary` | Absolute path to the `codex` CLI, exported as `CODEX_PATH`. |
+| `codexBinary` | **Opt-in.** Absolute path to a `codex` CLI that exposes `app-server`, exported as `CODEX_PATH`. Never auto-discovered; unset means the adapter's own bundled Codex. |
 | `nodeBinary` | Shared with claude-code: the `node` runtime to use instead of the service `PATH`'s. |
 
 Restart the node-agent (`apn restart`) after changing any of these keys.


### PR DESCRIPTION
## Why

Live verification of slice 4e failed on the Mac: opening a Codex session returned

> Codex process has exited with code 1: Error: Device not configured (os error 6)

I proved the cause with a two-way ACP handshake probe rather than guessing:

| configuration | result |
|---|---|
| `CODEX_PATH=/opt/homebrew/bin/codex` (the node's own CLI, **v0.36.0**) | `initialize` never returns |
| no `CODEX_PATH` (the adapter's bundled Codex) | `initialize` succeeds — protocol 1, `authMethods: ["api-key"]`, `loadSession: true` |

Local Codex 0.36.0 has **no `app-server` subcommand** — precisely the interface `codex-acp` drives — so it falls into interactive mode and dies on a terminal the node-agent deliberately doesn't give it (a PTY would corrupt the JSON-RPC framing).

**This was a flaw in the slice's design, not its implementation.** `CODEX_PATH` was set by analogy with `CLAUDE_CODE_EXECUTABLE`, but the analogy doesn't hold: Claude Code's adapter *tolerates* whatever CLI it drives, while `codex-acp` *requires* an interface from it. "Make Chat match the Health tab" was the wrong goal, because discovery cannot verify the thing that actually matters.

## Fix

`CODEX_PATH` is now opt-in: set only when an operator explicitly configures `codexBinary`, never from PATH or well-known-path discovery. The default lets the adapter use its own known-compatible bundle — the configuration that provably works. `codexBinary` remains the escape hatch for operators whose Codex is recent enough, where naming the key *is* the version assertion.

`NO_BROWSER=1` and `INITIAL_AGENT_MODE=agent` stay unconditional.

## Tests

The durable one asserts the **probe never happens**, not merely that the field is absent — an "absent field" assertion passes vacuously on any host where discovery finds nothing. It failed on five well-known-directory probes plus the PATH lookup before the fix. The 0.36.0 path from the repro is the fixture value, so the regression is named in the failure message.

node-agent `go test -race ./...` + `go vet` clean.

## Docs

`docs/OPERATING.md` carries the symptom verbatim, the `codex app-server --help` check for deciding whether `codexBinary` is safe to set, and a reordered auth section reflecting the probe evidence: a service-environment `CODEX_API_KEY` is the route for a fleet node, while `codex login` is demoted to unproven for Chat — stored `~/.codex` credentials belong to a Codex the adapter no longer runs by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbNjcG9KvVyeLFSZcXu8HB
