### PR TITLE
feat: Doors slice 1 — reach a station from any ACP editor

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -42,6 +42,7 @@ import { stationLifecycleRoutes } from './routes/station-lifecycle.ts';
 import { stationCleanupRoutes } from './routes/station-cleanup.ts';
 // ACP session routes (REST session management + console session WebSocket)
 import { stationAcpRoutes } from './routes/station-acp.ts';
+import { acpProxyRouter } from './routes/acp-proxy.ts';
 // Middleware
 import { activityLoggerMiddleware } from './middleware/activity-logger.ts';
 import { registerEnabledProvisioners } from './services/provisioner/bootstrap.ts';
@@ -122,7 +123,8 @@ const app = new Hono()
   .route('/api', stationWriteRoutes)                       // POST /api/stations/:id/fs/{write,mkdir,move,delete}
   .route('/api', stationLifecycleRoutes)                   // POST /api/stations/:id/lifecycle
   .route('/api', stationCleanupRoutes)                     // POST /api/stations/:id/cleanup/{plan,apply}
-  .route('/api', stationAcpRoutes);                        // POST/GET /api/stations/:id/acp/sessions, WS /api/acp/sessions/:sessionId/ws
+  .route('/api', stationAcpRoutes)                         // POST/GET /api/stations/:id/acp/sessions, WS /api/acp/sessions/:sessionId/ws
+  .route('/api', acpProxyRouter);                          // WS /api/acp/proxy — Doors: an editor's stdio, piped by `apn acp`
 
 app.onError((err, c) => {
   const requestId = c.req.header('x-request-id') || crypto.randomUUID();

--- a/apps/hub/src/routes/acp-proxy.ts
+++ b/apps/hub/src/routes/acp-proxy.ts
@@ -1,0 +1,66 @@
+/**
+ * ACP proxy socket — the hub end of Doors.
+ *
+ *   GET /api/acp/proxy?station=<id>
+ *
+ * Upgrades to a WebSocket carrying raw ACP frames and binds it to a hub-side
+ * ACP agent. On the other end, `apn acp` pipes an editor's stdio without
+ * parsing it, so an editor on a laptop can drive a station on a machine it
+ * cannot reach — including behind CGNAT, because the node dials out.
+ *
+ * Auth mirrors every other hub route: `authMiddleware` accepts a bearer token
+ * or `?token=`, which is how a WebSocket handshake authenticates at all — a
+ * browser cannot set headers on an upgrade, and neither can most clients.
+ *
+ * Design: docs/superpowers/specs/2026-08-11-doors-acp-proxy-design.md
+ */
+
+import { Hono } from "hono";
+import type { AuthUser } from "../auth/middleware";
+import { upgradeWebSocket } from "../ws";
+import { buildAcpAgent } from "../services/acp-agent";
+import { webSocketStream } from "../services/acp-ws-stream";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("acp-proxy");
+
+export const acpProxyRouter = new Hono().get("/acp/proxy", async (c, next) => {
+  // Gate BEFORE upgrading. An unauthenticated socket that reached the agent
+  // could open sessions on someone else's station, and a missing station id
+  // would leave us guessing which machine an editor meant.
+  const user = c.get("user") as AuthUser | undefined;
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const stationId = c.req.query("station");
+  if (!stationId) return c.json({ error: "A station query parameter is required." }, 400);
+
+  if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
+    // Someone opened the URL in a browser. Say so rather than failing oddly.
+    return c.json({ error: "This endpoint requires a WebSocket upgrade." }, 426);
+  }
+
+  return upgradeWebSocket(() => {
+    // Captured at upgrade time — `c` is not available inside the callbacks.
+    const userId = user.id;
+    let bridge: ReturnType<typeof webSocketStream> | undefined;
+
+    return {
+      onOpen(_evt: unknown, ws: { send(data: string): void }) {
+        bridge = webSocketStream({ send: (d) => ws.send(d) });
+        buildAcpAgent({ userId, stationId }).connect(bridge.stream);
+        log.debug("acp proxy attached", { userId, stationId });
+      },
+
+      onMessage(evt: { data: unknown }) {
+        // Raw ACP bytes from `apn acp`. Framing is ndJsonStream's problem:
+        // socket message boundaries are not JSON boundaries.
+        bridge?.push(typeof evt.data === "string" ? evt.data : String(evt.data));
+      },
+
+      onClose() {
+        bridge?.close();
+        log.debug("acp proxy detached", { userId, stationId });
+      },
+    };
+  })(c, next);
+});

--- a/apps/hub/src/services/acp-agent.ts
+++ b/apps/hub/src/services/acp-agent.ts
@@ -14,7 +14,13 @@
  * Design: docs/superpowers/specs/2026-08-11-doors-acp-proxy-design.md
  */
 
-import { agent, AGENT_METHODS, RequestError, type AgentApp } from "@agentclientprotocol/sdk";
+import {
+  agent,
+  AGENT_METHODS,
+  CLIENT_METHODS,
+  RequestError,
+  type AgentApp,
+} from "@agentclientprotocol/sdk";
 import type { AcpSessionMode } from "@agentpod/contract";
 import * as sessions from "./acp-sessions";
 
@@ -31,6 +37,11 @@ export interface AcpSessionService {
     userId: string;
     mode: AcpSessionMode;
   }): Promise<{ id: string }>;
+
+  promptSession(userId: string, sessionId: string, text: string): Promise<void>;
+
+  /** Returns an unsubscribe function. The hub fans out to N subscribers. */
+  subscribe(sessionId: string, fn: (e: { type: string; payload: unknown }) => void): () => void;
 }
 
 export interface AcpAgentOptions {
@@ -77,7 +88,49 @@ export function buildAcpAgent(opts: AcpAgentOptions): AgentApp {
         }),
       );
       return { sessionId: row.id };
+    })
+    // Handlers take ONE context object — `{ params, client }` — not
+    // (params, ctx). That is what the SDK's deprecation note means by "registers
+    // typed handlers with a single context object".
+    .onRequest(AGENT_METHODS.session_prompt, async ({ params, client }) => {
+      // Subscribe BEFORE prompting. The agent can emit its first update before
+      // promptSession resolves, and a late subscriber drops it silently — a bug
+      // that shows up as an occasional missing first line rather than a crash.
+      const unsubscribe = service.subscribe(params.sessionId, (event) => {
+        // Only agent-update carries a raw ACP sessionUpdate payload; the hub's
+        // other event types (permission-request, state, error) are its own
+        // vocabulary and are handled in slice 2. Forwarding them here would
+        // hand the editor frames it cannot parse.
+        if (event.type !== "agent-update") return;
+        void client.notify(CLIENT_METHODS.session_update, {
+          sessionId: params.sessionId,
+          update: event.payload,
+        } as never);
+      });
+
+      try {
+        await asAcpError(() =>
+          service.promptSession(opts.userId, params.sessionId, textOf(params.prompt)),
+        );
+        return { stopReason: "end_turn" };
+      } finally {
+        // The turn is over; stop writing to a client that is no longer waiting.
+        unsubscribe();
+      }
     });
+}
+
+/**
+ * ACP prompts are an array of content blocks; the session service takes text.
+ *
+ * Non-text blocks (images, resources) are dropped rather than stringified —
+ * pushing `[object Object]` at a harness is worse than sending less.
+ */
+function textOf(blocks: ReadonlyArray<{ type: string; text?: string }>): string {
+  return blocks
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("");
 }
 
 /** JSON-RPC internal error. */

--- a/apps/hub/src/services/acp-agent.ts
+++ b/apps/hub/src/services/acp-agent.ts
@@ -1,0 +1,106 @@
+/**
+ * The hub as an ACP agent.
+ *
+ * Editors do not dial URLs — they spawn a process and speak ACP over its stdio.
+ * `apn acp` is that process, and it pipes the bytes here without parsing them.
+ * So every protocol decision lives in this file, where the SDK is: initialize,
+ * capabilities, session lifecycle, and (later) permission round-trips and
+ * version negotiation.
+ *
+ * Uses the fluent `agent()` API. `AgentSideConnection` is deprecated in SDK
+ * 1.3.0 — "@deprecated Prefer agent({ name }).connect(stream)" — and must not
+ * gain new call sites.
+ *
+ * Design: docs/superpowers/specs/2026-08-11-doors-acp-proxy-design.md
+ */
+
+import { agent, AGENT_METHODS, RequestError, type AgentApp } from "@agentclientprotocol/sdk";
+import type { AcpSessionMode } from "@agentpod/contract";
+import * as sessions from "./acp-sessions";
+
+/**
+ * The slice of the session service this agent needs.
+ *
+ * Narrow and injected so the agent's protocol behaviour is testable without a
+ * live station: whether a node is reachable is the session service's problem,
+ * and it has its own tests for that.
+ */
+export interface AcpSessionService {
+  createSession(input: {
+    stationId: string;
+    userId: string;
+    mode: AcpSessionMode;
+  }): Promise<{ id: string }>;
+}
+
+export interface AcpAgentOptions {
+  userId: string;
+  stationId: string;
+  /** Defaults to the real session service. */
+  sessions?: AcpSessionService;
+}
+
+/**
+ * The ACP protocol version this agent speaks.
+ *
+ * Pinned to v1 deliberately. The SDK ships `agentProtocolRouter()` with
+ * `.withV1()` / `.withV2()`, but v2 is a draft and the router is marked
+ * `@experimental` — shipping our distribution story on someone else's
+ * unreleased draft is not a trade worth making. When v2 stabilises this becomes
+ * a registration rather than a rewrite.
+ */
+const PROTOCOL_VERSION = 1;
+
+export function buildAcpAgent(opts: AcpAgentOptions): AgentApp {
+  const service: AcpSessionService = opts.sessions ?? sessions;
+
+  return agent({ name: "agentpod" })
+    .onRequest(AGENT_METHODS.initialize, async () => ({
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        // Attaching to a station's existing session is the whole point of
+        // Doors. Without this an editor can only ever start a fresh
+        // conversation, and `session/load` — which the protocol says must
+        // stream the entire history back as notifications — is never offered.
+        loadSession: true,
+      },
+    }))
+    .onRequest(AGENT_METHODS.session_new, async () => {
+      // `ask` is not a placeholder. The editor is on a laptop and the agent is
+      // on a machine that may hold credentials; a client that never mentions
+      // permissions must not get an agent running unattended.
+      const row = await asAcpError(() =>
+        service.createSession({
+          stationId: opts.stationId,
+          userId: opts.userId,
+          mode: "ask",
+        }),
+      );
+      return { sessionId: row.id };
+    });
+}
+
+/** JSON-RPC internal error. */
+const INTERNAL_ERROR = -32603;
+
+/**
+ * Preserves the session service's message on the way to the editor.
+ *
+ * The SDK converts a thrown `Error` into a generic JSON-RPC `"Internal error"`,
+ * which is the right default for an unexpected crash and wrong here: the
+ * session service throws *deliberately human-readable* messages — "Station not
+ * found.", "This station does not support agent sessions.", "An active session
+ * already exists for this agent." — that the console already surfaces verbatim.
+ * Swallowing them would leave a Zed user staring at "Internal error" with no
+ * idea their station is offline.
+ *
+ * `RequestError` is the SDK's own type and passes through intact.
+ */
+async function asAcpError<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof RequestError) throw err;
+    throw new RequestError(INTERNAL_ERROR, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/apps/hub/src/services/acp-ws-stream.ts
+++ b/apps/hub/src/services/acp-ws-stream.ts
@@ -1,0 +1,71 @@
+/**
+ * Adapts a Bun/Hono WebSocket to the ACP SDK's `Stream`.
+ *
+ * The SDK speaks newline-delimited JSON over a pair of byte streams — the shape
+ * it uses for stdio. Doors carries exactly those bytes over a WebSocket, since
+ * `apn acp` pipes an editor's stdio without parsing it. This module is the only
+ * place the two representations meet.
+ *
+ * The subtle part is framing: **WebSocket message boundaries are not JSON
+ * boundaries.** A proxy piping raw bytes can split a frame anywhere and can
+ * coalesce several into one message. `ndJsonStream` handles that correctly as
+ * long as we hand it a faithful byte stream rather than pretending each socket
+ * message is a whole frame.
+ */
+
+import { ndJsonStream, type Stream } from "@agentclientprotocol/sdk";
+
+/** The minimum a socket must offer. Kept tiny so tests need no real socket. */
+export interface WsSink {
+  send(data: string): void;
+}
+
+export interface WebSocketStream {
+  stream: Stream;
+  /** Feed bytes that arrived on the socket. Safe to call with partial frames. */
+  push(chunk: string): void;
+  /** The socket closed; end the agent's input so it stops waiting. */
+  close(): void;
+}
+
+export function webSocketStream(sink: WsSink): WebSocketStream {
+  const encoder = new TextEncoder();
+
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let closed = false;
+
+  const input = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+
+  const output = new WritableStream<Uint8Array>({
+    write(chunk) {
+      try {
+        sink.send(new TextDecoder().decode(chunk));
+      } catch {
+        // The editor can vanish mid-turn. A throw here would surface as an
+        // unhandled rejection inside the hub rather than a closed session, so
+        // the write is dropped and the close path does the tidying.
+      }
+    },
+  });
+
+  return {
+    stream: ndJsonStream(output, input),
+    push(chunk: string) {
+      if (closed) return;
+      controller?.enqueue(encoder.encode(chunk));
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      try {
+        controller?.close();
+      } catch {
+        // Already closed by the stream itself.
+      }
+    },
+  };
+}

--- a/apps/hub/tests/unit/acp-agent.test.ts
+++ b/apps/hub/tests/unit/acp-agent.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { client, AGENT_METHODS } from "@agentclientprotocol/sdk";
+import { buildAcpAgent, type AcpSessionService } from "../../src/services/acp-agent";
+
+/**
+ * A stand-in for the session service. The ACP agent's job is protocol mapping;
+ * whether a station is reachable is the session service's problem and is
+ * covered by its own tests. Injecting it keeps these tests about ACP.
+ */
+function fakeSessions(overrides: Partial<AcpSessionService> = {}): {
+  service: AcpSessionService;
+  calls: Array<Record<string, unknown>>;
+} {
+  const calls: Array<Record<string, unknown>> = [];
+  const service: AcpSessionService = {
+    async createSession(input) {
+      calls.push({ fn: "createSession", ...input });
+      return { id: "acps_test" };
+    },
+    ...overrides,
+  };
+  return { service, calls };
+}
+
+const connect = (service: AcpSessionService) =>
+  client().connect(buildAcpAgent({ userId: "usr_1", stationId: "station_1", sessions: service }));
+
+describe("hub ACP agent — initialize", () => {
+  test("advertises the loadSession capability", async () => {
+    // Doors exists to attach to a station's EXISTING session. An agent that
+    // cannot load one hands the editor a blank pane and a fresh conversation,
+    // which is not the product. The handler itself lands in slice 2; the
+    // capability has to be true from the start or clients never ask.
+    const { service } = fakeSessions();
+    const res = await connect(service).agent.request(AGENT_METHODS.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+    });
+    expect(res.agentCapabilities?.loadSession).toBe(true);
+  });
+
+  test("reports a protocol version the client can negotiate against", async () => {
+    const { service } = fakeSessions();
+    const res = await connect(service).agent.request(AGENT_METHODS.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+    });
+    expect(res.protocolVersion).toBe(1);
+  });
+});
+
+describe("hub ACP agent — session/new", () => {
+  test("opens a session on the station the proxy was pointed at", async () => {
+    const { service, calls } = fakeSessions();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+
+    const res = await conn.agent.request(AGENT_METHODS.session_new, { cwd: "/tmp", mcpServers: [] });
+
+    expect(res.sessionId).toBe("acps_test");
+    expect(calls).toEqual([
+      { fn: "createSession", stationId: "station_1", userId: "usr_1", mode: "ask" },
+    ]);
+  });
+
+  test("defaults to ask mode, so a remote editor cannot silently get full-auto", async () => {
+    // The editor is on someone's laptop and the agent is on a machine that may
+    // hold credentials. Defaulting to anything but ask would let a client that
+    // never mentions permissions run unattended.
+    const { service, calls } = fakeSessions();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    await conn.agent.request(AGENT_METHODS.session_new, { cwd: "/tmp", mcpServers: [] });
+
+    expect(calls[0]!.mode).toBe("ask");
+  });
+
+  test("surfaces a session-service failure as an ACP error, not a crash", async () => {
+    const { service } = fakeSessions({
+      async createSession() {
+        throw new Error("Station not found.");
+      },
+    });
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+
+    await expect(conn.agent.request(AGENT_METHODS.session_new, { cwd: "/tmp", mcpServers: [] })).rejects.toThrow("Station not found.");
+  });
+});

--- a/apps/hub/tests/unit/acp-agent.test.ts
+++ b/apps/hub/tests/unit/acp-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { client, AGENT_METHODS } from "@agentclientprotocol/sdk";
+import { client, AGENT_METHODS, CLIENT_METHODS } from "@agentclientprotocol/sdk";
 import { buildAcpAgent, type AcpSessionService } from "../../src/services/acp-agent";
 
 /**
@@ -85,5 +85,103 @@ describe("hub ACP agent — session/new", () => {
     await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
 
     await expect(conn.agent.request(AGENT_METHODS.session_new, { cwd: "/tmp", mcpServers: [] })).rejects.toThrow("Station not found.");
+  });
+});
+
+describe("hub ACP agent — session/prompt", () => {
+  /** A fake that records call order and lets a test drive the event stream. */
+  function promptFake() {
+    const order: string[] = [];
+    let emit: ((e: { type: string; payload: unknown }) => void) | undefined;
+    const service: AcpSessionService = {
+      async createSession() {
+        return { id: "acps_test" };
+      },
+      subscribe(_sessionId, fn) {
+        order.push("subscribe");
+        emit = fn as typeof emit;
+        return () => order.push("unsubscribe");
+      },
+      async promptSession() {
+        order.push("prompt");
+        // The agent's first update can land before promptSession resolves —
+        // that is the whole reason ordering matters here.
+        emit?.({ type: "agent-update", payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } } });
+      },
+    };
+    return { service, order, emitNow: (e: { type: string; payload: unknown }) => emit?.(e) };
+  }
+
+  test("subscribes BEFORE prompting, or the first update is lost", async () => {
+    // A late subscriber silently drops whatever the agent said first. This is
+    // an ordering bug that looks like an occasional missing line, so it is
+    // pinned by a test rather than a comment.
+    const { service, order } = promptFake();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    await conn.agent.request(AGENT_METHODS.session_prompt, {
+      sessionId: "acps_test",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(order.indexOf("subscribe")).toBeLessThan(order.indexOf("prompt"));
+  });
+
+  test("unsubscribes when the turn ends, so a finished turn stops writing", async () => {
+    const { service, order } = promptFake();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    await conn.agent.request(AGENT_METHODS.session_prompt, {
+      sessionId: "acps_test",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(order).toContain("unsubscribe");
+  });
+
+  test("forwards agent-update events to the client as session/update", async () => {
+    const { service } = promptFake();
+    const updates: Array<Record<string, unknown>> = [];
+    const conn = client()
+      // Notification handlers take the same single context object.
+      .onNotification(CLIENT_METHODS.session_update, async ({ params }) => {
+        updates.push(params as Record<string, unknown>);
+      })
+      .connect(buildAcpAgent({ userId: "usr_1", stationId: "station_1", sessions: service }));
+
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    await conn.agent.request(AGENT_METHODS.session_prompt, {
+      sessionId: "acps_test",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(updates.length).toBeGreaterThan(0);
+    expect(updates[0]!.sessionId).toBe("acps_test");
+  });
+
+  test("joins multi-block prompts into the text the session service takes", async () => {
+    let seen = "";
+    const service: AcpSessionService = {
+      async createSession() {
+        return { id: "acps_test" };
+      },
+      subscribe() {
+        return () => {};
+      },
+      async promptSession(_u, _s, text) {
+        seen = text;
+      },
+    };
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    await conn.agent.request(AGENT_METHODS.session_prompt, {
+      sessionId: "acps_test",
+      prompt: [
+        { type: "text", text: "one " },
+        { type: "text", text: "two" },
+      ],
+    });
+
+    expect(seen).toBe("one two");
   });
 });

--- a/apps/hub/tests/unit/acp-proxy-route.test.ts
+++ b/apps/hub/tests/unit/acp-proxy-route.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { acpProxyRouter } from "../../src/routes/acp-proxy";
+
+/**
+ * A minimal app, per the repo rule that WS/gateway tests never import
+ * src/index.ts — that would start the sweeper and the boot hooks.
+ */
+function appWith(user: { id: string } | undefined) {
+  return new Hono()
+    .use("*", async (c, next) => {
+      c.set("user", user as never);
+      await next();
+    })
+    .route("/api", acpProxyRouter);
+}
+
+describe("GET /api/acp/proxy — gates before upgrading", () => {
+  test("401 without a user", async () => {
+    // The upgrade must be refused before any session is touched: an
+    // unauthenticated socket that reached the agent could open sessions on
+    // someone else's station.
+    const res = await appWith(undefined).request("/api/acp/proxy?station=station_1");
+    expect(res.status).toBe(401);
+  });
+
+  test("400 without a station", async () => {
+    // Guessing which station an editor meant is worse than refusing.
+    const res = await appWith({ id: "usr_1" }).request("/api/acp/proxy");
+    expect(res.status).toBe(400);
+  });
+
+  test("the 400 says what is missing", async () => {
+    const res = await appWith({ id: "usr_1" }).request("/api/acp/proxy");
+    expect((await res.json()).error).toContain("station");
+  });
+
+  test("426 when authenticated and addressed but not a WebSocket upgrade", async () => {
+    // A plain GET is a person poking the URL in a browser, not a bug. Saying
+    // "upgrade required" is more use than a stack trace.
+    const res = await appWith({ id: "usr_1" }).request("/api/acp/proxy?station=station_1");
+    expect(res.status).toBe(426);
+  });
+});

--- a/apps/hub/tests/unit/acp-ws-stream.test.ts
+++ b/apps/hub/tests/unit/acp-ws-stream.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { webSocketStream } from "../../src/services/acp-ws-stream";
+
+const dec = new TextDecoder();
+
+/** Collects everything the "socket" was asked to send. */
+function sink() {
+  const sent: string[] = [];
+  return { sent, send: (d: string) => void sent.push(d) };
+}
+
+describe("webSocketStream", () => {
+  test("frames written by the agent reach the socket as ndjson", async () => {
+    const s = sink();
+    const { stream } = webSocketStream(s);
+
+    const w = stream.writable.getWriter();
+    await w.write({ jsonrpc: "2.0", id: 1, result: {} } as never);
+    await w.close();
+
+    expect(s.sent).toHaveLength(1);
+    expect(JSON.parse(s.sent[0]!)).toEqual({ jsonrpc: "2.0", id: 1, result: {} });
+    // ndjson: exactly one trailing newline, so a reader can split on it.
+    expect(s.sent[0]!.endsWith("\n")).toBe(true);
+  });
+
+  test("frames pushed from the socket reach the agent", async () => {
+    const { stream, push } = webSocketStream(sink());
+
+    push(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n");
+
+    const reader = stream.readable.getReader();
+    const { value } = await reader.read();
+    expect(value).toMatchObject({ method: "initialize" });
+  });
+
+  test("a frame split across two socket messages is reassembled", async () => {
+    // WebSocket message boundaries are not JSON boundaries. A proxy piping raw
+    // bytes can split a frame anywhere, and treating each message as a whole
+    // frame would corrupt the stream under load.
+    const { stream, push } = webSocketStream(sink());
+
+    push(`{"jsonrpc":"2.0","id":7,"me`);
+    push(`thod":"session/new"}` + "\n");
+
+    const reader = stream.readable.getReader();
+    const { value } = await reader.read();
+    expect(value).toMatchObject({ id: 7, method: "session/new" });
+  });
+
+  test("two frames in one socket message both arrive", async () => {
+    const { stream, push } = webSocketStream(sink());
+
+    push(`{"jsonrpc":"2.0","id":1,"method":"a"}` + "\n" + `{"jsonrpc":"2.0","id":2,"method":"b"}` + "\n");
+
+    const reader = stream.readable.getReader();
+    expect((await reader.read()).value).toMatchObject({ id: 1 });
+    expect((await reader.read()).value).toMatchObject({ id: 2 });
+  });
+
+  test("close ends the input stream so the agent stops waiting", async () => {
+    const { stream, close } = webSocketStream(sink());
+    close();
+
+    const reader = stream.readable.getReader();
+    const { done } = await reader.read();
+    expect(done).toBe(true);
+  });
+
+  test("sending after the socket closed does not throw", async () => {
+    // The agent may still be mid-turn when the editor disappears. A throw here
+    // would surface as an unhandled rejection in the hub rather than a closed
+    // session.
+    const s = { send: () => { throw new Error("socket is closed"); } };
+    const { stream } = webSocketStream(s);
+
+    const w = stream.writable.getWriter();
+    await w.write({ jsonrpc: "2.0", id: 1, result: {} } as never);
+    // Reaching here without throwing is the assertion.
+    expect(true).toBe(true);
+  });
+});

--- a/apps/node-agent/cmd/agentpod-node/acp.go
+++ b/apps/node-agent/cmd/agentpod-node/acp.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/coder/websocket"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/acpproxy"
+)
+
+// acpCmd makes a station on another machine look like a local agent to any ACP
+// client — Zed, JetBrains, anything that speaks the protocol.
+//
+// The editor spawns this process and talks ACP over its stdio. We pipe those
+// bytes to the hub and back, parsing nothing: every protocol decision happens
+// in the hub, where the SDK is. That is why `apn` needs no ACP library, no
+// JSON-RPC, and no notion of a protocol version.
+//
+// This is the one `apn` subcommand that does not require an enrolled node. A
+// laptop running an editor installs `apn` purely as a client.
+func acpCmd(args []string) {
+	fs := flag.NewFlagSet("acp", flag.ExitOnError)
+	station := fs.String("station", "", "station to attach to")
+	session := fs.String("session", "", "specific session to resume")
+	hub := fs.String("hub", envOr("AGENTPOD_HUB", "https://hub.agentpod.dev"), "hub base URL")
+	token := fs.String("token", os.Getenv("AGENTPOD_TOKEN"), "hub token (prefer the AGENTPOD_TOKEN env var)")
+	_ = fs.Parse(args)
+
+	if err := acpproxy.ValidateTarget(*station, *session); err != nil {
+		fmt.Fprintf(os.Stderr, "apn acp: %v\n\nExample:\n  apn acp --station station_abc123\n", err)
+		os.Exit(2)
+	}
+
+	// Ctrl-C, or the editor being killed, must end the process rather than
+	// leave a session live on the hub.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	conn, err := acpproxy.Dial(ctx, *hub, *token, *station, *session)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apn acp: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.CloseNow()
+
+	// NetConn turns the message-oriented socket into an io.ReadWriter, which is
+	// all the pipe wants. MessageText because ACP is newline-delimited JSON.
+	sock := websocket.NetConn(ctx, conn, websocket.MessageText)
+
+	if err := acpproxy.Pipe(ctx, sock, os.Stdin, os.Stdout); err != nil {
+		// EOF and cancellation are how this ends normally: the editor exited,
+		// or someone pressed Ctrl-C.
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "apn acp: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/apps/node-agent/cmd/agentpod-node/help.go
+++ b/apps/node-agent/cmd/agentpod-node/help.go
@@ -108,6 +108,20 @@ var commands = []struct {
 			"reported as a pass.",
 	},
 	{
+		name: "acp", group: "Node",
+		oneline: "Attach an ACP editor to a station (--station, --session)",
+		detail: "apn acp --station <id> [--session <id>] [--hub <url>] [--token <t>] —\n" +
+			"make a station on another machine look like a local agent to any ACP\n" +
+			"client (Zed, JetBrains, anything that speaks the protocol).\n\n" +
+			"The editor spawns this and talks ACP over its stdio; the frames are\n" +
+			"piped to the hub, which does the protocol work. Reaches stations\n" +
+			"behind NAT or CGNAT, because the node dials out.\n\n" +
+			"Prefer the AGENTPOD_TOKEN environment variable over --token: a token\n" +
+			"on the command line lands in shell history.\n\n" +
+			"This is the one command that needs no enrolled node — a laptop can\n" +
+			"install apn purely as a client.",
+	},
+	{
 		name: "update", group: "Maintenance",
 		oneline: "Self-update from the latest release (--check, --force)",
 		detail: "apn update [--check] [--force] — self-update from the latest GitHub\n" +

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -1,11 +1,18 @@
 package main
 
-import ("context"; "errors"; "flag"; "fmt"; "os"; "runtime"
-  "github.com/rakeshgangwar/agentpod/node-agent/internal/config"
-  "github.com/rakeshgangwar/agentpod/node-agent/internal/enroll"
-  "github.com/rakeshgangwar/agentpod/node-agent/internal/host"
-  "github.com/rakeshgangwar/agentpod/node-agent/internal/selfupdate"
-  "github.com/rakeshgangwar/agentpod/node-agent/internal/service")
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/enroll"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/host"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/selfupdate"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/service"
+	"os"
+	"runtime"
+)
 
 // version is the agent's build version. Overridden at link time via:
 //
@@ -18,154 +25,205 @@ var version = "dev"
 // container restarts (which re-run the entrypoint) do not attempt to consume
 // an already-spent one-time enrollment token.
 func alreadyEnrolled(cfg config.Config, loadErr error) bool {
-  return loadErr == nil && cfg.NodeID != "" && cfg.NodeSecret != ""
+	return loadErr == nil && cfg.NodeID != "" && cfg.NodeSecret != ""
 }
 
 func main() {
-  if len(os.Args) < 2 { fmt.Println(helpText(version)); os.Exit(0) }
-  switch os.Args[1] {
-  case "help", "-h", "--help":
-    if os.Args[1] == "help" && len(os.Args) > 2 {
-      name := os.Args[2]
-      if !isCommand(name) {
-        fmt.Printf("unknown command: %q\n", name)
-        os.Exit(2)
-      }
-      fmt.Println(commandHelp(name))
-      os.Exit(0)
-    }
-    fmt.Println(helpText(version))
-    os.Exit(0)
-  case "enroll":
-    fs := flag.NewFlagSet("enroll", flag.ExitOnError)
-    fs.Usage = func() {
-      fmt.Fprintln(fs.Output(), commandHelp("enroll"))
-      fs.PrintDefaults()
-    }
-    flagHub := fs.String("hub", "", "hub base URL")
-    flagToken := fs.String("token", "", "enrollment token")
-    flagForce := fs.Bool("force", false, "re-enroll even when a valid config exists")
-    fs.Parse(os.Args[2:])
-    existing, loadErr := config.Load(config.DefaultPath())
-    haveConfig := alreadyEnrolled(existing, loadErr)
-    hub, token, err := resolveEnrollArgs(*flagHub, *flagToken, os.Getenv)
-    if err != nil {
-      // Bare `enroll` on an already-enrolled machine stays a friendly no-op.
-      if haveConfig { fmt.Println("already enrolled:", existing.NodeID); return }
-      fmt.Fprintln(os.Stderr, err); os.Exit(1)
-    }
-    decision, reason := decideEnroll(existing, haveConfig, hub, *flagForce, enroll.CheckCredential)
-    switch decision {
-    case decisionKeep:
-      fmt.Printf("already enrolled: %s (%s)\n", existing.NodeID, reason)
-      return
-    case decisionKeepUnverified:
-      // Keep a possibly-valid identity; `run` retries connecting anyway.
-      fmt.Fprintf(os.Stderr, "warning: keeping existing config (%s)\n", reason)
-      return
-    }
-    if haveConfig { fmt.Printf("re-enrolling: %s\n", reason) }
-    id, sec, err := enroll.Enroll(hub, token, host.Info())
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    // Preserve operator-set lifecycle commands across re-enrollment.
-    newCfg := config.Config{Hub: hub, NodeID: id, NodeSecret: sec,
-      HermesStartCmd: existing.HermesStartCmd, OpenClawStartCmd: existing.OpenClawStartCmd}
-    if err := config.Save(config.DefaultPath(), newCfg); err != nil {
-      fmt.Fprintln(os.Stderr, err); os.Exit(1)
-    }
-    fmt.Println("enrolled:", id)
-  case "run":
-    if maybeShowHelp(os.Stdout, "run", os.Args[2:]) { os.Exit(0) }
-    runCmd() // implemented in Task 9
-  case "detect":
-    if maybeShowHelp(os.Stdout, "detect", os.Args[2:]) { os.Exit(0) }
-    detectCmd() // debug/ops: print detected stations as JSON
-  case "scan":
-    if maybeShowHelp(os.Stdout, "scan", os.Args[2:]) { os.Exit(0) }
-    scanCmd(os.Args[2:]) // hubless posture check; exits non-zero on findings
-  case "update":
-    fs := flag.NewFlagSet("update", flag.ExitOnError)
-    fs.Usage = func() {
-      fmt.Fprintln(fs.Output(), commandHelp("update"))
-      fs.PrintDefaults()
-    }
-    check := fs.Bool("check", false, "resolve and report current/latest version, no changes")
-    force := fs.Bool("force", false, "update even when already on the latest version")
-    fs.Parse(os.Args[2:])
-    ctx := context.Background()
-    res, err := selfupdate.Update(ctx, selfupdate.Options{
-      CurrentVersion: version,
-      Force:          *force,
-      CheckOnly:      *check,
-    })
-    if err != nil {
-      if errors.Is(err, selfupdate.ErrRestartFailed) {
-        fmt.Fprintln(os.Stderr, "update: binary swapped but service restart failed:", err)
-        if runtime.GOOS == "darwin" {
-          fmt.Fprintf(os.Stderr, "restart it manually: launchctl kickstart -k gui/%d/dev.agentpod.node  (or re-run: apn run)\n", os.Getuid())
-        } else {
-          fmt.Fprintln(os.Stderr, "restart the service manually: systemctl restart agentpod-node")
-        }
-        os.Exit(1)
-      }
-      fmt.Fprintln(os.Stderr, "update:", err)
-      os.Exit(1)
-    }
-    fmt.Printf("current %s, latest %s\n", res.CurrentVersion, res.LatestTag)
-    switch {
-    case res.Updated:
-      fmt.Printf("updated to %s, restarting…\n", res.LatestTag)
-    case *check:
-      if res.CurrentVersion == res.LatestTag {
-        fmt.Println("up to date")
-      } else {
-        fmt.Printf("update available: %s → %s\n", res.CurrentVersion, res.LatestTag)
-      }
-    default:
-      fmt.Println(res.Reason)
-    }
-  case "version":
-    if maybeShowHelp(os.Stdout, "version", os.Args[2:]) { os.Exit(0) }
-    fmt.Printf("agentpod-node %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
-  case "stop":
-    // stopEntry gates on -h/--help itself (see help.go's maybeShowHelp) —
-    // NewManager has no side effects of its own (it only inspects
-    // runtime.GOOS/uid), so it's safe to construct before that gate runs.
-    mgr, err := service.NewManager(nil)
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(stopEntry(mgr, os.Args[2:], os.Stdout))
-  case "start":
-    mgr, err := service.NewManager(nil)
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(startEntry(mgr, os.Args[2:], os.Stdout))
-  case "restart":
-    mgr, err := service.NewManager(nil)
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(restartEntry(mgr, os.Args[2:], os.Stdout))
-  case "status":
-    jsonOut, done, code := parseStatusFlags(os.Args[2:], os.Stdout)
-    if done { os.Exit(code) }
-    mgr, err := service.NewManager(nil)
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    cfg, cfgErr := config.Load(config.DefaultPath())
-    os.Exit(statusCmd(mgr, cfg, cfgErr, enroll.CheckCredential, jsonOut, os.Stdout))
-  case "logs":
-    mgr, err := service.NewManager(nil)
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    os.Exit(logsCmd(mgr, os.Args[2:], os.Stdout, os.Stderr))
-  case "service":
-    mgr, err := service.NewManager(nil)
-    if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
-    var verb string; var rest []string
-    if len(os.Args) > 2 { verb = os.Args[2] }
-    if len(os.Args) > 3 { rest = os.Args[3:] }
-    os.Exit(runServiceVerb(verb, rest, mgr, os.Stdout))
-  default:
-    fmt.Printf("unknown command: %q\n", os.Args[1])
-    if s := suggestCommand(os.Args[1]); s != "" {
-      fmt.Printf("did you mean '%s'?\n", s)
-    }
-    fmt.Println("run 'apn help' for usage.")
-    os.Exit(2)
-  }
+	if len(os.Args) < 2 {
+		fmt.Println(helpText(version))
+		os.Exit(0)
+	}
+	switch os.Args[1] {
+	case "help", "-h", "--help":
+		if os.Args[1] == "help" && len(os.Args) > 2 {
+			name := os.Args[2]
+			if !isCommand(name) {
+				fmt.Printf("unknown command: %q\n", name)
+				os.Exit(2)
+			}
+			fmt.Println(commandHelp(name))
+			os.Exit(0)
+		}
+		fmt.Println(helpText(version))
+		os.Exit(0)
+	case "enroll":
+		fs := flag.NewFlagSet("enroll", flag.ExitOnError)
+		fs.Usage = func() {
+			fmt.Fprintln(fs.Output(), commandHelp("enroll"))
+			fs.PrintDefaults()
+		}
+		flagHub := fs.String("hub", "", "hub base URL")
+		flagToken := fs.String("token", "", "enrollment token")
+		flagForce := fs.Bool("force", false, "re-enroll even when a valid config exists")
+		fs.Parse(os.Args[2:])
+		existing, loadErr := config.Load(config.DefaultPath())
+		haveConfig := alreadyEnrolled(existing, loadErr)
+		hub, token, err := resolveEnrollArgs(*flagHub, *flagToken, os.Getenv)
+		if err != nil {
+			// Bare `enroll` on an already-enrolled machine stays a friendly no-op.
+			if haveConfig {
+				fmt.Println("already enrolled:", existing.NodeID)
+				return
+			}
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		decision, reason := decideEnroll(existing, haveConfig, hub, *flagForce, enroll.CheckCredential)
+		switch decision {
+		case decisionKeep:
+			fmt.Printf("already enrolled: %s (%s)\n", existing.NodeID, reason)
+			return
+		case decisionKeepUnverified:
+			// Keep a possibly-valid identity; `run` retries connecting anyway.
+			fmt.Fprintf(os.Stderr, "warning: keeping existing config (%s)\n", reason)
+			return
+		}
+		if haveConfig {
+			fmt.Printf("re-enrolling: %s\n", reason)
+		}
+		id, sec, err := enroll.Enroll(hub, token, host.Info())
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		// Preserve operator-set lifecycle commands across re-enrollment.
+		newCfg := config.Config{Hub: hub, NodeID: id, NodeSecret: sec,
+			HermesStartCmd: existing.HermesStartCmd, OpenClawStartCmd: existing.OpenClawStartCmd}
+		if err := config.Save(config.DefaultPath(), newCfg); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println("enrolled:", id)
+	case "run":
+		if maybeShowHelp(os.Stdout, "run", os.Args[2:]) {
+			os.Exit(0)
+		}
+		runCmd() // implemented in Task 9
+	case "detect":
+		if maybeShowHelp(os.Stdout, "detect", os.Args[2:]) {
+			os.Exit(0)
+		}
+		detectCmd() // debug/ops: print detected stations as JSON
+	case "scan":
+		if maybeShowHelp(os.Stdout, "scan", os.Args[2:]) {
+			os.Exit(0)
+		}
+		scanCmd(os.Args[2:]) // hubless posture check; exits non-zero on findings
+	case "acp":
+		if maybeShowHelp(os.Stdout, "acp", os.Args[2:]) {
+			os.Exit(0)
+		}
+		acpCmd(os.Args[2:]) // Doors: pipe an editor's stdio to a hub station
+	case "update":
+		fs := flag.NewFlagSet("update", flag.ExitOnError)
+		fs.Usage = func() {
+			fmt.Fprintln(fs.Output(), commandHelp("update"))
+			fs.PrintDefaults()
+		}
+		check := fs.Bool("check", false, "resolve and report current/latest version, no changes")
+		force := fs.Bool("force", false, "update even when already on the latest version")
+		fs.Parse(os.Args[2:])
+		ctx := context.Background()
+		res, err := selfupdate.Update(ctx, selfupdate.Options{
+			CurrentVersion: version,
+			Force:          *force,
+			CheckOnly:      *check,
+		})
+		if err != nil {
+			if errors.Is(err, selfupdate.ErrRestartFailed) {
+				fmt.Fprintln(os.Stderr, "update: binary swapped but service restart failed:", err)
+				if runtime.GOOS == "darwin" {
+					fmt.Fprintf(os.Stderr, "restart it manually: launchctl kickstart -k gui/%d/dev.agentpod.node  (or re-run: apn run)\n", os.Getuid())
+				} else {
+					fmt.Fprintln(os.Stderr, "restart the service manually: systemctl restart agentpod-node")
+				}
+				os.Exit(1)
+			}
+			fmt.Fprintln(os.Stderr, "update:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("current %s, latest %s\n", res.CurrentVersion, res.LatestTag)
+		switch {
+		case res.Updated:
+			fmt.Printf("updated to %s, restarting…\n", res.LatestTag)
+		case *check:
+			if res.CurrentVersion == res.LatestTag {
+				fmt.Println("up to date")
+			} else {
+				fmt.Printf("update available: %s → %s\n", res.CurrentVersion, res.LatestTag)
+			}
+		default:
+			fmt.Println(res.Reason)
+		}
+	case "version":
+		if maybeShowHelp(os.Stdout, "version", os.Args[2:]) {
+			os.Exit(0)
+		}
+		fmt.Printf("agentpod-node %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
+	case "stop":
+		// stopEntry gates on -h/--help itself (see help.go's maybeShowHelp) —
+		// NewManager has no side effects of its own (it only inspects
+		// runtime.GOOS/uid), so it's safe to construct before that gate runs.
+		mgr, err := service.NewManager(nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(stopEntry(mgr, os.Args[2:], os.Stdout))
+	case "start":
+		mgr, err := service.NewManager(nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(startEntry(mgr, os.Args[2:], os.Stdout))
+	case "restart":
+		mgr, err := service.NewManager(nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(restartEntry(mgr, os.Args[2:], os.Stdout))
+	case "status":
+		jsonOut, done, code := parseStatusFlags(os.Args[2:], os.Stdout)
+		if done {
+			os.Exit(code)
+		}
+		mgr, err := service.NewManager(nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		cfg, cfgErr := config.Load(config.DefaultPath())
+		os.Exit(statusCmd(mgr, cfg, cfgErr, enroll.CheckCredential, jsonOut, os.Stdout))
+	case "logs":
+		mgr, err := service.NewManager(nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(logsCmd(mgr, os.Args[2:], os.Stdout, os.Stderr))
+	case "service":
+		mgr, err := service.NewManager(nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		var verb string
+		var rest []string
+		if len(os.Args) > 2 {
+			verb = os.Args[2]
+		}
+		if len(os.Args) > 3 {
+			rest = os.Args[3:]
+		}
+		os.Exit(runServiceVerb(verb, rest, mgr, os.Stdout))
+	default:
+		fmt.Printf("unknown command: %q\n", os.Args[1])
+		if s := suggestCommand(os.Args[1]); s != "" {
+			fmt.Printf("did you mean '%s'?\n", s)
+		}
+		fmt.Println("run 'apn help' for usage.")
+		os.Exit(2)
+	}
 }

--- a/apps/node-agent/internal/acpproxy/dial.go
+++ b/apps/node-agent/internal/acpproxy/dial.go
@@ -1,0 +1,89 @@
+package acpproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// ProxyURL derives the ACP proxy WebSocket URL from the hub's HTTP(S) URL.
+//
+//	https://hub → wss://hub/api/acp/proxy?station=…
+//	http://hub  → ws://hub/api/acp/proxy?station=…
+//
+// Mirrors gateway.wsURL rather than inventing a second scheme rule, so the two
+// cannot drift.
+func ProxyURL(hub, station, session string) string {
+	base := strings.Replace(strings.Replace(hub, "http://", "ws://", 1), "https://", "wss://", 1)
+	base = strings.TrimSuffix(base, "/")
+
+	q := url.Values{}
+	if station != "" {
+		q.Set("station", station)
+	}
+	if session != "" {
+		q.Set("session", session)
+	}
+	return base + "/api/acp/proxy?" + q.Encode()
+}
+
+// ValidateTarget rejects an invocation that does not say what to attach to.
+//
+// Guessing which station an editor meant is worse than refusing: the wrong
+// guess starts an agent on the wrong machine, in someone's real workspace.
+func ValidateTarget(station, session string) error {
+	if station == "" && session == "" {
+		return errors.New("one of --station or --session is required")
+	}
+	return nil
+}
+
+// Conn is the subset of a WebSocket the pipe needs.
+type Conn interface {
+	Read(ctx context.Context) (websocket.MessageType, []byte, error)
+	Write(ctx context.Context, typ websocket.MessageType, p []byte) error
+	Close(code websocket.StatusCode, reason string) error
+}
+
+// Dial opens the proxy socket.
+//
+// The token goes in the Authorization header, not the query string: a query
+// parameter lands in proxy logs and shell history. The hub accepts `?token=`
+// too — a browser cannot set headers on an upgrade — but nothing here is a
+// browser, so the header is used.
+func Dial(ctx context.Context, hub, token, station, session string) (*websocket.Conn, error) {
+	if err := ValidateTarget(station, session); err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, errors.New("no hub token: set AGENTPOD_TOKEN or pass --token")
+	}
+
+	c, resp, err := websocket.Dial(ctx, ProxyURL(hub, station, session), &websocket.DialOptions{
+		HTTPHeader: map[string][]string{"Authorization": {"Bearer " + token}},
+	})
+	if err != nil {
+		if resp != nil {
+			switch resp.StatusCode {
+			case 401:
+				return nil, errors.New("hub rejected the token (401) — it may have expired")
+			case 404:
+				return nil, fmt.Errorf("station %q not found, or it belongs to another account (404)", station)
+			}
+			return nil, fmt.Errorf("hub returned %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("could not reach the hub: %w", err)
+	}
+	// ACP frames are small; the default read limit is not.
+	c.SetReadLimit(readLimitBytes)
+	return c, nil
+}
+
+// readLimitBytes caps a single inbound frame. Generous for ACP — a large tool
+// result is still far below it — and finite so a broken peer cannot exhaust
+// memory on someone's laptop.
+const readLimitBytes = 32 << 20 // 32 MiB

--- a/apps/node-agent/internal/acpproxy/dial_test.go
+++ b/apps/node-agent/internal/acpproxy/dial_test.go
@@ -1,0 +1,85 @@
+package acpproxy
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestProxyURLDerivesTheSchemeLikeTheGateway(t *testing.T) {
+	cases := []struct{ hub, want string }{
+		{"https://hub.agentpod.dev", "wss://hub.agentpod.dev/api/acp/proxy"},
+		{"http://localhost:3001", "ws://localhost:3001/api/acp/proxy"},
+		{"https://hub.agentpod.dev/", "wss://hub.agentpod.dev/api/acp/proxy"}, // trailing slash
+	}
+	for _, c := range cases {
+		got := ProxyURL(c.hub, "station_1", "")
+		if !strings.HasPrefix(got, c.want) {
+			t.Errorf("ProxyURL(%q) = %q, want prefix %q", c.hub, got, c.want)
+		}
+	}
+}
+
+func TestProxyURLCarriesTheTarget(t *testing.T) {
+	u, err := url.Parse(ProxyURL("https://h", "station_1", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := u.Query().Get("station"); got != "station_1" {
+		t.Errorf("station = %q", got)
+	}
+	if u.Query().Has("session") {
+		t.Error("an empty session must not be sent as a blank parameter")
+	}
+
+	u2, _ := url.Parse(ProxyURL("https://h", "", "acps_9"))
+	if got := u2.Query().Get("session"); got != "acps_9" {
+		t.Errorf("session = %q", got)
+	}
+}
+
+func TestProxyURLEscapesTheTarget(t *testing.T) {
+	// Ids come from a command line. An unescaped one could smuggle another
+	// query parameter into the request.
+	u, err := url.Parse(ProxyURL("https://h", "station_1&admin=true", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Query().Get("admin") != "" {
+		t.Error("a crafted station id injected a second query parameter")
+	}
+	if u.Query().Get("station") != "station_1&admin=true" {
+		t.Errorf("station round-tripped as %q", u.Query().Get("station"))
+	}
+}
+
+func TestValidateTargetRefusesToGuess(t *testing.T) {
+	// Guessing the wrong station starts an agent on the wrong machine, in
+	// someone's real workspace. Refusing is the kinder failure.
+	if err := ValidateTarget("", ""); err == nil {
+		t.Error("expected an error when neither --station nor --session is given")
+	}
+	if err := ValidateTarget("station_1", ""); err != nil {
+		t.Errorf("--station alone should be valid: %v", err)
+	}
+	if err := ValidateTarget("", "acps_1"); err != nil {
+		t.Errorf("--session alone should be valid: %v", err)
+	}
+}
+
+func TestDialRequiresAToken(t *testing.T) {
+	// Checked before any network call, so a missing token is an instant, clear
+	// error rather than a confusing 401 after a round-trip.
+	_, err := Dial(context.Background(), "https://h", "", "station_1", "")
+	if err == nil || !strings.Contains(err.Error(), "AGENTPOD_TOKEN") {
+		t.Errorf("err = %v, want a message naming AGENTPOD_TOKEN", err)
+	}
+}
+
+func TestDialRefusesAnUntargetedInvocation(t *testing.T) {
+	_, err := Dial(context.Background(), "https://h", "tok", "", "")
+	if err == nil || !strings.Contains(err.Error(), "--station") {
+		t.Errorf("err = %v, want a message naming --station", err)
+	}
+}

--- a/apps/node-agent/internal/acpproxy/pipe.go
+++ b/apps/node-agent/internal/acpproxy/pipe.go
@@ -1,0 +1,47 @@
+// Package acpproxy carries ACP frames between an editor's stdio and the hub.
+//
+// It deliberately understands nothing about ACP. Every protocol decision —
+// initialize, capabilities, session/load replay, permission round-trips,
+// version negotiation — happens in the hub, where the TypeScript SDK is. This
+// package moves bytes.
+//
+// That split is the whole design. `apn` is Go with two dependencies and has
+// never parsed an ACP frame; putting the protocol here would mean maintaining a
+// second implementation of a spec we do not control, in a language with no SDK,
+// while that spec moves to v2. See
+// docs/superpowers/specs/2026-08-11-doors-acp-proxy-design.md.
+package acpproxy
+
+import (
+	"context"
+	"io"
+)
+
+// Pipe copies in→sock and sock→out until either direction ends, or ctx is done.
+//
+// The first direction to finish ends the call. An editor that exits closes
+// stdin; a hub that drops the session closes the socket. Either way the process
+// should exit rather than linger holding a session open — an abandoned editor
+// must not leave a live agent on someone's machine.
+//
+// Both copies are transparent: no framing, no parsing, no buffering by line. A
+// frame this function cannot understand is a frame it does not need to.
+func Pipe(ctx context.Context, sock io.ReadWriter, in io.Reader, out io.Writer) error {
+	errc := make(chan error, 2)
+
+	go func() {
+		_, err := io.Copy(sock, in) // editor → hub
+		errc <- err
+	}()
+	go func() {
+		_, err := io.Copy(out, sock) // hub → editor
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/apps/node-agent/internal/acpproxy/pipe_test.go
+++ b/apps/node-agent/internal/acpproxy/pipe_test.go
@@ -1,0 +1,169 @@
+package acpproxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// rw joins a reader and a writer into one io.ReadWriter, standing in for a
+// socket without needing one.
+type rw struct {
+	io.Reader
+	io.Writer
+}
+
+// syncBuf is an io.Writer safe for the two concurrent copies inside Pipe.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// waitFor polls until cond holds, failing the test if it never does. Pipe's
+// copies are concurrent, so assertions have to wait for them rather than assume
+// they have run.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for !cond() {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", what)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func TestPipeCarriesBothDirections(t *testing.T) {
+	// The socket stays open for the duration. Letting both sides EOF instantly
+	// races the two copies against Pipe's first-to-finish return, and a socket
+	// that closes before its first frame is not a real scenario anyway.
+	editorIn := strings.NewReader(`{"jsonrpc":"2.0","method":"initialize"}` + "\n")
+	sockR, sockW := io.Pipe()
+	toSocket, toEditor := &syncBuf{}, &syncBuf{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = Pipe(ctx, rw{Reader: sockR, Writer: toSocket}, editorIn, toEditor)
+		close(done)
+	}()
+
+	waitFor(t, "editor→socket", func() bool { return strings.Contains(toSocket.String(), `"initialize"`) })
+
+	if _, err := sockW.Write([]byte(`{"jsonrpc":"2.0","result":{}}` + "\n")); err != nil {
+		t.Fatalf("write to socket: %v", err)
+	}
+	waitFor(t, "socket→editor", func() bool { return strings.Contains(toEditor.String(), `"result"`) })
+
+	sockW.Close()
+	cancel()
+	<-done
+}
+
+func TestPipeReturnsWhenEditorClosesStdin(t *testing.T) {
+	// An editor exiting closes stdin. The proxy must return rather than hang,
+	// or every abandoned editor leaves a session live on the hub.
+	done := make(chan error, 1)
+	go func() {
+		done <- Pipe(context.Background(),
+			rw{Reader: strings.NewReader(""), Writer: io.Discard},
+			strings.NewReader(""), io.Discard)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pipe did not return when both sides ended")
+	}
+}
+
+func TestPipeReturnsWhenContextIsCancelled(t *testing.T) {
+	// Ctrl-C must end the process even mid-conversation, with neither side
+	// having closed.
+	pr, pw := io.Pipe() // never written to, never closed: blocks forever
+	defer pw.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Pipe(ctx, rw{Reader: pr, Writer: io.Discard}, pr, io.Discard)
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pipe ignored a cancelled context")
+	}
+}
+
+func TestPipeDoesNotInspectFrames(t *testing.T) {
+	// The pipe must be transparent. If it ever parses ACP, the boundary is in
+	// the wrong place — so prove that malformed JSON and an unknown future
+	// method both travel through untouched.
+	//
+	// The socket read side stays OPEN here rather than returning EOF. A socket
+	// that EOFs before the first frame is not a real scenario, and modelling it
+	// races the editor→socket copy against Pipe's first-to-finish return.
+	junk := "not json at all\n" + `{"jsonrpc":"2.0","method":"some/future/method/v9"}` + "\n"
+	toSocket := &syncBuf{}
+
+	sockR, sockW := io.Pipe() // open until we close it
+	defer sockW.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = Pipe(ctx, rw{Reader: sockR, Writer: toSocket}, strings.NewReader(junk), io.Discard)
+		close(done)
+	}()
+
+	waitFor(t, "the stream to pass through unaltered", func() bool { return toSocket.String() == junk })
+	cancel()
+	<-done
+}
+
+func TestPipeReturnsWhenTheSocketClosesFirst(t *testing.T) {
+	// The liveness case that shapes the semantics above: the hub ends the
+	// session while the editor is still sitting on stdin with nothing to say.
+	// Pipe must return, or the process hangs holding a dead session.
+	editorStdin, _ := io.Pipe() // blocks forever; never written, never closed
+
+	done := make(chan struct{})
+	go func() {
+		_ = Pipe(context.Background(),
+			rw{Reader: strings.NewReader(""), Writer: io.Discard}, // socket EOFs
+			editorStdin, io.Discard)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pipe hung after the socket closed — an abandoned editor would hold a live session")
+	}
+}


### PR DESCRIPTION
Implements [the slice 1 plan](docs/superpowers/plans/2026-08-11-doors-slice1-relay.md) from [the Doors design](docs/superpowers/specs/2026-08-11-doors-acp-proxy-design.md). First item of Horizon 1.

An ACP client — Zed, JetBrains — spawns `apn acp --station <id>` and talks to a station on another machine, including behind CGNAT, because the node dials out.

## The design changed before any code was written

The strategy said "be an ACP **server**". That does not map onto how ACP works: **clients spawn a subprocess and speak JSON-RPC over its stdio, they do not dial URLs.** Built literally, a hub that "is an ACP server" has no socket an editor would ever open.

And my first spec then put the ACP implementation in `apn` — except that SDK is TypeScript and `apn` is Go, with two dependencies and no JSON-RPC anywhere.

So: **the hub runs the ACP agent, and `apn acp` is a byte pipe.**

```
Zed  ⇅ stdio   apn acp   ⇅ WSS   hub (ACP agent, TS SDK)   ⇅ broker   node ⇅ harness
```

The protocol lives where its SDK lives, v1/v2 negotiation comes free later via `agentProtocolRouter()`, and it stays one binary with one release pipeline.

## Verified end to end

Not just unit tested — driven by hand through the whole chain against a local hub:

```
→ {"jsonrpc":"2.0","id":1,"method":"initialize",...}
← {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}

→ {"jsonrpc":"2.0","id":2,"method":"session/new",...}
← {"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Station not found."}}
```

That second one is the important one. The SDK converts a thrown `Error` into a generic `"Internal error"`; the hub's session service throws *deliberately human-readable* messages the console already surfaces verbatim. Left alone, a Zed user whose station was offline would have seen `"Internal error"` and had nowhere to go.

## Things found by running it

- **The SDK's fluent handlers take one context object**, `{ params, client }`, not `(params, ctx)` — exactly what the deprecation note means. It only surfaced at `session/prompt`, because `initialize` and `session/new` never read their params. A handler that ignores its arguments proves nothing about how they arrive.
- **WebSocket message boundaries are not JSON boundaries.** `apn acp` pipes raw bytes, so a frame can split across messages or two can arrive in one. Both cases have tests.
- **Bun needs a single `websocket` handler** on the server export — a second `createBunWebSocket()` would have silently broken the terminal and gateway sockets.
- **`echo … | apn acp` returns nothing**, because stdin EOFs instantly and the pipe returns on first-completion. Correct for an editor, a trap for anyone smoke-testing.
- My first two pipe tests were **flaky, 1 run in 3**. Caught by running the suite repeatedly rather than trusting one green. Fixed and verified over 8 consecutive `-race` runs.

## Scope

In: initialize, `session/new`, `session/prompt` with streamed updates, the proxy socket, the subcommand.

Out, by design: permissions, cancel, mode, `session/load`'s replay handler, concurrent-attach tests. Slices 2–3. `loadSession` **is** advertised now, because clients never ask for a capability that is not.

## Not done

**Driving it from a real editor** — plan Task 6 Step 2 — needs a GUI I cannot operate. The protocol path is proven; whether Zed is happy with this agent in practice is the slice's real acceptance criterion and still wants a human.

Suites: contract 64, hub 398, node-agent 13 packages. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW