### PR TITLE
feat: run provisioned runtimes under gVisor

### DIFF
--- a/apps/console/src/routes/runtimes/+page.svelte
+++ b/apps/console/src/routes/runtimes/+page.svelte
@@ -132,6 +132,16 @@
       header: "Provider",
     },
     {
+      id: "runtime",
+      header: "Isolation",
+      enableSorting: false,
+      // The runtime the provider REPORTED, not the one requested — blank when
+      // not recorded rather than defaulting to "runc", which would be a guess
+      // presented as a fact.
+      accessorFn: (row) => row.runtime ?? "",
+      cell: (ctx) => renderSnippet(runtimeCell, { value: ctx.getValue<string>() }),
+    },
+    {
       id: "node",
       header: "Node",
       enableSorting: false,
@@ -164,6 +174,12 @@
 
 {#snippet nameCell({ value }: { value: string })}
   <span class="font-mono text-sm font-medium">{value}</span>
+{/snippet}
+
+{#snippet runtimeCell({ value }: { value: string })}
+  {#if value}
+    <Badge variant="outline" class="font-mono text-xs">{value}</Badge>
+  {/if}
 {/snippet}
 
 {#snippet nodeCell({ value }: { value: string })}

--- a/apps/console/src/routes/runtimes/page.svelte.test.ts
+++ b/apps/console/src/routes/runtimes/page.svelte.test.ts
@@ -277,3 +277,30 @@ test("calls listRuntimes on mount", async () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Container runtime column
+// ---------------------------------------------------------------------------
+
+test("a runtime running under gVisor says so", async () => {
+  // The operator needs to see which isolation a runtime actually got. Showing
+  // nothing would make a hardened and an unhardened runtime look identical.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-gvisor", name: "hardened", runtime: "runsc" },
+  ]);
+
+  const { container } = render(RuntimesPage);
+  await waitFor(() => expect(container.textContent).toMatch(/runsc/));
+});
+
+test("a runtime with no reported runtime shows none", async () => {
+  // Null means "not recorded", not "runc". Printing a default here would be a
+  // guess presented as a fact.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-plain", name: "plain", runtime: null },
+  ]);
+
+  const { container } = render(RuntimesPage);
+  await waitFor(() => expect(container.textContent).toMatch(/plain/));
+  expect(container.textContent).not.toMatch(/runsc|runc/);
+});

--- a/apps/hub/src/db/drizzle-migrations/0030_faulty_next_avengers.sql
+++ b/apps/hub/src/db/drizzle-migrations/0030_faulty_next_avengers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provisioned_runtimes" ADD COLUMN "runtime" text;

--- a/apps/hub/src/db/drizzle-migrations/meta/0030_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0030_snapshot.json
@@ -1,0 +1,2009 @@
+{
+  "id": "ba45b16f-b30d-4432-9b26-c3ff77b56c4c",
+  "prevId": "85a9af58-095f-4270-bddb-b0ec4e069ec9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "online",
+        "stopped",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1786472791668,
       "tag": "0029_cuddly_expediter",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1786479002917,
+      "tag": "0030_faulty_next_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/nodes.ts
+++ b/apps/hub/src/db/schema/nodes.ts
@@ -33,6 +33,9 @@ export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   name: text("name").notNull(),
   resourceTier: text("resource_tier").notNull().default("small"),
   harness: text("harness").notNull().default("none"),
+  // Container runtime the provider reported, e.g. "runsc". Null when the
+  // provider has no such concept, or the row predates the field.
+  runtime: text("runtime"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 }, (t) => [index("provisioned_runtimes_user_id_idx").on(t.userId)]);

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -478,3 +478,42 @@ test("DELETE /api/runtimes/:id with unregistered provisioner → row still marke
     registerProvisioner(fakeDockerProvisioner);
   }
 }, 30_000);
+
+// ─── container runtime round-trip ─────────────────────────────────────────────
+
+test("the runtime a driver reports is stored and returned", async () => {
+  // Proves the value survives the whole path: driver → column → DTO. Without
+  // this the field can be plumbed everywhere and still arrive null.
+  registerProvisioner({
+    provider: "docker",
+    async provision() {
+      return { externalId: "rt_gvisor_ext", runtime: "runsc" };
+    },
+    async destroy() {},
+  } as never);
+
+  try {
+    const res = await testApp.request("/api/runtimes", {
+      method: "POST",
+      headers: { "X-Test-User-Id": TEST_USER, "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "docker", name: "gvisor-rt", resourceTier: "small" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as Record<string, unknown>).runtime).toBe("runsc");
+  } finally {
+    registerProvisioner(fakeDockerProvisioner); // restore for later tests
+  }
+});
+
+test("a driver that reports no runtime stores null", async () => {
+  // Null means "not recorded", never a guessed default.
+  const res = await testApp.request("/api/runtimes", {
+    method: "POST",
+    headers: { "X-Test-User-Id": TEST_USER, "Content-Type": "application/json" },
+    body: JSON.stringify({ provider: "docker", name: "plain-rt", resourceTier: "small" }),
+  });
+
+  expect(res.status).toBe(201);
+  expect(((await res.json()) as Record<string, unknown>).runtime).toBeNull();
+});

--- a/apps/hub/src/services/provisioner/docker-orchestrator.test.ts
+++ b/apps/hub/src/services/provisioner/docker-orchestrator.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests: DockerOrchestrator container options.
+ *
+ * No real Docker daemon. buildContainerOptions is private, so these reach it
+ * via a cast — the alternative is exporting a function purely for tests, and
+ * the option object is exactly what we need to assert on.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { DockerOrchestrator } from "./docker-orchestrator";
+import type { SandboxConfig } from "./docker-orchestrator";
+
+const CONFIG: SandboxConfig = {
+  id: "rt_test",
+  name: "test",
+  image: "agentpod-node:local",
+  env: { AGENTPOD_HUB_URL: "https://hub.example" },
+  volumes: [],
+  ports: [],
+  labels: {},
+  resources: { cpus: "1.0", memory: "1g", pidsLimit: 100 },
+};
+
+/** buildContainerOptions is private; this is the narrow escape hatch. */
+function optionsFor(orch: DockerOrchestrator, cfg: SandboxConfig = CONFIG) {
+  return (
+    orch as unknown as {
+      buildContainerOptions: (c: SandboxConfig, name: string) => Record<string, any>;
+    }
+  ).buildContainerOptions(cfg, "agentpod-rt_test");
+}
+
+describe("DockerOrchestrator container options", () => {
+  it("omits HostConfig.Runtime entirely when no runtime is configured", () => {
+    // Not "" and not undefined-valued — ABSENT. An unconfigured hub must send
+    // exactly the request it sends today, so this change cannot alter the
+    // default path even subtly.
+    const opts = optionsFor(new DockerOrchestrator());
+    expect("Runtime" in opts.HostConfig).toBe(false);
+  });
+
+  it("sets HostConfig.Runtime when one is configured", () => {
+    const opts = optionsFor(new DockerOrchestrator({ runtime: "runsc" }));
+    expect(opts.HostConfig.Runtime).toBe("runsc");
+  });
+
+  it("leaves the rest of HostConfig untouched when a runtime is set", () => {
+    // The runtime is an addition, not a replacement: resource limits and the
+    // tini init that stops zombie stations must survive it.
+    const plain = optionsFor(new DockerOrchestrator());
+    const withRt = optionsFor(new DockerOrchestrator({ runtime: "runsc" }));
+
+    expect(withRt.HostConfig.Init).toBe(plain.HostConfig.Init);
+    expect(withRt.HostConfig.NanoCpus).toBe(plain.HostConfig.NanoCpus);
+    expect(withRt.HostConfig.Memory).toBe(plain.HostConfig.Memory);
+    expect(withRt.HostConfig.RestartPolicy).toEqual(plain.HostConfig.RestartPolicy);
+  });
+
+  it("keeps the image and labels identical", () => {
+    const withRt = optionsFor(new DockerOrchestrator({ runtime: "runsc" }));
+    expect(withRt.Image).toBe(CONFIG.image);
+    expect(withRt.Labels["agentpod.managed"]).toBe("true");
+  });
+});

--- a/apps/hub/src/services/provisioner/docker-orchestrator.ts
+++ b/apps/hub/src/services/provisioner/docker-orchestrator.ts
@@ -62,6 +62,14 @@ export interface Sandbox {
   startedAt?: Date;
   image: string;
   labels?: Record<string, string>;
+  /**
+   * The runtime Docker reports for this container, read back from inspect.
+   *
+   * Deliberately the observed value rather than the requested one: "we asked
+   * for runsc" is a hope, "Docker says this is running under runsc" is a fact,
+   * and the gap between them is exactly what this field exists to expose.
+   */
+  runtime?: string;
 }
 
 // ─── Configuration ────────────────────────────────────────────────────────────
@@ -70,6 +78,11 @@ export interface DockerOrchestratorConfig {
   socketPath?: string;
   host?: string;
   port?: number;
+  /**
+   * Container runtime name, e.g. "runsc" for gVisor. Omitted means Docker's
+   * default (runc) and a create request byte-identical to before this existed.
+   */
+  runtime?: string;
   containerPrefix?: string;
   hostPathPrefix?: string;
   defaultNetwork?: string;
@@ -80,6 +93,7 @@ const DEFAULT_CONFIG: Required<DockerOrchestratorConfig> = {
   socketPath: "/var/run/docker.sock",
   host: "",
   port: 2375,
+  runtime: "",
   containerPrefix: "agentpod",
   defaultNetwork: "agentpod-net",
   hostPathPrefix: "",
@@ -221,6 +235,9 @@ export class DockerOrchestrator {
         // reports "running" forever after its process died (live-fleet
         // finding, 2026-08-09).
         Init: true,
+        // Only present when configured: an unset runtime must produce the same
+        // request Docker received before this option existed.
+        ...(this.config.runtime ? { Runtime: this.config.runtime } : {}),
         NanoCpus: resources.cpus
           ? Math.floor(parseFloat(resources.cpus) * 1e9)
           : undefined,
@@ -268,6 +285,7 @@ export class DockerOrchestrator {
       startedAt: state?.StartedAt ? new Date(state.StartedAt) : undefined,
       image: info.Config?.Image ?? "",
       labels,
+      runtime: info.HostConfig?.Runtime || undefined,
     };
   }
 }

--- a/apps/hub/src/services/provisioner/docker.test.ts
+++ b/apps/hub/src/services/provisioner/docker.test.ts
@@ -31,8 +31,13 @@ interface RecordedCall {
 class FakeDockerOrchestrator {
   readonly calls: RecordedCall[] = [];
   capturedConfig: SandboxConfig | null = null;
+  /** What inspect would report as the container's runtime. */
+  runtimeToReport: string | undefined = undefined;
+  /** Set to make createSandbox throw, as Docker does for an unknown runtime. */
+  createError: Error | null = null;
 
   async createSandbox(config: SandboxConfig): Promise<Sandbox> {
+    if (this.createError) throw this.createError;
     this.capturedConfig = config;
     this.calls.push({ method: "createSandbox", args: [config] });
     return {
@@ -43,6 +48,7 @@ class FakeDockerOrchestrator {
       urls: {},
       createdAt: new Date(),
       image: config.image,
+      runtime: this.runtimeToReport,
     };
   }
 
@@ -221,5 +227,63 @@ describe("DockerRuntimeProvisioner", () => {
       expect(call).toBeDefined();
       expect(call!.args[0]).toBe("c1");
     });
+  });
+});
+
+// ─── Runtime selection ────────────────────────────────────────────────────────
+
+describe("DockerRuntimeProvisioner runtime selection", () => {
+  const ORIGINAL = process.env.DOCKER_RUNTIME;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.DOCKER_RUNTIME;
+    else process.env.DOCKER_RUNTIME = ORIGINAL;
+  });
+
+  const SPEC = {
+    runtimeId: "rt_1",
+    name: "n",
+    resourceTier: "small" as const,
+    hubUrl: "https://hub.example",
+    enrollToken: "enr_x",
+    image: "agentpod-node:local",
+  };
+
+  it("returns the runtime the orchestrator observed, not the one configured", async () => {
+    // The whole point of the field. If config says runsc and Docker actually
+    // ran runc, we must record runc — that mismatch is what this catches, and
+    // recording the request instead would hide it forever.
+    process.env.DOCKER_RUNTIME = "runsc";
+
+    const fake = new FakeDockerOrchestrator();
+    fake.runtimeToReport = "runc"; // Docker disagreed with us
+
+    const res = await makeProvisioner(fake).provision(SPEC);
+    expect(res.runtime).toBe("runc");
+  });
+
+  it("omits runtime when the orchestrator reports none", async () => {
+    delete process.env.DOCKER_RUNTIME;
+
+    const fake = new FakeDockerOrchestrator();
+    fake.runtimeToReport = undefined;
+
+    const res = await makeProvisioner(fake).provision(SPEC);
+    expect(res.runtime).toBeUndefined();
+    // externalId is the runtimeId, NOT the container id — destroy/start/stop
+    // look the container up by name "agentpod-<id>", so this is the lifecycle
+    // key and must not drift.
+    expect(res.externalId).toBe(SPEC.runtimeId);
+  });
+
+  it("surfaces an unavailable runtime as a failure, never a silent fallback", async () => {
+    // Docker rejects an unknown runtime at create. That must reach the caller:
+    // quietly running under runc would leave the operator believing they had
+    // kernel isolation when they had none.
+    process.env.DOCKER_RUNTIME = "not-installed";
+
+    const fake = new FakeDockerOrchestrator();
+    fake.createError = new Error("Unknown runtime specified not-installed");
+
+    await expect(makeProvisioner(fake).provision(SPEC)).rejects.toThrow(/not-installed/);
   });
 });

--- a/apps/hub/src/services/provisioner/docker.ts
+++ b/apps/hub/src/services/provisioner/docker.ts
@@ -41,7 +41,11 @@ export class DockerRuntimeProvisioner implements RuntimeProvisioner {
    *   (no-arg constructor uses socket defaults from DockerOrchestratorConfig).
    */
   constructor(
-    private readonly orchestrator: DockerOrchestrator = new DockerOrchestrator()
+    private readonly orchestrator: DockerOrchestrator = new DockerOrchestrator({
+      // Set by the operator to harden the host, e.g. DOCKER_RUNTIME=runsc for
+      // gVisor. Unset keeps Docker's default and today's exact behaviour.
+      runtime: process.env.DOCKER_RUNTIME || "",
+    })
   ) {}
 
   /**
@@ -55,8 +59,13 @@ export class DockerRuntimeProvisioner implements RuntimeProvisioner {
    * methods (startSandbox / stopSandbox / deleteSandbox) resolve containers by
    * the sandbox config.id (name: "agentpod-<id>" or label agentpod.sandbox.id),
    * NOT by the raw hex Docker container id.
+   *
+   * Also returns the runtime the daemon reports for the container — observed
+   * via inspect, not the one requested via DOCKER_RUNTIME.
    */
-  async provision(spec: ProvisionSpec): Promise<{ externalId: string }> {
+  async provision(
+    spec: ProvisionSpec
+  ): Promise<{ externalId: string; runtime?: string }> {
     const image = spec.image;
     const resources = RUNTIME_RESOURCE_TIERS[spec.resourceTier];
 
@@ -82,8 +91,10 @@ export class DockerRuntimeProvisioner implements RuntimeProvisioner {
     // Use runtimeId (= config.id) so that destroy/start/stop can pass it
     // directly to deleteSandbox/startSandbox/stopSandbox, which look up the
     // container by name "agentpod-<id>" or label agentpod.sandbox.id=<id>.
-    void sandbox; // containerId is intentionally not used as the lifecycle key
-    return { externalId: spec.runtimeId };
+    // containerId is intentionally not used as the lifecycle key, but the
+    // runtime the daemon reports for the container is worth carrying back:
+    // it is the observed value, not the one we asked for.
+    return { externalId: spec.runtimeId, runtime: sandbox.runtime };
   }
 
   /**

--- a/apps/hub/src/services/provisioner/types.ts
+++ b/apps/hub/src/services/provisioner/types.ts
@@ -38,9 +38,13 @@ export interface RuntimeProvisioner {
 
   /**
    * Create and start a new runtime for the given spec.
-   * Returns the provider-specific external identifier (container id, sandbox id, …).
+   *
+   * Returns the provider-specific external identifier (container id, sandbox
+   * id, …), and — where the provider can report it — the container runtime
+   * actually used. `runtime` is optional so providers with no such concept
+   * (Cloudflare) are unaffected.
    */
-  provision(spec: ProvisionSpec): Promise<{ externalId: string }>;
+  provision(spec: ProvisionSpec): Promise<{ externalId: string; runtime?: string }>;
 
   /**
    * Permanently destroy the runtime identified by externalId.

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -61,6 +61,7 @@ function toContract(row: RuntimeRow): ProvisionedRuntime {
     name: row.name,
     resourceTier: row.resourceTier as ProvisionedRuntime["resourceTier"],
     harness: (row.harness ?? "none") as ProvisionedRuntime["harness"],
+    runtime: row.runtime ?? null,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
@@ -143,7 +144,7 @@ export async function createRuntime(
   }
 
   try {
-    const { externalId } = await provisioner.provision({
+    const { externalId, runtime } = await provisioner.provision({
       runtimeId: id,
       name: req.name,
       resourceTier: (req.resourceTier ?? "small") as "small" | "medium" | "large",
@@ -154,7 +155,7 @@ export async function createRuntime(
 
     await db
       .update(provisionedRuntimes)
-      .set({ externalId, updatedAt: new Date() })
+      .set({ externalId, runtime: runtime ?? null, updatedAt: new Date() })
       .where(eq(provisionedRuntimes.id, id));
 
     const [row] = await db

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -170,6 +170,49 @@ curl -s http://127.0.0.1:3001/health
 
 > If you need to run migrations manually: `cd /opt/agentpod/apps/hub && bun run db:migrate`
 
+### Optional: gVisor isolation for provisioned runtimes
+
+Provisioned runtimes run on the hub box and execute agent-generated code. Under
+Docker's default `runc` they share the host kernel, so a container escape is a
+hub compromise. gVisor (`runsc`) gives each container its own userspace kernel.
+
+It needs **no nested virtualisation and no bare metal** — Linux 4.14.77+ is the
+only requirement, so it works on an ordinary cloud VM.
+
+```bash
+ARCH=$(uname -m)
+URL="https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}"
+curl -fsSL -o runsc "${URL}/runsc" -o runsc.sha512 "${URL}/runsc.sha512" \
+     -o containerd-shim-runsc-v1 "${URL}/containerd-shim-runsc-v1" \
+     -o containerd-shim-runsc-v1.sha512 "${URL}/containerd-shim-runsc-v1.sha512"
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+chmod a+rx runsc containerd-shim-runsc-v1
+sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin/
+sudo /usr/local/bin/runsc install
+sudo systemctl reload docker      # reload, NOT restart — running containers keep running
+```
+
+Verify Docker sees it, then enable it for newly provisioned runtimes:
+
+```bash
+docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}'   # expect runsc listed
+echo 'DOCKER_RUNTIME=runsc' >> /etc/agentpod/hub.env
+systemctl restart agentpod-hub
+```
+
+Existing runtimes keep whatever they were created with; this affects new ones.
+The console's **Isolation** column shows each runtime's actual runtime, read back
+from Docker rather than from config, so you can confirm rather than assume.
+
+**If `runsc` is not installed and `DOCKER_RUNTIME=runsc` is set, provisioning
+fails loudly.** It never falls back to `runc` — a silent fallback would leave you
+believing you had kernel isolation when you had none.
+
+Verified on the reference box (Ubuntu 24.04, kernel 6.8, Docker 29.6.1): the
+node-agent enrols, heartbeats, allocates PTYs for the terminal capability, and
+runs ACP stdio children under `runsc` identically to `runc`. Expect 5–20% CPU
+overhead depending on syscall frequency.
+
 ---
 
 ## 6. Console — build + deploy to Cloudflare Pages

--- a/packages/contract/src/runtime.test.ts
+++ b/packages/contract/src/runtime.test.ts
@@ -63,3 +63,25 @@ describe("ProvisionedRuntime", () => {
     expect(result.nodeId).toBeNull();
   });
 });
+
+// ─── container runtime ───────────────────────────────────────────────────────
+
+describe("ProvisionedRuntime.runtime", () => {
+  const BASE = {
+    id: "rt_1", ownerId: "u_1", provider: "docker" as const, externalId: "abc",
+    status: "online" as const, nodeId: null, name: "n",
+    resourceTier: "small" as const, harness: "opencode" as const,
+    createdAt: "2026-08-12T00:00:00Z", updatedAt: "2026-08-12T00:00:00Z",
+  };
+
+  it("can report the container runtime it runs under", () => {
+    expect(ProvisionedRuntime.parse({ ...BASE, runtime: "runsc" }).runtime).toBe("runsc");
+  });
+
+  it("is absent on rows that predate it and providers without the concept", () => {
+    // Null rather than a guess: a Cloudflare sandbox has no container runtime,
+    // and a row created before this field existed never had one recorded.
+    expect(ProvisionedRuntime.parse(BASE).runtime).toBeUndefined();
+    expect(ProvisionedRuntime.parse({ ...BASE, runtime: null }).runtime).toBeNull();
+  });
+});

--- a/packages/contract/src/runtime.ts
+++ b/packages/contract/src/runtime.ts
@@ -30,6 +30,12 @@ export const ProvisionedRuntime = z.object({
   name: z.string(),
   resourceTier: ResourceTier,
   harness: RuntimeHarness,
+  /**
+   * Container runtime the provider reports this runtime is running under, e.g.
+   * "runsc" for gVisor. Null for providers with no such concept and for rows
+   * created before it was recorded — never inferred.
+   */
+  runtime: z.string().min(1).nullable().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-12-gvisor-runtime-design.md` — step 2 of the
re-planned driver wave.

Provisioned runtimes land on the hub box and execute agent-generated code. Under
`runc` they share the host kernel, so a container escape is a hub compromise.
`DOCKER_RUNTIME=runsc` gives each container its own userspace kernel.

## Validated before it was designed

`runsc` was installed on the hub box and the whole path exercised first, because a
runtime flag that breaks the agent would be worse than no flag:

| Check | Result |
|---|---|
| gVisor genuinely intercepting | container kernel `4.19.0-gvisor` vs host `6.8.0-107-generic` |
| `/proc` — health metrics | works |
| **PTY: `pty.StartWithSize`, `Setsize`, read/write** | **byte-identical to `runc`** |
| Long-lived stdio child (ACP shape) | works |
| Signals and child reaping | works |
| Node-agent enrols, dials the hub, heartbeats | `status: online`, last seen 3s |
| `apn scan` inside the sandbox | grade A, `unknown` for absent `lsof` |

`docker run -t` *does* differ under gVisor — `tty` cannot resolve `/dev/pts/0` — but
the node-agent allocates its own PTY via `creack/pty`, and a probe built against that
library was identical to `runc`. Testing the convenient thing rather than the real
thing would have produced a false alarm and possibly killed this slice.

## Two properties worth reviewing for

**Fails closed.** An unavailable runtime fails the provision with an error naming it.
It never silently falls back to `runc`, which would leave an operator believing they
had kernel isolation while they had none — the same failure shape as the scanner that
graded machines A on files it never opened.

**Records what ran, not what was asked.** The stored value is read back from `inspect`,
so a config saying `runsc` while Docker ran `runc` records `runc`. That mismatch is the
whole reason the field exists, and there is a test for exactly it.

Unset `DOCKER_RUNTIME` produces a create request byte-identical to today's —
`HostConfig.Runtime` is **absent from the object**, not empty — and a test asserts it.

## One thing the plan got wrong

The plan said to return `sandbox.containerId` as `externalId`. Reading the code showed
it deliberately returns `spec.runtimeId`, because destroy/start/stop resolve containers
by name `agentpod-<id>`. Following the plan literally would have broken runtime
lifecycle management. Only `runtime` was added; `externalId` is untouched, and a test
now pins it.

## Not in scope

Remote Docker host (deferred: it needs either a credential on the hub or Tailscale, and
both were declined), per-user runtime choice, other isolation technologies. This does
not fix co-location — a runaway agent can still starve the hub — only the shared-kernel
half. The default does not change: `runsc` is installed on the hub box but nothing uses
it until an operator sets `DOCKER_RUNTIME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW