### PR TITLE
feat: Doors slices 3 and 4 — session/load replay, sharing, discovery

### DIFF
--- a/apps/hub/src/services/acp-agent.ts
+++ b/apps/hub/src/services/acp-agent.ts
@@ -60,6 +60,12 @@ export interface AcpSessionService {
   cancelTurn(userId: string, sessionId: string): Promise<void>;
 
   setMode(userId: string, sessionId: string, mode: AcpSessionMode): Promise<void>;
+
+  /** The stored transcript, ordered by seq. Replay is the caller's job. */
+  readEvents(
+    sessionId: string,
+    sinceSeq: number,
+  ): Promise<Array<{ seq: number; type: string; payload: unknown }>>;
 }
 
 /**
@@ -257,6 +263,41 @@ export function buildAcpAgent(opts: AcpAgentOptions): AgentApp {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+    })
+    /**
+     * Attach to an existing session and stream its history back.
+     *
+     * The protocol is explicit that the AGENT replays, not the client: on load
+     * it must "restore the session context and conversation history" and
+     * "stream the entire conversation history back to the client via
+     * notifications". `apn acp` is the agent as far as the editor is concerned,
+     * so that work lands here.
+     *
+     * This is what makes Doors worth having. Without it an editor can only ever
+     * start a fresh conversation, and attaching to the station you have worked
+     * on all afternoon shows a blank pane.
+     *
+     * NOTE: session/load is REMOVED in ACP v2, where session/resume explicitly
+     * does NOT replay. "Join and see what happened" is a v1 affordance with no
+     * settled v2 equivalent — another reason the versions get separate surfaces
+     * rather than a field map.
+     */
+    .onRequest(AGENT_METHODS.session_load, async ({ params, client }) => {
+      const events = await asAcpError(() => service.readEvents(params.sessionId, 0));
+
+      for (const event of events) {
+        // Same filter as the live path: only agent-update carries a raw ACP
+        // sessionUpdate. Replaying the hub's own vocabulary would hand the
+        // editor frames it cannot parse, and replaying a permission-request
+        // would re-prompt for something already answered.
+        if (event.type !== "agent-update") continue;
+        await client.notify(CLIENT_METHODS.session_update, {
+          sessionId: params.sessionId,
+          update: event.payload,
+        } as never);
+      }
+
+      return {};
     })
     // NOTE: session/set_mode is REMOVED in ACP v2, replaced by config options.
     // Implemented here for v1; when the version router lands, this handler stays

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -26,7 +26,7 @@
  * `waiting` and a grace timer ends it.
  */
 
-import { and, desc, eq, isNotNull, lt, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNotNull, lt, ne, or, sql } from "drizzle-orm";
 import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import {
   client,
@@ -1064,6 +1064,26 @@ async function appendEndedState(sessionId: string, reason: string): Promise<void
 /** Test hook: live subscriber count for a session (leak detection). */
 export function _subscriberCountForTest(sessionId: string): number {
   return subscribers.get(sessionId)?.size ?? 0;
+}
+
+/**
+ * The stored transcript for a session, ordered by seq.
+ *
+ * Replay has always been the caller's job — the console's session socket does
+ * this query inline. Doors needs the same read for `session/load`, where the
+ * ACP protocol requires the AGENT to stream history back, so it lives here now
+ * rather than being copied a second time.
+ */
+export async function readEvents(
+  sessionId: string,
+  sinceSeq = 0,
+): Promise<Array<{ seq: number; type: string; payload: unknown }>> {
+  const rows = await db
+    .select({ seq: acpEvents.seq, type: acpEvents.type, payload: acpEvents.payload })
+    .from(acpEvents)
+    .where(and(eq(acpEvents.sessionId, sessionId), gt(acpEvents.seq, sinceSeq)))
+    .orderBy(asc(acpEvents.seq));
+  return rows as Array<{ seq: number; type: string; payload: unknown }>;
 }
 
 /** Subscribe to live events; replay is the caller's job (read acp_events). */

--- a/apps/hub/tests/unit/acp-agent.test.ts
+++ b/apps/hub/tests/unit/acp-agent.test.ts
@@ -377,3 +377,149 @@ describe("hub ACP agent — cancel and mode", () => {
     expect(calls).toHaveLength(0);
   });
 });
+
+describe("hub ACP agent — session/load", () => {
+  const HISTORY = [
+    { seq: 1, type: "user-prompt", payload: { text: "hello" } },
+    { seq: 2, type: "agent-update", payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } } },
+    { seq: 3, type: "permission-request", payload: { toolCall: { toolCallId: "t1" }, options: [] } },
+    { seq: 4, type: "agent-update", payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: " there" } } },
+    { seq: 5, type: "state", payload: { status: "idle" } },
+  ];
+
+  function loadFake(history = HISTORY) {
+    const calls: Array<Record<string, unknown>> = [];
+    const service = {
+      async createSession() { return { id: "acps_test" }; },
+      subscribe() { return () => {}; },
+      async promptSession() {},
+      async answerPermission() {},
+      async cancelTurn() {},
+      async setMode() {},
+      async readEvents(sessionId: string, sinceSeq: number) {
+        calls.push({ fn: "readEvents", sessionId, sinceSeq });
+        return history.filter((e) => e.seq > sinceSeq);
+      },
+    } as unknown as AcpSessionService;
+    return { service, calls };
+  }
+
+  async function connectCollecting(service: AcpSessionService) {
+    const updates: Array<Record<string, unknown>> = [];
+    const conn = client()
+      .onNotification(CLIENT_METHODS.session_update, async ({ params }) => {
+        updates.push(params as Record<string, unknown>);
+      })
+      .connect(buildAcpAgent({ userId: "usr_1", stationId: "station_1", sessions: service }));
+    await conn.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    return { conn, updates };
+  }
+
+  test("streams the stored transcript back before returning", async () => {
+    // The protocol is explicit: on load the agent must "stream the entire
+    // conversation history back to the client via notifications". An editor
+    // that attaches and sees a blank pane has reached a fresh agent, not the
+    // one it asked for — which would defeat the point of Doors.
+    const { service } = loadFake();
+    const { conn, updates } = await connectCollecting(service);
+
+    await conn.agent.request(AGENT_METHODS.session_load, {
+      sessionId: "acps_test",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    expect(updates.length).toBeGreaterThan(0);
+  });
+
+  test("replays only the frames an editor can render, in order", async () => {
+    // Same filter as the live path: agent-update carries a raw ACP
+    // sessionUpdate, the hub's own types do not.
+    const { service } = loadFake();
+    const { conn, updates } = await connectCollecting(service);
+
+    await conn.agent.request(AGENT_METHODS.session_load, {
+      sessionId: "acps_test",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    expect(updates).toHaveLength(2);
+    const texts = updates.map((u) => ((u.update as Record<string, any>).content?.text));
+    expect(texts).toEqual(["hi", " there"]);
+  });
+
+  test("reads the whole transcript, not a tail", async () => {
+    const { service, calls } = loadFake();
+    const { conn } = await connectCollecting(service);
+
+    await conn.agent.request(AGENT_METHODS.session_load, {
+      sessionId: "acps_test",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    expect(calls).toContainEqual({ fn: "readEvents", sessionId: "acps_test", sinceSeq: 0 });
+  });
+
+  test("an empty transcript loads cleanly rather than erroring", async () => {
+    // A session opened but never prompted is legitimate.
+    const { service } = loadFake([]);
+    const { conn, updates } = await connectCollecting(service);
+
+    await conn.agent.request(AGENT_METHODS.session_load, {
+      sessionId: "acps_test",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe("hub ACP agent — concurrent attach", () => {
+  test("two agents on one session both receive live events", async () => {
+    // The hub has always fanned out to N subscribers; the console was simply
+    // the only client. Doors makes that real, so it gets a test.
+    const subscribers: Array<(e: { type: string; seq: number; payload: unknown }) => void> = [];
+    const service = {
+      async createSession() { return { id: "acps_test" }; },
+      subscribe(_s: string, fn: (e: { type: string; seq: number; payload: unknown }) => void) {
+        subscribers.push(fn);
+        return () => {
+          const i = subscribers.indexOf(fn);
+          if (i >= 0) subscribers.splice(i, 1);
+        };
+      },
+      async promptSession() {
+        subscribers.forEach((fn) =>
+          fn({ type: "agent-update", seq: 1, payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "shared" } } }),
+        );
+        await Bun.sleep(20);
+      },
+      async answerPermission() {}, async cancelTurn() {}, async setMode() {},
+      async readEvents() { return []; },
+    } as unknown as AcpSessionService;
+
+    const seenA: unknown[] = [];
+    const seenB: unknown[] = [];
+    const mk = (sink: unknown[]) =>
+      client()
+        .onNotification(CLIENT_METHODS.session_update, async ({ params }) => { sink.push(params); })
+        .connect(buildAcpAgent({ userId: "usr_1", stationId: "station_1", sessions: service }));
+
+    const a = mk(seenA);
+    const b = mk(seenB);
+    await a.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+    await b.agent.request(AGENT_METHODS.initialize, { protocolVersion: 1, clientCapabilities: {} });
+
+    // B is mid-turn (subscribed) when A prompts, so both see A's event.
+    const bTurn = b.agent.request(AGENT_METHODS.session_prompt, { sessionId: "acps_test", prompt: [{ type: "text", text: "b" }] });
+    await Bun.sleep(5);
+    await a.agent.request(AGENT_METHODS.session_prompt, { sessionId: "acps_test", prompt: [{ type: "text", text: "a" }] });
+    await bTurn;
+
+    expect(seenA.length).toBeGreaterThan(0);
+    expect(seenB.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/node-agent/cmd/agentpod-node/acp.go
+++ b/apps/node-agent/cmd/agentpod-node/acp.go
@@ -26,14 +26,30 @@ import (
 // laptop running an editor installs `apn` purely as a client.
 func acpCmd(args []string) {
 	fs := flag.NewFlagSet("acp", flag.ExitOnError)
+	list := fs.Bool("list", false, "list the stations you can attach an editor to")
 	station := fs.String("station", "", "station to attach to")
 	session := fs.String("session", "", "specific session to resume")
 	hub := fs.String("hub", envOr("AGENTPOD_HUB", "https://hub.agentpod.dev"), "hub base URL")
 	token := fs.String("token", os.Getenv("AGENTPOD_TOKEN"), "hub token (prefer the AGENTPOD_TOKEN env var)")
 	_ = fs.Parse(args)
 
+	// Discovery first: someone who has never used this has no station id, and
+	// telling them to go and find one in a web console is a poor answer for a
+	// command line tool.
+	if *list {
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		stations, err := acpproxy.ListStations(ctx, *hub, *token)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "apn acp: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Print(acpproxy.FormatStations(stations))
+		return
+	}
+
 	if err := acpproxy.ValidateTarget(*station, *session); err != nil {
-		fmt.Fprintf(os.Stderr, "apn acp: %v\n\nExample:\n  apn acp --station station_abc123\n", err)
+		fmt.Fprintf(os.Stderr, "apn acp: %v\n\nFind one with:\n  apn acp --list\n", err)
 		os.Exit(2)
 	}
 

--- a/apps/node-agent/cmd/agentpod-node/help.go
+++ b/apps/node-agent/cmd/agentpod-node/help.go
@@ -109,8 +109,9 @@ var commands = []struct {
 	},
 	{
 		name: "acp", group: "Node",
-		oneline: "Attach an ACP editor to a station (--station, --session)",
-		detail: "apn acp --station <id> [--session <id>] [--hub <url>] [--token <t>] —\n" +
+		oneline: "Attach an ACP editor to a station (--list, --station)",
+		detail: "apn acp --list — show the stations you can attach an editor to.\n\n" +
+			"apn acp --station <id> [--session <id>] [--hub <url>] [--token <t>] —\n" +
 			"make a station on another machine look like a local agent to any ACP\n" +
 			"client (Zed, JetBrains, anything that speaks the protocol).\n\n" +
 			"The editor spawns this and talks ACP over its stdio; the frames are\n" +

--- a/apps/node-agent/internal/acpproxy/list.go
+++ b/apps/node-agent/internal/acpproxy/list.go
@@ -1,0 +1,156 @@
+package acpproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// Station is the subset of a fleet row `apn acp --list` prints.
+// Field names verified against a live GET /api/fleet/agents on 2026-08-11 —
+// the name is `agentName`, not `displayName`, and `nodeName` matters here
+// because the whole point of Doors is reaching a station on another machine.
+type Station struct {
+	StationID     string   `json:"stationId"`
+	AgentName     string   `json:"agentName"`
+	NodeName      string   `json:"nodeName"`
+	WorkspacePath string   `json:"workspacePath"`
+	Harness       string   `json:"harness"`
+	Status        string   `json:"status"`
+	Capabilities  []string `json:"capabilities"`
+}
+
+// SupportsACP reports whether a station can host an agent session.
+//
+// A station without this capability cannot be attached to, and offering it in
+// a list of things to attach to would only produce a confusing failure later.
+func (s Station) SupportsACP() bool {
+	for _, c := range s.Capabilities {
+		if c == "acp" {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseFleetAgents extracts stations from GET /api/fleet/agents.
+//
+// A pure function so the formatting and filtering are testable without a hub.
+func ParseFleetAgents(body []byte) ([]Station, error) {
+	var payload struct {
+		Agents []Station `json:"agents"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("could not read the fleet list: %w", err)
+	}
+	return payload.Agents, nil
+}
+
+// FormatStations renders the list a person actually needs: the id to paste into
+// an editor's agent command, and enough context to know which machine it is.
+//
+// Stations that cannot host a session are excluded rather than shown greyed
+// out — this list exists to be copied from.
+func FormatStations(stations []Station) string {
+	var usable []Station
+	for _, s := range stations {
+		if s.SupportsACP() {
+			usable = append(usable, s)
+		}
+	}
+
+	if len(usable) == 0 {
+		if len(stations) == 0 {
+			return "No stations found. Enrol a machine first: apn enroll --hub <url> --token <token>\n"
+		}
+		return fmt.Sprintf(
+			"None of your %d station(s) support agent sessions.\nThe harness must expose the `acp` capability — check `apn detect` on that machine.\n",
+			len(stations))
+	}
+
+	// Grouped by machine: someone scanning this is usually looking for "the one
+	// on the Hetzner box", not for a particular harness.
+	sort.Slice(usable, func(i, j int) bool {
+		if usable[i].NodeName != usable[j].NodeName {
+			return usable[i].NodeName < usable[j].NodeName
+		}
+		if usable[i].Harness != usable[j].Harness {
+			return usable[i].Harness < usable[j].Harness
+		}
+		return usable[i].AgentName < usable[j].AgentName
+	})
+
+	var b strings.Builder
+	b.WriteString("\nStations you can attach an editor to:\n")
+
+	node := ""
+	for _, s := range usable {
+		if s.NodeName != node {
+			node = s.NodeName
+			fmt.Fprintf(&b, "\n  %s\n", orUnknown(node, "(unnamed machine)"))
+		}
+		name := s.AgentName
+		if name == "" {
+			name = truncate(s.WorkspacePath, 30) // fall back to where it runs
+		}
+		fmt.Fprintf(&b, "    %-11s %-30s %s\n", s.Harness, truncate(name, 30), s.StationID)
+		fmt.Fprintf(&b, "    %-11s %s\n", "", orUnknown(s.Status, "unknown"))
+	}
+
+	b.WriteString("\nAttach with:\n  apn acp --station <id>\n")
+	return b.String()
+}
+
+func orUnknown(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+// ListStations fetches the caller's stations from the hub.
+func ListStations(ctx context.Context, hub, token string) ([]Station, error) {
+	if token == "" {
+		return nil, fmt.Errorf("no hub token: set AGENTPOD_TOKEN or pass --token")
+	}
+
+	url := strings.TrimSuffix(hub, "/") + "/api/fleet/agents"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach the hub: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("hub rejected the token (401) — it may have expired")
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hub returned %d", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	return ParseFleetAgents(body)
+}

--- a/apps/node-agent/internal/acpproxy/list_test.go
+++ b/apps/node-agent/internal/acpproxy/list_test.go
@@ -1,0 +1,96 @@
+package acpproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+const fleetJSON = `{
+  "stats": {"total": 3},
+  "agents": [
+    {"stationId":"station_b","agentName":"research","nodeName":"mac","harness":"codex","status":"online","capabilities":["health","acp"]},
+    {"stationId":"station_a","agentName":"gateway","nodeName":"mac","harness":"openclaw","status":"offline","capabilities":["health","logs"]},
+    {"stationId":"station_c","agentName":"api","nodeName":"hetzner","harness":"claude-code","status":"online","capabilities":["acp","terminal"]}
+  ]
+}`
+
+func TestParseFleetAgents(t *testing.T) {
+	got, err := ParseFleetAgents([]byte(fleetJSON))
+	if err != nil {
+		t.Fatalf("ParseFleetAgents: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("parsed %d stations, want 3", len(got))
+	}
+	if got[0].StationID != "station_b" || got[0].Harness != "codex" {
+		t.Errorf("first station = %+v", got[0])
+	}
+}
+
+func TestSupportsACP(t *testing.T) {
+	yes := Station{Capabilities: []string{"health", "acp"}}
+	no := Station{Capabilities: []string{"health", "logs"}}
+	if !yes.SupportsACP() {
+		t.Error("a station advertising acp should support sessions")
+	}
+	if no.SupportsACP() {
+		t.Error("a station without acp must not be offered as attachable")
+	}
+}
+
+func TestFormatOmitsStationsThatCannotHostASession(t *testing.T) {
+	// This list exists to be copied from. Showing a station you cannot attach to
+	// only produces a confusing failure one command later.
+	stations, _ := ParseFleetAgents([]byte(fleetJSON))
+	out := FormatStations(stations)
+
+	if !strings.Contains(out, "station_b") || !strings.Contains(out, "station_c") {
+		t.Errorf("attachable stations missing from output:\n%s", out)
+	}
+	if strings.Contains(out, "station_a") {
+		t.Errorf("a station without the acp capability was offered:\n%s", out)
+	}
+}
+
+func TestFormatShowsTheAttachCommand(t *testing.T) {
+	stations, _ := ParseFleetAgents([]byte(fleetJSON))
+	if out := FormatStations(stations); !strings.Contains(out, "apn acp --station") {
+		t.Errorf("output does not say how to use an id:\n%s", out)
+	}
+}
+
+func TestFormatDistinguishesNoStationsFromNoneUsable(t *testing.T) {
+	// Two different problems needing two different fixes: enrol a machine, or
+	// check why the harness is not advertising acp. One message for both would
+	// send someone down the wrong path.
+	empty := FormatStations(nil)
+	if !strings.Contains(empty, "apn enroll") {
+		t.Errorf("an empty fleet should point at enrolment:\n%s", empty)
+	}
+
+	noneUsable := FormatStations([]Station{
+		{StationID: "s1", Harness: "openclaw", Capabilities: []string{"health"}},
+	})
+	if strings.Contains(noneUsable, "apn enroll") {
+		t.Errorf("stations exist, so this must not suggest enrolling:\n%s", noneUsable)
+	}
+	if !strings.Contains(noneUsable, "acp") {
+		t.Errorf("should name the missing capability:\n%s", noneUsable)
+	}
+}
+
+func TestFormatIsOrderedForScanning(t *testing.T) {
+	stations, _ := ParseFleetAgents([]byte(fleetJSON))
+	out := FormatStations(stations)
+	// Sorted by harness: claude-code before codex.
+	if strings.Index(out, "claude-code") > strings.Index(out, "codex") {
+		t.Errorf("output is not sorted by harness:\n%s", out)
+	}
+}
+
+func TestListStationsRequiresAToken(t *testing.T) {
+	if _, err := ListStations(t.Context(), "https://h", ""); err == nil ||
+		!strings.Contains(err.Error(), "AGENTPOD_TOKEN") {
+		t.Errorf("err = %v, want a message naming AGENTPOD_TOKEN", err)
+	}
+}


### PR DESCRIPTION
Completes Doors. Builds on #233 (relay) and #234 (permissions).

## Closes the gap slice 2 left open

`loadSession` was **advertised but unimplemented** — an editor calling it got a method error instead of a transcript. That was the most misleading state the feature could be in, since the capability flag is a promise to clients.

`session/load` now streams the stored history back as notifications. The protocol puts replay on the **agent**, not the client, and `apn acp` is the agent as far as the editor is concerned — so attaching to the station you have been working on all afternoon shows the conversation rather than a blank pane.

Replay applies the same filter as the live path: only `agent-update` carries a raw ACP `sessionUpdate`, and replaying a `permission-request` would re-prompt for something already answered.

> Noted in place: `session/load` is **removed in ACP v2**, where `session/resume` explicitly does not replay. "Join and see what happened" is a v1 affordance with no settled v2 equivalent.

`readEvents` moved into the session service rather than being copied — the console socket has always done this query inline, and two copies of a transcript query is how they drift.

## Concurrent attach is now tested, not assumed

The hub has always fanned out to N subscribers; the console was simply the only client that existed. Doors depends on that, so it gets a test with two live agents on one session.

## `apn acp --list`

Answers the question a CLI could not: someone who has never used this has no station id, and "open the web console" is a poor answer.

```
Stations you can attach an editor to:

  9247e5a88cfa
    opencode    workspace          station_12d4efe6-…
                running

  Rakeshs-MacBook-Pro.local
    codex       research           station_f4693267-…
                running
```

Only stations that can actually host a session are listed — offering one that cannot produces a confusing failure a command later. An empty fleet and a fleet with no usable stations get **different** messages, because they need different fixes (enrol a machine, versus check why the harness is not advertising `acp`).

## Two things running it against the live fleet corrected

- **The name field is `agentName`, not `displayName`.** My first version printed a blank column against real data and looked fine against my fixtures.
- **The response carries `nodeName`**, which matters more than I had allowed for. Doors exists to reach stations on *other machines*, so the list is now grouped by machine rather than sorted by harness.

Verified against `hub.agentpod.dev` — real stations across a container node and the Mac, correctly filtered.

## Still not done

**Driving any of this from a real editor.** That needs a GUI I cannot operate, and it remains the real acceptance criterion for Doors. Point Zed at `apn acp --station <id>` as a custom agent.

Also worth knowing: `/api/acp/proxy` only exists on `main` once this and #233 deploy, so an editor cannot reach the live hub until then.

Suites: contract 64, hub 410, node-agent 13 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW