### PR TITLE
fix: gVisor runtimes cannot use a user-defined Docker network (#243)

### DIFF
--- a/apps/hub/src/services/provisioner/docker-orchestrator.test.ts
+++ b/apps/hub/src/services/provisioner/docker-orchestrator.test.ts
@@ -40,7 +40,7 @@ describe("DockerOrchestrator container options", () => {
   });
 
   it("sets HostConfig.Runtime when one is configured", () => {
-    const opts = optionsFor(new DockerOrchestrator({ runtime: "runsc" }));
+    const opts = optionsFor(new DockerOrchestrator({ runtime: "runsc", defaultNetwork: "bridge" }));
     expect(opts.HostConfig.Runtime).toBe("runsc");
   });
 
@@ -48,7 +48,7 @@ describe("DockerOrchestrator container options", () => {
     // The runtime is an addition, not a replacement: resource limits and the
     // tini init that stops zombie stations must survive it.
     const plain = optionsFor(new DockerOrchestrator());
-    const withRt = optionsFor(new DockerOrchestrator({ runtime: "runsc" }));
+    const withRt = optionsFor(new DockerOrchestrator({ runtime: "runsc", defaultNetwork: "bridge" }));
 
     expect(withRt.HostConfig.Init).toBe(plain.HostConfig.Init);
     expect(withRt.HostConfig.NanoCpus).toBe(plain.HostConfig.NanoCpus);
@@ -57,8 +57,59 @@ describe("DockerOrchestrator container options", () => {
   });
 
   it("keeps the image and labels identical", () => {
-    const withRt = optionsFor(new DockerOrchestrator({ runtime: "runsc" }));
+    const withRt = optionsFor(new DockerOrchestrator({ runtime: "runsc", defaultNetwork: "bridge" }));
     expect(withRt.Image).toBe(CONFIG.image);
     expect(withRt.Labels["agentpod.managed"]).toBe("true");
+  });
+});
+
+describe("runtime and network compatibility", () => {
+  // Root cause of #243: on a USER-DEFINED network Docker injects
+  // `nameserver 127.0.0.11` and runs an embedded DNS proxy on that loopback
+  // address inside the container's netns. gVisor's netstack cannot reach it,
+  // so every lookup times out and the node-agent never enrols — while ICMP,
+  // TCP and UDP to real addresses all work, which makes it look like DNS
+  // "just broke".
+  //
+  // `--dns` does NOT help: it only changes what the embedded proxy forwards
+  // upstream, and resolv.conf still points at 127.0.0.11.
+  //
+  // Docker's built-in networks (bridge/host/none) write the host's real
+  // resolvers directly, so they are unaffected.
+
+  it("rejects a non-default runtime on a user-defined network", () => {
+    // Fail closed. Allowing this produces runtimes that provision "successfully"
+    // and then restart-loop forever — the worst kind of failure, because the
+    // API reports success.
+    expect(() =>
+      optionsFor(new DockerOrchestrator({ runtime: "runsc", defaultNetwork: "agentpod-net" }))
+    ).toThrow(/runsc/);
+  });
+
+  it("names the incompatibility and the fix in the error", () => {
+    // An operator hitting this at 2am needs to know what to change, not just
+    // that something is wrong.
+    let msg = "";
+    try {
+      optionsFor(new DockerOrchestrator({ runtime: "runsc", defaultNetwork: "agentpod-net" }));
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toMatch(/agentpod-net/);
+    expect(msg).toMatch(/DOCKER_NETWORK/);
+  });
+
+  it("allows a non-default runtime on Docker's built-in bridge", () => {
+    // bridge/host/none do not use the embedded resolver, so they are fine.
+    const opts = optionsFor(new DockerOrchestrator({ runtime: "runsc", defaultNetwork: "bridge" }));
+    expect(opts.HostConfig.Runtime).toBe("runsc");
+    expect(opts.HostConfig.NetworkMode).toBe("bridge");
+  });
+
+  it("leaves the default runtime free to use any network", () => {
+    // runc reaches the embedded resolver fine; this restriction is specific to
+    // sandboxed runtimes and must not change existing behaviour.
+    const opts = optionsFor(new DockerOrchestrator({ defaultNetwork: "agentpod-net" }));
+    expect(opts.HostConfig.NetworkMode).toBe("agentpod-net");
   });
 });

--- a/apps/hub/src/services/provisioner/docker-orchestrator.ts
+++ b/apps/hub/src/services/provisioner/docker-orchestrator.ts
@@ -100,6 +100,40 @@ const DEFAULT_CONFIG: Required<DockerOrchestratorConfig> = {
   defaultResources: { cpus: "1.0", memory: "2g", pidsLimit: 256 },
 };
 
+// ─── Runtime / network compatibility ──────────────────────────────────────────
+
+/**
+ * Docker's built-in networks. These write the host's real resolvers into
+ * /etc/resolv.conf. Every other network is user-defined, and Docker injects
+ * `nameserver 127.0.0.11` plus an embedded DNS proxy on that loopback address
+ * inside the container's network namespace.
+ */
+const BUILTIN_NETWORKS = new Set(["bridge", "host", "none"]);
+
+/**
+ * Refuses a sandboxed runtime on a user-defined network (#243).
+ *
+ * gVisor's netstack cannot reach Docker's embedded resolver at 127.0.0.11, so
+ * every lookup times out and a node-agent never enrols — while ICMP, TCP and
+ * UDP to real addresses all work, which makes it read as "DNS randomly broke".
+ * `--dns` does not help: it only changes what the embedded proxy forwards
+ * upstream, and resolv.conf still points at 127.0.0.11.
+ *
+ * This throws rather than silently switching networks or falling back to runc.
+ * The failure it prevents is the worst kind: provisioning reports success and
+ * the container then restart-loops forever.
+ */
+export function assertRuntimeSupportsNetwork(runtime: string, network: string): void {
+  if (!runtime || BUILTIN_NETWORKS.has(network)) return;
+  throw new Error(
+    `runtime "${runtime}" cannot be used on the user-defined network "${network}": ` +
+      `Docker's embedded DNS resolver (127.0.0.11) is unreachable from a sandboxed ` +
+      `runtime, so containers never resolve the hub and never enrol. ` +
+      `Set DOCKER_NETWORK=bridge alongside DOCKER_RUNTIME, or unset DOCKER_RUNTIME. ` +
+      `See https://github.com/rakeshgangwar/agentpod/issues/243`
+  );
+}
+
 // ─── Orchestrator ─────────────────────────────────────────────────────────────
 
 export class DockerOrchestrator {
@@ -187,6 +221,7 @@ export class DockerOrchestrator {
     containerName: string
   ): ContainerCreateOptions {
     const network = config.network ?? this.config.defaultNetwork;
+    assertRuntimeSupportsNetwork(this.config.runtime, network);
     const resources = { ...this.config.defaultResources, ...config.resources };
 
     const binds: string[] = config.volumes.map((v) => {

--- a/apps/hub/src/services/provisioner/docker.test.ts
+++ b/apps/hub/src/services/provisioner/docker.test.ts
@@ -287,3 +287,31 @@ describe("DockerRuntimeProvisioner runtime selection", () => {
     await expect(makeProvisioner(fake).provision(SPEC)).rejects.toThrow(/not-installed/);
   });
 });
+
+describe("DockerRuntimeProvisioner network selection", () => {
+  const ORIGINAL = process.env.DOCKER_NETWORK;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.DOCKER_NETWORK;
+    else process.env.DOCKER_NETWORK = ORIGINAL;
+  });
+
+  it("passes DOCKER_NETWORK through to the orchestrator", () => {
+    // config.ts exposed DOCKER_NETWORK for a long time but nothing passed it
+    // here, so setting it did nothing. That silent no-op is what made the #243
+    // guard fire on a hub that was, as far as its operator knew, configured
+    // correctly.
+    process.env.DOCKER_NETWORK = "bridge";
+    const p = new DockerRuntimeProvisioner();
+    const cfg = (p as unknown as { orchestrator: { config: { defaultNetwork: string } } })
+      .orchestrator.config;
+    expect(cfg.defaultNetwork).toBe("bridge");
+  });
+
+  it("defaults to agentpod-net when unset", () => {
+    delete process.env.DOCKER_NETWORK;
+    const p = new DockerRuntimeProvisioner();
+    const cfg = (p as unknown as { orchestrator: { config: { defaultNetwork: string } } })
+      .orchestrator.config;
+    expect(cfg.defaultNetwork).toBe("agentpod-net");
+  });
+});

--- a/apps/hub/src/services/provisioner/docker.ts
+++ b/apps/hub/src/services/provisioner/docker.ts
@@ -45,6 +45,11 @@ export class DockerRuntimeProvisioner implements RuntimeProvisioner {
       // Set by the operator to harden the host, e.g. DOCKER_RUNTIME=runsc for
       // gVisor. Unset keeps Docker's default and today's exact behaviour.
       runtime: process.env.DOCKER_RUNTIME || "",
+      // config.ts has exposed DOCKER_NETWORK for a long time but nothing ever
+      // passed it here, so the orchestrator always used its own default. That
+      // matters now: a sandboxed runtime REQUIRES a built-in network, because
+      // Docker's embedded resolver is unreachable from one (#243).
+      defaultNetwork: process.env.DOCKER_NETWORK || "agentpod-net",
     })
   ) {}
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -196,9 +196,21 @@ Verify Docker sees it, then enable it for newly provisioned runtimes:
 
 ```bash
 docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}'   # expect runsc listed
-echo 'DOCKER_RUNTIME=runsc' >> /etc/agentpod/hub.env
+printf 'DOCKER_RUNTIME=runsc\nDOCKER_NETWORK=bridge\n' >> /etc/agentpod/hub.env
 systemctl restart agentpod-hub
 ```
+
+> **`DOCKER_NETWORK=bridge` is required, not optional** ([#243](https://github.com/rakeshgangwar/agentpod/issues/243)).
+> Every user-defined Docker network injects `nameserver 127.0.0.11` and runs an
+> embedded DNS proxy on that loopback address inside the container. A sandboxed
+> runtime cannot reach it, so the container never resolves the hub and never
+> enrols — while ICMP, TCP and UDP to real addresses all work, which makes it
+> read as "DNS randomly broke". `--dns` does **not** help: it only changes what
+> the embedded proxy forwards upstream.
+>
+> The hub refuses this combination rather than provisioning a runtime that would
+> restart-loop forever, so a misconfiguration fails at provision time with an
+> error naming the fix.
 
 Existing runtimes keep whatever they were created with; this affects new ones.
 The console's **Isolation** column shows each runtime's actual runtime, read back
@@ -208,17 +220,12 @@ from Docker rather than from config, so you can confirm rather than assume.
 fails loudly.** It never falls back to `runc` — a silent fallback would leave you
 believing you had kernel isolation when you had none.
 
-> **Do not enable this yet — [#243](https://github.com/rakeshgangwar/agentpod/issues/243).**
-> A runtime provisioned under `runsc` never enrols: DNS does not resolve inside
-> containers on `agentpod-net`, the network the provisioner uses. On the default
-> bridge it works, which is why the original spike passed. ICMP works and the
-> container gets an address, so this is narrower than "no networking", but the
-> cause is not yet established. `DOCKER_RUNTIME` is unset on the reference hub.
-
 Verified on the reference box (Ubuntu 24.04, kernel 6.8, Docker 29.6.1): the
 node-agent enrols, heartbeats, allocates PTYs for the terminal capability, and
-runs ACP stdio children under `runsc` identically to `runc` — **on the default
-bridge**. Expect 5–20% CPU overhead depending on syscall frequency.
+runs ACP stdio children under `runsc` identically to `runc`. Verified end to end
+on 2026-08-12 by provisioning through `createRuntime`: the runtime came back
+`status=online runtime=runsc` with its node heartbeating. Expect 5–20% CPU
+overhead depending on syscall frequency.
 
 ---
 


### PR DESCRIPTION
Closes #243.

## Root cause

Every **user-defined** Docker network injects `nameserver 127.0.0.11` into
`/etc/resolv.conf` and runs an embedded DNS proxy on that loopback address inside
the container's network namespace. **gVisor's netstack cannot reach it.**

Isolated by comparison, same image, same command:

| Network | Runtime | DNS |
|---|---|---|
| default bridge | `runsc` | works — `nameserver 185.12.64.1` |
| `agentpod-net` | `runsc` | **fails** — `nameserver 127.0.0.11` |
| `agentpod-net` | `runc` | works |

And decisively, in one container on `agentpod-net` under `runsc`:

```
nslookup hub.agentpod.dev 1.1.1.1     → 178.105.68.68     ✅
nslookup hub.agentpod.dev 127.0.0.11  → timed out          ❌
```

**`--dns` does not help** and that misled the initial diagnosis: on a user-defined
network it only changes what the embedded proxy forwards *upstream*; resolv.conf
still says `127.0.0.11`.

The failure is nasty because ICMP, TCP and UDP to real addresses all work — the
container pings 1.1.1.1 in 10ms — so it reads as "DNS randomly broke" rather than
"this network is incompatible".

## Fix

**Fail closed at provision time.** A sandboxed runtime on a user-defined network
now throws an error naming the network, the cause, and the fix. It does not
silently switch networks or fall back to `runc`: the failure it prevents is the
worst kind, where provisioning reports success and the container restart-loops
forever.

**Wire `DOCKER_NETWORK` through to the orchestrator.** `config.ts` has exposed it
for a long time but nothing ever passed it down, so setting it did nothing. The
guard caught this on live infrastructure — it fired on a hub whose operator had,
as far as they knew, configured it correctly.

## Verified end to end on the live hub

With `DOCKER_RUNTIME=runsc` and `DOCKER_NETWORK=bridge`, provisioning through
`createRuntime` (not by hand):

```
runtime row: status=online  runtime=runsc  nodeId=node_32cf...
node:        status=online  lastSeen=9s
```

Container up under `runsc` on `bridge`, no DNS errors, no restart loop. Test
runtime removed afterwards.

## Note on the earlier spike

The original spike ran the node-agent under `runsc` with no `--network` flag, so
it landed on the default bridge and passed. Testing the right *runtime* on the
wrong *network* is what let this through — which is why the verification here
goes through `createRuntime` rather than `docker run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW