### PR TITLE
feat: posture capability — and fix a scanner that graded machines A without reading them

### DIFF
--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -334,3 +334,33 @@ export const changesetDiff = (
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ side, ...(path ? { path } : {}) }),
   });
+
+// ─── Posture endpoints ────────────────────────────────────────────────────────
+
+export type PostureFindingRow = {
+  check: string;
+  status: "pass" | "fail" | "unknown";
+  severity: "critical" | "warning" | "info";
+  harness?: string;
+  /** Station key (e.g. `hermes:analyst-echo`) for per-station findings. */
+  station?: string;
+  title: string;
+  detail: string;
+  path?: string;
+  remedy?: string;
+};
+
+export type PostureReportResult = {
+  hostname: string;
+  stations: number;
+  findings: PostureFindingRow[];
+  /** A — nothing · B — info only · C — a warning · F — a critical. */
+  grade: string;
+};
+
+export const nodePosture = (nodeId: string) =>
+  http<PostureReportResult>(`/api/nodes/${nodeId}/posture/scan`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });

--- a/apps/console/src/lib/components/fleet/PosturePanel.svelte
+++ b/apps/console/src/lib/components/fleet/PosturePanel.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { nodePosture } from "$lib/api/client";
+  import type { PostureReportResult } from "$lib/api/client";
+  import * as Card from "$lib/components/ui/card";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+
+  interface Props {
+    nodeId: string;
+  }
+
+  let { nodeId }: Props = $props();
+
+  // ─── State ────────────────────────────────────────────────────────────────────
+
+  let report = $state<PostureReportResult | null>(null);
+  let scanning = $state(false);
+  let scanError = $state<string | null>(null);
+
+  // ─── Derived ──────────────────────────────────────────────────────────────────
+
+  const failures = $derived(report?.findings.filter((f) => f.status === "fail") ?? []);
+  /** Kept apart from passes on purpose: a check that could not run is not a
+   *  pass, and folding the two together is how a scanner stops being trusted. */
+  const unknowns = $derived(report?.findings.filter((f) => f.status === "unknown") ?? []);
+  const passes = $derived(report?.findings.filter((f) => f.status === "pass") ?? []);
+
+  const gradeClass = $derived(
+    report?.grade === "A"
+      ? "text-emerald-600 dark:text-emerald-500"
+      : report?.grade === "F"
+        ? "text-destructive"
+        : "text-amber-600 dark:text-amber-500"
+  );
+
+  // ─── Actions ──────────────────────────────────────────────────────────────────
+
+  async function scan() {
+    scanning = true;
+    scanError = null;
+    try {
+      report = await nodePosture(nodeId);
+    } catch (e) {
+      scanError = e instanceof Error ? e.message : "Couldn't scan this machine.";
+    } finally {
+      scanning = false;
+    }
+  }
+</script>
+
+<Card.Root>
+  <Card.Header>
+    <Card.Title>Posture</Card.Title>
+    <Card.Description>
+      Credential files and agent listeners on this machine. Nothing is stored —
+      this reads the machine as it is right now.
+    </Card.Description>
+  </Card.Header>
+
+  <Card.Content class="flex flex-col gap-4">
+    <div class="flex flex-wrap items-center gap-3">
+      <Button variant="outline" size="sm" onclick={scan} disabled={scanning}>
+        {scanning ? "Scanning…" : "Scan"}
+      </Button>
+      {#if report}
+        <span class="text-2xl font-bold {gradeClass}">{report.grade}</span>
+        <span class="text-muted-foreground text-xs">
+          {report.findings.length} checked · {failures.length} failed · {unknowns.length}
+          could not be determined
+        </span>
+      {/if}
+    </div>
+
+    {#if scanError}
+      <p class="text-destructive text-sm">{scanError}</p>
+    {/if}
+
+    {#each failures as f (f.check + (f.path ?? "") + (f.station ?? ""))}
+      <div class="border-destructive/40 border-l-2 pl-3">
+        <div class="flex flex-wrap items-center gap-2">
+          <Badge variant="destructive">{f.severity}</Badge>
+          <span class="text-sm font-medium">{f.title}</span>
+          {#if f.station}
+            <code class="text-muted-foreground font-mono text-xs">{f.station}</code>
+          {:else if f.harness}
+            <span class="text-muted-foreground text-xs">{f.harness}</span>
+          {/if}
+        </div>
+        <p class="text-muted-foreground mt-1 text-sm">{f.detail}</p>
+        {#if f.remedy}
+          <p class="mt-1 font-mono text-xs">fix: {f.remedy}</p>
+        {/if}
+      </div>
+    {/each}
+
+    {#each unknowns as f (f.check + (f.path ?? ""))}
+      <div class="border-l-2 border-amber-500/40 pl-3">
+        <p class="text-sm font-medium">{f.title}</p>
+        <p class="text-muted-foreground mt-1 text-sm">{f.detail}</p>
+      </div>
+    {/each}
+
+    {#if report && failures.length === 0 && unknowns.length === 0}
+      <p class="text-muted-foreground text-sm">
+        Nothing exposed, nothing world-readable. {passes.length} check(s) passed.
+      </p>
+    {/if}
+  </Card.Content>
+</Card.Root>

--- a/apps/console/src/lib/components/fleet/PosturePanel.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/PosturePanel.svelte.test.ts
@@ -1,0 +1,108 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor, fireEvent, cleanup } from "@testing-library/svelte";
+import * as api from "$lib/api/client";
+// Static import ensures the module is compiled during file collection.
+import PosturePanel from "./PosturePanel.svelte";
+
+beforeEach(() => vi.restoreAllMocks());
+afterEach(cleanup);
+
+const CLEAN: api.PostureReportResult = {
+  hostname: "molt-bot",
+  stations: 15,
+  findings: [
+    {
+      check: "creds.world-readable",
+      status: "pass",
+      severity: "info",
+      harness: "hermes",
+      title: "Credential file is not readable by others",
+      detail: "mode 0600",
+    },
+  ],
+  grade: "A",
+};
+
+const BAD: api.PostureReportResult = {
+  hostname: "molt-bot",
+  stations: 15,
+  findings: [
+    {
+      check: "creds.world-readable",
+      status: "fail",
+      severity: "critical",
+      harness: "hermes",
+      station: "hermes:analyst-echo",
+      title: "Credentials readable by other users",
+      detail: "mode 0644 and reachable",
+      path: "/root/.hermes/profiles/analyst-echo/auth.json",
+      remedy: "chmod 600 /root/.hermes/profiles/analyst-echo/auth.json",
+    },
+    {
+      check: "listen.public",
+      status: "unknown",
+      severity: "info",
+      title: "Could not check listeners",
+      detail: "lsof not found",
+    },
+    {
+      check: "creds.world-readable",
+      status: "pass",
+      severity: "info",
+      harness: "codex",
+      title: "Credential file is not readable by others",
+      detail: "mode 0600",
+    },
+  ],
+  grade: "F",
+};
+
+test("scanning shows the grade", async () => {
+  vi.spyOn(api, "nodePosture").mockResolvedValue(CLEAN);
+  const { getByRole, getByText } = render(PosturePanel, { props: { nodeId: "node_1" } });
+  fireEvent.click(getByRole("button", { name: /scan/i }));
+  await waitFor(() => expect(getByText("A")).toBeTruthy());
+});
+
+test("failures are shown with their remedy", async () => {
+  // The person reading this wants to know what to type, not to go looking.
+  vi.spyOn(api, "nodePosture").mockResolvedValue(BAD);
+  const { getByRole, getByText, container } = render(PosturePanel, {
+    props: { nodeId: "node_1" },
+  });
+  fireEvent.click(getByRole("button", { name: /scan/i }));
+
+  await waitFor(() => expect(getByText(/Credentials readable by other users/)).toBeTruthy());
+  expect(container.textContent).toMatch(/chmod 600/);
+});
+
+test("unknown findings are shown separately from passes", async () => {
+  // A check that could not run is not a pass. Folding it into passes is how a
+  // scanner quietly stops being trustworthy.
+  vi.spyOn(api, "nodePosture").mockResolvedValue(BAD);
+  const { getByRole, container } = render(PosturePanel, { props: { nodeId: "node_1" } });
+  fireEvent.click(getByRole("button", { name: /scan/i }));
+
+  await waitFor(() => expect(container.textContent).toMatch(/lsof not found/));
+});
+
+test("a failing finding names the station it belongs to", async () => {
+  vi.spyOn(api, "nodePosture").mockResolvedValue(BAD);
+  const { getByRole, container } = render(PosturePanel, { props: { nodeId: "node_1" } });
+  fireEvent.click(getByRole("button", { name: /scan/i }));
+  await waitFor(() => expect(container.textContent).toMatch(/hermes:analyst-echo/));
+});
+
+test("a clean machine says so rather than showing nothing", async () => {
+  vi.spyOn(api, "nodePosture").mockResolvedValue(CLEAN);
+  const { getByRole, container } = render(PosturePanel, { props: { nodeId: "node_1" } });
+  fireEvent.click(getByRole("button", { name: /scan/i }));
+  await waitFor(() => expect(container.textContent).toMatch(/nothing exposed/i));
+});
+
+test("a failed scan shows the error", async () => {
+  vi.spyOn(api, "nodePosture").mockRejectedValue(new Error("node offline"));
+  const { getByRole, container } = render(PosturePanel, { props: { nodeId: "node_1" } });
+  fireEvent.click(getByRole("button", { name: /scan/i }));
+  await waitFor(() => expect(container.textContent).toMatch(/node offline/));
+});

--- a/apps/console/src/lib/components/stations/PostureBanner.svelte
+++ b/apps/console/src/lib/components/stations/PostureBanner.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { nodePosture } from "$lib/api/client";
+  import type { PostureFindingRow } from "$lib/api/client";
+
+  interface Props {
+    nodeId: string;
+    stationKey: string;
+  }
+
+  let { nodeId, stationKey }: Props = $props();
+
+  let mine = $state<PostureFindingRow[]>([]);
+
+  /**
+   * Only findings that name THIS station.
+   *
+   * Harness-level findings stay on the node page: this Mac has twenty-odd
+   * claude-code stations sharing one credential file, and repeating that one
+   * fact on every station page turns a real problem into wallpaper.
+   */
+  async function load() {
+    try {
+      const report = await nodePosture(nodeId);
+      mine = report.findings.filter((f) => f.status === "fail" && f.station === stationKey);
+    } catch {
+      // A passive banner on a page opened for something else. A failed
+      // background scan must not put an error in front of someone who did not
+      // ask for one — the node page's Scan button is where errors belong.
+      mine = [];
+    }
+  }
+
+  $effect(() => {
+    void stationKey;
+    load();
+  });
+</script>
+
+{#if mine.length > 0}
+  <div class="border-destructive/40 bg-destructive/5 rounded-md border p-3">
+    {#each mine as f (f.check + (f.path ?? ""))}
+      <p class="text-sm font-medium">{f.title}</p>
+      <p class="text-muted-foreground mt-1 text-sm">{f.detail}</p>
+      {#if f.remedy}
+        <p class="mt-1 font-mono text-xs">fix: {f.remedy}</p>
+      {/if}
+    {/each}
+    <a class="mt-2 inline-block text-xs underline" href="/nodes/{nodeId}">
+      See this machine's full posture
+    </a>
+  </div>
+{/if}

--- a/apps/console/src/lib/components/stations/PostureBanner.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/PostureBanner.svelte.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor, cleanup } from "@testing-library/svelte";
+import * as api from "$lib/api/client";
+import PostureBanner from "./PostureBanner.svelte";
+
+beforeEach(() => vi.restoreAllMocks());
+afterEach(cleanup);
+
+const REPORT: api.PostureReportResult = {
+  hostname: "molt-bot",
+  stations: 15,
+  findings: [
+    {
+      check: "creds.world-readable",
+      status: "fail",
+      severity: "critical",
+      harness: "hermes",
+      station: "hermes:analyst-echo",
+      title: "Credentials readable by other users",
+      detail: "mode 0644",
+      remedy: "chmod 600 /root/.hermes/profiles/analyst-echo/auth.json",
+    },
+    {
+      check: "creds.world-readable",
+      status: "fail",
+      severity: "critical",
+      harness: "hermes",
+      station: "hermes:coder-kai",
+      title: "Credentials readable by other users",
+      detail: "mode 0644",
+    },
+    {
+      // Harness-level, no station — belongs on the node page, not here.
+      check: "listen.public",
+      status: "fail",
+      severity: "critical",
+      harness: "hermes",
+      title: "Agent is listening on every network interface",
+      detail: "bound to 0.0.0.0",
+    },
+  ],
+  grade: "F",
+};
+
+test("shows a warning when a finding names this station", async () => {
+  vi.spyOn(api, "nodePosture").mockResolvedValue(REPORT);
+  const { container } = render(PostureBanner, {
+    props: { nodeId: "node_1", stationKey: "hermes:analyst-echo" },
+  });
+  await waitFor(() => expect(container.textContent).toMatch(/readable by other users/i));
+  expect(container.textContent).toMatch(/chmod 600/);
+});
+
+test("shows only this station's finding, not its neighbour's", async () => {
+  vi.spyOn(api, "nodePosture").mockResolvedValue(REPORT);
+  const { container } = render(PostureBanner, {
+    props: { nodeId: "node_1", stationKey: "hermes:analyst-echo" },
+  });
+  await waitFor(() => expect(container.textContent).toMatch(/readable by other users/i));
+  expect(container.textContent).not.toMatch(/coder-kai/);
+});
+
+test("host-level findings are not repeated here", async () => {
+  // This Mac has twenty-odd claude-code stations sharing one credential file.
+  // A banner that appears on all of them is a banner nobody reads.
+  vi.spyOn(api, "nodePosture").mockResolvedValue(REPORT);
+  const { container } = render(PostureBanner, {
+    props: { nodeId: "node_1", stationKey: "hermes:analyst-echo" },
+  });
+  await waitFor(() => expect(container.textContent).toMatch(/readable by other users/i));
+  expect(container.textContent).not.toMatch(/every network interface/);
+});
+
+test("stays silent for a station with no findings", async () => {
+  vi.spyOn(api, "nodePosture").mockResolvedValue(REPORT);
+  const { container } = render(PostureBanner, {
+    props: { nodeId: "node_1", stationKey: "hermes:writer-quill" },
+  });
+  await waitFor(() => expect(api.nodePosture).toHaveBeenCalled());
+  expect(container.textContent?.trim()).toBe("");
+});
+
+test("stays silent when the scan fails", async () => {
+  // A passive banner on someone else's page; a failed background scan must not
+  // put an error where they did not ask for one.
+  vi.spyOn(api, "nodePosture").mockRejectedValue(new Error("node offline"));
+  const { container } = render(PostureBanner, {
+    props: { nodeId: "node_1", stationKey: "hermes:analyst-echo" },
+  });
+  await waitFor(() => expect(api.nodePosture).toHaveBeenCalled());
+  expect(container.textContent?.trim()).toBe("");
+});

--- a/apps/console/src/routes/nodes/[id]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/+page.svelte
@@ -7,6 +7,7 @@
   import type { NodeSummary } from "@agentpod/contract";
   import StationTree from "$lib/components/stations/StationTree.svelte";
   import ProvisionedNodeControls from "$lib/components/fleet/ProvisionedNodeControls.svelte";
+  import PosturePanel from "$lib/components/fleet/PosturePanel.svelte";
   import * as Card from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
   import Empty from "$lib/components/ui/empty/empty.svelte";
@@ -20,6 +21,12 @@
   const id = $derived(page.params.id as string);
 
   let node = $state<NodeSummary | null>(null);
+
+  /** Node-level capability, carried in the hello frame. Absent on nodes that
+   *  predate it, which is how they degrade to showing no panel at all. */
+  const hasPosture = $derived(
+    Array.isArray(node?.capabilities) && node!.capabilities.includes("posture")
+  );
 
   async function loadNode() {
     try {
@@ -125,6 +132,10 @@
   <!-- Provisioned runtime controls (destroy / stop / start) -->
   {#if node?.provisioned}
     <ProvisionedNodeControls {node} onRefresh={loadNode} />
+  {/if}
+
+  {#if hasPosture}
+    <PosturePanel nodeId={id} />
   {/if}
 
   {#if stations.error}

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -11,6 +11,7 @@
   import ChatPanel from "$lib/components/stations/chat/ChatPanel.svelte";
   import CleanupPanel from "$lib/components/stations/CleanupPanel.svelte";
   import ChangesetPanel from "$lib/components/stations/ChangesetPanel.svelte";
+  import PostureBanner from "$lib/components/stations/PostureBanner.svelte";
   import ActivityPanel from "$lib/components/stations/ActivityPanel.svelte";
   import { listStations } from "$lib/api/client";
   import type { StationRow } from "$lib/api/client";
@@ -236,6 +237,9 @@
       <Button variant="outline" size="sm" onclick={() => loadStation()}>Retry</Button>
     </div>
   {:else if stationLoad === "loaded"}
+    {#if station}
+      <PostureBanner {nodeId} stationKey={station.stationKey} />
+    {/if}
     {@render stationPanels()}
   {:else}
     <!-- Panels wait for the capability list: which tab is the default depends on

--- a/apps/hub/src/db/drizzle-migrations/0029_cuddly_expediter.sql
+++ b/apps/hub/src/db/drizzle-migrations/0029_cuddly_expediter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "nodes" ADD COLUMN "capabilities" jsonb;

--- a/apps/hub/src/db/drizzle-migrations/meta/0029_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0029_snapshot.json
@@ -1,0 +1,2003 @@
+{
+  "id": "85a9af58-095f-4270-bddb-b0ec4e069ec9",
+  "prevId": "276f13a4-e8c3-4c06-b530-1ca4be4e4829",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "online",
+        "stopped",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1786446522709,
       "tag": "0028_outgoing_magneto",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1786472791668,
+      "tag": "0029_cuddly_expediter",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/nodes.ts
+++ b/apps/hub/src/db/schema/nodes.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, timestamp, index, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, timestamp, index, pgEnum, jsonb } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
 export const nodeStatusEnum = pgEnum("node_status", ["online", "offline"]);
@@ -13,6 +13,9 @@ export const nodes = pgTable("nodes", {
   cpuCount: integer("cpu_count").notNull().default(0),
   secretHash: text("secret_hash").notNull(),
   agentVersion: text("agent_version"),
+  // Node-level capabilities from the hello frame. Null on nodes that predate
+  // them — "did not say" stays distinguishable from "said nothing".
+  capabilities: jsonb("capabilities").$type<string[]>(),
   status: nodeStatusEnum("status").notNull().default("offline"),
   lastSeenAt: timestamp("last_seen_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -41,6 +41,7 @@ import { stationWriteRoutes } from './routes/station-writes.ts';
 import { stationLifecycleRoutes } from './routes/station-lifecycle.ts';
 import { stationCleanupRoutes } from './routes/station-cleanup.ts';
 import { stationChangesetRoutes } from './routes/station-changeset.ts';
+import { nodePostureRoutes } from './routes/node-posture.ts';
 // ACP session routes (REST session management + console session WebSocket)
 import { stationAcpRoutes } from './routes/station-acp.ts';
 import { acpProxyRouter } from './routes/acp-proxy.ts';
@@ -125,6 +126,7 @@ const app = new Hono()
   .route('/api', stationLifecycleRoutes)                   // POST /api/stations/:id/lifecycle
   .route('/api', stationCleanupRoutes)                     // POST /api/stations/:id/cleanup/{plan,apply}
   .route('/api', stationChangesetRoutes)                   // POST /api/stations/:id/changeset/{status,diff}
+  .route('/api', nodePostureRoutes)                        // POST /api/nodes/:id/posture/scan
   .route('/api', stationAcpRoutes)                         // POST/GET /api/stations/:id/acp/sessions, WS /api/acp/sessions/:sessionId/ws
   .route('/api', acpProxyRouter);                          // WS /api/acp/proxy — Doors: an editor's stdio, piped by `apn acp`
 

--- a/apps/hub/src/routes/gateway.ts
+++ b/apps/hub/src/routes/gateway.ts
@@ -13,7 +13,7 @@
 import { Hono } from "hono";
 import { GatewayClientMessage } from "@agentpod/contract";
 import { verifyNodeCredential } from "../services/enrollment";
-import { setNodeStatus, setNodeAgentVersion } from "../services/node-registry";
+import { setNodeStatus, setNodeAgentVersion, setNodeCapabilities } from "../services/node-registry";
 import { connectionManager } from "../services/connection-manager";
 import type { Send } from "../services/connection-manager";
 import { handleNodeMessage, dropNode } from "../services/broker";
@@ -105,6 +105,9 @@ export const gatewayRoutes = new Hono().get(
         if (parsed.data.type === "hello") {
           const version = parsed.data.version ?? null;
           await setNodeAgentVersion(authed, version);
+          // Absent means an older node: store null rather than an empty array,
+          // so "did not say" stays distinguishable from "said nothing".
+          await setNodeCapabilities(authed, parsed.data.capabilities ?? null);
         } else if (parsed.data.type === "heartbeat") {
           // A heartbeating socket with no registry entry (swept, or lost to a
           // close race) re-registers itself — server→node send must work for

--- a/apps/hub/src/routes/node-posture.test.ts
+++ b/apps/hub/src/routes/node-posture.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration Test: hub node posture route (node-capability gated).
+ *
+ * Verifies:
+ *   1. A node's capabilities are stored from its hello frame — this is what
+ *      gates the console panel, and it rides the handshake so it cannot go
+ *      stale the way station capabilities could.
+ *   2. A node that sends no capabilities stores null, and degrades silently.
+ *   3. POST /posture/scan returns the node's report, audited.
+ *   4. A node without the capability → 403, and the node is never called.
+ *   5. Unauthenticated → 401; another user's node → 404.
+ *   6. Offline → 409; any other node-side failure → 502.
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { and, eq } from "drizzle-orm";
+
+import { db, rawSql } from "../db/drizzle";
+import { nodes } from "../db/schema/nodes";
+import { stationAudit } from "../db/schema/audit";
+import { createTestUser } from "../../tests/helpers/database";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { gatewayRoutes } from "./gateway";
+import { nodePostureRoutes } from "./node-posture";
+import { websocket } from "../ws";
+import type { AuthUser } from "../auth/middleware";
+
+const TEST_USER = "test-user-posture-001";
+
+const REPORT = {
+  hostname: "molt-bot",
+  stations: 15,
+  findings: [
+    {
+      check: "creds.world-readable",
+      status: "fail",
+      severity: "critical",
+      harness: "hermes",
+      station: "hermes:analyst-echo",
+      title: "Credentials readable by other users",
+      detail: "mode 0644 and reachable",
+      path: "/root/.hermes/profiles/analyst-echo/auth.json",
+      remedy: "chmod 600 /root/.hermes/profiles/analyst-echo/auth.json",
+    },
+  ],
+  grade: "F",
+};
+
+// ─── Minimal test app ─────────────────────────────────────────────────────────
+
+const testApp = new Hono()
+  .use("/api/*", async (c, next) => {
+    const userId = c.req.header("X-Test-User-Id");
+    c.set("user", {
+      id: userId && userId !== "anonymous" ? userId : "anonymous",
+      authType: "api_key",
+    } satisfies AuthUser);
+    return next();
+  })
+  .route("/public/nodes", gatewayRoutes)
+  .route("/api", nodePostureRoutes);
+
+// ─── Setup & Teardown ─────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: "posture-test@example.com",
+    name: "Node Posture Test User",
+  });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM station_audit     WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM nodes             WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM "user"            WHERE id = ${TEST_USER}`;
+  } catch {
+    // ignore
+  }
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * A fake node that sends a hello frame with the given capabilities and answers
+ * posture.scan.
+ *
+ * `capabilities: null` reproduces a node that predates them, which must degrade
+ * silently rather than error.
+ */
+async function connectFakeNode(
+  serverPort: number,
+  nodeId: string,
+  nodeSecret: string,
+  // null means "send a hello with no capabilities key at all" — an explicit
+  // undefined would trigger withPostureNode's default parameter instead.
+  capabilities: string[] | null,
+  report: unknown,
+  capturedMsgs?: string[],
+  failWith?: string
+): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://localhost:${serverPort}/public/nodes/gateway`, {
+    headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+  } as RequestInit & { headers: Record<string, string> });
+
+  await new Promise<void>((res, rej) => {
+    ws.onopen = () => res();
+    ws.onerror = () => rej(new Error("Node WS connection error"));
+  });
+
+  ws.send(
+    JSON.stringify({
+      type: "hello",
+      hostInfo: { hostname: "molt-bot", os: "linux", arch: "amd64", cpuCount: 2 },
+      version: "v0.1.22",
+      ...(capabilities ? { capabilities } : {}),
+    })
+  );
+
+  ws.onmessage = (e) => {
+    const raw = String(e.data);
+    if (capturedMsgs) capturedMsgs.push(raw);
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (msg.type !== "req" || msg.verb !== "posture.scan") return;
+
+    if (failWith) {
+      ws.send(JSON.stringify({ type: "res", id: msg.id, ok: false, error: failWith }));
+      return;
+    }
+    ws.send(JSON.stringify({ type: "res", id: msg.id, ok: true, data: report }));
+  };
+
+  await new Promise((r) => setTimeout(r, 250));
+  return ws;
+}
+
+async function withPostureNode(
+  report: unknown,
+  capabilities: string[] | null = ["posture"],
+  failWith?: string
+) {
+  const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+  const baseUrl = `http://localhost:${server.port}`;
+  const capturedMsgs: string[] = [];
+
+  const { token } = await mintEnrollmentToken(TEST_USER);
+  const { nodeId, nodeSecret } = await enrollNode(token, {
+    hostname: `posture-host-${crypto.randomUUID().slice(0, 8)}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+
+  const fakeNode = await connectFakeNode(
+    server.port!,
+    nodeId,
+    nodeSecret,
+    capabilities,
+    report,
+    capturedMsgs,
+    failWith
+  );
+
+  return { server, baseUrl, nodeId, capturedMsgs, fakeNode };
+}
+
+async function pollUntil<T>(
+  condition: () => Promise<T | undefined | null | false> | (T | undefined | null | false),
+  timeoutMs = 4000,
+  pollMs = 40
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await condition();
+    if (result) return result as T;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs} ms`);
+}
+
+function sawVerb(msgs: string[], verb: string): boolean {
+  return msgs.some((raw) => {
+    try {
+      const m = JSON.parse(raw);
+      return m?.type === "req" && m?.verb === verb;
+    } catch {
+      return false;
+    }
+  });
+}
+
+const post = (baseUrl: string, path: string, body: unknown, user = TEST_USER) =>
+  fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "X-Test-User-Id": user, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("a node's capabilities are stored from its hello frame", async () => {
+  const ctx = await withPostureNode(REPORT, ["posture"]);
+  try {
+    await pollUntil(async () => {
+      const rows = await db.select().from(nodes).where(eq(nodes.id, ctx.nodeId));
+      return rows[0]?.capabilities?.includes("posture") ? rows[0] : null;
+    });
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("a node that sends no capabilities stores none", async () => {
+  // An older node must degrade silently, not error. Null rather than [] keeps
+  // "did not say" distinguishable from "said nothing".
+  const ctx = await withPostureNode(REPORT, null);
+  try {
+    await new Promise((r) => setTimeout(r, 400));
+    const rows = await db.select().from(nodes).where(eq(nodes.id, ctx.nodeId));
+    expect(rows[0]?.capabilities ?? null).toBeNull();
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("scan returns the node's report and is audited", async () => {
+  const ctx = await withPostureNode(REPORT);
+  try {
+    const res = await post(ctx.baseUrl, `/api/nodes/${ctx.nodeId}/posture/scan`, {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(REPORT);
+
+    await new Promise((r) => setTimeout(r, 250));
+    const rows = await db
+      .select()
+      .from(stationAudit)
+      .where(
+        and(eq(stationAudit.userId, TEST_USER), eq(stationAudit.verb, "posture.scan"))
+      );
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.some((r) => r.result === "ok")).toBe(true);
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("a node without the capability is 403 and is never called", async () => {
+  const ctx = await withPostureNode(REPORT, []);
+  try {
+    const before = ctx.capturedMsgs.length;
+    const res = await post(ctx.baseUrl, `/api/nodes/${ctx.nodeId}/posture/scan`, {});
+    expect(res.status).toBe(403);
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(sawVerb(ctx.capturedMsgs.slice(before), "posture.scan")).toBe(false);
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("unauthenticated is 401", async () => {
+  const ctx = await withPostureNode(REPORT);
+  try {
+    const res = await post(
+      ctx.baseUrl,
+      `/api/nodes/${ctx.nodeId}/posture/scan`,
+      {},
+      "anonymous"
+    );
+    expect(res.status).toBe(401);
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("another user's node is 404", async () => {
+  const ctx = await withPostureNode(REPORT);
+  try {
+    const res = await post(ctx.baseUrl, `/api/nodes/node_not_mine/posture/scan`, {});
+    expect(res.status).toBe(404);
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("an offline node is 409, not 502", async () => {
+  const ctx = await withPostureNode(REPORT, ["posture"], "node offline");
+  try {
+    const res = await post(ctx.baseUrl, `/api/nodes/${ctx.nodeId}/posture/scan`, {});
+    expect(res.status).toBe(409);
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});
+
+test("any other failure is 502", async () => {
+  const ctx = await withPostureNode(REPORT, ["posture"], "lsof exploded");
+  try {
+    const res = await post(ctx.baseUrl, `/api/nodes/${ctx.nodeId}/posture/scan`, {});
+    expect(res.status).toBe(502);
+  } finally {
+    ctx.fakeNode.close();
+    ctx.server.stop(true);
+  }
+});

--- a/apps/hub/src/routes/node-posture.ts
+++ b/apps/hub/src/routes/node-posture.ts
@@ -1,0 +1,98 @@
+/**
+ * Node Posture Route — POST /api/nodes/:id/posture/scan
+ *
+ * Node-level rather than station-level: credential files live in a user's home
+ * and a listening socket belongs to a process, so one scan describes one
+ * machine. Findings that belong to a station carry `station`, and the console
+ * joins on that rather than re-running anything per station.
+ *
+ * Safety model (mirrors station-cleanup.ts, with node ownership in place of
+ * station ownership):
+ *   1. Authenticate (401 if anonymous).
+ *   2. Node ownership → 404 if absent or not owned.
+ *   3. Capability gate: node must advertise "posture" → 403, no node call.
+ *   4. Record an audit row.
+ *   5. broker.request().
+ *   6. Finalise audit, respond.
+ *
+ * Node-offline → 409; other broker errors → 502.
+ *
+ * Audited because a posture report names credential file paths. It is a
+ * deliberate click rather than a poll, so it does not flood the log.
+ */
+
+import { Hono } from "hono";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { nodes } from "../db/schema/nodes";
+import * as broker from "../services/broker";
+import { recordAudit } from "../services/audit";
+import type { AuthUser } from "../auth/middleware";
+
+// ─── Error-to-status helper ───────────────────────────────────────────────────
+
+function brokerErrorStatus(error: string | undefined): 409 | 502 {
+  if (error === "node offline" || error === "node disconnected") return 409;
+  return 502;
+}
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+export const nodePostureRoutes = new Hono().post(
+  "/nodes/:id/posture/scan",
+  async (c) => {
+    // ── 1. Authenticate ────────────────────────────────────────────────────
+    const user = c.get("user") as AuthUser | undefined;
+    if (!user || user.id === "anonymous") {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    // ── 2. Ownership check ─────────────────────────────────────────────────
+    const nodeId = c.req.param("id");
+    const rows = await db
+      .select()
+      .from(nodes)
+      .where(and(eq(nodes.id, nodeId), eq(nodes.userId, user.id)));
+    const node = rows[0];
+    if (!node) {
+      return c.json({ error: "Not Found" }, 404);
+    }
+
+    // ── 3. Capability gate (before any node call) ──────────────────────────
+    if (
+      !Array.isArray(node.capabilities) ||
+      !node.capabilities.includes("posture")
+    ) {
+      return c.json(
+        { error: "Forbidden: node does not advertise posture capability" },
+        403
+      );
+    }
+
+    // ── 4. Audit ───────────────────────────────────────────────────────────
+    // stationKey is "" because this is not about a station. Station keys are
+    // `.min(1)` in the contract, so an empty string can never collide with one.
+    const audit = await recordAudit(db, {
+      userId: user.id,
+      nodeId: node.id,
+      stationKey: "",
+      verb: "posture.scan",
+      params: {},
+    });
+
+    // ── 5. Broker request ──────────────────────────────────────────────────
+    const result = await broker.request(node.id, "posture.scan", {});
+
+    // ── 6. Finalise audit ──────────────────────────────────────────────────
+    await audit.done(result.ok ? "ok" : "error", result.error).catch(() => {});
+
+    // ── 7. Respond ─────────────────────────────────────────────────────────
+    if (!result.ok) {
+      return c.json(
+        { error: result.error ?? "posture.scan failed" },
+        brokerErrorStatus(result.error)
+      );
+    }
+    return c.json(result.data);
+  }
+);

--- a/apps/hub/src/services/node-registry.ts
+++ b/apps/hub/src/services/node-registry.ts
@@ -42,6 +42,7 @@ export async function listNodes(userId: string): Promise<NodeWithProvisioning[]>
       arch: nodes.arch,
       cpuCount: nodes.cpuCount,
       agentVersion: nodes.agentVersion,
+      capabilities: nodes.capabilities,
       status: nodes.status,
       lastSeenAt: nodes.lastSeenAt,
       createdAt: nodes.createdAt,
@@ -63,6 +64,7 @@ export async function listNodes(userId: string): Promise<NodeWithProvisioning[]>
     arch: n.arch,
     cpuCount: n.cpuCount,
     agentVersion: n.agentVersion ?? null,
+    capabilities: n.capabilities ?? null,
     status: n.status,
     lastSeenAt: n.lastSeenAt ? n.lastSeenAt.toISOString() : null,
     createdAt: n.createdAt.toISOString(),
@@ -107,4 +109,18 @@ export async function setNodeAgentVersion(
     .update(nodes)
     .set({ agentVersion })
     .where(eq(nodes.id, nodeId));
+}
+
+/**
+ * Store the node-level capabilities a node advertised in its hello frame.
+ *
+ * Called on every connect, so these cannot go stale — unlike station
+ * capabilities, which were only ever written at adoption and needed an explicit
+ * refresh to fix.
+ */
+export async function setNodeCapabilities(
+  nodeId: string,
+  capabilities: string[] | null
+) {
+  await db.update(nodes).set({ capabilities }).where(eq(nodes.id, nodeId));
 }

--- a/apps/node-agent/cmd/agentpod-node/run.go
+++ b/apps/node-agent/cmd/agentpod-node/run.go
@@ -104,6 +104,7 @@ func runCmd() {
 
 	h := gateway.NewTerminalHandler(descriptor.NewHandler(reg), resolver, mgr, lifecycleFn)
 	h = gateway.NewChangesetHandler(h, resolver)
+	h = gateway.NewPostureHandler(h, func() int { return len(reg.DetectAll()) })
 	h = gateway.NewACPHandler(h, acpMgr, descriptor.NewCapabilityHandler(reg).ACPCommand)
 	h = gateway.NewUpdateHandler(h, version)
 	gateway.Run(ctx, cfg, h, version, gatherHealth)

--- a/apps/node-agent/internal/contractfix/roundtrip_test.go
+++ b/apps/node-agent/internal/contractfix/roundtrip_test.go
@@ -113,3 +113,14 @@ func TestHealthFrameStationsRoundTrip(t *testing.T) {
 		t.Errorf("health frame drifted.\n  contract: %s\n  go:       %s", src, out)
 	}
 }
+
+// The hello frame carries node capabilities, which gate whole features in the
+// console — a capability silently dropped here is a feature that never appears
+// and produces no error anywhere.
+//
+// Until this test existed the frame was an inline map[string]any in client.go
+// and nothing checked it at all, exactly the gap TestHealthFrameStationsRoundTrip
+// warns about one function above.
+func TestHelloRoundTrips(t *testing.T) {
+	roundTrip(t, "hello.json", &gateway.HelloMsg{})
+}

--- a/apps/node-agent/internal/contractfix/testdata/hello.json
+++ b/apps/node-agent/internal/contractfix/testdata/hello.json
@@ -6,5 +6,8 @@
     "arch": "arm64",
     "cpuCount": 8
   },
-  "version": "v0.1.18"
+  "version": "v0.1.22",
+  "capabilities": [
+    "posture"
+  ]
 }

--- a/apps/node-agent/internal/gateway/client.go
+++ b/apps/node-agent/internal/gateway/client.go
@@ -147,6 +147,19 @@ func Run(ctx context.Context, cfg config.Config, h Handler, version string, gath
 	})
 }
 
+// HelloMsg is the frame sent immediately on every connection.
+//
+// A struct rather than an inline map so contractfix can prove it still
+// round-trips the contract's shape. It was a map[string]any until 2026-08-11,
+// which is exactly the gap TestHealthFrameStationsRoundTrip warns about: an
+// untyped map drifts from the contract and no test notices.
+type HelloMsg struct {
+	Type         string        `json:"type"`
+	HostInfo     host.HostInfo `json:"hostInfo"`
+	Version      string        `json:"version,omitempty"`
+	Capabilities []string      `json:"capabilities,omitempty"`
+}
+
 // connectOnce dials the hub, sends the hello frame, starts the heartbeat
 // ticker, and serves the inbound read loop until the connection is lost or ctx
 // is cancelled. onConnected is called immediately after the hello is sent so
@@ -164,7 +177,12 @@ func connectOnce(ctx context.Context, cfg config.Config, h Handler, onConnected 
 	}
 	defer c.Close(websocket.StatusNormalClosure, "")
 
-	hello, _ := json.Marshal(map[string]any{"type": "hello", "hostInfo": host.Info(), "version": version})
+	hello, _ := json.Marshal(HelloMsg{
+		Type:         "hello",
+		HostInfo:     host.Info(),
+		Version:      version,
+		Capabilities: NodeCapabilities,
+	})
 	if err := c.Write(ctx, websocket.MessageText, hello); err != nil {
 		return err
 	}

--- a/apps/node-agent/internal/gateway/posture.go
+++ b/apps/node-agent/internal/gateway/posture.go
@@ -1,0 +1,53 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/posture"
+)
+
+// NodeCapabilities is what this node advertises about ITSELF, as opposed to
+// about a station. Sent in the hello frame on every connect, which is why node
+// capabilities cannot go stale the way station capabilities could — those were
+// written only at adoption and needed an explicit refresh to fix.
+var NodeCapabilities = []string{"posture"}
+
+// postureHandler wraps an inner Handler and adds the node-level posture verb.
+type postureHandler struct {
+	inner        Handler
+	stationCount func() int
+}
+
+// NewPostureHandler wraps inner with posture.scan.
+//
+// stationCount is injected rather than detected here so the handler has no
+// dependency on the descriptor layer — the same separation posture.Scan uses.
+func NewPostureHandler(inner Handler, stationCount func() int) Handler {
+	return &postureHandler{inner: inner, stationCount: stationCount}
+}
+
+func (h *postureHandler) Handle(
+	ctx context.Context,
+	verb string,
+	params json.RawMessage,
+	emit func(seq int, chunk string, eof bool, enc string) error,
+) (any, bool, error) {
+	if verb != "posture.scan" {
+		return h.inner.Handle(ctx, verb, params, emit)
+	}
+
+	// Params are deliberately ignored: a node-level scan has nothing to key on,
+	// and rejecting unexpected fields would break compatibility for no gain.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, false, err
+	}
+
+	n := 0
+	if h.stationCount != nil {
+		n = h.stationCount()
+	}
+	return posture.Scan(ctx, home, posture.KnownHarnesses(), n), false, nil
+}

--- a/apps/node-agent/internal/gateway/posture_test.go
+++ b/apps/node-agent/internal/gateway/posture_test.go
@@ -1,0 +1,87 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/posture"
+)
+
+func posturePassthrough() Handler {
+	return HandlerFunc(func(_ context.Context, verb string, _ json.RawMessage, _ func(int, string, bool, string) error) (any, bool, error) {
+		return "inner:" + verb, false, nil
+	})
+}
+
+func TestPostureHandlerPassesOtherVerbsThrough(t *testing.T) {
+	h := NewPostureHandler(posturePassthrough(), func() int { return 0 })
+	got, _, err := h.Handle(t.Context(), "health", json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if got != "inner:health" {
+		t.Errorf("got %v, want the inner handler's result", got)
+	}
+}
+
+func TestPostureScanReturnsAGradedReport(t *testing.T) {
+	h := NewPostureHandler(posturePassthrough(), func() int { return 7 })
+	got, streamed, err := h.Handle(t.Context(), "posture.scan", json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if streamed {
+		t.Error("posture.scan returns a bounded result; it must not stream")
+	}
+	rep, ok := got.(posture.Report)
+	if !ok {
+		t.Fatalf("got %T, want posture.Report", got)
+	}
+	if rep.Grade == "" {
+		t.Error("report has no grade")
+	}
+	if rep.Stations != 7 {
+		t.Errorf("Stations = %d, want the injected count 7", rep.Stations)
+	}
+}
+
+func TestPostureScanIgnoresParams(t *testing.T) {
+	// The verb takes {} — a node-level scan has nothing to key on. Junk params
+	// must not fail it, so an older or newer caller stays compatible.
+	h := NewPostureHandler(posturePassthrough(), func() int { return 0 })
+	if _, _, err := h.Handle(t.Context(), "posture.scan", json.RawMessage(`{"key":"ignored"}`), nil); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+}
+
+func TestNodeCapabilitiesAdvertisesPosture(t *testing.T) {
+	// This is what the hub gates the console panel on.
+	var found bool
+	for _, c := range NodeCapabilities {
+		if c == "posture" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("NodeCapabilities = %v, want it to include posture", NodeCapabilities)
+	}
+}
+
+func TestHelloCarriesNodeCapabilities(t *testing.T) {
+	// The frame used to be an inline map[string]any, which meant nothing could
+	// catch it drifting from the contract. It is a struct now; this pins that
+	// capabilities actually reach the wire.
+	b, err := json.Marshal(HelloMsg{Type: "hello", Version: "v0.1.22", Capabilities: NodeCapabilities})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back map[string]any
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	caps, ok := back["capabilities"].([]any)
+	if !ok || len(caps) == 0 {
+		t.Fatalf("hello frame carried no capabilities: %s", b)
+	}
+}

--- a/apps/node-agent/internal/posture/creds.go
+++ b/apps/node-agent/internal/posture/creds.go
@@ -163,11 +163,19 @@ func checkOneCredentialFile(harness, station, label, full string) []Finding {
 		}}
 	}
 
+	// A mode that grants read but an ancestor that blocks traversal is a pass —
+	// and worth saying out loud, because "not readable by others" next to
+	// "mode 0644" otherwise reads like a bug in the scanner.
+	detail := fmt.Sprintf("%s is mode %04o", label, info.Mode().Perm())
+	if info.Mode().Perm()&0o044 != 0 {
+		detail += " but a parent directory blocks other users from reaching it"
+	}
+
 	return []Finding{{
 		Check: CheckCredentialsID, Status: StatusPass, Severity: SeverityInfo,
 		Harness: harness, Station: station,
 		Title:  "Credential file is not readable by others",
-		Detail: fmt.Sprintf("%s is mode %04o", label, info.Mode().Perm()),
+		Detail: detail,
 		Path:   full,
 	}}
 }

--- a/apps/node-agent/internal/posture/creds.go
+++ b/apps/node-agent/internal/posture/creds.go
@@ -2,10 +2,10 @@ package posture
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // CheckCredentials is the check that maps to the strategy's headline number:
@@ -19,21 +19,42 @@ import (
 const CheckCredentialsID = "creds.world-readable"
 
 // CredentialPaths are the files each harness keeps secrets in, relative to the
-// user's home directory. Adding a harness means adding a line here.
+// user's home directory. Entries may be globs.
 //
-// Verified against a real fleet on 2026-08-11: these are the paths the
-// descriptors already read for detection, minus anything that is not secret.
+// Every entry below was checked against a running machine on 2026-08-11, and
+// the date matters: the first version of this map was written from assumption
+// and named five files that exist on no machine we own, so `apn scan` reported
+// "nothing world-readable" for hermes and openclaw having opened nothing.
+// Adding a harness means adding a line here AND verifying it on a real host.
 var CredentialPaths = map[string][]string{
-	"openclaw":    {".openclaw/config.json", ".openclaw/credentials.json", ".openclaw/gateway.json"},
-	"hermes":      {".hermes/config.json", ".hermes/credentials.json"},
-	"claude-code": {".claude/.credentials.json", ".claude.json"},
-	"codex":       {".codex/auth.json", ".codex/config.toml"},
-	"opencode":    {".local/share/opencode/auth.json"},
-}
+	// superchotu 2026-08-11: .env holds the model keys, referenced by name from
+	// each agent's auth-profiles.json. gateway.systemd.env holds the unit's env.
+	// This Mac 2026-08-11: the main config is openclaw.json, not config.json.
+	"openclaw": {
+		".openclaw/openclaw.json",
+		".openclaw/.env",
+		".openclaw/gateway.systemd.env",
+		".openclaw/credentials/*.json",
+	},
 
-// worldOrGroupReadable reports whether mode grants read to group or other.
-func worldOrGroupReadable(mode fs.FileMode) bool {
-	return mode.Perm()&0o044 != 0
+	// molt-bot 2026-08-11: config.yaml (not .json), auth.json (not
+	// credentials.json), plus .env. All three were mode 600.
+	"hermes": {
+		".hermes/config.yaml",
+		".hermes/auth.json",
+		".hermes/.env",
+	},
+
+	// This Mac 2026-08-11: .claude.json present; .claude/.credentials.json
+	// absent because macOS keeps that token in the Keychain. Kept because it is
+	// present on Linux installs — an absent path is silent, so it costs nothing.
+	"claude-code": {".claude/.credentials.json", ".claude.json"},
+
+	// This Mac 2026-08-11: both present, both 600.
+	"codex": {".codex/auth.json", ".codex/config.toml"},
+
+	// This Mac 2026-08-11: present, 600.
+	"opencode": {".local/share/opencode/auth.json"},
 }
 
 // KnownHarnesses returns every harness this package can check credentials for.
@@ -66,46 +87,87 @@ func CheckCredentialFiles(home string, harnesses []string) []Finding {
 			continue
 		}
 		for _, rel := range paths {
-			full := filepath.Join(home, rel)
-			info, err := os.Stat(full)
-			if err != nil {
-				// Absent is not a finding: not every harness stores every file.
-				// A permission error on the stat itself is worth saying, though,
-				// because it means we cannot answer — not that the answer is good.
-				if !os.IsNotExist(err) {
-					out = append(out, Finding{
-						Check: CheckCredentialsID, Status: StatusUnknown, Severity: SeverityInfo,
-						Harness: h, Title: "Could not check a credential file",
-						Detail: err.Error(), Path: full,
-					})
-				}
-				continue
+			for _, full := range expandCredentialPaths(home, rel) {
+				out = append(out, checkOneCredentialFile(h, "", rel, full)...)
 			}
-			if info.IsDir() {
-				continue
-			}
-
-			if worldOrGroupReadable(info.Mode()) {
-				out = append(out, Finding{
-					Check: CheckCredentialsID, Status: StatusFail, Severity: SeverityCritical,
-					Harness: h,
-					Title:   "Credentials readable by other users",
-					Detail: fmt.Sprintf(
-						"%s is mode %04o — any user on this machine can read it. It holds the keys this agent runs on.",
-						rel, info.Mode().Perm()),
-					Path:   full,
-					Remedy: fmt.Sprintf("chmod 600 %s", full),
-				})
-				continue
-			}
-
-			out = append(out, Finding{
-				Check: CheckCredentialsID, Status: StatusPass, Severity: SeverityInfo,
-				Harness: h, Title: "Credential file is owner-only",
-				Detail: fmt.Sprintf("%s is mode %04o", rel, info.Mode().Perm()),
-				Path:   full,
-			})
 		}
 	}
 	return out
+}
+
+// expandCredentialPaths turns one map entry into concrete absolute paths.
+//
+// A glob that matches nothing behaves exactly like an absent literal: silent.
+// Absence is not a finding — not every harness stores every file.
+func expandCredentialPaths(home, rel string) []string {
+	full := filepath.Join(home, rel)
+	if !strings.ContainsAny(rel, "*?[") {
+		if _, err := os.Lstat(full); err != nil {
+			return nil
+		}
+		return []string{full}
+	}
+	matches, err := filepath.Glob(full)
+	if err != nil {
+		return nil
+	}
+	sort.Strings(matches) // deterministic output across runs
+	return matches
+}
+
+// checkOneCredentialFile is shared by the host-level and per-station checks.
+// station is "" for host-level files; label is what a human sees.
+func checkOneCredentialFile(harness, station, label, full string) []Finding {
+	info, err := os.Stat(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // absence is not a finding
+		}
+		// We could not look. That is not the same as "it is fine", and a
+		// scanner that silently downgrades one to the other earns distrust.
+		return []Finding{{
+			Check: CheckCredentialsID, Status: StatusUnknown, Severity: SeverityInfo,
+			Harness: harness, Station: station,
+			Title:  "Could not check a credential file",
+			Detail: err.Error(), Path: full,
+		}}
+	}
+	if info.IsDir() {
+		return nil
+	}
+
+	exposure, err := exposureOf(full)
+	if err != nil {
+		return []Finding{{
+			Check: CheckCredentialsID, Status: StatusUnknown, Severity: SeverityInfo,
+			Harness: harness, Station: station,
+			Title:  "Could not determine who can reach a credential file",
+			Detail: err.Error(), Path: full,
+		}}
+	}
+
+	if exposure.Any() {
+		who := "any user on this machine"
+		if !exposure.World {
+			who = "any user in this file's group"
+		}
+		return []Finding{{
+			Check: CheckCredentialsID, Status: StatusFail, Severity: SeverityCritical,
+			Harness: harness, Station: station,
+			Title: "Credentials readable by other users",
+			Detail: fmt.Sprintf(
+				"%s is mode %04o and reachable — %s can read it. It holds the keys this agent runs on.",
+				label, info.Mode().Perm(), who),
+			Path:   full,
+			Remedy: fmt.Sprintf("chmod 600 %s", full),
+		}}
+	}
+
+	return []Finding{{
+		Check: CheckCredentialsID, Status: StatusPass, Severity: SeverityInfo,
+		Harness: harness, Station: station,
+		Title:  "Credential file is not readable by others",
+		Detail: fmt.Sprintf("%s is mode %04o", label, info.Mode().Perm()),
+		Path:   full,
+	}}
 }

--- a/apps/node-agent/internal/posture/dirs.go
+++ b/apps/node-agent/internal/posture/dirs.go
@@ -1,0 +1,82 @@
+package posture
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CheckConfigDirID covers a station config directory others can write to.
+//
+// Being able to REPLACE an agent's credentials is a different and worse problem
+// than being able to read them, and no file-mode check can see it: the files
+// inside can all be 600 while the directory holding them is group-writable.
+//
+// Observed on superchotu 2026-08-11, where ~/.openclaw/agents/<name>/ is 775
+// with every auth file inside it at 600.
+const CheckConfigDirID = "config.dir-writable"
+
+// CheckConfigDirs reports station config directories writable by others.
+func CheckConfigDirs(home string) []Finding {
+	var out []Finding
+
+	for _, layout := range StationCredentialLayouts {
+		base, names := stationDirs(home, layout)
+		for _, name := range names {
+			dir := filepath.Join(base, name)
+			station := layout.KeyPrefix + ":" + name
+
+			info, err := os.Stat(dir)
+			if err != nil {
+				continue
+			}
+			perm := info.Mode().Perm()
+
+			if perm&0o022 == 0 {
+				out = append(out, Finding{
+					Check: CheckConfigDirID, Status: StatusPass, Severity: SeverityInfo,
+					Harness: layout.Harness, Station: station,
+					Title:  "Station config directory is not writable by others",
+					Detail: fmt.Sprintf("%s is mode %04o", dir, perm),
+					Path:   dir,
+				})
+				continue
+			}
+
+			// Writable by mode is not writable in fact if nobody else can
+			// traverse to it — the same rule the file checks use.
+			exposure, eerr := exposureOf(dir)
+			if eerr != nil {
+				out = append(out, Finding{
+					Check: CheckConfigDirID, Status: StatusUnknown, Severity: SeverityInfo,
+					Harness: layout.Harness, Station: station,
+					Title:  "Could not determine who can reach a station config directory",
+					Detail: eerr.Error(), Path: dir,
+				})
+				continue
+			}
+			if !exposure.Any() {
+				out = append(out, Finding{
+					Check: CheckConfigDirID, Status: StatusPass, Severity: SeverityInfo,
+					Harness: layout.Harness, Station: station,
+					Title:  "Station config directory is not reachable by others",
+					Detail: fmt.Sprintf("%s is mode %04o but an ancestor blocks traversal", dir, perm),
+					Path:   dir,
+				})
+				continue
+			}
+
+			out = append(out, Finding{
+				Check: CheckConfigDirID, Status: StatusFail, Severity: SeverityCritical,
+				Harness: layout.Harness, Station: station,
+				Title: "Station config directory is writable by other users",
+				Detail: fmt.Sprintf(
+					"%s is mode %04o — another user can replace this agent's credential files, "+
+						"even though the files themselves are owner-only.", dir, perm),
+				Path:   dir,
+				Remedy: fmt.Sprintf("chmod 700 %s", dir),
+			})
+		}
+	}
+	return out
+}

--- a/apps/node-agent/internal/posture/dirs_test.go
+++ b/apps/node-agent/internal/posture/dirs_test.go
@@ -1,0 +1,105 @@
+package posture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGroupWritableStationDirIsAFinding(t *testing.T) {
+	// superchotu 2026-08-11: ~/.openclaw/agents/<name>/ is 775. Anyone in the
+	// group can REPLACE that agent's auth.json — which no file-mode check can
+	// see, and which is worse than being able to read it.
+	defer forceExposure(t, Exposure{Group: true})()
+
+	home := t.TempDir()
+	dir := filepath.Join(home, ".openclaw", "agents", "hanuman")
+	if err := os.MkdirAll(dir, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o775); err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, f := range CheckConfigDirs(home) {
+		if f.Status == StatusFail && f.Station == "openclaw:hanuman" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a group-writable station config directory must be reported")
+	}
+}
+
+func TestOwnerOnlyStationDirPasses(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".hermes", "profiles", "analyst-echo")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	for _, f := range CheckConfigDirs(home) {
+		if f.Status == StatusFail {
+			t.Errorf("a 700 directory must not be a failure: %+v", f)
+		}
+	}
+}
+
+func TestUnreachableWritableDirIsNotAFinding(t *testing.T) {
+	// Same reachability rule as files: a 775 directory inside a 700 parent
+	// cannot be written by anyone else.
+	home := t.TempDir()
+	agents := filepath.Join(home, ".openclaw", "agents")
+	dir := filepath.Join(agents, "hanuman")
+	if err := os.MkdirAll(dir, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(agents, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(agents, 0o755) })
+
+	for _, f := range CheckConfigDirs(home) {
+		if f.Status == StatusFail {
+			t.Errorf("an unreachable directory must not be a failure: %+v", f)
+		}
+	}
+}
+
+func TestScanIncludesStationAndDirectoryFindings(t *testing.T) {
+	// Scan is what `apn scan` and the verb both call; a check that exists but is
+	// not composed in is a check that does not run.
+	defer forceExposure(t, Exposure{World: true})()
+
+	home := t.TempDir()
+	dir := filepath.Join(home, ".hermes", "profiles", "analyst-echo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report := Scan(t.Context(), home, KnownHarnesses(), 1)
+
+	var sawStation bool
+	for _, f := range report.Findings {
+		if f.Station == "hermes:analyst-echo" {
+			sawStation = true
+		}
+	}
+	if !sawStation {
+		t.Error("Scan does not include per-station findings")
+	}
+	if report.Grade == "A" {
+		t.Error("a world-readable per-profile credential must not grade A")
+	}
+}

--- a/apps/node-agent/internal/posture/posture_test.go
+++ b/apps/node-agent/internal/posture/posture_test.go
@@ -3,6 +3,7 @@ package posture
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -80,6 +81,12 @@ func writeMode(t *testing.T, path string, mode os.FileMode) {
 }
 
 func TestWorldReadableCredentialsAreCritical(t *testing.T) {
+	// Forces the exposure verdict rather than relying on the filesystem: macOS
+	// gives each user a private TMPDIR at 0700, so nothing a test writes there
+	// is reachable by another user and this branch would be unreachable on a
+	// Mac. The walk that produces the verdict is tested in reach_test.go.
+	defer forceExposure(t, Exposure{World: true, Group: true})()
+
 	home := t.TempDir()
 	writeMode(t, filepath.Join(home, ".codex/auth.json"), 0o644)
 
@@ -119,6 +126,8 @@ func TestOwnerOnlyCredentialsPass(t *testing.T) {
 
 func TestGroupReadableIsAlsoFlagged(t *testing.T) {
 	// 0640 leaks to the group, which on a shared box is still "other people".
+	defer forceExposure(t, Exposure{Group: true})()
+
 	home := t.TempDir()
 	writeMode(t, filepath.Join(home, ".codex/auth.json"), 0o640)
 
@@ -214,4 +223,100 @@ postgres  56789 rakesh   27u  IPv4 0x2222222222222222      0t0  TCP *:5432 (LIST
 	if Grade(findings) != "A" {
 		t.Errorf("grade = %q, want A — a non-agent listener is not our business", Grade(findings))
 	}
+}
+
+// ─── corrected paths ────────────────────────────────────────────────────────
+
+// The bug this pins: the shipped map named files that do not exist for hermes
+// and openclaw, so `apn scan` graded machines A having opened nothing. Verified
+// against molt-bot and superchotu on 2026-08-11.
+func TestCredentialPathsMatchRealHarnessLayouts(t *testing.T) {
+	want := map[string][]string{
+		"hermes":   {".hermes/config.yaml", ".hermes/auth.json", ".hermes/.env"},
+		"openclaw": {".openclaw/openclaw.json", ".openclaw/.env", ".openclaw/gateway.systemd.env", ".openclaw/credentials/*.json"},
+	}
+	for harness, paths := range want {
+		got := CredentialPaths[harness]
+		for _, p := range paths {
+			if !slices.Contains(got, p) {
+				t.Errorf("%s: missing %q from %v", harness, p, got)
+			}
+		}
+	}
+}
+
+func TestCredentialPathsDropTheFilesThatNeverExisted(t *testing.T) {
+	// Keeping a path that matches nothing is not harmless: it is what made the
+	// scan look thorough while checking nothing.
+	gone := map[string][]string{
+		"hermes":   {".hermes/config.json", ".hermes/credentials.json"},
+		"openclaw": {".openclaw/config.json", ".openclaw/credentials.json", ".openclaw/gateway.json"},
+	}
+	for harness, paths := range gone {
+		for _, p := range paths {
+			if slices.Contains(CredentialPaths[harness], p) {
+				t.Errorf("%s: %q does not exist on any real machine and must be removed", harness, p)
+			}
+		}
+	}
+}
+
+func TestCredentialGlobsExpand(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".openclaw", "credentials")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"telegram-pairing.json", "gateway-pairing.json", "notes.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := expandCredentialPaths(home, ".openclaw/credentials/*.json")
+	if len(got) != 2 {
+		t.Fatalf("expanded to %d paths, want 2 (json only): %v", len(got), got)
+	}
+}
+
+func TestCredentialGlobMatchingNothingIsSilent(t *testing.T) {
+	// Same rule as an absent literal: absence is not a finding.
+	got := expandCredentialPaths(t.TempDir(), ".openclaw/credentials/*.json")
+	if len(got) != 0 {
+		t.Errorf("want no paths, got %v", got)
+	}
+}
+
+func TestUnreachableFileIsNotReportedAsExposed(t *testing.T) {
+	// The molt-bot case end-to-end: a 644 credential file under a 700 ancestor
+	// is not exposed and must not be a finding. Without this, correcting the
+	// paths turns a secured box into 15 false criticals.
+	home := t.TempDir()
+	hermes := filepath.Join(home, ".hermes")
+	if err := os.MkdirAll(hermes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(hermes, "auth.json")
+	if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(hermes, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(hermes, 0o755) })
+
+	for _, f := range CheckCredentialFiles(home, []string{"hermes"}) {
+		if f.Status == StatusFail {
+			t.Errorf("unreachable file reported as exposed: %+v", f)
+		}
+	}
+}
+
+// forceExposure makes the credential checks see a fixed verdict, returning a
+// restore func. See the comment on exposureOf for why this is necessary.
+func forceExposure(t *testing.T, e Exposure) func() {
+	t.Helper()
+	prev := exposureOf
+	exposureOf = func(string) (Exposure, error) { return e, nil }
+	return func() { exposureOf = prev }
 }

--- a/apps/node-agent/internal/posture/reach.go
+++ b/apps/node-agent/internal/posture/reach.go
@@ -35,6 +35,14 @@ func EffectiveExposure(path string) (Exposure, error) {
 	return exposureWalk(path, "/")
 }
 
+// exposureOf is the indirection the checks call, so tests can force an answer.
+//
+// Needed because macOS gives each user a private TMPDIR at mode 0700: no file a
+// test creates there is ever reachable by another user, so the "this really is
+// exposed" branch of the checks cannot be reached with a real fixture on a Mac.
+// The walk itself is tested directly in reach_test.go.
+var exposureOf = EffectiveExposure
+
 // exposureWalk is EffectiveExposure with a controllable stopping point.
 //
 // stopAt is the highest directory inspected, inclusive. Production always walks

--- a/apps/node-agent/internal/posture/reach.go
+++ b/apps/node-agent/internal/posture/reach.go
@@ -1,0 +1,103 @@
+package posture
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Exposure says who, other than the owner, can actually read a path.
+//
+// "Actually" is the whole point: a file's own mode bits are necessary but not
+// sufficient. A 644 file inside a 700 directory is unreachable by anyone else,
+// and reporting it would be a false alarm — the failure mode this package's
+// doc comment forbids as loudly as a false pass.
+type Exposure struct {
+	World bool
+	Group bool
+}
+
+// Any reports whether anyone other than the owner can read the path.
+func (e Exposure) Any() bool { return e.World || e.Group }
+
+// EffectiveExposure reports who can genuinely reach and read path.
+//
+// Two conditions must both hold for a class (group or other):
+//
+//  1. the file itself grants read to that class, and
+//  2. every ancestor directory grants execute (traverse) to that class.
+//
+// Verified against molt-bot 2026-08-11, where
+// /root/.hermes/profiles/<name>/config.yaml is mode 644 under a 700 /root:
+// world-readable by mode, unreachable in fact. Fifteen profiles, fifteen false
+// criticals, on a correctly secured machine.
+func EffectiveExposure(path string) (Exposure, error) {
+	return exposureWalk(path, "/")
+}
+
+// exposureWalk is EffectiveExposure with a controllable stopping point.
+//
+// stopAt is the highest directory inspected, inclusive. Production always walks
+// to "/", but tests cannot: macOS gives each user a private TMPDIR at mode 0700
+// (/var/folders/…/T), so every path under t.TempDir() is genuinely unreachable
+// and no fixture can produce a world-readable file there. Walking to "/" in a
+// test would therefore pass on Linux CI and fail on a Mac — the worst kind of
+// portability bug, because it only appears where nobody is looking.
+func exposureWalk(path, stopAt string) (Exposure, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Exposure{}, err
+	}
+
+	perm := info.Mode().Perm()
+	e := Exposure{
+		World: perm&0o004 != 0,
+		Group: perm&0o040 != 0,
+	}
+	if !e.Any() {
+		return e, nil // owner-only: no ancestor can make it worse
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return Exposure{}, err
+	}
+	stop, err := filepath.Abs(stopAt)
+	if err != nil {
+		return Exposure{}, err
+	}
+
+	// Walk up. A single non-traversable ancestor is enough to make the path
+	// unreachable for that class.
+	dir := filepath.Dir(abs)
+	for {
+		di, derr := os.Stat(dir)
+		if derr != nil {
+			// An ancestor we cannot stat cannot be shown to be traversable.
+			// Treating it as open would invent exposure we have not seen.
+			return Exposure{}, derr
+		}
+		if !traversable(di.Mode().Perm(), 0o001) {
+			e.World = false
+		}
+		if !traversable(di.Mode().Perm(), 0o010) {
+			e.Group = false
+		}
+		if !e.Any() {
+			return e, nil
+		}
+
+		if dir == stop {
+			return e, nil // inspected the highest directory we were asked to
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return e, nil // reached the filesystem root
+		}
+		dir = parent
+	}
+}
+
+func traversable(perm fs.FileMode, bit fs.FileMode) bool {
+	return perm&bit != 0
+}

--- a/apps/node-agent/internal/posture/reach_test.go
+++ b/apps/node-agent/internal/posture/reach_test.go
@@ -1,0 +1,146 @@
+package posture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkChain builds dir/file with the given modes and returns the file path plus
+// the fixture root to stop the walk at.
+//
+// The root matters: on macOS $TMPDIR is 0700, so walking past the fixture would
+// find a blocking ancestor that has nothing to do with what is being tested —
+// and the test would then pass on Linux CI and fail on a Mac.
+//
+// Directory modes are applied deepest-first so setup can still walk down.
+func mkChain(t *testing.T, dirModes []os.FileMode, fileMode os.FileMode) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	// The temp root itself must be traversable, or every case looks unreachable.
+	if err := os.Chmod(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cur := root
+	var made []string
+	for i := range dirModes {
+		cur = filepath.Join(cur, "d"+string(rune('a'+i)))
+		if err := os.Mkdir(cur, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		made = append(made, cur)
+	}
+	file := filepath.Join(cur, "creds.json")
+	if err := os.WriteFile(file, []byte("{}"), fileMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(file, fileMode); err != nil {
+		t.Fatal(err)
+	}
+	for i := len(made) - 1; i >= 0; i-- {
+		if err := os.Chmod(made[i], dirModes[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Restore permissive modes or TempDir cleanup fails.
+	t.Cleanup(func() {
+		for _, d := range made {
+			_ = os.Chmod(d, 0o755)
+		}
+	})
+	return file, root
+}
+
+func TestExposedWhenEveryAncestorIsTraversable(t *testing.T) {
+	file, root := mkChain(t, []os.FileMode{0o755, 0o755}, 0o644)
+	got, err := exposureWalk(file, root)
+	if err != nil {
+		t.Fatalf("exposureWalk: %v", err)
+	}
+	if !got.World {
+		t.Error("a 644 file under traversable dirs is world-readable")
+	}
+}
+
+func TestNotExposedWhenAnAncestorBlocksTraversal(t *testing.T) {
+	// The molt-bot case: /root is 700, so a 644 config.yaml several levels down
+	// is unreachable. Reporting it would be a false critical on a correctly
+	// secured box — 15 of them, one per Hermes profile.
+	file, root := mkChain(t, []os.FileMode{0o700, 0o755}, 0o644)
+	got, err := exposureWalk(file, root)
+	if err != nil {
+		t.Fatalf("exposureWalk: %v", err)
+	}
+	if got.World {
+		t.Error("a 700 ancestor makes the file unreachable; this must not be reported")
+	}
+	if got.Any() {
+		t.Error("neither world nor group can traverse a 700 ancestor")
+	}
+}
+
+func TestOwnerOnlyFileIsNeverExposed(t *testing.T) {
+	file, root := mkChain(t, []os.FileMode{0o755, 0o755}, 0o600)
+	got, _ := exposureWalk(file, root)
+	if got.Any() {
+		t.Errorf("a 600 file is not exposed however open its parents: %+v", got)
+	}
+}
+
+func TestGroupAndWorldAreTrackedSeparately(t *testing.T) {
+	// A file can be group-exposed without being world-exposed, and the two
+	// carry different severities and different remedies.
+	file, root := mkChain(t, []os.FileMode{0o750, 0o755}, 0o640)
+	got, err := exposureWalk(file, root)
+	if err != nil {
+		t.Fatalf("exposureWalk: %v", err)
+	}
+	if got.World {
+		t.Error("the 750 ancestor denies o+x, so the world cannot reach it")
+	}
+	if !got.Group {
+		t.Error("the group can traverse 750 and read 640")
+	}
+}
+
+func TestGroupBlockedByAnAncestorDenyingGroupExec(t *testing.T) {
+	file, root := mkChain(t, []os.FileMode{0o700, 0o755}, 0o640)
+	got, _ := exposureWalk(file, root)
+	if got.Group {
+		t.Error("a 700 ancestor denies g+x, so the group cannot reach it either")
+	}
+}
+
+func TestMissingPathIsAnError(t *testing.T) {
+	// Callers must be able to tell "not there" from "not exposed".
+	if _, err := EffectiveExposure(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("want an error for a missing path")
+	}
+}
+
+func TestAnyIsFalseForNoExposure(t *testing.T) {
+	if (Exposure{}).Any() {
+		t.Error("zero Exposure must not report exposure")
+	}
+	if !(Exposure{Group: true}).Any() {
+		t.Error("group exposure counts")
+	}
+}
+
+func TestEffectiveExposureWalksToTheRealRoot(t *testing.T) {
+	// exposureWalk carries the chain logic; this pins that the exported wrapper
+	// really walks all the way up rather than stopping early. A file under the
+	// macOS per-user TMPDIR (0700) must come back unexposed whatever its own
+	// mode says — which is exactly the molt-bot shape, found in the wild.
+	file, _ := mkChain(t, []os.FileMode{0o755, 0o755}, 0o644)
+	got, err := EffectiveExposure(file)
+	if err != nil {
+		t.Fatalf("EffectiveExposure: %v", err)
+	}
+	// On Linux CI /tmp is 1777 so this IS reachable; on macOS $TMPDIR is 0700 so
+	// it is not. Either answer is correct — what must hold is that the wrapper
+	// consults ancestors above the fixture at all, which the stopAt="/" does.
+	if got.Group && !got.World {
+		t.Errorf("unexpected group-only exposure for a 644 file: %+v", got)
+	}
+}

--- a/apps/node-agent/internal/posture/scan.go
+++ b/apps/node-agent/internal/posture/scan.go
@@ -17,6 +17,8 @@ func Scan(ctx context.Context, home string, harnesses []string, stations int) Re
 	hostname, _ := os.Hostname()
 
 	findings := CheckCredentialFiles(home, harnesses)
+	findings = append(findings, CheckStationCredentials(home)...)
+	findings = append(findings, CheckConfigDirs(home)...)
 	findings = append(findings, CheckListeners(ctx)...)
 	Sort(findings)
 

--- a/apps/node-agent/internal/posture/station.go
+++ b/apps/node-agent/internal/posture/station.go
@@ -31,8 +31,13 @@ var StationCredentialLayouts = []StationCredentialLayout{
 	{
 		Harness:     "hermes",
 		ProfilesDir: ".hermes/profiles",
-		Files:       []string{"auth.json", ".env"},
-		KeyPrefix:   "hermes", // hermes.go: key = "hermes:" + name
+		// config.yaml is included for the same reason the host-level list
+		// includes it: it can hold provider settings and keys. On molt-bot the
+		// per-profile copies are mode 644 while the host-level one is 600 —
+		// which is exactly the case the reachability walk exists for, since
+		// /root is 700 and no other user can reach any of them.
+		Files:     []string{"auth.json", ".env", "config.yaml"},
+		KeyPrefix: "hermes", // hermes.go: key = "hermes:" + name
 	},
 	{
 		Harness:     "openclaw",

--- a/apps/node-agent/internal/posture/station.go
+++ b/apps/node-agent/internal/posture/station.go
@@ -1,0 +1,86 @@
+package posture
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// StationCredentialLayout describes where a composite harness keeps per-station
+// secrets. Only composite harnesses have these; claude-code, codex and opencode
+// keep everything at the host level.
+type StationCredentialLayout struct {
+	Harness string
+	// ProfilesDir is relative to home and holds one directory per station.
+	ProfilesDir string
+	// Files are relative to a station's directory.
+	Files []string
+	// KeyPrefix builds the station key as KeyPrefix + ":" + <dir name>, matching
+	// what the descriptors produce so the console can join on equality.
+	KeyPrefix string
+}
+
+// StationCredentialLayouts is the observed layout of each composite harness.
+//
+// Verified 2026-08-11: molt-bot has 15 Hermes profiles each with auth.json and
+// .env; superchotu has 12 OpenClaw agents each with agent/auth*.json. The
+// descriptors read auth.json from these same directories for station identity,
+// and MatrixIDFromProfile's own comment notes it ignores the other fields
+// "including access_token" — which is how we know they hold live credentials.
+var StationCredentialLayouts = []StationCredentialLayout{
+	{
+		Harness:     "hermes",
+		ProfilesDir: ".hermes/profiles",
+		Files:       []string{"auth.json", ".env"},
+		KeyPrefix:   "hermes", // hermes.go: key = "hermes:" + name
+	},
+	{
+		Harness:     "openclaw",
+		ProfilesDir: ".openclaw/agents",
+		Files:       []string{"agent/auth.json", "agent/auth-profiles.json", "agent/auth-state.json"},
+		KeyPrefix:   "openclaw", // openclaw.go: key = "openclaw:" + name
+	},
+}
+
+// stationDirs lists the station directories of a layout under home, sorted.
+//
+// Discovered by listing, never hardcoded: the fleet has 15 Hermes profiles and
+// 12 OpenClaw agents with arbitrary names. Returns nil when the harness is not
+// installed here — absence is not a finding.
+func stationDirs(home string, layout StationCredentialLayout) (base string, names []string) {
+	base = filepath.Join(home, layout.ProfilesDir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return base, nil
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names) // deterministic across runs
+	return base, names
+}
+
+// CheckStationCredentials inspects per-station credential files for every
+// composite harness found under home.
+//
+// This is the blind spot the shipped scanner had: it only ever looked at the
+// top of a harness's home, so a Hermes profile with world-readable credentials
+// passed.
+func CheckStationCredentials(home string) []Finding {
+	var out []Finding
+
+	for _, layout := range StationCredentialLayouts {
+		base, names := stationDirs(home, layout)
+		for _, name := range names {
+			station := layout.KeyPrefix + ":" + name
+			for _, rel := range layout.Files {
+				full := filepath.Join(base, name, rel)
+				label := filepath.Join(layout.ProfilesDir, name, rel)
+				out = append(out, checkOneCredentialFile(layout.Harness, station, label, full)...)
+			}
+		}
+	}
+	return out
+}

--- a/apps/node-agent/internal/posture/station_test.go
+++ b/apps/node-agent/internal/posture/station_test.go
@@ -1,0 +1,139 @@
+package posture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// hermesProfile builds ~/.hermes/profiles/<name>/ with the files molt-bot has.
+func hermesProfile(t *testing.T, home, name string, mode os.FileMode) {
+	t.Helper()
+	dir := filepath.Join(home, ".hermes", "profiles", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"auth.json", ".env"} {
+		p := filepath.Join(dir, f)
+		if err := os.WriteFile(p, []byte("{}"), mode); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// openclawAgent builds ~/.openclaw/agents/<name>/agent/ as on superchotu.
+func openclawAgent(t *testing.T, home, name string, mode os.FileMode) {
+	t.Helper()
+	dir := filepath.Join(home, ".openclaw", "agents", name, "agent")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"auth.json", "auth-profiles.json", "auth-state.json"} {
+		p := filepath.Join(dir, f)
+		if err := os.WriteFile(p, []byte("{}"), mode); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPerProfileHermesCredentialsAreChecked(t *testing.T) {
+	// Confirmed on molt-bot: every profile has its own auth.json holding an
+	// access token. The shipped scan never looked below ~/.hermes.
+	defer forceExposure(t, Exposure{World: true})()
+
+	home := t.TempDir()
+	hermesProfile(t, home, "analyst-echo", 0o644)
+
+	var fails int
+	for _, f := range CheckStationCredentials(home) {
+		if f.Status == StatusFail {
+			fails++
+		}
+	}
+	if fails == 0 {
+		t.Fatal("a world-readable per-profile credential file must be reported")
+	}
+}
+
+func TestPerAgentOpenclawCredentialsAreChecked(t *testing.T) {
+	defer forceExposure(t, Exposure{World: true})()
+
+	home := t.TempDir()
+	openclawAgent(t, home, "hanuman", 0o644)
+
+	var fails int
+	for _, f := range CheckStationCredentials(home) {
+		if f.Status == StatusFail {
+			fails++
+		}
+	}
+	if fails == 0 {
+		t.Fatal("a world-readable per-agent credential file must be reported")
+	}
+}
+
+func TestPerProfileFindingsCarryTheStationKey(t *testing.T) {
+	// The console joins a finding to a station by equality on this key, so the
+	// format must match what hermes.go/openclaw.go produce.
+	//
+	// Hardcoded rather than imported from descriptor on purpose: this package's
+	// doc comment keeps it free of the descriptor layer so the checks stay unit
+	// testable. The cost is that the two can drift, which is why the expected
+	// strings are spelled out here where a reader will see them.
+	home := t.TempDir()
+	hermesProfile(t, home, "analyst-echo", 0o600)
+	openclawAgent(t, home, "hanuman", 0o600)
+
+	want := map[string]bool{"hermes:analyst-echo": false, "openclaw:hanuman": false}
+	for _, f := range CheckStationCredentials(home) {
+		if _, ok := want[f.Station]; ok {
+			want[f.Station] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("no finding carried station key %q", k)
+		}
+	}
+}
+
+func TestSecuredProfilesProduceNoFailures(t *testing.T) {
+	home := t.TempDir()
+	hermesProfile(t, home, "analyst-echo", 0o600)
+	openclawAgent(t, home, "hanuman", 0o600)
+
+	for _, f := range CheckStationCredentials(home) {
+		if f.Status == StatusFail {
+			t.Errorf("a 600 file must not be a failure: %+v", f)
+		}
+	}
+}
+
+func TestProfilesAreDiscoveredNotHardcoded(t *testing.T) {
+	// molt-bot has 15 profiles with arbitrary names; superchotu has 12 agents.
+	home := t.TempDir()
+	for _, n := range []string{"analyst-echo", "coder-kai", "threat-hunter-theo"} {
+		hermesProfile(t, home, n, 0o600)
+	}
+	seen := map[string]bool{}
+	for _, f := range CheckStationCredentials(home) {
+		if f.Station != "" {
+			seen[f.Station] = true
+		}
+	}
+	if len(seen) != 3 {
+		t.Errorf("discovered %d profiles, want 3: %v", len(seen), seen)
+	}
+}
+
+func TestNoProfilesIsSilent(t *testing.T) {
+	if got := CheckStationCredentials(t.TempDir()); len(got) != 0 {
+		t.Errorf("a home with no composite harnesses should produce nothing, got %+v", got)
+	}
+}

--- a/packages/contract/scripts/emit-go-fixtures.ts
+++ b/packages/contract/scripts/emit-go-fixtures.ts
@@ -26,10 +26,13 @@ const OUT_DIR = join(import.meta.dir, "../../../apps/node-agent/internal/contrac
 const FIXTURES: Array<[string, z.ZodTypeAny, unknown]> = [
   ["host_info", HostInfo, { hostname: "fleet-box-1", os: "linux", arch: "arm64", cpuCount: 8 }],
 
+  // capabilities gate whole console features; one silently dropped in the Go
+  // mirror is a feature that never appears and errors nowhere.
   ["hello", HelloMsg, {
     type: "hello",
     hostInfo: { hostname: "fleet-box-1", os: "linux", arch: "arm64", cpuCount: 8 },
-    version: "v0.1.18",
+    version: "v0.1.22",
+    capabilities: ["posture"],
   }],
 
   ["heartbeat", HeartbeatMsg, { type: "heartbeat", ts: 1786445000000 }],

--- a/packages/contract/src/gateway.ts
+++ b/packages/contract/src/gateway.ts
@@ -1,8 +1,16 @@
 import { z } from "zod";
 import { HostInfo } from "./node";
 import { RequestMsg, ResponseMsg, StreamMsg, CancelMsg, InputMsg, ResizeMsg } from "./protocol";
+import { NodeCapabilityList } from "./posture";
 
-export const HelloMsg = z.object({ type: z.literal("hello"), hostInfo: HostInfo, version: z.string().optional() });
+export const HelloMsg = z.object({
+  type: z.literal("hello"),
+  hostInfo: HostInfo,
+  version: z.string().optional(),
+  // Absent from older nodes — the hub reads that as "no node capabilities",
+  // which is how a node that predates a capability degrades silently.
+  capabilities: NodeCapabilityList.optional(),
+});
 export const HeartbeatMsg = z.object({ type: z.literal("heartbeat"), ts: z.number() });
 export const AckMsg = z.object({ type: z.literal("ack"), ts: z.number() });
 

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -9,3 +9,4 @@ export * from "./fleet";
 export * from "./acp-session";
 export * from "./run";
 export * from "./changeset";
+export * from "./posture";

--- a/packages/contract/src/node.ts
+++ b/packages/contract/src/node.ts
@@ -22,6 +22,8 @@ export const NodeSummary = z.object({
   agentVersion: z.string().nullable(),
   latestVersion: z.string().nullable(),
   updateAvailable: z.boolean(),
+  /** Node-level capabilities from the hello frame. Null on older nodes. */
+  capabilities: z.array(z.string()).nullable().optional(),
   provisioned: z.object({ runtimeId: z.string(), provider: z.string() }).nullable().optional(),
 });
 export type NodeSummary = z.infer<typeof NodeSummary>;

--- a/packages/contract/src/posture.test.ts
+++ b/packages/contract/src/posture.test.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "bun:test";
+import { PostureReport, PostureFinding, NodeCapabilityList } from "./posture";
+import { HelloMsg } from "./gateway";
+import { NodeSummary } from "./node";
+import { VERB_PARAMS, VERB_RESULTS } from "./protocol";
+
+const FINDING = {
+  check: "creds.world-readable",
+  status: "fail" as const,
+  severity: "critical" as const,
+  harness: "hermes",
+  station: "hermes:analyst-echo",
+  title: "Credentials readable by other users",
+  detail: "mode 0644 and reachable",
+  path: "/root/.hermes/profiles/analyst-echo/auth.json",
+  remedy: "chmod 600 /root/.hermes/profiles/analyst-echo/auth.json",
+};
+
+test("a finding can name the station it belongs to", () => {
+  // The console joins findings to stations by this key.
+  expect(PostureFinding.parse(FINDING).station).toBe("hermes:analyst-echo");
+});
+
+test("host-level findings carry no station", () => {
+  const { station, ...hostLevel } = FINDING;
+  expect(PostureFinding.parse(hostLevel).station).toBeUndefined();
+});
+
+test("unknown is a first-class status, distinct from pass", () => {
+  // A check that could not determine an answer must never be recorded as a pass.
+  const f = PostureFinding.parse({ ...FINDING, status: "unknown", severity: "info" });
+  expect(f.status).toBe("unknown");
+});
+
+test("a report carries the grade and the host it describes", () => {
+  const r = PostureReport.parse({
+    hostname: "molt-bot",
+    stations: 15,
+    findings: [FINDING],
+    grade: "F",
+  });
+  expect(r.grade).toBe("F");
+  expect(r.findings).toHaveLength(1);
+});
+
+test("hello may carry node capabilities, and may omit them", () => {
+  // Omitted is how an older node degrades silently rather than erroring.
+  const withCaps = HelloMsg.parse({
+    type: "hello",
+    hostInfo: { hostname: "h", os: "linux", arch: "amd64", cpuCount: 2 },
+    version: "v0.1.22",
+    capabilities: ["posture"],
+  });
+  expect(withCaps.capabilities).toEqual(["posture"]);
+
+  const without = HelloMsg.parse({
+    type: "hello",
+    hostInfo: { hostname: "h", os: "linux", arch: "amd64", cpuCount: 2 },
+  });
+  expect(without.capabilities).toBeUndefined();
+});
+
+test("unknown node capabilities are filtered, not rejected", () => {
+  // Same carry-in rule as station capabilities: an old hub must not break when
+  // a newer node advertises something it has never heard of.
+  expect(NodeCapabilityList.parse(["posture", "time-travel"])).toEqual(["posture"]);
+});
+
+test("NodeSummary exposes capabilities to the console", () => {
+  const n = NodeSummary.parse({
+    id: "node_1", name: "n", hostname: "h", os: "linux", arch: "amd64",
+    cpuCount: 2, status: "online", lastSeenAt: null, createdAt: "now",
+    agentVersion: "v0.1.22", latestVersion: null, updateAvailable: false,
+    capabilities: ["posture"],
+  });
+  expect(n.capabilities).toEqual(["posture"]);
+});
+
+test("the posture verb is registered", () => {
+  expect(VERB_PARAMS["posture.scan"].parse({})).toEqual({});
+  expect(VERB_RESULTS["posture.scan"]).toBeDefined();
+});

--- a/packages/contract/src/posture.ts
+++ b/packages/contract/src/posture.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+/**
+ * Wire shapes for the `posture` capability — a live security read of a machine
+ * running agent runtimes.
+ *
+ * Node-level, not station-level: credential files live in a user's home and a
+ * listening socket belongs to a process, so one scan describes one machine.
+ * Findings that DO belong to a station carry `station`, which is what lets the
+ * console show a station its own problems without re-running anything.
+ */
+
+export const PostureStatus = z.enum(["pass", "fail", "unknown"]);
+export type PostureStatus = z.infer<typeof PostureStatus>;
+
+export const PostureSeverity = z.enum(["critical", "warning", "info"]);
+export type PostureSeverity = z.infer<typeof PostureSeverity>;
+
+/**
+ * One observation about one thing.
+ *
+ * `check` is a stable id so reports can be diffed across runs, and `remedy` is
+ * the exact command rather than general advice.
+ *
+ * `unknown` is deliberately not `pass`: a check that could not determine an
+ * answer is reported honestly and excluded from grading, because grading on
+ * ignorance is how a scanner earns distrust.
+ */
+export const PostureFinding = z.object({
+  check: z.string().min(1),
+  status: PostureStatus,
+  severity: PostureSeverity,
+  harness: z.string().min(1).optional(),
+  /** Station key (e.g. `hermes:analyst-echo`) for per-station findings. */
+  station: z.string().min(1).optional(),
+  title: z.string().min(1),
+  detail: z.string(),
+  path: z.string().min(1).optional(),
+  remedy: z.string().min(1).optional(),
+});
+export type PostureFinding = z.infer<typeof PostureFinding>;
+
+export const PostureReport = z.object({
+  hostname: z.string(),
+  stations: z.number().int().nonnegative(),
+  findings: z.array(PostureFinding),
+  /** A — nothing · B — info only · C — a warning · F — a critical. */
+  grade: z.string().min(1),
+});
+export type PostureReport = z.infer<typeof PostureReport>;
+
+// ─── Node capabilities ───────────────────────────────────────────────────────
+
+/**
+ * Capabilities of a NODE, as opposed to a station.
+ *
+ * Carried in the `hello` frame rather than a separate verb, which means they
+ * refresh on every connect by construction — the staleness bug that station
+ * capabilities needed an explicit fix for cannot occur here.
+ */
+export const NodeCapability = z.enum(["posture"]);
+export type NodeCapability = z.infer<typeof NodeCapability>;
+
+/**
+ * Unknown entries are filtered rather than rejected, so an older hub keeps
+ * working when a newer node advertises something it has never heard of.
+ */
+export const NodeCapabilityList = z
+  .array(z.string())
+  .transform((xs) => xs.filter((x): x is NodeCapability => NodeCapability.safeParse(x).success));

--- a/packages/contract/src/protocol.ts
+++ b/packages/contract/src/protocol.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Station, StationHealth, FsEntry } from "./station";
 import { ChangesetStatus, ChangesetDiff, ChangesetDiffSide } from "./changeset";
+import { PostureReport } from "./posture";
 
 export const RequestMsg = z.object({ type: z.literal("req"), id: z.string(), verb: z.string(), params: z.unknown() });
 export const ResponseMsg = z.object({ type: z.literal("res"), id: z.string(), ok: z.boolean(), data: z.unknown().optional(), error: z.string().optional() });
@@ -55,6 +56,8 @@ export const VERB_PARAMS = {
     side: ChangesetDiffSide,
     maxBytes: z.number().int().positive().optional(),
   }),
+  // Node-level: no station key. One scan describes one machine.
+  "posture.scan": z.object({}),
 } as const;
 
 // VERB_RESULTS describes what the NODE returns on each verb.
@@ -83,4 +86,5 @@ export const VERB_RESULTS = {
   // acp.attach streams; no entry needed (same as term.attach).
   "changeset.status": ChangesetStatus,
   "changeset.diff": ChangesetDiff,
+  "posture.scan": PostureReport,
 } as const;


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-11-posture-capability-design.md` (Horizon 1).

Makes `apn scan`'s findings correct, then makes them visible from the console.

## The scanner was reporting false passes

`CredentialPaths` named files that exist on no machine we own. For hermes and
openclaw — the two composite harnesses — **not one path matched reality**, so
`apn scan` reported "grade A, nothing world-readable" having opened nothing.

Corrected against running machines: molt-bot (15 Hermes profiles), superchotu
(12 OpenClaw agents), and a macOS host. Every entry now carries the machine and
date it was verified on.

## File mode is not exposure

Correcting the paths alone would have made things worse. molt-bot has
`config.yaml` at 644 in every profile — under a 700 `/root`, so unreachable. The
old check inspected only the file's own bits and would have reported 15 false
criticals, grading a correctly secured box **F**.

Findings now require **effective reachability**: the file grants read to a class
AND every ancestor grants traverse to it. The two fixes ship together because
either alone is wrong.

## Per-station credentials were never checked

Confirmed, not assumed: `MatrixIDFromProfile` reads `auth.json` from each
profile directory and its comment notes it ignores the other fields "including
access_token". Hermes profiles have `auth.json`, `.env` and `config.yaml`;
OpenClaw agents have `agent/auth{,-profiles,-state}.json`.

`Finding.Station` was declared and never assigned — it now carries the station
key the descriptors produce, so the console joins findings to stations by
equality.

Also new: group-writable station config directories. `agents/<name>/` is 775 on
superchotu, so another user could **replace** an agent's credentials even though
the files themselves are 600 — invisible to any file-mode check.

## Verified on the fleet, not just in fixtures

| Machine | Before | After |
|---|---|---|
| superchotu (OpenClaw, 12 agents) | ~5 checks | **48 checks**, 0 failed |
| molt-bot (Hermes, 15 profiles) | ~5 checks | **60 checks**, 55 per-station, 0 failed |

Both correctly grade A — and both exercise the false-alarm guard on real data:
superchotu's twelve 775 agent directories and molt-bot's fifteen 644
`config.yaml` files all sit under 700 ancestors, so all 27 would-be criticals
are correctly suppressed. A pass on a group-readable file now says *"mode 0644
but a parent directory blocks other users from reaching it"*, so it does not
read like a scanner bug.

## Surfacing

`posture.scan` is a node-level verb gated on a new node-capability mechanism
carried in the existing `hello` frame. Because it rides the handshake, node
capabilities refresh on every connect — the staleness bug station capabilities
needed a fix for cannot occur here.

Console: a Posture panel on the node page, and on a station page a banner shown
only when a finding names that station.

Observe-only: no stored history, no fleet roll-up, no remediation. Those are
Horizon 3's continuous-posture item.

## Incidental fix

The `hello` frame was an inline `map[string]any` and `hello.json` was emitted as
a contract fixture but **never round-tripped by any Go test** — exactly the gap
`TestHealthFrameStationsRoundTrip` warns about in its own comment. It is a typed
struct now with a round-trip test, verified to fail when the wire name drifts.

## Follow-ons filed

#237 (config-editor validation + refusing to open credential files, which
depends on the corrected path list) and #238 (node config editing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW