### PR TITLE
feat: Doors slice 2 — permissions, cancel and mode

### DIFF
--- a/apps/hub/src/services/acp-agent.ts
+++ b/apps/hub/src/services/acp-agent.ts
@@ -56,6 +56,29 @@ export interface AcpSessionService {
     requestSeq: number,
     optionId: string,
   ): Promise<void>;
+
+  cancelTurn(userId: string, sessionId: string): Promise<void>;
+
+  setMode(userId: string, sessionId: string, mode: AcpSessionMode): Promise<void>;
+}
+
+/**
+ * ACP's `modeId` is a free-form string; ours is a fixed enum.
+ *
+ * An unrecognised mode is refused rather than ignored. Silently accepting one
+ * would leave the editor believing it had loosened permissions when nothing
+ * changed — the most dangerous direction for that mistake to point.
+ */
+const MODES: readonly AcpSessionMode[] = ["ask", "accept-edits", "full-auto"];
+
+function toSessionMode(modeId: unknown): AcpSessionMode {
+  if (typeof modeId === "string" && (MODES as readonly string[]).includes(modeId)) {
+    return modeId as AcpSessionMode;
+  }
+  throw new RequestError(
+    INVALID_PARAMS,
+    `Unknown mode ${JSON.stringify(modeId)}. Supported: ${MODES.join(", ")}.`,
+  );
 }
 
 export interface AcpAgentOptions {
@@ -219,6 +242,29 @@ export function buildAcpAgent(opts: AcpAgentOptions): AgentApp {
         // The turn is over; stop writing to a client that is no longer waiting.
         unsubscribe();
       }
+    })
+    // A NOTIFICATION, not a request. ACP models cancellation as fire-and-forget,
+    // so an editor's stop button never waits for an ack — registering this as a
+    // request would make it hang.
+    .onNotification(AGENT_METHODS.session_cancel, async ({ params }) => {
+      try {
+        await service.cancelTurn(opts.userId, params.sessionId);
+      } catch (err) {
+        // Nothing to reply to; a cancel that arrives after the turn already
+        // ended is normal, not an error worth surfacing.
+        log.debug("cancel failed", {
+          sessionId: params.sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })
+    // NOTE: session/set_mode is REMOVED in ACP v2, replaced by config options.
+    // Implemented here for v1; when the version router lands, this handler stays
+    // on the v1 surface rather than being carried forward.
+    .onRequest(AGENT_METHODS.session_set_mode, async ({ params }) => {
+      const mode = toSessionMode((params as { modeId?: unknown }).modeId);
+      await asAcpError(() => service.setMode(opts.userId, params.sessionId, mode));
+      return {};
     });
 }
 
@@ -237,6 +283,8 @@ function textOf(blocks: ReadonlyArray<{ type: string; text?: string }>): string 
 
 /** JSON-RPC internal error. */
 const INTERNAL_ERROR = -32603;
+/** JSON-RPC invalid params. */
+const INVALID_PARAMS = -32602;
 
 /**
  * Preserves the session service's message on the way to the editor.

--- a/apps/hub/src/services/acp-agent.ts
+++ b/apps/hub/src/services/acp-agent.ts
@@ -23,6 +23,9 @@ import {
 } from "@agentclientprotocol/sdk";
 import type { AcpSessionMode } from "@agentpod/contract";
 import * as sessions from "./acp-sessions";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("acp-agent");
 
 /**
  * The slice of the session service this agent needs.
@@ -41,7 +44,18 @@ export interface AcpSessionService {
   promptSession(userId: string, sessionId: string, text: string): Promise<void>;
 
   /** Returns an unsubscribe function. The hub fans out to N subscribers. */
-  subscribe(sessionId: string, fn: (e: { type: string; payload: unknown }) => void): () => void;
+  subscribe(
+    sessionId: string,
+    fn: (e: { type: string; seq: number; payload: unknown }) => void,
+  ): () => void;
+
+  /** Throws "No pending permission request." when another client answered first. */
+  answerPermission(
+    userId: string,
+    sessionId: string,
+    requestSeq: number,
+    optionId: string,
+  ): Promise<void>;
 }
 
 export interface AcpAgentOptions {
@@ -96,17 +110,105 @@ export function buildAcpAgent(opts: AcpAgentOptions): AgentApp {
       // Subscribe BEFORE prompting. The agent can emit its first update before
       // promptSession resolves, and a late subscriber drops it silently — a bug
       // that shows up as an occasional missing first line rather than a crash.
+      // Permission prompts we have put to the editor and are still awaiting.
+      // Keyed by the request's event seq, which is what answerPermission takes.
+      const outstanding = new Map<number, AbortController>();
+
       const unsubscribe = service.subscribe(params.sessionId, (event) => {
-        // Only agent-update carries a raw ACP sessionUpdate payload; the hub's
-        // other event types (permission-request, state, error) are its own
-        // vocabulary and are handled in slice 2. Forwarding them here would
-        // hand the editor frames it cannot parse.
-        if (event.type !== "agent-update") return;
-        void client.notify(CLIENT_METHODS.session_update, {
-          sessionId: params.sessionId,
-          update: event.payload,
-        } as never);
+        switch (event.type) {
+          case "agent-update":
+            // The only type carrying a raw ACP sessionUpdate payload.
+            void client.notify(CLIENT_METHODS.session_update, {
+              sessionId: params.sessionId,
+              update: event.payload,
+            } as never);
+            return;
+
+          case "permission-request":
+            void askEditor(event);
+            return;
+
+          case "permission-answer": {
+            // Someone answered — possibly the console, possibly us. Either way
+            // this prompt is settled, so stop asking the editor about it.
+            const seq = (event.payload as { requestSeq?: number })?.requestSeq;
+            if (typeof seq === "number") {
+              outstanding.get(seq)?.abort();
+              outstanding.delete(seq);
+            }
+            return;
+          }
+
+          default:
+            // state and error are the hub's own vocabulary, not ACP frames.
+            return;
+        }
       });
+
+      /**
+       * Put a permission to the editor and apply whatever it says.
+       *
+       * Both clients are asked and the first answer wins — the honest
+       * expression of two live clients on one session. The loser's call finds
+       * nothing pending, which is the expected path rather than an error.
+       */
+      async function askEditor(event: { seq: number; payload: unknown }): Promise<void> {
+        const payload = event.payload as {
+          toolCall?: unknown;
+          options?: unknown[];
+          auto?: boolean;
+        };
+
+        // accept-edits and full-auto resolve server-side and persist the
+        // request with auto:true. Prompting for something already decided is a
+        // phantom dialog the editor can never usefully answer.
+        if (payload?.auto) return;
+
+        const ac = new AbortController();
+        outstanding.set(event.seq, ac);
+
+        try {
+          const res = (await client.request(
+            CLIENT_METHODS.session_request_permission,
+            {
+              sessionId: params.sessionId,
+              toolCall: payload?.toolCall,
+              options: payload?.options,
+            } as never,
+            // Cooperative: aborting sends $/cancel_request, but whether the
+            // editor dismisses its dialog is the editor's call.
+            { cancellationSignal: ac.signal },
+          )) as { outcome?: { outcome?: string; optionId?: string } };
+
+          const optionId = res?.outcome?.optionId;
+          if (!optionId) return; // cancelled, or the editor declined to choose
+
+          await service.answerPermission(opts.userId, params.sessionId, event.seq, optionId);
+        } catch (err) {
+          // Exactly two losses are expected, and neither is worth crashing a
+          // turn over: another client answered first ("No pending permission
+          // request."), or our own outstanding request was cancelled because it
+          // did. ANYTHING else is a real failure and must be visible.
+          //
+          // This was a blanket `catch {}` first, and it silently ate an
+          // "Invalid params" from the SDK — the editor was never asked and
+          // nothing said so. A permission that vanishes is precisely the bug
+          // you cannot afford to hide.
+          const msg = err instanceof Error ? err.message : String(err);
+          const expected =
+            msg.includes("No pending permission request") ||
+            msg.toLowerCase().includes("cancel");
+          if (!expected) {
+            log.error("failed to put a permission to the editor", {
+              sessionId: params.sessionId,
+              requestSeq: event.seq,
+              error: msg,
+            });
+          }
+        } finally {
+          outstanding.delete(event.seq);
+        }
+      }
 
       try {
         await asAcpError(() =>

--- a/apps/hub/tests/unit/acp-agent.test.ts
+++ b/apps/hub/tests/unit/acp-agent.test.ts
@@ -306,3 +306,74 @@ describe("hub ACP agent — permissions", () => {
     expect(true).toBe(true);
   });
 });
+
+describe("hub ACP agent — cancel and mode", () => {
+  function verbFake() {
+    const calls: Array<Record<string, unknown>> = [];
+    const service = {
+      async createSession() {
+        return { id: "acps_test" };
+      },
+      subscribe() {
+        return () => {};
+      },
+      async promptSession() {},
+      async answerPermission() {},
+      async cancelTurn(userId: string, sessionId: string) {
+        calls.push({ fn: "cancelTurn", userId, sessionId });
+      },
+      async setMode(userId: string, sessionId: string, mode: string) {
+        calls.push({ fn: "setMode", userId, sessionId, mode });
+      },
+    } as unknown as AcpSessionService;
+    return { service, calls };
+  }
+
+  test("session/cancel is a NOTIFICATION and stops the turn", async () => {
+    // Not a request — ACP models cancellation as fire-and-forget, so the editor
+    // never waits for an ack. Registering it as a request would mean an editor's
+    // stop button hangs.
+    const { service, calls } = verbFake();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+
+    await conn.agent.notify(AGENT_METHODS.session_cancel, { sessionId: "acps_test" });
+    await Bun.sleep(20);
+
+    expect(calls).toContainEqual({ fn: "cancelTurn", userId: "usr_1", sessionId: "acps_test" });
+  });
+
+  test("session/set_mode maps modeId onto our permission mode", async () => {
+    const { service, calls } = verbFake();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+
+    await conn.agent.request(AGENT_METHODS.session_set_mode, {
+      sessionId: "acps_test",
+      modeId: "accept-edits",
+    });
+
+    expect(calls).toContainEqual({
+      fn: "setMode",
+      userId: "usr_1",
+      sessionId: "acps_test",
+      mode: "accept-edits",
+    });
+  });
+
+  test("an unknown modeId is refused rather than silently ignored", async () => {
+    // ACP's modeId is a free-form string; our modes are a fixed enum. Accepting
+    // an unrecognised one would leave the editor believing it had loosened
+    // permissions when nothing changed — the most dangerous possible direction
+    // for that mistake.
+    const { service, calls } = verbFake();
+    const conn = connect(service);
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+
+    await expect(
+      conn.agent.request(AGENT_METHODS.session_set_mode, { sessionId: "acps_test", modeId: "yolo" }),
+    ).rejects.toThrow();
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/apps/hub/tests/unit/acp-agent.test.ts
+++ b/apps/hub/tests/unit/acp-agent.test.ts
@@ -185,3 +185,124 @@ describe("hub ACP agent — session/prompt", () => {
     expect(seen).toBe("one two");
   });
 });
+
+describe("hub ACP agent — permissions", () => {
+  /** Drives a session and lets a test push events at the agent. */
+  function permFake(over: Partial<AcpSessionService> = {}) {
+    const calls: Array<Record<string, unknown>> = [];
+    let emit: ((e: { type: string; seq: number; payload: unknown }) => void) | undefined;
+    let pending: Array<{ type: string; seq: number; payload: unknown }> | undefined;
+    const service = {
+      async createSession() {
+        return { id: "acps_test" };
+      },
+      subscribe(_s: string, fn: unknown) {
+        emit = fn as typeof emit;
+        return () => {};
+      },
+      async promptSession() {
+        // Permissions arrive DURING a turn — the agent subscribes for the
+        // duration of session/prompt and unsubscribes when it ends. Raising it
+        // from here is what a harness actually does.
+        pending?.forEach((e) => emit?.(e));
+        await Bun.sleep(40); // hold the turn open while the editor answers
+      },
+      async answerPermission(_u: string, _s: string, requestSeq: number, optionId: string) {
+        calls.push({ fn: "answerPermission", requestSeq, optionId });
+      },
+      ...over,
+    } as unknown as AcpSessionService;
+    return {
+      service,
+      calls,
+      // Queue an event to be raised from inside the next turn.
+      raiseDuringTurn: (e: { type: string; seq: number; payload: unknown }) => {
+        pending = [...(pending ?? []), e];
+      },
+    };
+  }
+
+  // Must satisfy the ACP schema — the SDK validates OUTGOING params too.
+  // PermissionOption requires {optionId, name, kind}; ToolCallUpdate requires
+  // toolCallId. Real payloads come from the harness's own request and do.
+  const OPTIONS = [
+    { optionId: "allow", name: "Allow", kind: "allow_once" },
+    { optionId: "reject", name: "Reject", kind: "reject_once" },
+  ];
+  const TOOL_CALL = { toolCallId: "tc_1", title: "Write hello.txt" };
+
+  async function connectAsking(
+    service: AcpSessionService,
+    onAsk: (params: Record<string, unknown>) => Promise<{ outcome: unknown }>,
+  ) {
+    const conn = client()
+      .onRequest(CLIENT_METHODS.session_request_permission, async ({ params }) => {
+        return onAsk(params as Record<string, unknown>);
+      })
+      .connect(buildAcpAgent({ userId: "usr_1", stationId: "station_1", sessions: service }));
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    return conn;
+  }
+
+  test("a permission request reaches the editor", async () => {
+    // With an editor attached, the hub is the ACP agent — so a permission the
+    // harness raises must travel OUT to the editor, the reverse of the console
+    // flow where the hub parks it and waits.
+    const { service, raiseDuringTurn } = permFake();
+    let asked: Record<string, unknown> | undefined;
+    const conn = await connectAsking(service, async (params) => {
+      asked = params;
+      return { outcome: { outcome: "selected", optionId: "allow" } };
+    });
+
+    raiseDuringTurn({ type: "permission-request", seq: 7, payload: { toolCall: TOOL_CALL, options: OPTIONS } });
+    await conn.agent.request(AGENT_METHODS.session_prompt, { sessionId: "acps_test", prompt: [{ type: "text", text: "go" }] });
+
+    expect(asked).toBeDefined();
+    expect((asked!.options as unknown[])).toHaveLength(2);
+  });
+
+  test("the editor's answer is applied to the session", async () => {
+    const { service, calls, raiseDuringTurn } = permFake();
+    const conn = await connectAsking(service, async () => ({ outcome: { outcome: "selected", optionId: "reject" } }));
+
+    raiseDuringTurn({ type: "permission-request", seq: 7, payload: { toolCall: TOOL_CALL, options: OPTIONS } });
+    await conn.agent.request(AGENT_METHODS.session_prompt, { sessionId: "acps_test", prompt: [{ type: "text", text: "go" }] });
+
+    expect(calls).toContainEqual({ fn: "answerPermission", requestSeq: 7, optionId: "reject" });
+  });
+
+  test("an auto-answered permission is never forwarded", async () => {
+    // accept-edits and full-auto resolve server-side and persist the request
+    // with auto:true. Prompting the editor for something already decided would
+    // be a phantom dialog it can never usefully answer.
+    const { service, raiseDuringTurn } = permFake();
+    let asked = false;
+    const conn = await connectAsking(service, async () => {
+      asked = true;
+      return { outcome: { outcome: "selected", optionId: "allow" } };
+    });
+
+    raiseDuringTurn({ type: "permission-request", seq: 7, payload: { toolCall: TOOL_CALL, options: OPTIONS, auto: true } });
+    await conn.agent.request(AGENT_METHODS.session_prompt, { sessionId: "acps_test", prompt: [{ type: "text", text: "go" }] });
+
+    expect(asked).toBe(false);
+  });
+
+  test("losing the race to the console is swallowed, not thrown", async () => {
+    // Both clients are asked and the first answer wins. The loser's call finds
+    // nothing pending — that is the expected path, not an error worth crashing
+    // a turn over.
+    const { service, raiseDuringTurn } = permFake({
+      async answerPermission() {
+        throw new Error("No pending permission request.");
+      },
+    });
+    const conn = await connectAsking(service, async () => ({ outcome: { outcome: "selected", optionId: "allow" } }));
+
+    raiseDuringTurn({ type: "permission-request", seq: 7, payload: { toolCall: TOOL_CALL, options: OPTIONS } });
+    await conn.agent.request(AGENT_METHODS.session_prompt, { sessionId: "acps_test", prompt: [{ type: "text", text: "go" }] });
+    // Surviving without an unhandled rejection is the assertion.
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Completes the interaction surface from [the Doors design](docs/superpowers/specs/2026-08-11-doors-acp-proxy-design.md). Builds on slice 1 (#233).

## Permissions reverse direction

With an editor attached the hub **is** the ACP agent, so a permission the harness raises travels *out* via `session/request_permission` — the opposite of the console flow, where the hub parks it and waits.

**Both clients are asked; first answer wins**, as agreed. That was nearly free: the hub already had first-answer-wins semantics, and when either side answers it persists a `permission-answer` event this agent is already subscribed to — so the loser's outstanding request is aborted via `cancellationSignal`. Cancellation is cooperative by the SDK's own admission, so whether the editor dismisses its dialog is the editor's call, but we do ask.

Auto-answered permissions are never forwarded. `accept-edits` and `full-auto` resolve server-side and persist with `auto: true`; prompting for something already decided is a phantom dialog the editor can never usefully answer.

## `session/cancel` is a notification, not a request

ACP models cancellation as fire-and-forget. Registering it as a request would make an editor's **stop button hang** waiting for an ack that the protocol never promises.

## `session/set_mode` refuses unknown modes

ACP's `modeId` is a free-form string; ours is a fixed enum. An unrecognised one is rejected with invalid-params rather than ignored — silently accepting would leave the editor believing it had loosened permissions when nothing changed, and the user would then expect the agent to stop asking when it will not. That is the most dangerous direction for the mistake to point.

Noted in place: **`session/set_mode` is removed in ACP v2**, replaced by config options. Implemented for v1 and stays on the v1 surface when the version router lands.

## Two bugs debugging found, both worth more than the feature

**My first `catch` was blanket, and it silently ate a real `Invalid params` from the SDK.** The editor was never asked and nothing said so. A permission that vanishes is exactly the bug you cannot afford to hide — so now only the two genuinely expected losses are swallowed (another client answered first, or our request was cancelled because it did) and anything else is logged. I found it only by temporarily logging inside the catch to see what it was concealing.

**The SDK validates *outgoing* params too.** My test fixtures were invalid — `PermissionOption` needs `{optionId, name, kind}`, `ToolCallUpdate` needs `toolCallId` — which is what produced that `Invalid params`. Real payloads come from the harness's own ACP request and satisfy it.

## Also pinned by a test

The subscription is live **only for the duration of a turn**, so a permission can only arrive during `session/prompt`. My first version of these tests emitted events outside a turn and asserted against a subscriber that did not exist.

## Not covered

Concurrent-attach integration tests (two live subscribers on one session) and `session/load`'s replay handler remain slice 3. `loadSession` is advertised but its handler is still unimplemented — an editor calling it today gets a method error rather than a transcript.

hub: 405 pass, contract 64. Stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW