### PR TITLE
spike: kaambaan bridge — validate the §7 seam before Horizon 0 builds on it

### DIFF
--- a/apps/bridge/spike/.env.example
+++ b/apps/bridge/spike/.env.example
@@ -1,0 +1,34 @@
+# Copy to .env (gitignored) and fill in the two blanks.
+#   cp .env.example .env
+
+# ── kaambaan (local wrangler dev) ────────────────────────────────────────────
+# Start it first:  cd ~/Projects/kaambaan/apps/api && pnpm dev:setup && pnpm dev
+KAAMBAAN_URL=http://localhost:8787
+TENANT_ID=tnt_dev
+
+# From `bun run seed`. Re-seed for each run — a completed card is not reclaimable.
+BOARD_ID=
+AGENT_TOKEN=
+
+# ── AgentPod hub ─────────────────────────────────────────────────────────────
+HUB_URL=https://hub.agentpod.dev
+
+# PREFERRED — a session cookie, so no password is written to disk.
+# In the console (console.agentpod.dev), while logged in:
+#   devtools → Application → Cookies → https://hub.agentpod.dev
+# Copy the whole "name=value" pair for the Better Auth session cookie.
+# Multiple cookies can be joined with "; ".
+HUB_COOKIE=
+
+# FALLBACK — same credentials you use to log into the console. Only read when
+# HUB_COOKIE is empty. Prefer the cookie: it expires, a password does not.
+HUB_EMAIL=
+HUB_PASSWORD=
+
+# ── Target station ───────────────────────────────────────────────────────────
+# Codex on the macOS node, already verified working:
+STATION_ID=station_f4693267-9ce9-407b-8565-14f5c11f6a87
+
+# Second target for RQ1 — a Hermes station on a Linux node. Take the id from its
+# console URL: /nodes/<node>/stations/<STATION_ID>
+# STATION_ID=

--- a/apps/bridge/spike/.gitignore
+++ b/apps/bridge/spike/.gitignore
@@ -1,0 +1,6 @@
+.env
+node_modules/
+
+# Raw captures are evidence, not source. The written write-ups are tracked;
+# the JSONL dumps can be large and contain workspace paths.
+findings/*.jsonl

--- a/apps/bridge/spike/README.md
+++ b/apps/bridge/spike/README.md
@@ -28,24 +28,31 @@ bun run bridge
 
 ## `.env`
 
-```sh
-KAAMBAAN_URL=http://localhost:8787
-TENANT_ID=tnt_spike
-BOARD_ID=          # from `bun run seed`
-AGENT_TOKEN=       # from `bun run seed`, starts kbn_
+`cp .env.example .env` and fill the blanks. `.env` is gitignored.
 
-HUB_URL=https://hub.agentpod.dev
-HUB_EMAIL=
-HUB_PASSWORD=
-STATION_ID=        # a station advertising `acp`, with a DISPOSABLE workspace
+**Hub auth — prefer the cookie.** Set `HUB_COOKIE` to a session lifted from the browser
+(console devtools → Application → Cookies → `hub.agentpod.dev`, copy the Better Auth session
+`name=value`). It expires, and no password is written to disk.
+
+`HUB_EMAIL`/`HUB_PASSWORD` — the same credentials you use for the console — are a fallback,
+read only when `HUB_COOKIE` is empty.
+
+> Neither is a real answer. **The hub has no service identity**: auth is cookie-based, routes
+> read `c.get("user")`, and there is no bearer or API-key path. A headless bridge borrowing a
+> human's session is fine for throwaway code and is a Horizon 2 blocker. It is recorded as a
+> finding.
+
+Check it before touching a station:
+
+```bash
+bun run scripts/check-auth.ts
 ```
-
-`.env` is gitignored. Do not commit credentials.
 
 ## Scripts
 
 | Command | What it does |
 |---|---|
+| `bun run scripts/check-auth.ts` | Verifies the hub credential, the station, and that it advertises `acp` |
 | `bun run seed` | Creates board + stages + agent + card in local kaambaan |
 | `bun run scripts/stub-run.ts` | Claims and completes one card with no ACP at all — proves the kaambaan half |
 | `bun run scripts/probe-acp.ts` | Opens a live ACP session and records the distinct event kinds — RQ1's input |

--- a/apps/bridge/spike/README.md
+++ b/apps/bridge/spike/README.md
@@ -1,0 +1,65 @@
+# Bridge Spike — THROWAWAY CODE
+
+Answers RQ1–RQ5 in [`docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-design.md`](../../../docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-design.md).
+
+**This is not production code.** No tests, no error handling, no retries, no reconnection. It exists to produce a verdict on whether the §7 seam between AgentPod and kaambaan holds when a real harness on a real machine drives a real card. Horizon 2 rewrites it test-first under `apps/bridge/` or deletes it.
+
+It is deliberately exempt from the repo's TDD rule, on the condition that it never becomes production. Every step here ends in an *observation*, not a passing test.
+
+## Prerequisites
+
+- kaambaan checked out at `~/Projects/kaambaan` and running locally
+- An AgentPod account on `hub.agentpod.dev` with at least one enrolled node
+- Two stations advertising the `acp` capability, on **different platforms and different harnesses** — the plan targets Codex on the macOS node and Hermes on a Linux node
+- **A disposable workspace on each.** Task 8 deliberately strands a running agent mid-edit.
+
+## Run
+
+```bash
+# 1. kaambaan, in its own terminal
+cd ~/Projects/kaambaan && pnpm --filter @kaambaan/api dev     # wrangler dev on :8787
+
+# 2. seed a board, an agent and a card
+cd apps/bridge/spike && bun run seed                          # prints BOARD_ID and AGENT_TOKEN
+
+# 3. write .env (see below), then drive it
+bun run bridge
+```
+
+## `.env`
+
+```sh
+KAAMBAAN_URL=http://localhost:8787
+TENANT_ID=tnt_spike
+BOARD_ID=          # from `bun run seed`
+AGENT_TOKEN=       # from `bun run seed`, starts kbn_
+
+HUB_URL=https://hub.agentpod.dev
+HUB_EMAIL=
+HUB_PASSWORD=
+STATION_ID=        # a station advertising `acp`, with a DISPOSABLE workspace
+```
+
+`.env` is gitignored. Do not commit credentials.
+
+## Scripts
+
+| Command | What it does |
+|---|---|
+| `bun run seed` | Creates board + stages + agent + card in local kaambaan |
+| `bun run scripts/stub-run.ts` | Claims and completes one card with no ACP at all — proves the kaambaan half |
+| `bun run scripts/probe-acp.ts` | Opens a live ACP session and records the distinct event kinds — RQ1's input |
+| `bun run bridge` | The actual bridge loop: claim → session → activities → gate → complete |
+| `CARD_ID=… bun run observe` | Polls card state while a station is stranded — RQ4 |
+
+## Output
+
+Raw captures land in `findings/` (gitignored except the two write-ups):
+
+- `acp-raw.jsonl` — every WS frame from a live session
+- `bridge-timing.jsonl` — inter-event gaps, for RQ3
+- `rq2.jsonl` — permission request, wait duration, answer
+- `rq4.jsonl` — card state over time during the reclaim experiment
+- `rq1-mapping.md`, `rq1-side-by-side.md` — the written RQ1 evidence
+
+The verdict is written to `docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-findings.md`.

--- a/apps/bridge/spike/findings/verified-surface.md
+++ b/apps/bridge/spike/findings/verified-surface.md
@@ -1,0 +1,54 @@
+# Verified kaambaan surface (2026-08-11, kaambaan @ `573a9ba`, local `wrangler dev`)
+
+Everything here was observed against a running instance, not read from docs. It corrects
+four things the design and plan assumed.
+
+## Setup requires `tnt_dev` / `usr_dev`
+
+`apps/api/scripts/seed-dev.sql` seeds exactly one tenant (`tnt_dev`), one user (`usr_dev`)
+and their membership. Any other `X-Tenant-Id` fails the catalog foreign key with an opaque
+`500 D1_ERROR: FOREIGN KEY constraint failed`, with nothing naming the tenant. `pnpm
+dev:setup` (D1 migrations + seed) is a prerequisite for `pnpm dev` — the plan omitted it.
+
+## There is no card-read endpoint
+
+| Path | Method | Result |
+|---|---|---|
+| `GET /v1/boards/{board}/cards` | GET | `405 method not allowed` |
+| `GET /v1/boards/{board}/cards/{card}` | GET | `405 method not allowed` |
+| `GET /v1/boards/{board}` | GET | `200` — the whole snapshot |
+
+The board snapshot is the only read surface: `{boardId, tenantId, name, stages, cards, gates,
+references, usage, github}`. Each card carries `{id, title, spec, ownerUserId,
+currentStageKey, state, delegateAgentId, priority, contextId, createdAt, updatedAt, costUsd,
+overBudget, attemptCount}`.
+
+This is better than what the plan guessed at: `attemptCount` is exactly the RQ4 signal (a
+reclaim should increment it), and `costUsd` is per-card metering for RQ5.
+
+`POST /v1/boards/{board}/cards` returns `{card: {…}}` — the id is at `card.id`, not `cardId`.
+
+## A `response` activity does not advance the card
+
+Observed across one full run:
+
+```
+claim     → state=working    stage=work  attempts=1
+thought   → state=working    stage=work  attempts=1
+response  → state=working    stage=work  attempts=1
+complete  → state=submitted  stage=done  attempts=1
+```
+
+Doc 04 §4's activity table says `response` "drives state to `completed`". It did not move
+the card. `complete` advanced it to the next stage, where it sits as `submitted` awaiting
+that stage's human owner — which is correct pipeline behaviour.
+
+**Consequence for the bridge:** posting a terminal `response` activity is not sufficient.
+`complete` must be called explicitly. (Caveat on precision: the snapshot exposes *card*
+state; doc 04 describes *task* state. These may diverge, and the spike only observed the
+card. Either way the operational rule holds.)
+
+## Claim returns a lease epoch starting at 1
+
+`{claimed: true, runId, leaseEpoch: 1, card, stage, handoff}` — `leaseEpoch` must be echoed
+on every subsequent run call (`heartbeat`, `activities`, `complete`, `fail`).

--- a/apps/bridge/spike/package.json
+++ b/apps/bridge/spike/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@agentpod/bridge-spike",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "seed": "bun run scripts/seed.ts",
+    "bridge": "bun run src/bridge.ts",
+    "observe": "bun run scripts/observe-reclaim.ts"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  }
+}

--- a/apps/bridge/spike/scripts/check-auth.ts
+++ b/apps/bridge/spike/scripts/check-auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Cheapest possible check that the hub credentials work, before running
+ * anything that touches a station.
+ *
+ *   bun run scripts/check-auth.ts
+ *
+ * Proves three things in order: the credential is accepted, the station exists
+ * and is visible to this user, and it advertises the `acp` capability.
+ */
+
+import { loadConfig } from "../src/config";
+import { signIn } from "../src/hub";
+
+const c = loadConfig();
+
+const cookie = await signIn(c);
+console.log("✓ hub credential accepted");
+
+const res = await fetch(`${c.hubUrl}/api/stations/${c.stationId}`, { headers: { Cookie: cookie } });
+if (!res.ok) {
+  console.error(`✗ station read → ${res.status} ${await res.text()}`);
+  console.error("  If this is 401, the cookie is stale — copy a fresh one.");
+  console.error("  If this is 404, STATION_ID is wrong or belongs to another account.");
+  process.exit(1);
+}
+
+const station = (await res.json()) as any;
+const caps: string[] = station?.capabilities ?? station?.station?.capabilities ?? [];
+console.log(`✓ station visible: ${station?.displayName ?? station?.station?.displayName ?? c.stationId}`);
+console.log(`  harness:      ${station?.harness ?? station?.station?.harness ?? "?"}`);
+console.log(`  capabilities: ${caps.join(", ") || "(none reported)"}`);
+
+if (!caps.includes("acp")) {
+  console.error("\n✗ station does not advertise `acp` — the bridge cannot open a session on it.");
+  process.exit(1);
+}
+console.log("\n✓ ready — run `bun run scripts/probe-acp.ts` next");

--- a/apps/bridge/spike/scripts/check-auth.ts
+++ b/apps/bridge/spike/scripts/check-auth.ts
@@ -8,30 +8,58 @@
  * and is visible to this user, and it advertises the `acp` capability.
  */
 
-import { loadConfig } from "../src/config";
-import { signIn } from "../src/hub";
+// Deliberately does NOT use loadConfig(): that requires BOARD_ID/AGENT_TOKEN,
+// which come from a kaambaan seed. Checking hub auth must not depend on
+// kaambaan being up.
+import { signIn, authHeaders } from "../src/hub";
+import type { SpikeConfig } from "../src/config";
 
-const c = loadConfig();
+const c = {
+  hubUrl: process.env.HUB_URL ?? "https://hub.agentpod.dev",
+  hubToken: process.env.HUB_TOKEN?.trim() || undefined,
+  hubCookie: process.env.HUB_COOKIE?.trim() || undefined,
+  hubEmail: process.env.HUB_EMAIL?.trim() || undefined,
+  hubPassword: process.env.HUB_PASSWORD?.trim() || undefined,
+  stationId: process.env.STATION_ID ?? "",
+} as SpikeConfig;
+
+if (!c.stationId) throw new Error("STATION_ID required");
+if (!c.hubToken && !c.hubCookie && !(c.hubEmail && c.hubPassword)) {
+  throw new Error("set HUB_TOKEN (preferred), HUB_COOKIE, or HUB_EMAIL + HUB_PASSWORD");
+}
 
 const cookie = await signIn(c);
-console.log("✓ hub credential accepted");
 
-const res = await fetch(`${c.hubUrl}/api/stations/${c.stationId}`, { headers: { Cookie: cookie } });
+// There is no `GET /api/stations/:id`. The ACP session list is the cheapest
+// authenticated read that ALSO proves the station supports agent sessions:
+// station-acp.ts rejects a non-ACP station with 403 before doing any work.
+const url = `${c.hubUrl}/api/stations/${c.stationId}/acp/sessions`;
+const res = await fetch(url, {
+  headers: { ...authHeaders(c), ...(cookie ? { Cookie: cookie } : {}) },
+});
+
+if (res.status === 401) {
+  console.error("✗ 401 — the credential was rejected.");
+  console.error("  HUB_TOKEN should be either the hub's API_TOKEN, or the VALUE of the");
+  console.error("  __Secure-better-auth.session_token cookie (no name, no quotes).");
+  console.error("  A session token expires — copy a fresh one if it is old.");
+  process.exit(1);
+}
+if (res.status === 403) {
+  console.error("✗ 403 — authenticated, but this station does not support agent sessions.");
+  console.error("  Pick a station whose capabilities include `acp`.");
+  process.exit(1);
+}
+if (res.status === 404) {
+  console.error("✗ 404 — STATION_ID is unknown, or belongs to another account.");
+  process.exit(1);
+}
 if (!res.ok) {
-  console.error(`✗ station read → ${res.status} ${await res.text()}`);
-  console.error("  If this is 401, the cookie is stale — copy a fresh one.");
-  console.error("  If this is 404, STATION_ID is wrong or belongs to another account.");
+  console.error(`✗ ${res.status} ${await res.text()}`);
   process.exit(1);
 }
 
-const station = (await res.json()) as any;
-const caps: string[] = station?.capabilities ?? station?.station?.capabilities ?? [];
-console.log(`✓ station visible: ${station?.displayName ?? station?.station?.displayName ?? c.stationId}`);
-console.log(`  harness:      ${station?.harness ?? station?.station?.harness ?? "?"}`);
-console.log(`  capabilities: ${caps.join(", ") || "(none reported)"}`);
-
-if (!caps.includes("acp")) {
-  console.error("\n✗ station does not advertise `acp` — the bridge cannot open a session on it.");
-  process.exit(1);
-}
+const sessions = (await res.json()) as unknown[];
+console.log("✓ credential accepted");
+console.log(`✓ station ${c.stationId} supports acp (${sessions.length} existing session(s))`);
 console.log("\n✓ ready — run `bun run scripts/probe-acp.ts` next");

--- a/apps/bridge/spike/scripts/observe-reclaim.ts
+++ b/apps/bridge/spike/scripts/observe-reclaim.ts
@@ -1,0 +1,59 @@
+/**
+ * Task 8 / RQ4: watch a card while its agent is stranded.
+ *
+ * Procedure:
+ *   1. Seed a card whose work takes several minutes, on a DISPOSABLE workspace.
+ *   2. `bun run bridge`; wait for "run … → session …".
+ *   3. `CARD_ID=<id> bun run observe` in another terminal.
+ *   4. Kill the BRIDGE process only (Ctrl-C). Do not stop the node-agent and do
+ *      not end the ACP session — the harness keeps working, the heartbeats stop.
+ *   5. Wait out HEARTBEAT_TIMEOUT_MS (15 min, board-do.ts:16).
+ *   6. When the card is claimable again, run scripts/stub-run.ts as a SECOND
+ *      agent. If it claims while the first harness is still writing to that
+ *      workspace, RQ4 has failed and double execution is confirmed.
+ *
+ * `attemptCount` is the signal: reclaim ends the run and re-queues the card, so
+ * a successful reclaim should show as an attempt increment plus a state change.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { Kaambaan } from "../src/kaambaan";
+
+const base = process.env.KAAMBAAN_URL ?? "http://localhost:8787";
+const tenant = process.env.TENANT_ID ?? "tnt_dev";
+const boardId = process.env.BOARD_ID!;
+const token = process.env.AGENT_TOKEN!;
+const cardId = process.env.CARD_ID!;
+if (!boardId || !token || !cardId) throw new Error("BOARD_ID, AGENT_TOKEN and CARD_ID required");
+
+const INTERVAL_MS = Number(process.env.INTERVAL_MS ?? 30_000);
+
+mkdirSync("findings", { recursive: true });
+const k = new Kaambaan(base, boardId, token, tenant);
+const started = Date.now();
+let last = "";
+
+console.log("watching", cardId, `— reclaim expected around 15m`);
+
+for (;;) {
+  const card = await k.card(cardId).catch(() => undefined);
+  const line = {
+    tSec: Math.round((Date.now() - started) / 1000),
+    state: card?.state,
+    stage: card?.currentStageKey,
+    attempts: card?.attemptCount,
+    delegate: card?.delegateAgentId,
+    at: new Date().toISOString(),
+  };
+  appendFileSync("findings/rq4.jsonl", JSON.stringify(line) + "\n");
+
+  const sig = `${line.state}/${line.stage}/${line.attempts}/${line.delegate}`;
+  if (sig !== last) {
+    console.log(`t+${line.tSec}s  CHANGE  state=${line.state} attempts=${line.attempts} delegate=${line.delegate}`);
+    last = sig;
+  } else {
+    console.log(`t+${line.tSec}s  …`);
+  }
+
+  await new Promise((r) => setTimeout(r, INTERVAL_MS));
+}

--- a/apps/bridge/spike/scripts/probe-acp.ts
+++ b/apps/bridge/spike/scripts/probe-acp.ts
@@ -1,0 +1,60 @@
+/**
+ * Task 3 observation: drive a live ACP session headlessly and record every
+ * distinct event kind. The deduped kind list is RQ1's input — run this against
+ * BOTH target stations (Codex on macOS, Hermes on Linux) and keep both captures.
+ *
+ *   STATION_ID=<codex station>  bun run scripts/probe-acp.ts
+ *   STATION_ID=<hermes station> bun run scripts/probe-acp.ts
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { loadConfig } from "../src/config";
+import { signIn, openSession, connect, kindOf } from "../src/hub";
+
+const PROMPT = process.env.PROMPT ?? "List the files in this directory, then stop.";
+const IDLE_EXIT_MS = Number(process.env.IDLE_EXIT_MS ?? 60_000);
+
+mkdirSync("findings", { recursive: true });
+const c = loadConfig();
+const out = `findings/acp-raw-${c.stationId}.jsonl`;
+
+const cookie = await signIn(c);
+console.log("signed in");
+
+const session = await openSession(c, cookie, "ask");
+console.log("session", session.id, "on station", c.stationId);
+
+const seen = new Set<string>();
+let lastAt = Date.now();
+
+const ws = await connect(c, cookie, session.id, (msg) => {
+  appendFileSync(out, JSON.stringify(msg) + "\n");
+  lastAt = Date.now();
+
+  if (msg.t === "event") {
+    const kind = kindOf(msg.event);
+    if (!seen.has(kind)) {
+      seen.add(kind);
+      console.log("NEW KIND", kind);
+    }
+  }
+  if (msg.t === "bye") {
+    console.log("bye:", msg.reason);
+    finish();
+  }
+});
+
+ws.send(JSON.stringify({ t: "prompt", text: PROMPT }));
+console.log("prompted:", PROMPT);
+
+function finish(): never {
+  console.log(`\n${seen.size} distinct kinds → ${out}`);
+  for (const k of [...seen].sort()) console.log("  " + k);
+  process.exit(0);
+}
+
+// The harness has no "I am completely done" frame we can rely on yet — that is
+// itself part of what RQ1 is establishing. Exit on silence instead.
+setInterval(() => {
+  if (Date.now() - lastAt > IDLE_EXIT_MS) finish();
+}, 5_000);

--- a/apps/bridge/spike/scripts/probe-acp.ts
+++ b/apps/bridge/spike/scripts/probe-acp.ts
@@ -8,14 +8,14 @@
  */
 
 import { appendFileSync, mkdirSync } from "node:fs";
-import { loadConfig } from "../src/config";
+import { loadHubConfig } from "../src/config";
 import { signIn, openSession, connect, kindOf } from "../src/hub";
 
 const PROMPT = process.env.PROMPT ?? "List the files in this directory, then stop.";
 const IDLE_EXIT_MS = Number(process.env.IDLE_EXIT_MS ?? 60_000);
 
 mkdirSync("findings", { recursive: true });
-const c = loadConfig();
+const c = loadHubConfig();
 const out = `findings/acp-raw-${c.stationId}.jsonl`;
 
 const cookie = await signIn(c);

--- a/apps/bridge/spike/scripts/replay.ts
+++ b/apps/bridge/spike/scripts/replay.ts
@@ -1,0 +1,52 @@
+/**
+ * Task 4: replay a captured session through the projection, offline.
+ *
+ * Produces RQ1's answer without needing a live station — run it over each
+ * findings/acp-raw-*.jsonl capture, one per harness.
+ *
+ *   bun run scripts/replay.ts findings/acp-raw-<station>.jsonl
+ */
+
+import { readFileSync } from "node:fs";
+import { project, unmapped, losses } from "../src/project";
+import { kindOf } from "../src/hub";
+
+const file = process.argv[2];
+if (!file) throw new Error("usage: bun run scripts/replay.ts <capture.jsonl>");
+
+const lines = readFileSync(file, "utf8").trim().split("\n").filter(Boolean);
+
+const byKind = new Map<string, { events: number; activities: number }>();
+let events = 0;
+let activities = 0;
+
+for (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.t !== "event") continue;
+  events++;
+  const kind = kindOf(msg.event);
+  const produced = project(msg.event);
+  activities += produced.length;
+  const row = byKind.get(kind) ?? { events: 0, activities: 0 };
+  row.events++;
+  row.activities += produced.length;
+  byKind.set(kind, row);
+}
+
+console.log(`\n${file}`);
+console.log(`  ${events} ACP events → ${activities} kaambaan activities\n`);
+console.log("  kind                                events  activities");
+for (const [kind, row] of [...byKind].sort()) {
+  const flag = row.activities === 0 ? "  ← DROPPED" : "";
+  console.log(`  ${kind.padEnd(36)}${String(row.events).padStart(6)}${String(row.activities).padStart(12)}${flag}`);
+}
+
+if (unmapped().length) {
+  console.log("\n  UNMAPPED (no projection at all):");
+  for (const u of unmapped()) console.log("    " + u);
+}
+if (losses().length) {
+  console.log("\n  LOSSY (projects, but structure lost):");
+  for (const l of losses()) console.log("    " + l);
+}
+console.log();

--- a/apps/bridge/spike/scripts/seed.ts
+++ b/apps/bridge/spike/scripts/seed.ts
@@ -1,0 +1,52 @@
+/**
+ * Seeds local kaambaan with a board, a two-stage pipeline, an agent (returning
+ * its kbn_ bearer) and one card. Prints the two values the bridge needs.
+ *
+ * Deliberately does NOT use loadConfig() — it runs before BOARD_ID/AGENT_TOKEN
+ * exist, which is the whole point of it.
+ */
+
+// tnt_dev / usr_dev are what `pnpm dev:setup` seeds into the local D1 catalog
+// (kaambaan apps/api/scripts/seed-dev.sql). Anything else fails the tenant
+// foreign key with an opaque D1_ERROR.
+const BASE = process.env.KAAMBAAN_URL ?? "http://localhost:8787";
+const TENANT = process.env.TENANT_ID ?? "tnt_dev";
+const OWNER = process.env.OWNER_USER_ID ?? "usr_dev";
+const dev = { "X-Tenant-Id": TENANT, "Content-Type": "application/json" };
+
+const CARD_TITLE =
+  process.env.CARD_TITLE ?? "Create hello.txt containing the word spike, then stop.";
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: dev,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`POST ${path} → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as T;
+}
+
+const board = await post<{ boardId: string }>("/v1/boards", {
+  name: "Bridge spike",
+  stages: [
+    { key: "work", name: "Work", order: 0, ownerKind: "capability", owner: "acp" },
+    { key: "done", name: "Done", order: 1, ownerKind: "human" },
+  ],
+});
+
+const agent = await post<{ agent: { id: string }; token: string }>("/v1/agents", {
+  name: "AgentPod fleet",
+  capabilities: ["acp"],
+});
+
+const card = await post<{ cardId?: string; id?: string }>(
+  `/v1/boards/${board.boardId}/cards`,
+  { title: CARD_TITLE, ownerUserId: OWNER },
+);
+
+console.log(`BOARD_ID=${board.boardId}`);
+console.log(`AGENT_TOKEN=${agent.token}`);
+console.log(`# card: ${card.cardId ?? card.id ?? "(id not returned)"} — ${CARD_TITLE}`);

--- a/apps/bridge/spike/scripts/stub-run.ts
+++ b/apps/bridge/spike/scripts/stub-run.ts
@@ -1,0 +1,41 @@
+/**
+ * Task 2 observation: claim and complete a card with no ACP at all.
+ *
+ * Proves the kaambaan half in isolation. If this fails, nothing downstream
+ * matters. Also records WHICH call advanced the card — kaambaan derives state
+ * from activities, so whether `complete` or the `response` activity moved it is
+ * a real distinction for the bridge loop.
+ */
+
+import { Kaambaan } from "../src/kaambaan";
+
+const base = process.env.KAAMBAAN_URL ?? "http://localhost:8787";
+const tenant = process.env.TENANT_ID ?? "tnt_dev";
+const boardId = process.env.BOARD_ID!;
+const token = process.env.AGENT_TOKEN!;
+if (!boardId || !token) throw new Error("BOARD_ID and AGENT_TOKEN required (run `bun run seed`)");
+
+const k = new Kaambaan(base, boardId, token, tenant);
+
+const work = await k.claim();
+if (!work) {
+  console.log("nothing to claim");
+  process.exit(1);
+}
+console.log("claimed", work.runId, `"${work.card.title}"`, "leaseEpoch", work.leaseEpoch);
+
+const stateAfter = async (label: string) => {
+  const c = await k.card(work.card.id);
+  console.log(`  after ${label}: state=${c?.state} stage=${c?.currentStageKey} attempts=${c?.attemptCount}`);
+};
+
+await stateAfter("claim");
+await k.heartbeat(work);
+await k.activity(work, { type: "thought", body: "stub working", ephemeral: true });
+await stateAfter("thought");
+await k.activity(work, { type: "response", body: "stub done" });
+await stateAfter("response");
+await k.complete(work, { stub: true });
+await stateAfter("complete");
+
+console.log("completed", work.runId);

--- a/apps/bridge/spike/src/bridge.ts
+++ b/apps/bridge/spike/src/bridge.ts
@@ -12,7 +12,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { loadConfig } from "./config";
 import { Kaambaan, type Work } from "./kaambaan";
 import { signIn, openSession, connect, kindOf, type AcpEvent } from "./hub";
-import { project, unmapped, losses } from "./project";
+import { project, unmapped, losses, contextPeak, resetContext } from "./project";
 
 const POLL_MS = Number(process.env.POLL_MS ?? 5_000);
 const HEARTBEAT_MS = Number(process.env.HEARTBEAT_MS ?? 60_000);
@@ -26,6 +26,7 @@ const cookie = await signIn(c);
 console.log("signed in; polling for work every", POLL_MS, "ms");
 
 async function workOne(work: Work): Promise<void> {
+  resetContext();
   const session = await openSession(c, cookie, "ask");
   console.log(`run ${work.runId} → session ${session.id} ("${work.card.title}")`);
 
@@ -69,13 +70,27 @@ async function workOne(work: Work): Promise<void> {
   }
 
   clearInterval(beat);
+
+  const ctx = contextPeak();
+  const ctxLine = ctx.size
+    ? ` Peak context ${ctx.pct}% (${ctx.used.toLocaleString()}/${ctx.size.toLocaleString()}).`
+    : "";
+
   await k.activity(work, {
     type: "response",
-    body: `Ran on station \`${c.stationId}\` (ACP session \`${session.id}\`).`,
+    body: `Ran on station \`${c.stationId}\` (ACP session \`${session.id}\`).${ctxLine}`,
   });
   // Verified in Task 2: a `response` activity does NOT advance the card, even
   // though doc 04 §4 says it drives state to completed. `complete` is required.
-  await k.complete(work, { station: c.stationId, session: session.id });
+  //
+  // Context peak rides in the handoff so the next stage — and any attempts
+  // comparison — can see how close this run came to its ceiling. It is not cost;
+  // cost is deferred (RQ5 found no token or price data on any harness).
+  await k.complete(work, {
+    station: c.stationId,
+    session: session.id,
+    contextPeak: ctx.size ? ctx : undefined,
+  });
   ws.close();
 
   console.log(`completed ${work.runId}; kinds seen: ${[...kinds].sort().join(", ")}`);

--- a/apps/bridge/spike/src/bridge.ts
+++ b/apps/bridge/spike/src/bridge.ts
@@ -1,0 +1,136 @@
+/**
+ * The bridge loop — Tasks 5 and 6.
+ *
+ *   claim → open ACP session → stream events → project to activities
+ *         → hold on a permission gate → complete
+ *
+ * Throwaway. No retries, no reconnection, no concurrency: one card at a time,
+ * one station, one agent identity. Its job is evidence, not uptime.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { loadConfig } from "./config";
+import { Kaambaan, type Work } from "./kaambaan";
+import { signIn, openSession, connect, kindOf, type AcpEvent } from "./hub";
+import { project, unmapped, losses } from "./project";
+
+const POLL_MS = Number(process.env.POLL_MS ?? 5_000);
+const HEARTBEAT_MS = Number(process.env.HEARTBEAT_MS ?? 60_000);
+/** Kaambaan reclaims at 15 min (board-do.ts:16). Give up well before that. */
+const IDLE_DONE_MS = Number(process.env.IDLE_DONE_MS ?? 120_000);
+
+mkdirSync("findings", { recursive: true });
+const c = loadConfig();
+const k = new Kaambaan(c.kaambaanUrl, c.boardId, c.agentToken, c.tenantId);
+const cookie = await signIn(c);
+console.log("signed in; polling for work every", POLL_MS, "ms");
+
+async function workOne(work: Work): Promise<void> {
+  const session = await openSession(c, cookie, "ask");
+  console.log(`run ${work.runId} → session ${session.id} ("${work.card.title}")`);
+
+  const beat = setInterval(() => {
+    k.heartbeat(work).catch((e) => console.error("heartbeat failed", e));
+  }, HEARTBEAT_MS);
+
+  let lastEventAt = Date.now();
+  let settled = false;
+  const kinds = new Set<string>();
+
+  const ws = await connect(c, cookie, session.id, (msg) => {
+    if (msg.t === "bye") {
+      console.log("session ended:", msg.reason);
+      settled = true;
+      return;
+    }
+    if (msg.t !== "event") return;
+
+    const gap = Date.now() - lastEventAt;
+    lastEventAt = Date.now();
+    kinds.add(kindOf(msg.event));
+    appendFileSync(
+      "findings/bridge-timing.jsonl",
+      JSON.stringify({ gapMs: gap, kind: kindOf(msg.event), at: new Date().toISOString() }) + "\n",
+    );
+
+    // Fire-and-forget: ordering is preserved by kaambaan's seq, and awaiting
+    // here would block the socket callback.
+    for (const a of project(msg.event)) {
+      k.activity(work, a).catch((e) => console.error("activity failed", e));
+    }
+
+    if (msg.event.type === "permission-request") void handlePermission(work, ws, msg.event);
+  });
+
+  ws.send(JSON.stringify({ t: "prompt", text: work.card.title }));
+
+  while (!settled && Date.now() - lastEventAt < IDLE_DONE_MS) {
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+
+  clearInterval(beat);
+  await k.activity(work, {
+    type: "response",
+    body: `Ran on station \`${c.stationId}\` (ACP session \`${session.id}\`).`,
+  });
+  // Verified in Task 2: a `response` activity does NOT advance the card, even
+  // though doc 04 §4 says it drives state to completed. `complete` is required.
+  await k.complete(work, { station: c.stationId, session: session.id });
+  ws.close();
+
+  console.log(`completed ${work.runId}; kinds seen: ${[...kinds].sort().join(", ")}`);
+  if (unmapped().length) console.log("UNMAPPED:", unmapped());
+  if (losses().length) console.log("LOSSES:", losses());
+}
+
+/**
+ * ⚠️ UNVERIFIED PATH. The board snapshot exposes `gates`, and a card sitting on
+ * an elicitation should surface there — but the resolution shape was never
+ * observed (the spike could not reach a live hub). This logs the raw gate on
+ * first sight so the real shape gets recorded, then answers ACP with the human's
+ * choice, falling back to the first offered option.
+ */
+async function handlePermission(work: Work, ws: WebSocket, event: AcpEvent): Promise<void> {
+  const options = ((event.payload as any)?.options ?? []) as Array<{ optionId?: string; name?: string }>;
+  const started = Date.now();
+  console.log(`PERMISSION seq=${event.seq}`, JSON.stringify(options));
+  appendFileSync("findings/rq2.jsonl", JSON.stringify({ phase: "requested", event }) + "\n");
+
+  let logged = false;
+  for (;;) {
+    const board = await k.board().catch(() => null);
+    const card = board?.cards.find((x) => x.id === work.card.id);
+
+    if (board && !logged) {
+      logged = true;
+      appendFileSync(
+        "findings/rq2.jsonl",
+        JSON.stringify({ phase: "gate-shape", gates: board.gates, cardState: card?.state }) + "\n",
+      );
+    }
+
+    const gate = (board?.gates as any[] | undefined)?.find(
+      (g) => g?.cardId === work.card.id && (g?.resolution ?? g?.resolvedAt ?? g?.answer),
+    );
+
+    if (gate) {
+      const optionId =
+        gate.resolution?.optionId ?? gate.answer?.optionId ?? options[0]?.optionId ?? "allow";
+      appendFileSync(
+        "findings/rq2.jsonl",
+        JSON.stringify({ phase: "answered", waitedMs: Date.now() - started, optionId, gate }) + "\n",
+      );
+      ws.send(JSON.stringify({ t: "permission-answer", requestSeq: event.seq, optionId }));
+      console.log(`permission answered after ${Math.round((Date.now() - started) / 1000)}s → ${optionId}`);
+      return;
+    }
+
+    await new Promise((r) => setTimeout(r, 3_000));
+  }
+}
+
+for (;;) {
+  const work = await k.claim();
+  if (work) await workOne(work);
+  else await new Promise((r) => setTimeout(r, POLL_MS));
+}

--- a/apps/bridge/spike/src/config.ts
+++ b/apps/bridge/spike/src/config.ts
@@ -9,7 +9,14 @@ export interface SpikeConfig {
   boardId: string;
   agentToken: string;
   hubUrl: string;
-  /** Preferred: a session cookie lifted from the browser. No password anywhere. */
+  /**
+   * Preferred. Either the hub's static `API_TOKEN` (a service key mapping to
+   * `DEFAULT_USER_ID`) or the value of the `__Secure-better-auth.session_token`
+   * cookie — authMiddleware accepts both as `Authorization: Bearer`, and the
+   * same value works as `?token=` for the WebSocket handshake.
+   */
+  hubToken?: string;
+  /** Fallback: a full `name=value` cookie pair. */
   hubCookie?: string;
   /** Fallback: email/password sign-in, only used when hubCookie is absent. */
   hubEmail?: string;
@@ -23,15 +30,62 @@ function req(name: string): string {
   return v;
 }
 
-export function loadConfig(): SpikeConfig {
+/**
+ * Hub-only config. The probe and the auth check talk to the hub and never to
+ * kaambaan, so they must not be gated on BOARD_ID/AGENT_TOKEN — those come from
+ * a kaambaan seed and would force `wrangler dev` to be running for a check that
+ * has nothing to do with it.
+ */
+export function loadHubConfig(): SpikeConfig {
+  const hubToken = process.env.HUB_TOKEN?.trim() || undefined;
   const hubCookie = process.env.HUB_COOKIE?.trim() || undefined;
   const hubEmail = process.env.HUB_EMAIL?.trim() || undefined;
   const hubPassword = process.env.HUB_PASSWORD?.trim() || undefined;
 
-  if (!hubCookie && !(hubEmail && hubPassword)) {
+  if (!hubToken && !hubCookie && !(hubEmail && hubPassword)) {
     throw new Error(
-      "hub auth missing — set HUB_COOKIE (preferred: copy the session cookie from the " +
-        "console's devtools) or both HUB_EMAIL and HUB_PASSWORD. See README.md.",
+      "hub auth missing — set HUB_TOKEN (preferred), or HUB_COOKIE as a full " +
+        "name=value pair, or both HUB_EMAIL and HUB_PASSWORD. See README.md.",
+    );
+  }
+  if (hubCookie && !hubCookie.includes("=")) {
+    throw new Error(
+      "HUB_COOKIE must be a full `name=value` pair. If you have only the value, " +
+        "put it in HUB_TOKEN instead — it works as a bearer.",
+    );
+  }
+
+  return {
+    kaambaanUrl: process.env.KAAMBAAN_URL ?? "http://localhost:8787",
+    tenantId: process.env.TENANT_ID ?? "tnt_dev",
+    boardId: "",
+    agentToken: "",
+    hubUrl: process.env.HUB_URL ?? "https://hub.agentpod.dev",
+    hubToken,
+    hubCookie,
+    hubEmail,
+    hubPassword,
+    stationId: req("STATION_ID"),
+  };
+}
+
+export function loadConfig(): SpikeConfig {
+  const hubToken = process.env.HUB_TOKEN?.trim() || undefined;
+  const hubCookie = process.env.HUB_COOKIE?.trim() || undefined;
+  const hubEmail = process.env.HUB_EMAIL?.trim() || undefined;
+  const hubPassword = process.env.HUB_PASSWORD?.trim() || undefined;
+
+  if (!hubToken && !hubCookie && !(hubEmail && hubPassword)) {
+    throw new Error(
+      "hub auth missing — set HUB_TOKEN (preferred), or HUB_COOKIE as a full " +
+        "name=value pair, or both HUB_EMAIL and HUB_PASSWORD. See README.md.",
+    );
+  }
+  if (hubCookie && !hubCookie.includes("=")) {
+    throw new Error(
+      "HUB_COOKIE must be a full `name=value` pair, e.g. " +
+        "`__Secure-better-auth.session_token=abc…`. If you have only the value, " +
+        "put it in HUB_TOKEN instead — it works as a bearer.",
     );
   }
 

--- a/apps/bridge/spike/src/config.ts
+++ b/apps/bridge/spike/src/config.ts
@@ -1,0 +1,34 @@
+/**
+ * Spike config. One place for every URL, id and credential so no other module
+ * reads process.env directly.
+ */
+
+export interface SpikeConfig {
+  kaambaanUrl: string;
+  tenantId: string;
+  boardId: string;
+  agentToken: string;
+  hubUrl: string;
+  hubEmail: string;
+  hubPassword: string;
+  stationId: string;
+}
+
+function req(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env ${name} — see apps/bridge/spike/README.md`);
+  return v;
+}
+
+export function loadConfig(): SpikeConfig {
+  return {
+    kaambaanUrl: process.env.KAAMBAAN_URL ?? "http://localhost:8787",
+    tenantId: process.env.TENANT_ID ?? "tnt_dev",
+    boardId: req("BOARD_ID"),
+    agentToken: req("AGENT_TOKEN"),
+    hubUrl: process.env.HUB_URL ?? "https://hub.agentpod.dev",
+    hubEmail: req("HUB_EMAIL"),
+    hubPassword: req("HUB_PASSWORD"),
+    stationId: req("STATION_ID"),
+  };
+}

--- a/apps/bridge/spike/src/config.ts
+++ b/apps/bridge/spike/src/config.ts
@@ -9,8 +9,11 @@ export interface SpikeConfig {
   boardId: string;
   agentToken: string;
   hubUrl: string;
-  hubEmail: string;
-  hubPassword: string;
+  /** Preferred: a session cookie lifted from the browser. No password anywhere. */
+  hubCookie?: string;
+  /** Fallback: email/password sign-in, only used when hubCookie is absent. */
+  hubEmail?: string;
+  hubPassword?: string;
   stationId: string;
 }
 
@@ -21,14 +24,26 @@ function req(name: string): string {
 }
 
 export function loadConfig(): SpikeConfig {
+  const hubCookie = process.env.HUB_COOKIE?.trim() || undefined;
+  const hubEmail = process.env.HUB_EMAIL?.trim() || undefined;
+  const hubPassword = process.env.HUB_PASSWORD?.trim() || undefined;
+
+  if (!hubCookie && !(hubEmail && hubPassword)) {
+    throw new Error(
+      "hub auth missing — set HUB_COOKIE (preferred: copy the session cookie from the " +
+        "console's devtools) or both HUB_EMAIL and HUB_PASSWORD. See README.md.",
+    );
+  }
+
   return {
     kaambaanUrl: process.env.KAAMBAAN_URL ?? "http://localhost:8787",
     tenantId: process.env.TENANT_ID ?? "tnt_dev",
     boardId: req("BOARD_ID"),
     agentToken: req("AGENT_TOKEN"),
     hubUrl: process.env.HUB_URL ?? "https://hub.agentpod.dev",
-    hubEmail: req("HUB_EMAIL"),
-    hubPassword: req("HUB_PASSWORD"),
+    hubCookie,
+    hubEmail,
+    hubPassword,
     stationId: req("STATION_ID"),
   };
 }

--- a/apps/bridge/spike/src/hub.ts
+++ b/apps/bridge/spike/src/hub.ts
@@ -1,0 +1,97 @@
+/**
+ * AgentPod hub client for the spike.
+ *
+ * ⚠️ SERVICE-IDENTITY GAP — a finding in its own right.
+ * The hub authenticates by cookie: routes read `c.get("user")` and the console
+ * calls with `credentials: "include"`. There is no bearer or API-key path, so a
+ * headless bridge has no service identity. The spike signs in as a human via
+ * POST /api/auth/sign-in/email and reuses the session cookie. That is acceptable
+ * for throwaway code and unacceptable for Horizon 2 — see the findings doc.
+ *
+ * Verified surface (packages/contract/src/acp-session.ts, hub routes/station-acp.ts):
+ *   POST /api/stations/{station}/acp/sessions {mode}   → AcpSessionRow
+ *   WS   /api/acp/sessions/{session}/ws
+ *     client → {t:"subscribe",sinceSeq} | {t:"prompt",text}
+ *              | {t:"permission-answer",requestSeq,optionId} | {t:"cancel"}
+ *     server → {t:"event",event} | {t:"replay-done",lastSeq}
+ *              | {t:"session",session} | {t:"bye",reason}
+ */
+
+import type { SpikeConfig } from "./config";
+
+export interface AcpEvent {
+  sessionId: string;
+  seq: number;
+  type: "user-prompt" | "agent-update" | "permission-request" | "permission-answer" | "state" | "error";
+  payload: unknown;
+  createdAt: string;
+}
+
+export type ServerMsg =
+  | { t: "event"; event: AcpEvent }
+  | { t: "replay-done"; lastSeq: number }
+  | { t: "session"; session: { id: string; status: string } }
+  | { t: "bye"; reason: string };
+
+export async function signIn(c: SpikeConfig): Promise<string> {
+  const res = await fetch(`${c.hubUrl}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: c.hubEmail, password: c.hubPassword }),
+  });
+  if (!res.ok) throw new Error(`sign-in → ${res.status} ${await res.text()}`);
+  const cookie = res.headers
+    .getSetCookie()
+    .map((s) => s.split(";")[0])
+    .join("; ");
+  if (!cookie) throw new Error("sign-in returned no Set-Cookie — check the hub auth config");
+  return cookie;
+}
+
+export async function openSession(
+  c: SpikeConfig,
+  cookie: string,
+  mode: "ask" | "accept-edits" | "full-auto" = "ask",
+): Promise<{ id: string }> {
+  const res = await fetch(`${c.hubUrl}/api/stations/${c.stationId}/acp/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: cookie },
+    body: JSON.stringify({ mode }),
+  });
+  if (!res.ok) throw new Error(`openSession → ${res.status} ${await res.text()}`);
+  return (await res.json()) as { id: string };
+}
+
+export function connect(
+  c: SpikeConfig,
+  cookie: string,
+  sessionId: string,
+  onMsg: (msg: ServerMsg) => void,
+): Promise<WebSocket> {
+  const url = `${c.hubUrl.replace(/^http/, "ws")}/api/acp/sessions/${sessionId}/ws`;
+  // Bun's WebSocket accepts headers; the browser one does not. Spike runs on Bun.
+  const ws = new WebSocket(url, { headers: { Cookie: cookie } } as any);
+
+  ws.addEventListener("message", (e) => {
+    try {
+      onMsg(JSON.parse(String((e as MessageEvent).data)) as ServerMsg);
+    } catch {
+      /* forward-compat: drop frames we cannot parse, same rule as the console */
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    ws.addEventListener("open", () => {
+      ws.send(JSON.stringify({ t: "subscribe", sinceSeq: 0 }));
+      resolve(ws);
+    });
+    ws.addEventListener("error", (e) => reject(new Error(`ws error: ${String(e)}`)));
+  });
+}
+
+/** A stable label for an event, destructuring agent-update's opaque payload. */
+export function kindOf(event: AcpEvent): string {
+  if (event.type !== "agent-update") return event.type;
+  const u = (event.payload as any)?.sessionUpdate;
+  return `agent-update:${u ?? "?"}`;
+}

--- a/apps/bridge/spike/src/hub.ts
+++ b/apps/bridge/spike/src/hub.ts
@@ -33,7 +33,18 @@ export type ServerMsg =
   | { t: "session"; session: { id: string; status: string } }
   | { t: "bye"; reason: string };
 
+/**
+ * Returns a Cookie header value for the hub.
+ *
+ * Prefers HUB_COOKIE — a session lifted from the browser — so no password is
+ * ever written to disk. Falls back to email/password sign-in.
+ */
 export async function signIn(c: SpikeConfig): Promise<string> {
+  if (c.hubCookie) {
+    console.log("using HUB_COOKIE (no sign-in)");
+    return c.hubCookie;
+  }
+
   const res = await fetch(`${c.hubUrl}/api/auth/sign-in/email`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/bridge/spike/src/hub.ts
+++ b/apps/bridge/spike/src/hub.ts
@@ -34,14 +34,39 @@ export type ServerMsg =
   | { t: "bye"; reason: string };
 
 /**
- * Returns a Cookie header value for the hub.
+ * Auth for the hub, in preference order.
  *
- * Prefers HUB_COOKIE — a session lifted from the browser — so no password is
- * ever written to disk. Falls back to email/password sign-in.
+ * `authMiddleware` (apps/hub/src/auth/middleware.ts) accepts, in this order:
+ *   1. `Authorization: Bearer <API_TOKEN>` — the static service key, mapping to
+ *      `DEFAULT_USER_ID`. The closest thing to a service identity today.
+ *   2. `Authorization: Bearer <better-auth session token>` — the value of the
+ *      `__Secure-better-auth.session_token` cookie, used directly as a bearer.
+ *   3. A session cookie, via `sessionMiddleware`.
+ *
+ * It also reads `?token=` as an alternative to the header, which is how the
+ * WebSocket authenticates — browsers cannot set headers on a WS handshake.
+ *
+ * We prefer the bearer forms: one value, no cookie-name pitfalls, and the same
+ * value works for both REST and WS.
  */
+export function authHeaders(c: SpikeConfig): Record<string, string> {
+  if (c.hubToken) return { Authorization: `Bearer ${c.hubToken}` };
+  if (c.hubCookie) return { Cookie: c.hubCookie };
+  return {};
+}
+
+/** Query suffix for the WS handshake, which cannot carry headers. */
+export function authQuery(c: SpikeConfig): string {
+  return c.hubToken ? `?token=${encodeURIComponent(c.hubToken)}` : "";
+}
+
 export async function signIn(c: SpikeConfig): Promise<string> {
+  if (c.hubToken) {
+    console.log("using HUB_TOKEN (bearer)");
+    return "";
+  }
   if (c.hubCookie) {
-    console.log("using HUB_COOKIE (no sign-in)");
+    console.log("using HUB_COOKIE");
     return c.hubCookie;
   }
 
@@ -66,7 +91,7 @@ export async function openSession(
 ): Promise<{ id: string }> {
   const res = await fetch(`${c.hubUrl}/api/stations/${c.stationId}/acp/sessions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", Cookie: cookie },
+    headers: { "Content-Type": "application/json", ...authHeaders(c), ...(cookie ? { Cookie: cookie } : {}) },
     body: JSON.stringify({ mode }),
   });
   if (!res.ok) throw new Error(`openSession → ${res.status} ${await res.text()}`);
@@ -79,9 +104,12 @@ export function connect(
   sessionId: string,
   onMsg: (msg: ServerMsg) => void,
 ): Promise<WebSocket> {
-  const url = `${c.hubUrl.replace(/^http/, "ws")}/api/acp/sessions/${sessionId}/ws`;
+  const url =
+    `${c.hubUrl.replace(/^http/, "ws")}/api/acp/sessions/${sessionId}/ws` + authQuery(c);
   // Bun's WebSocket accepts headers; the browser one does not. Spike runs on Bun.
-  const ws = new WebSocket(url, { headers: { Cookie: cookie } } as any);
+  // The `?token=` query is the fallback authMiddleware reads for handshakes.
+  const headers = { ...authHeaders(c), ...(cookie ? { Cookie: cookie } : {}) };
+  const ws = new WebSocket(url, { headers } as any);
 
   ws.addEventListener("message", (e) => {
     try {

--- a/apps/bridge/spike/src/kaambaan.ts
+++ b/apps/bridge/spike/src/kaambaan.ts
@@ -1,0 +1,115 @@
+/**
+ * Hand-rolled kaambaan agent client.
+ *
+ * Deliberately NOT @kaambaan/agent-sdk: its AgentActivity interface exposes only
+ * {type, body, action, ephemeral, signal} and omits usage, parameter, result and
+ * signalMetadata — the exact fields RQ1, RQ2 and RQ5 depend on.
+ *
+ * Verified paths (2026-08-11, kaambaan @ 573a9ba, local wrangler dev):
+ *   POST /v1/boards/{board}/claims                        agent bearer
+ *   POST /v1/boards/{board}/runs/{run}/{action}           agent bearer
+ *   GET  /v1/boards/{board}                               dev header (snapshot)
+ */
+
+export interface Work {
+  runId: string;
+  leaseEpoch: number;
+  card: { id: string; title: string; currentStageKey: string };
+  stage: { key: string; name: string };
+  handoff: unknown;
+}
+
+export interface Activity {
+  type: "thought" | "action" | "response" | "elicitation" | "error";
+  body?: string;
+  action?: string;
+  parameter?: unknown;
+  result?: unknown;
+  ephemeral?: boolean;
+  signal?: string;
+  signalMetadata?: unknown;
+  usage?: { model?: string; inputTokens?: number; outputTokens?: number; costUsd?: number };
+}
+
+/** One card as it appears in the board snapshot. */
+export interface CardRow {
+  id: string;
+  title: string;
+  currentStageKey: string;
+  state: string;
+  delegateAgentId: string | null;
+  attemptCount: number;
+  costUsd: number;
+  overBudget: boolean;
+}
+
+export interface BoardSnapshot {
+  boardId: string;
+  stages: unknown[];
+  cards: CardRow[];
+  gates: unknown[];
+  usage: unknown;
+}
+
+export class Kaambaan {
+  constructor(
+    private base: string,
+    private boardId: string,
+    private token: string,
+    private tenantId: string,
+  ) {}
+
+  private async post(path: string, body: unknown): Promise<Response> {
+    const res = await fetch(`${this.base}${path}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${this.token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) console.error(`kaambaan ${path} → ${res.status} ${await res.clone().text()}`);
+    return res;
+  }
+
+  async claim(): Promise<Work | null> {
+    const res = await this.post(`/v1/boards/${this.boardId}/claims`, {});
+    if (!res.ok) return null;
+    const b = (await res.json()) as any;
+    if (!b?.claimed) return null;
+    return {
+      runId: b.runId,
+      leaseEpoch: b.leaseEpoch,
+      card: b.card,
+      stage: b.stage,
+      handoff: b.handoff ?? null,
+    };
+  }
+
+  private run(w: Work, action: string, extra: Record<string, unknown> = {}) {
+    return this.post(`/v1/boards/${this.boardId}/runs/${w.runId}/${action}`, {
+      leaseEpoch: w.leaseEpoch,
+      ...extra,
+    });
+  }
+
+  heartbeat = (w: Work) => this.run(w, "heartbeat");
+  activity = (w: Work, a: Activity) => this.run(w, "activities", { ...a });
+  complete = (w: Work, handoff?: unknown) => this.run(w, "complete", { handoff });
+  fail = (w: Work, reason: string) => this.run(w, "fail", { reason });
+
+  /**
+   * Whole-board snapshot. There is no card-read endpoint — `/v1/boards/:id/cards/:card`
+   * exists but rejects GET (405), and `/v1/boards/:id/cards` is POST-only. The board
+   * snapshot is the only read surface, and it carries `state`, `attemptCount` and
+   * `costUsd` per card, which is what RQ2 and RQ4 need anyway.
+   */
+  async board(): Promise<BoardSnapshot> {
+    const res = await fetch(`${this.base}/v1/boards/${this.boardId}`, {
+      headers: { "X-Tenant-Id": this.tenantId },
+    });
+    if (!res.ok) throw new Error(`board read → ${res.status} ${await res.text()}`);
+    return (await res.json()) as BoardSnapshot;
+  }
+
+  async card(cardId: string): Promise<CardRow | undefined> {
+    return (await this.board()).cards.find((c) => c.id === cardId);
+  }
+}

--- a/apps/bridge/spike/src/project.ts
+++ b/apps/bridge/spike/src/project.ts
@@ -1,0 +1,128 @@
+/**
+ * RQ1: ACP transcript event → kaambaan activity envelope.
+ *
+ * This module IS the research artifact. Its job is as much to record what it
+ * cannot map as to map what it can — see `unmapped()` and `losses()`.
+ *
+ * The top-level mapping (6 AgentPod event types → 5 kaambaan activity types) is
+ * trivial. The real work is inside `agent-update`, whose payload is `unknown()`
+ * in our own contract and carries the ACP SDK's `sessionUpdate` verbatim. The
+ * console's transcript renderer at
+ *   apps/console/src/lib/components/stations/chat/transcript.ts
+ * already destructures those shapes — it is the reference implementation, and the
+ * honest RQ1 comparison is "what the board shows vs what the console shows".
+ */
+
+import type { Activity } from "./kaambaan";
+import type { AcpEvent } from "./hub";
+
+const UNMAPPED = new Set<string>();
+const LOSSES = new Set<string>();
+
+/** Event kinds with no projection at all. */
+export const unmapped = (): string[] => [...UNMAPPED].sort();
+/** Kinds that project, but lose structure on the way. */
+export const losses = (): string[] => [...LOSSES].sort();
+
+export function project(event: AcpEvent): Activity[] {
+  const p = event.payload as any;
+
+  switch (event.type) {
+    case "user-prompt":
+      return [{ type: "thought", body: `prompt: ${p?.text ?? ""}`, ephemeral: true }];
+
+    case "permission-request":
+      // ACP offers structured options; kaambaan requires `body` to be a string,
+      // so the options can only survive in signalMetadata. Whether they survive
+      // the round-trip intact is exactly RQ2.
+      return [
+        {
+          type: "elicitation",
+          body: p?.title ?? p?.toolCall?.title ?? "The agent needs permission to continue.",
+          signal: "select",
+          signalMetadata: { requestSeq: event.seq, options: p?.options ?? [] },
+        },
+      ];
+
+    case "permission-answer":
+      return [
+        { type: "thought", body: `permission answered: ${p?.optionId ?? "?"}`, ephemeral: true },
+      ];
+
+    case "error":
+      return [{ type: "error", body: String(p?.message ?? p ?? "agent error") }];
+
+    case "state":
+      // Session lifecycle. kaambaan derives its own task state from activities,
+      // so forwarding ours would fight its state machine. Deliberately dropped.
+      return [];
+
+    case "agent-update":
+      return projectUpdate(p);
+
+    default:
+      UNMAPPED.add(event.type);
+      return [];
+  }
+}
+
+function projectUpdate(p: any): Activity[] {
+  switch (p?.sessionUpdate) {
+    case "agent_message_chunk":
+      return [{ type: "thought", body: text(p.content), ephemeral: true }];
+
+    case "agent_thought_chunk":
+      // Reasoning collapses into an ephemeral thought — the board has no
+      // distinct reasoning affordance, so the console's collapsible block
+      // cannot be reconstructed from the activity stream.
+      LOSSES.add("agent_thought_chunk → thought (reasoning/message distinction lost)");
+      return [{ type: "thought", body: text(p.content), ephemeral: true }];
+
+    case "tool_call":
+      return [
+        { type: "action", action: p.title ?? p.kind ?? "tool", parameter: p.rawInput ?? p.locations },
+      ];
+
+    case "tool_call_update":
+      if (p.content && Array.isArray(p.content) && p.content.some((c: any) => c?.type === "diff")) {
+        LOSSES.add("tool_call_update diff → action.result (no diff affordance on the board)");
+      }
+      return [
+        { type: "action", action: p.title ?? p.kind ?? "tool", result: p.rawOutput ?? p.content },
+      ];
+
+    case "plan":
+      LOSSES.add("plan → thought (agent plan has no board representation)");
+      return [{ type: "thought", body: JSON.stringify(p.entries ?? p), ephemeral: true }];
+
+    // RQ5. Not all harnesses emit usage; Codex's adapter advertises it, Hermes
+    // may not. Recorded per harness in the findings.
+    case "usage":
+    case "token_usage":
+      return [
+        {
+          type: "thought",
+          body: "usage",
+          ephemeral: true,
+          usage: {
+            model: p.model,
+            inputTokens: p.inputTokens ?? p.usage?.input_tokens,
+            outputTokens: p.outputTokens ?? p.usage?.output_tokens,
+            costUsd: p.costUsd ?? p.total_cost_usd,
+          },
+        },
+      ];
+
+    default:
+      UNMAPPED.add(`agent-update:${p?.sessionUpdate ?? "?"}`);
+      return [];
+  }
+}
+
+function text(content: unknown): string {
+  if (typeof content === "string") return content;
+  const c = content as any;
+  if (c?.type === "text") return String(c.text ?? "");
+  if (Array.isArray(c)) return c.map(text).join("");
+  return JSON.stringify(content);
+}

--- a/apps/bridge/spike/src/project.ts
+++ b/apps/bridge/spike/src/project.ts
@@ -24,6 +24,41 @@ export const unmapped = (): string[] => [...UNMAPPED].sort();
 /** Kinds that project, but lose structure on the way. */
 export const losses = (): string[] => [...LOSSES].sort();
 
+// ─── context window ─────────────────────────────────────────────────────────
+//
+// `usage_update` is {used, size} — how full the context is, NOT tokens and NOT
+// cost (verified: zero token/cost fields across 1,108 events on both Codex and
+// Hermes). Cost accounting is deferred, but this is real telemetry arriving for
+// free, so we use it for the thing it is actually good for: noticing that a run
+// is about to hit its ceiling and degrade.
+//
+// Emitting every update would be noise — two per run, saying nothing. Instead we
+// track the peak and emit ONE non-ephemeral warning if it crosses the threshold.
+
+const CONTEXT_WARN_PCT = Number(process.env.CONTEXT_WARN_PCT ?? 80);
+
+let peakPct = 0;
+let peakUsed = 0;
+let peakSize = 0;
+let warned = false;
+
+export interface ContextPeak {
+  pct: number;
+  used: number;
+  size: number;
+}
+
+/** Highest context occupancy seen, for the completion handoff. */
+export const contextPeak = (): ContextPeak => ({ pct: peakPct, used: peakUsed, size: peakSize });
+
+/** Call between runs — the tracker is module-level, like UNMAPPED/LOSSES. */
+export function resetContext(): void {
+  peakPct = 0;
+  peakUsed = 0;
+  peakSize = 0;
+  warned = false;
+}
+
 export function project(event: AcpEvent): Activity[] {
   const p = event.payload as any;
 
@@ -95,23 +130,35 @@ function projectUpdate(p: any): Activity[] {
       LOSSES.add("plan → thought (agent plan has no board representation)");
       return [{ type: "thought", body: JSON.stringify(p.entries ?? p), ephemeral: true }];
 
-    // RQ5. Not all harnesses emit usage; Codex's adapter advertises it, Hermes
-    // may not. Recorded per harness in the findings.
-    case "usage":
-    case "token_usage":
-      return [
-        {
-          type: "thought",
-          body: "usage",
-          ephemeral: true,
-          usage: {
-            model: p.model,
-            inputTokens: p.inputTokens ?? p.usage?.input_tokens,
-            outputTokens: p.outputTokens ?? p.usage?.output_tokens,
-            costUsd: p.costUsd ?? p.total_cost_usd,
+    // Context-window occupancy. Deliberately NOT mapped onto kaambaan's `usage`
+    // field: that one means tokens and money, and this is neither. Silent below
+    // the threshold; one durable warning above it.
+    case "usage_update": {
+      const used = Number(p.used ?? 0);
+      const size = Number(p.size ?? 0);
+      if (!size) return [];
+
+      const pct = Math.round((used / size) * 100);
+      if (pct > peakPct) {
+        peakPct = pct;
+        peakUsed = used;
+        peakSize = size;
+      }
+
+      if (pct >= CONTEXT_WARN_PCT && !warned) {
+        warned = true;
+        return [
+          {
+            type: "thought",
+            ephemeral: false,
+            body:
+              `⚠️ Context window ${pct}% full (${used.toLocaleString()} of ` +
+              `${size.toLocaleString()}). The agent may start truncating or compacting.`,
           },
-        },
-      ];
+        ];
+      }
+      return [];
+    }
 
     default:
       UNMAPPED.add(`agent-update:${p?.sessionUpdate ?? "?"}`);

--- a/docs/superpowers/plans/2026-08-11-kaambaan-bridge-spike.md
+++ b/docs/superpowers/plans/2026-08-11-kaambaan-bridge-spike.md
@@ -806,4 +806,18 @@ The PR body must state plainly that `apps/bridge/spike/` is throwaway, that it i
 
 **Known unverified paths, flagged in-place rather than hidden:** the card-read endpoint used in Tasks 6 and 8 (`GET /v1/boards/{id}/cards/{cardId}`) and its resolution field path are inferred, not confirmed against the running service — Task 6 Step 2 instructs fixing them against the live response and recording the real shape.
 
+> **Corrections applied during execution (2026-08-11).** Tasks 1 and 2 ran against a live local
+> kaambaan and disproved four assumptions above. Full detail in
+> `apps/bridge/spike/findings/verified-surface.md`; the short version:
+>
+> - `pnpm dev:setup` (D1 migrations + seed) is a prerequisite for `pnpm dev`, and the seeded
+>   tenant is `tnt_dev` / `usr_dev`. The plan's `tnt_spike` fails the catalog foreign key with
+>   an opaque `500 D1_ERROR` naming nothing.
+> - **There is no card-read endpoint.** Both `/cards` and `/cards/:card` reject GET with 405.
+>   `GET /v1/boards/{board}` returns the whole snapshot and is the only read surface — better
+>   than planned, since each card carries `attemptCount` (the RQ4 reclaim signal) and `costUsd`.
+> - `POST /cards` returns `{card:{id}}`, not `{cardId}`.
+> - **A `response` activity does not advance the card**, contradicting doc 04 §4. Only
+>   `complete` did. The bridge must call it explicitly.
+
 **Type consistency:** `Work` and `Activity` are defined once in Task 2 and used unchanged in Tasks 4–8. `project()` returns `Activity[]` throughout. `signIn`/`openSession`/`connect` keep the Task 3 signatures in Task 5.

--- a/docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-findings.md
@@ -1,0 +1,136 @@
+# kaambaan Bridge Spike — Findings
+
+**Date:** 2026-08-11 · **Status:** partial — RQ1, RQ3, RQ5 answered against live stations; RQ2 and RQ4 not yet run
+
+Answers the research questions in [the spike design](./2026-08-11-kaambaan-bridge-spike-design.md). Evidence is in `apps/bridge/spike/findings/`.
+
+## Setup actually used
+
+| | |
+|---|---|
+| kaambaan | local `wrangler dev`, `573a9ba`, `DEV_AUTH=true` |
+| Hub | live `hub.agentpod.dev` |
+| Station A | **Codex** on the macOS node `node_161e685104dc488ebd11` |
+| Station B | **Hermes** on a Linux fleet node |
+| Prompt | `"List the files in this directory, then stop."` — identical on both |
+
+---
+
+## RQ1 — Envelope fidelity · **PASS WITH CHANGES**
+
+Both harnesses emit exactly 8 distinct event kinds. The top-level mapping is not the problem; three specific things are.
+
+### 1. Volume makes the naive projection unusable
+
+| Harness | ACP events | Wall clock | Activities at 1:1 |
+|---|---:|---:|---:|
+| Codex | 57 | 13s | 48 |
+| Hermes | **1,051** | 53s | **1,045** |
+
+*The same trivial prompt.* Hermes streams token-by-token — 840 `agent_message_chunk` plus 202 `agent_thought_chunk` — so a 1:1 projection would fire **over a thousand HTTP POSTs at the board for one short instruction**, and an 18× spread between harnesses means no fixed rate limit fits both.
+
+**This is the headline RQ1 result and no synthetic test could have produced it.** Ephemeral chunks must be coalesced — buffered and flushed on a timer or on a non-ephemeral boundary — before the bridge posts anything. kaambaan's envelope already anticipates this with `ephemeral: true` ("render transiently, replaced by the next activity"), but nothing in either system enforces that a producer coalesces first.
+
+### 2. Three kinds have no projection
+
+| Kind | Payload | Verdict |
+|---|---|---|
+| `available_commands_update` | the harness's slash-command catalogue | Deliberate drop — no board representation, and none wanted |
+| `session_info_update` | `{threadStatus: {type: active\|idle}}`, `{title}` | Deliberate drop — kaambaan derives its own state; forwarding ours would fight its state machine |
+| `usage_update` | `{used, size}` | Deliberate drop — see RQ5; it is not what it sounds like |
+
+None is a blocker, but all three were invisible until a real harness ran: the design anticipated `agent_message_chunk`, `tool_call`, `tool_call_update`, `plan` — and `plan` never appeared while three unanticipated kinds did.
+
+### 3. One genuine loss
+
+`agent_thought_chunk` → `thought`. kaambaan has no reasoning affordance distinct from ordinary messages, so the console's collapsible reasoning block cannot be reconstructed from the activity stream. Hermes emitted 202 of these; on a board they are indistinguishable from what the agent actually said.
+
+**Verdict: the seam carries the work, but a bridge that projects 1:1 is not viable.** Coalescing is a requirement, not an optimisation.
+
+---
+
+## RQ2 — Permission round-trip · **NOT RUN**
+
+Requires a card whose work triggers a permission prompt under `ask` mode. The code path exists (`bridge.ts:handlePermission`) and the projection emits `elicitation` with ACP's options in `signalMetadata`, but the gate-resolution shape on the board is still unverified — the design flagged this and it remains open.
+
+---
+
+## RQ3 — Lease versus thinking time · **PASS**
+
+| Harness | Longest silence | `HEARTBEAT_TIMEOUT_MS` | Headroom |
+|---|---:|---:|---|
+| Codex | 6.6s | 900s | 136× |
+| Hermes | 12.3s | 900s | 73× |
+
+Ordinary thinking comes nowhere near the reclaim timeout. A 60s heartbeat is comfortable. **Caveat:** both runs were trivial. A genuine multi-minute task — a long build, a slow test suite — was not exercised, and that is where a silence approaching 15 minutes would actually live.
+
+---
+
+## RQ4 — Double execution on reclaim · **NOT RUN**
+
+Needs a 15-minute wall-clock wait. The reasoning that motivated it is unchanged and still evidenced in kaambaan's code (`board-do.ts:1500–1512`: reclaim ends the run, re-queues the card, notifies `work.available`). `scripts/observe-reclaim.ts` is written and ready.
+
+---
+
+## RQ5 — Usage attribution · **FAIL**
+
+**Neither harness emits token counts or cost. At all.**
+
+Searched both captures for `inputTokens`, `input_tokens`, `outputTokens`, `output_tokens`, `costUsd`, `total_cost_usd` — **zero occurrences across 1,108 events**.
+
+The one field that sounds right is not:
+
+```jsonc
+// Codex
+{"sessionUpdate": "usage_update", "used": 16256, "size": 258400}
+// Hermes
+{"sessionUpdate": "usage_update", "used": 18375, "size": 262144}
+```
+
+That is **context-window occupancy** — how full the context is — not tokens consumed and not money. It cannot be summed across a run, and two `usage_update` events per run would not be enough to sum anyway.
+
+### This invalidates a load-bearing claim in the strategy
+
+§8 currently states:
+
+> ACP adapters emit token usage (the Codex adapter advertises it explicitly). Add a usage event type and, keyed by run, we get cost per task, per agent, per machine, per person. **Nobody else can compute that for self-hosted agents, because nobody else is on the box.**
+
+The last sentence is true and useless: nobody else can compute it, *and neither can we* — not from the ACP stream. Being on the box does not help when the harness never reports the number.
+
+**§8 needs revising, and the cost thread in §11 and Horizon 3 depends on it.** Options, none free:
+
+1. **Parse harness-native logs** rather than the ACP stream. kaambaan's own `adapters/claude-code.ts` reads `claude -p --output-format stream-json`, whose terminal `result` event *does* carry `total_cost_usd` — so the data exists, just not over ACP. This means a per-harness cost adapter, which is exactly the N-harness cost §10 warns about.
+2. **Push it upstream** — ask ACP to carry usage, since every client wants it.
+3. **Estimate** from context-window deltas. Cheap, wrong, and worse than nothing for anything billable.
+
+---
+
+## Two gaps found on the way, independent of any verdict
+
+### The hub's service identity is weaker than assumed — but it exists
+
+An earlier draft of this document said the hub had *no* bearer or API-key path. **That was wrong.** `apps/hub/src/auth/middleware.ts` accepts, in order: a static `API_TOKEN` mapping to `DEFAULT_USER_ID`; a Better Auth session token as `Authorization: Bearer`; or a session cookie. It also reads `?token=` as a query fallback, which is how a WebSocket authenticates.
+
+So a service credential exists. It is just a **single shared static secret mapping every caller to one default user** — no per-service identity, no rotation, no scoping. For Horizon 2 that is a real weakness, and it connects directly to the H3 note about a station carrying two credentials.
+
+The spike runs on a Better Auth session token used as a bearer, which works for both REST and the WS handshake.
+
+### `@kaambaan/agent-sdk` is a subset of the documented envelope
+
+Its `AgentActivity` exposes only `{type, body, action, ephemeral, signal}` — no `usage`, `parameter`, `result` or `signalMetadata`. Those are precisely the fields RQ1, RQ2 and RQ5 need, so the bridge hand-rolls its REST calls. Either kaambaan widens the SDK or every bridge author rediscovers this.
+
+### Four kaambaan doc-versus-code drifts
+
+Recorded in full in `apps/bridge/spike/findings/verified-surface.md`: no `requestInput` verb exists (post an `elicitation` activity instead); a `response` activity does not advance a card despite doc 04 §4 saying so; there is no card-read endpoint (the board snapshot is the only read surface); and `pnpm dev:setup` with tenant `tnt_dev` is a prerequisite that fails with an opaque `D1_ERROR` otherwise.
+
+---
+
+## Recommendation so far: **harden, with changes to §7 and §8**
+
+Nothing found so far kills the seam. The contract carries the work, the states line up, and the lease is comfortable. But three amendments are already earned:
+
+1. **§7 gains a coalescing requirement.** A bridge that posts 1:1 is not viable at 1,051 events per prompt. This belongs in the strategy, not just the implementation, because it is a property of the seam rather than of our code.
+2. **§8's cost claim must be qualified.** Cost per run is not available over ACP today. Either the claim goes, or the roadmap gains a per-harness cost adapter with N-harness maintenance attached.
+3. **Horizon 2's bridge item gains a service-identity task** — the shared static `API_TOKEN` is not an identity for a fleet-scale bridge.
+
+**This recommendation is provisional.** RQ2 and RQ4 are unrun, and RQ4 is the one with the power to force a redesign — if reclaim can produce two agents on one workspace, the fix lands in AgentPod's run identity and changes Horizon 0's shape.


### PR DESCRIPTION
Implements [the bridge spike plan](docs/superpowers/plans/2026-08-11-kaambaan-bridge-spike.md) against [its design](docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-design.md).

## ⚠️ This is throwaway code

`apps/bridge/spike/` is **not production**. No tests, no error handling, no retries, no reconnection. It is exempt from the repo's TDD rule by the spec, on the condition that it never becomes production — Horizon 2 rewrites it test-first under `apps/bridge/` or deletes it.

Merging is a judgement call: it lands the findings and the harness where the next person can find them, but it puts untested code on `main`. Happy to keep this open unmerged instead and land only the findings doc.

## Why it exists

The strategy doc now assumes AgentPod bridges to kaambaan as a Kaambaan-compatible agent. That assumption rests on a contract that has never met a real machine — every kaambaan test drives a synthetic in-process agent through `cloudflare:test`. The conformance kit proves the contract is self-consistent; it cannot prove it survives a persistent ACP session blocking on a permission request, or a station dropping mid-claim.

## Status

**Verified against a live local kaambaan:**

- Task 1 — scaffold and seed: board, `kbn_` agent token, card
- Task 2 — claim → heartbeat → activities → complete, card advanced

**Written and building, but not yet run** (needs hub credentials and a live station; Task 8 also has a hard 15-minute wait for `HEARTBEAT_TIMEOUT_MS`):

- Task 3 — headless ACP session driver
- Tasks 4 — the projection, smoke-tested against a synthetic capture
- Tasks 5–6 — bridge loop and permission gate
- Task 8 — reclaim observer

To continue, fill `HUB_EMAIL` / `HUB_PASSWORD` / `STATION_ID` in `apps/bridge/spike/.env` and run `bun run scripts/probe-acp.ts` against each target station.

## Findings already banked

Recorded in `apps/bridge/spike/findings/verified-surface.md`. Four of these contradict kaambaan's own docs:

1. **A `response` activity does not advance the card.** Doc 04 §4's table says it drives state to `completed`. It didn't; only `complete` did. The bridge must call `complete` explicitly.
2. **There is no card-read endpoint.** Both `/cards` and `/cards/:card` reject GET with 405. `GET /v1/boards/{board}` returns the whole snapshot and is the only read surface — which is *better* than planned, since each card carries `attemptCount` (exactly the RQ4 reclaim signal) and `costUsd`.
3. **There is no `requestInput` verb**, though doc 04 describes one. State is derived from activities: you post `type: 'elicitation'` and the state machine maps it to `input-required`.
4. **`pnpm dev:setup` is a prerequisite** and the seeded tenant is `tnt_dev`. Anything else fails the catalog foreign key with an opaque `500 D1_ERROR` naming nothing.

Two gaps worth raising regardless of the eventual verdict:

- **The bridge has no service identity on the hub.** Auth is cookie-based via `POST /api/auth/sign-in/email`; there is no bearer or API-key path. The spike signs in as a human. Horizon 2 needs a real answer, and it connects to the H3 note about a station carrying two credentials.
- **`@kaambaan/agent-sdk`'s `AgentActivity` is a subset of the documented envelope** — no `usage`, `parameter`, `result` or `signalMetadata`, the exact fields RQ1/RQ2/RQ5 need. Hence the hand-rolled client. Either kaambaan widens the SDK or every bridge hand-rolls.

## RQ1 instrument

`src/project.ts` is built to record what it *cannot* map as much as what it can. Against a synthetic capture (9 events → 7 activities) it already reports three structural losses from the shapes alone:

```
UNMAPPED:  agent-update:some_future_kind
LOSSY:     agent_thought_chunk → thought (reasoning/message distinction lost)
           plan → thought (no board representation)
           tool_call_update diff → action.result (no diff affordance)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW