### PR TITLE
feat: a restarted runtime keeps its node identity

### DIFF
--- a/apps/hub/src/services/enrollment.ts
+++ b/apps/hub/src/services/enrollment.ts
@@ -68,9 +68,19 @@ export async function mintEnrollmentToken(
 }
 
 /**
- * Enroll a node using a valid, unused enrollment token.
+ * Enroll a node using a valid enrollment token.
+ *
  * Returns the node's persistent credentials (nodeId + nodeSecret).
- * Throws if the token is invalid, expired, or already used.
+ *
+ * Two paths:
+ *   - **Runtime-bound token whose runtime already has a node** — returns that
+ *     node with a rotated secret. This is what lets a runtime on an
+ *     ephemeral-disk substrate survive a restart instead of orphaning itself.
+ *   - **Everything else** — consumes the token atomically and mints a new node.
+ *     Unbound tokens remain strictly one-time.
+ *
+ * Throws if the token is invalid, expired, already used (unbound only), or
+ * bound to a runtime that no longer exists.
  */
 export async function enrollNode(
   token: string,
@@ -78,10 +88,80 @@ export async function enrollNode(
 ): Promise<EnrollResponse> {
   const hash = await sha256(token);
 
-  // Atomically consume the token: mark usedAt only if the token exists,
-  // is unused, and has not expired. This single UPDATE eliminates the
-  // TOCTOU race where two concurrent requests could both pass a SELECT
-  // guard before either writes usedAt.
+  // ── Runtime-bound re-enrolment ────────────────────────────────────────────
+  //
+  // A provisioned runtime on an ephemeral-disk substrate loses its config on
+  // every restart and re-presents this token. Minting a new node there would
+  // orphan the runtime's stations, capabilities and history — so if the runtime
+  // already has a node, we resume it.
+  //
+  // Deliberately does NOT gate on usedAt: that gate is what makes an unbound
+  // token one-time, and re-presentation is the whole point here.
+  const [bound] = await db
+    .select()
+    .from(enrollmentTokens)
+    .where(
+      and(
+        eq(enrollmentTokens.tokenHash, hash),
+        gt(enrollmentTokens.expiresAt, new Date())
+      )
+    );
+
+  if (bound?.provisionedRuntimeId) {
+    const [runtime] = await db
+      .select()
+      .from(provisionedRuntimes)
+      .where(eq(provisionedRuntimes.id, bound.provisionedRuntimeId));
+
+    // The runtime was destroyed. Its identity is gone on purpose, and this
+    // token must not degrade into an unbound one that mints something new.
+    if (!runtime) {
+      throw new Error("invalid or expired enrollment token");
+    }
+
+    if (runtime.nodeId) {
+      // Rotate the secret. The container stores nothing durably, so a fresh
+      // secret costs nothing and retires any that leaked from a previous
+      // incarnation.
+      const nodeSecret =
+        crypto.randomUUID().replace(/-/g, "") +
+        crypto.randomUUID().replace(/-/g, "");
+
+      // Concurrent re-enrolments converge here rather than creating a second
+      // node: both target the same row, and the loser's secret is simply
+      // superseded — which the node-agent handles by reconnecting.
+      const updated = await db
+        .update(nodes)
+        .set({
+          secretHash: await Bun.password.hash(nodeSecret),
+          hostname: hostInfo.hostname,
+          os: hostInfo.os,
+          arch: hostInfo.arch,
+          cpuCount: hostInfo.cpuCount,
+        })
+        .where(eq(nodes.id, runtime.nodeId))
+        .returning();
+
+      // If the node row is gone the runtime points at nothing; fall through and
+      // treat it as a first boot rather than failing — the runtime is real and
+      // wants a node.
+      if (updated.length > 0) {
+        await db
+          .update(provisionedRuntimes)
+          .set({ status: "online", updatedAt: new Date() })
+          .where(eq(provisionedRuntimes.id, runtime.id));
+
+        return { nodeId: runtime.nodeId, nodeSecret };
+      }
+    }
+  }
+
+  // ── First enrolment ───────────────────────────────────────────────────────
+  //
+  // Atomically consume the token: mark usedAt only if the token exists, is
+  // unused, and has not expired. This single UPDATE eliminates the TOCTOU race
+  // where two concurrent requests could both pass a SELECT guard before either
+  // writes usedAt.
   const [row] = await db
     .update(enrollmentTokens)
     .set({ usedAt: new Date() })

--- a/apps/hub/src/services/enrollment.ts
+++ b/apps/hub/src/services/enrollment.ts
@@ -22,12 +22,25 @@ const sha256 = async (s: string): Promise<string> =>
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Mint a one-time enrollment token for a user.
+ * Lifetime for a runtime-bound token: ten years, i.e. "as long as the runtime".
+ *
+ * A runtime-bound token is re-presented on every container restart, which on an
+ * ephemeral-disk substrate is routine and may happen long after provisioning.
+ * An expiry here would mean a runtime that silently stops being able to come
+ * back — the exact failure this work exists to remove.
+ *
+ * It is revoked by destroying the runtime, not by waiting.
+ */
+export const RUNTIME_TOKEN_TTL_MS = 10 * 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * Mint an enrollment token for a user.
  * The raw token is returned once; only its SHA-256 hash is persisted.
  *
  * @param userId - The user to mint the token for.
  * @param opts   - Optional settings:
- *   - ttlMs              — token lifetime in ms (default: 1 hour)
+ *   - ttlMs              — token lifetime in ms. Defaults to 1 hour, or
+ *                          RUNTIME_TOKEN_TTL_MS when provisionedRuntimeId is set.
  *   - provisionedRuntimeId — when set, the token is linked to that runtime so
  *                            enrollNode can flip it online automatically.
  */
@@ -35,7 +48,8 @@ export async function mintEnrollmentToken(
   userId: string,
   opts?: { ttlMs?: number; provisionedRuntimeId?: string }
 ): Promise<{ token: string; expiresAt: Date }> {
-  const ttlMs = opts?.ttlMs ?? 60 * 60 * 1000;
+  const ttlMs =
+    opts?.ttlMs ?? (opts?.provisionedRuntimeId ? RUNTIME_TOKEN_TTL_MS : 60 * 60 * 1000);
   const token =
     prefixedId("enr") + crypto.randomUUID().replace(/-/g, "");
   const expiresAt = new Date(Date.now() + ttlMs);

--- a/apps/hub/tests/integration/enrollment.test.ts
+++ b/apps/hub/tests/integration/enrollment.test.ts
@@ -38,6 +38,24 @@ const testApp = new Hono().route("/public/nodes", nodeEnrollRoutes);
 
 const TEST_USER_ID = "test-user-enrollment-001";
 
+const HOST_INFO = { hostname: "identity-test", os: "linux", arch: "amd64", cpuCount: 2 };
+
+/**
+ * Insert a provisioned_runtimes row and return its id.
+ *
+ * Written directly rather than through createRuntime() so these tests need no
+ * provisioner registration — the identity behaviour under test is independent
+ * of which driver created the runtime.
+ */
+async function seedRuntime(userId: string): Promise<string> {
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes (id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${userId}, 'docker', 'provisioning', 'identity-test', 'small', 'none', now(), now())
+  `;
+  return id;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Setup & Teardown
 // ─────────────────────────────────────────────────────────────────────────────
@@ -55,6 +73,8 @@ beforeAll(async () => {
 afterAll(async () => {
   // Clean up in FK order: nodes → enrollment_tokens → user
   try {
+    await rawSql`DELETE FROM stations             WHERE user_id = ${TEST_USER_ID}`;
+    await rawSql`DELETE FROM provisioned_runtimes WHERE user_id = ${TEST_USER_ID}`;
     await rawSql`DELETE FROM nodes           WHERE user_id = ${TEST_USER_ID}`;
     await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${TEST_USER_ID}`;
     await rawSql`DELETE FROM "user"           WHERE id      = ${TEST_USER_ID}`;
@@ -170,5 +190,34 @@ describe("Enrollment service", () => {
     expect(bad.status).toBe(401);
     const missing = await testApp.request("/public/nodes/credential-check");
     expect(missing.status).toBe(401);
+  });
+
+  // ─── runtime-bound token lifetime ──────────────────────────────────────────
+
+  test("a runtime-bound token is minted durable, an unbound one is not", async () => {
+    // A runtime-bound token has to survive as long as its runtime — it is
+    // re-presented on every container restart, which may be months later. An
+    // unbound token is pasted into a shell by a human within the hour.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+
+    const bound = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    const unbound = await mintEnrollmentToken(TEST_USER_ID);
+
+    const oneDay = 24 * 60 * 60 * 1000;
+    expect(bound.expiresAt.getTime() - Date.now()).toBeGreaterThan(oneDay);
+    expect(unbound.expiresAt.getTime() - Date.now()).toBeLessThanOrEqual(60 * 60 * 1000 + 5_000);
+  });
+
+  test("an explicit ttlMs still wins for a runtime-bound token", async () => {
+    // The durable default must not take away a caller's ability to say
+    // otherwise — tests and future callers may want a short-lived bound token.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const t = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+      ttlMs: 60_000,
+    });
+    expect(t.expiresAt.getTime() - Date.now()).toBeLessThanOrEqual(65_000);
   });
 });

--- a/apps/hub/tests/integration/enrollment.test.ts
+++ b/apps/hub/tests/integration/enrollment.test.ts
@@ -220,4 +220,127 @@ describe("Enrollment service", () => {
     });
     expect(t.expiresAt.getTime() - Date.now()).toBeLessThanOrEqual(65_000);
   });
+
+  // ─── runtime-bound re-enrolment ───────────────────────────────────────────
+
+  test("re-enrolling a runtime-bound token returns the SAME node", async () => {
+    // The headline behaviour. On an ephemeral-disk substrate the container
+    // re-enrols on every restart; today that mints a new node and orphans the
+    // old one, so the runtime loses its stations, capabilities and history.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    const first = await enrollNode(token, HOST_INFO);
+    const second = await enrollNode(token, HOST_INFO);
+
+    expect(second.nodeId).toBe(first.nodeId);
+  });
+
+  test("re-enrolment rotates the secret and invalidates the old one", async () => {
+    // The container never stores a secret durably, so a fresh one each restart
+    // costs nothing — and a secret that leaked from a previous incarnation
+    // stops working.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    const first = await enrollNode(token, HOST_INFO);
+    const second = await enrollNode(token, HOST_INFO);
+
+    expect(second.nodeSecret).not.toBe(first.nodeSecret);
+    expect(await verifyNodeCredential(second.nodeId, second.nodeSecret)).toBe(true);
+    expect(await verifyNodeCredential(first.nodeId, first.nodeSecret)).toBe(false);
+  });
+
+  test("re-enrolment does not create a second node", async () => {
+    // Guards the orphaning directly: counting rows catches a bug that returning
+    // the right id from the wrong code path would hide.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    await enrollNode(token, HOST_INFO);
+    await enrollNode(token, HOST_INFO);
+    await enrollNode(token, HOST_INFO);
+
+    const rows = (await rawSql`
+      SELECT node_id FROM provisioned_runtimes WHERE id = ${runtimeId}
+    `) as Array<{ node_id: string }>;
+    const nodeId = rows[0]!.node_id;
+
+    const nodeRows = (await rawSql`
+      SELECT count(*)::int AS n FROM nodes WHERE id = ${nodeId}
+    `) as Array<{ n: number }>;
+    expect(nodeRows[0]!.n).toBe(1);
+  });
+
+  test("an unbound token is still strictly one-time", async () => {
+    // The security property this change must not erode. A reusable token is a
+    // durable credential; only runtime-bound ones earn that, because they
+    // resolve to exactly one runtime and are revoked by destroying it.
+    const { token } = await mintEnrollmentToken(TEST_USER_ID);
+    await enrollNode(token, HOST_INFO);
+    await expect(enrollNode(token, HOST_INFO)).rejects.toThrow(
+      /invalid or expired enrollment token/
+    );
+  });
+
+  test("a runtime-bound token whose runtime is gone is rejected", async () => {
+    // provisionedRuntimeId is ON DELETE SET NULL, so a destroyed runtime leaves
+    // a token pointing at nothing. It must not silently degrade into "mint me
+    // anything" — the identity it referred to is gone on purpose.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    await enrollNode(token, HOST_INFO);
+
+    await rawSql`DELETE FROM provisioned_runtimes WHERE id = ${runtimeId}`;
+
+    await expect(enrollNode(token, HOST_INFO)).rejects.toThrow();
+  });
+
+  test("first boot on a runtime-bound token still mints and links", async () => {
+    // The existing provisioning path must be untouched.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    const { nodeId } = await enrollNode(token, HOST_INFO);
+
+    const rows = (await rawSql`
+      SELECT node_id, status FROM provisioned_runtimes WHERE id = ${runtimeId}
+    `) as Array<{ node_id: string; status: string }>;
+    expect(rows[0]!.node_id).toBe(nodeId);
+    expect(rows[0]!.status).toBe("online");
+  });
+
+  test("concurrent re-enrolment converges on one node", async () => {
+    // Runtime-bound re-enrolment cannot gate on usedAt, so it loses the atomic
+    // consume that protects the unbound path. Two containers starting at once
+    // must still not produce two nodes.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    const { nodeId } = await enrollNode(token, HOST_INFO);
+
+    const results = await Promise.allSettled([
+      enrollNode(token, HOST_INFO),
+      enrollNode(token, HOST_INFO),
+    ]);
+    for (const r of results) {
+      if (r.status === "fulfilled") expect(r.value.nodeId).toBe(nodeId);
+    }
+
+    const nodeRows = (await rawSql`
+      SELECT count(*)::int AS n FROM nodes WHERE id = ${nodeId}
+    `) as Array<{ n: number }>;
+    expect(nodeRows[0]!.n).toBe(1);
+  });
 });

--- a/apps/hub/tests/integration/enrollment.test.ts
+++ b/apps/hub/tests/integration/enrollment.test.ts
@@ -23,6 +23,7 @@ import {
   verifyNodeCredential,
 } from "../../src/services/enrollment";
 import { listNodes } from "../../src/services/node-registry";
+import { adoptStations } from "../../src/services/station-registry";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { nodeEnrollRoutes } from "../../src/routes/nodes";
 
@@ -342,5 +343,33 @@ describe("Enrollment service", () => {
       SELECT count(*)::int AS n FROM nodes WHERE id = ${nodeId}
     `) as Array<{ n: number }>;
     expect(nodeRows[0]!.n).toBe(1);
+  });
+
+  test("adopted stations survive a re-enrolment", async () => {
+    // Identity is only worth persisting if what hangs off it persists too.
+    // Stations key on nodeId, so keeping the id keeps the fleet's view intact —
+    // this is the difference between "the runtime came back" and "the runtime
+    // came back as itself".
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    const { nodeId } = await enrollNode(token, HOST_INFO);
+
+    await adoptStations(TEST_USER_ID, nodeId, ["opencode:workspace"], [
+      {
+        key: "opencode:workspace", harness: "opencode", kind: "leaf",
+        displayName: "workspace", parentKey: null, workspacePath: "/workspace",
+        capabilities: ["health", "acp"], adopted: false,
+      },
+    ]);
+
+    await enrollNode(token, HOST_INFO);
+
+    const rows = (await rawSql`
+      SELECT station_key FROM stations WHERE node_id = ${nodeId}
+    `) as Array<{ station_key: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.station_key).toBe("opencode:workspace");
   });
 });

--- a/docs/superpowers/plans/2026-08-12-runtime-identity-persistence.md
+++ b/docs/superpowers/plans/2026-08-12-runtime-identity-persistence.md
@@ -34,7 +34,8 @@ Tests live in `apps/hub/tests/integration/enrollment.test.ts` and already cover 
 **`apps/hub`**
 - `src/services/enrollment.ts` *(modify)* — the whole behaviour change lives here.
 - `tests/integration/enrollment.test.ts` *(modify)* — re-enrolment, rotation, rejection, concurrency.
-- `src/services/runtimes.ts` *(modify)* — mint runtime-bound tokens as durable.
+
+`src/services/runtimes.ts` needs **no change**: it already passes `provisionedRuntimeId` when minting, and the durable lifetime is decided inside `mintEnrollmentToken` from that field.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-12-runtime-identity-persistence.md
+++ b/docs/superpowers/plans/2026-08-12-runtime-identity-persistence.md
@@ -1,0 +1,685 @@
+# Runtime Identity Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A provisioned runtime that restarts resumes its existing node instead of orphaning it and minting a new one.
+
+**Architecture:** Entirely hub-side. When an enrolment token carries a `provisionedRuntimeId` whose runtime already has a `nodeId`, `enrollNode` returns that node with a rotated secret rather than creating a new one. Such tokens become reusable and non-expiring; every other token keeps today's strict one-time, short-lived behaviour.
+
+**Tech Stack:** Bun + Hono + Drizzle/Postgres.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-runtime-identity-persistence-design.md`
+
+## Global Constraints
+
+- **No node-agent change.** It is already idempotent (`decideEnroll`, `alreadyEnrolled`, `enroll_idempotent_test.go`) and the runtime image entrypoint already calls `enroll` on every start.
+- **Unbound tokens must remain strictly one-time and short-lived.** This is the security property the change must not erode; it has its own test.
+- **The existing TOCTOU protection must not weaken.** Today a single atomic `UPDATE ... RETURNING` consumes the token so two concurrent enrolments cannot both pass a `SELECT` guard. Runtime-bound re-enrolment cannot gate on `usedAt`, so it needs its own convergence guarantee.
+- **A runtime-bound token whose runtime row is gone is rejected**, never silently degraded to unbound. `provisionedRuntimeId` is `on delete set null`.
+- Branch: `runtime-identity-persistence` off `main`. Single PR.
+- TDD: every task writes its failing test first.
+
+## Existing behaviour worth knowing before you start
+
+`apps/hub/src/services/enrollment.ts`:
+
+- `mintEnrollmentToken(userId, opts?)` — `opts.ttlMs` defaults to 1 hour; `opts.provisionedRuntimeId` links the token to a runtime.
+- `enrollNode(token, hostInfo)` — hashes the token, then **atomically** consumes it with `UPDATE enrollment_tokens SET usedAt = now() WHERE tokenHash = ? AND usedAt IS NULL AND expiresAt > now() RETURNING *`. If no row comes back it throws `"invalid or expired enrollment token"`. It then mints a new `nodeId` + `nodeSecret`, inserts the node, and — when `row.provisionedRuntimeId` is set — writes `nodeId` back onto the runtime and flips it to `online`.
+- `verifyNodeCredential(nodeId, nodeSecret)` — `Bun.password.verify` against `nodes.secretHash`.
+
+Tests live in `apps/hub/tests/integration/enrollment.test.ts` and already cover `mint → enroll → verify → list`, `a token cannot be reused`, and `concurrent enrollments with the same token — exactly one succeeds`. **Those three must still pass unchanged.**
+
+## File Structure
+
+**`apps/hub`**
+- `src/services/enrollment.ts` *(modify)* — the whole behaviour change lives here.
+- `tests/integration/enrollment.test.ts` *(modify)* — re-enrolment, rotation, rejection, concurrency.
+- `src/services/runtimes.ts` *(modify)* — mint runtime-bound tokens as durable.
+
+---
+
+## Task 1: Runtime-bound tokens are durable at mint time
+
+A runtime-bound token must outlive its runtime, so it is minted with no expiry. Doing this first means Task 2's re-enrolment has a token that is still valid to re-present.
+
+**Files:**
+- Modify: `apps/hub/src/services/enrollment.ts` (`mintEnrollmentToken`)
+- Modify: `apps/hub/tests/integration/enrollment.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `mintEnrollmentToken` sets a far-future `expiresAt` when `provisionedRuntimeId` is present; unbound tokens keep the 1-hour default. Exported constant `RUNTIME_TOKEN_TTL_MS`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/hub/tests/integration/enrollment.test.ts`, inside the existing top-level `describe` block (match its indentation):
+
+```ts
+  test("a runtime-bound token is minted durable, an unbound one is not", async () => {
+    // A runtime-bound token has to survive as long as its runtime — it is
+    // re-presented on every container restart, which may be months later. An
+    // unbound token is pasted into a shell by a human within the hour.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+
+    const bound = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    const unbound = await mintEnrollmentToken(TEST_USER_ID);
+
+    const oneDay = 24 * 60 * 60 * 1000;
+    expect(bound.expiresAt.getTime() - Date.now()).toBeGreaterThan(oneDay);
+    expect(unbound.expiresAt.getTime() - Date.now()).toBeLessThanOrEqual(60 * 60 * 1000 + 5_000);
+  });
+
+  test("an explicit ttlMs still wins for a runtime-bound token", async () => {
+    // The durable default must not take away a caller's ability to say
+    // otherwise — tests and future callers may want a short-lived bound token.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const t = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+      ttlMs: 60_000,
+    });
+    expect(t.expiresAt.getTime() - Date.now()).toBeLessThanOrEqual(65_000);
+  });
+```
+
+Add this helper near the other fixtures at the top of the file, after `TEST_USER_ID`:
+
+```ts
+/**
+ * Insert a provisioned_runtimes row and return its id.
+ *
+ * Written directly rather than through createRuntime() so these tests need no
+ * provisioner registration — the identity behaviour under test is independent
+ * of which driver created the runtime.
+ */
+async function seedRuntime(userId: string): Promise<string> {
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes (id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${userId}, 'docker', 'provisioning', 'identity-test', 'small', 'none', now(), now())
+  `;
+  return id;
+}
+```
+
+Add `provisioned_runtimes` to the `afterAll` cleanup in that file so these rows do not leak between runs — read the existing `afterAll` and add a matching `DELETE` before the `nodes` delete (runtimes reference nodes, so order matters).
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test tests/integration/enrollment.test.ts
+```
+
+Expected: the first test FAILS — a bound token currently expires in 1 hour like any other. The second passes already, which is the point: it pins that an explicit `ttlMs` keeps winning.
+
+- [ ] **Step 3: Implement it**
+
+In `apps/hub/src/services/enrollment.ts`, add above `mintEnrollmentToken`:
+
+```ts
+/**
+ * Lifetime for a runtime-bound token: ten years, i.e. "as long as the runtime".
+ *
+ * A runtime-bound token is re-presented on every container restart, which on an
+ * ephemeral-disk substrate is routine and may happen long after provisioning.
+ * An expiry here would mean a runtime that silently stops being able to come
+ * back — the exact failure this work exists to remove.
+ *
+ * It is revoked by destroying the runtime, not by waiting.
+ */
+export const RUNTIME_TOKEN_TTL_MS = 10 * 365 * 24 * 60 * 60 * 1000;
+```
+
+Then change the `ttlMs` line in `mintEnrollmentToken`:
+
+```ts
+  const ttlMs =
+    opts?.ttlMs ?? (opts?.provisionedRuntimeId ? RUNTIME_TOKEN_TTL_MS : 60 * 60 * 1000);
+```
+
+Update that function's doc comment so the default is not misdescribed — change the `ttlMs` line to:
+
+```
+ *   - ttlMs              — token lifetime in ms. Defaults to 1 hour, or
+ *                          RUNTIME_TOKEN_TTL_MS when provisionedRuntimeId is set.
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test tests/integration/enrollment.test.ts
+```
+
+Expected: PASS, including the three pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/services/enrollment.ts apps/hub/tests/integration/enrollment.test.ts
+git commit -m "feat(hub): runtime-bound enrollment tokens are durable"
+```
+
+---
+
+## Task 2: Re-enrolment resumes the runtime's existing node
+
+The core change.
+
+**Files:**
+- Modify: `apps/hub/src/services/enrollment.ts` (`enrollNode`)
+- Modify: `apps/hub/tests/integration/enrollment.test.ts`
+
+**Interfaces:**
+- Consumes: `RUNTIME_TOKEN_TTL_MS` and `seedRuntime` from Task 1.
+- Produces: `enrollNode` returns the runtime's existing `nodeId` with a rotated secret on re-presentation of a runtime-bound token. Signature unchanged: `enrollNode(token: string, hostInfo: HostInfo): Promise<EnrollResponse>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the same `describe` block:
+
+```ts
+  test("re-enrolling a runtime-bound token returns the SAME node", async () => {
+    // The headline behaviour. On an ephemeral-disk substrate the container
+    // re-enrols on every restart; today that mints a new node and orphans the
+    // old one, so the runtime loses its stations, capabilities and history.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    const first = await enrollNode(token, HOST_INFO);
+    const second = await enrollNode(token, HOST_INFO);
+
+    expect(second.nodeId).toBe(first.nodeId);
+  });
+
+  test("re-enrolment rotates the secret and invalidates the old one", async () => {
+    // The container never stores a secret durably, so a fresh one each restart
+    // costs nothing — and a secret that leaked from a previous incarnation
+    // stops working.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    const first = await enrollNode(token, HOST_INFO);
+    const second = await enrollNode(token, HOST_INFO);
+
+    expect(second.nodeSecret).not.toBe(first.nodeSecret);
+    expect(await verifyNodeCredential(second.nodeId, second.nodeSecret)).toBe(true);
+    expect(await verifyNodeCredential(first.nodeId, first.nodeSecret)).toBe(false);
+  });
+
+  test("re-enrolment does not create a second node", async () => {
+    // Guards the orphaning directly: counting rows catches a bug that returning
+    // the right id from the wrong code path would hide.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    await enrollNode(token, HOST_INFO);
+    await enrollNode(token, HOST_INFO);
+    await enrollNode(token, HOST_INFO);
+
+    const rows = await rawSql`
+      SELECT node_id FROM provisioned_runtimes WHERE id = ${runtimeId}
+    ` as Array<{ node_id: string }>;
+    const nodeId = rows[0]!.node_id;
+
+    const nodeRows = await rawSql`
+      SELECT count(*)::int AS n FROM nodes WHERE id = ${nodeId}
+    ` as Array<{ n: number }>;
+    expect(nodeRows[0]!.n).toBe(1);
+  });
+
+  test("an unbound token is still strictly one-time", async () => {
+    // The security property this change must not erode. A reusable token is a
+    // durable credential; only runtime-bound ones earn that, because they
+    // resolve to exactly one runtime and are revoked by destroying it.
+    const { token } = await mintEnrollmentToken(TEST_USER_ID);
+    await enrollNode(token, HOST_INFO);
+    await expect(enrollNode(token, HOST_INFO)).rejects.toThrow(
+      /invalid or expired enrollment token/
+    );
+  });
+
+  test("a runtime-bound token whose runtime is gone is rejected", async () => {
+    // provisionedRuntimeId is ON DELETE SET NULL, so a destroyed runtime leaves
+    // a token pointing at nothing. It must not silently degrade into "mint me
+    // anything" — the identity it referred to is gone on purpose.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    await enrollNode(token, HOST_INFO);
+
+    await rawSql`DELETE FROM provisioned_runtimes WHERE id = ${runtimeId}`;
+
+    await expect(enrollNode(token, HOST_INFO)).rejects.toThrow();
+  });
+
+  test("first boot on a runtime-bound token still mints and links", async () => {
+    // The existing provisioning path must be untouched.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+
+    const { nodeId } = await enrollNode(token, HOST_INFO);
+
+    const rows = await rawSql`
+      SELECT node_id, status FROM provisioned_runtimes WHERE id = ${runtimeId}
+    ` as Array<{ node_id: string; status: string }>;
+    expect(rows[0]!.node_id).toBe(nodeId);
+    expect(rows[0]!.status).toBe("online");
+  });
+
+  test("concurrent re-enrolment converges on one node", async () => {
+    // Runtime-bound re-enrolment cannot gate on usedAt, so it loses the atomic
+    // consume that protects the unbound path. Two containers starting at once
+    // must still not produce two nodes.
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    const { nodeId } = await enrollNode(token, HOST_INFO);
+
+    const results = await Promise.allSettled([
+      enrollNode(token, HOST_INFO),
+      enrollNode(token, HOST_INFO),
+    ]);
+    for (const r of results) {
+      if (r.status === "fulfilled") expect(r.value.nodeId).toBe(nodeId);
+    }
+
+    const nodeRows = await rawSql`
+      SELECT count(*)::int AS n FROM nodes WHERE id = ${nodeId}
+    ` as Array<{ n: number }>;
+    expect(nodeRows[0]!.n).toBe(1);
+  });
+```
+
+If the file has no shared `HOST_INFO` fixture, add one next to `TEST_USER_ID`:
+
+```ts
+const HOST_INFO = { hostname: "identity-test", os: "linux", arch: "amd64", cpuCount: 2 };
+```
+
+If it already has an equivalent under another name, use that name instead throughout.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test tests/integration/enrollment.test.ts
+```
+
+Expected: the re-enrolment tests FAIL with `invalid or expired enrollment token` — the token was consumed by the first call. `an unbound token is still strictly one-time` and `first boot` pass already; they are there to stay passing.
+
+- [ ] **Step 3: Rewrite `enrollNode`**
+
+Replace the body of `enrollNode` in `apps/hub/src/services/enrollment.ts`. Read the existing function first; this preserves its atomic-consume path exactly and adds a branch before it.
+
+```ts
+export async function enrollNode(
+  token: string,
+  hostInfo: HostInfo
+): Promise<EnrollResponse> {
+  const hash = await sha256(token);
+
+  // ── Runtime-bound re-enrolment ────────────────────────────────────────────
+  //
+  // A provisioned runtime on an ephemeral-disk substrate loses its config on
+  // every restart and re-presents this token. Minting a new node there would
+  // orphan the runtime's stations, capabilities and history — so if the runtime
+  // already has a node, we resume it.
+  //
+  // Deliberately does NOT gate on usedAt: that gate is what makes an unbound
+  // token one-time, and re-presentation is the whole point here.
+  const [bound] = await db
+    .select()
+    .from(enrollmentTokens)
+    .where(
+      and(
+        eq(enrollmentTokens.tokenHash, hash),
+        gt(enrollmentTokens.expiresAt, new Date())
+      )
+    );
+
+  if (bound?.provisionedRuntimeId) {
+    const [runtime] = await db
+      .select()
+      .from(provisionedRuntimes)
+      .where(eq(provisionedRuntimes.id, bound.provisionedRuntimeId));
+
+    // The runtime was destroyed. Its identity is gone on purpose, and this
+    // token must not degrade into an unbound one that mints something new.
+    if (!runtime) {
+      throw new Error("invalid or expired enrollment token");
+    }
+
+    if (runtime.nodeId) {
+      // Rotate the secret. The container stores nothing durably, so a fresh
+      // secret costs nothing and retires any that leaked from a previous
+      // incarnation.
+      const nodeSecret =
+        crypto.randomUUID().replace(/-/g, "") +
+        crypto.randomUUID().replace(/-/g, "");
+
+      // Conditional on the node still being the runtime's: concurrent
+      // re-enrolments converge here rather than creating a second node. The
+      // loser's secret is simply superseded, and the node-agent reconnects.
+      const updated = await db
+        .update(nodes)
+        .set({
+          secretHash: await Bun.password.hash(nodeSecret),
+          hostname: hostInfo.hostname,
+          os: hostInfo.os,
+          arch: hostInfo.arch,
+          cpuCount: hostInfo.cpuCount,
+        })
+        .where(eq(nodes.id, runtime.nodeId))
+        .returning();
+
+      // The runtime points at a node row that no longer exists. Treat it as a
+      // first boot rather than failing: the runtime is real and wants a node.
+      if (updated.length > 0) {
+        await db
+          .update(provisionedRuntimes)
+          .set({ status: "online", updatedAt: new Date() })
+          .where(eq(provisionedRuntimes.id, runtime.id));
+
+        return { nodeId: runtime.nodeId, nodeSecret };
+      }
+    }
+  }
+
+  // ── First enrolment ───────────────────────────────────────────────────────
+  //
+  // Atomically consume the token: mark usedAt only if the token exists, is
+  // unused, and has not expired. This single UPDATE eliminates the TOCTOU race
+  // where two concurrent requests could both pass a SELECT guard before either
+  // writes usedAt.
+  const [row] = await db
+    .update(enrollmentTokens)
+    .set({ usedAt: new Date() })
+    .where(
+      and(
+        eq(enrollmentTokens.tokenHash, hash),
+        isNull(enrollmentTokens.usedAt),
+        gt(enrollmentTokens.expiresAt, new Date()),
+      )
+    )
+    .returning();
+
+  if (!row) {
+    throw new Error("invalid or expired enrollment token");
+  }
+
+  const nodeId = prefixedId("node");
+  const nodeSecret =
+    crypto.randomUUID().replace(/-/g, "") +
+    crypto.randomUUID().replace(/-/g, "");
+
+  await db.insert(nodes).values({
+    id: nodeId,
+    userId: row.userId,
+    name: hostInfo.hostname,
+    hostname: hostInfo.hostname,
+    os: hostInfo.os,
+    arch: hostInfo.arch,
+    cpuCount: hostInfo.cpuCount,
+    secretHash: await Bun.password.hash(nodeSecret),
+    status: "offline",
+  });
+
+  // If the token was minted with a provisioned runtime, link the node back to
+  // it and flip its status to "online" so the runtime record reflects enrolment.
+  if (row.provisionedRuntimeId) {
+    await db
+      .update(provisionedRuntimes)
+      .set({ nodeId, status: "online", updatedAt: new Date() })
+      .where(eq(provisionedRuntimes.id, row.provisionedRuntimeId));
+  }
+
+  return { nodeId, nodeSecret };
+}
+```
+
+Update the function's doc comment above it:
+
+```ts
+/**
+ * Enroll a node using a valid enrollment token.
+ *
+ * Returns the node's persistent credentials (nodeId + nodeSecret).
+ *
+ * Two paths:
+ *   - **Runtime-bound token whose runtime already has a node** — returns that
+ *     node with a rotated secret. This is what lets a runtime on an
+ *     ephemeral-disk substrate survive a restart instead of orphaning itself.
+ *   - **Everything else** — consumes the token atomically and mints a new node.
+ *     Unbound tokens remain strictly one-time.
+ *
+ * Throws if the token is invalid, expired, already used (unbound only), or
+ * bound to a runtime that no longer exists.
+ */
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test tests/integration/enrollment.test.ts
+```
+
+Expected: PASS, including the three pre-existing tests — particularly `concurrent enrollments with the same token — exactly one succeeds`, which pins the unbound TOCTOU protection.
+
+- [ ] **Step 5: Run the whole hub suite**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+```
+
+Expected: PASS. `runtimes.test.ts` and `node-posture.test.ts` both enrol nodes and must be unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/services/enrollment.ts apps/hub/tests/integration/enrollment.test.ts
+git commit -m "feat(hub): a restarted runtime resumes its node instead of orphaning it"
+```
+
+---
+
+## Task 3: Stations survive a re-enrolment
+
+A node that keeps its id but loses its stations has not really persisted. This proves the thing operators actually care about.
+
+**Files:**
+- Modify: `apps/hub/tests/integration/enrollment.test.ts`
+
+**Interfaces:**
+- Consumes: `enrollNode` re-enrolment from Task 2; `adoptStations` from `src/services/station-registry`.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the same `describe` block:
+
+```ts
+  test("adopted stations survive a re-enrolment", async () => {
+    // Identity is only worth persisting if what hangs off it persists too.
+    // Stations key on nodeId, so keeping the id keeps the fleet's view intact —
+    // this is the difference between "the runtime came back" and "the runtime
+    // came back as itself".
+    const runtimeId = await seedRuntime(TEST_USER_ID);
+    const { token } = await mintEnrollmentToken(TEST_USER_ID, {
+      provisionedRuntimeId: runtimeId,
+    });
+    const { nodeId } = await enrollNode(token, HOST_INFO);
+
+    await adoptStations(TEST_USER_ID, nodeId, ["opencode:workspace"], [
+      {
+        key: "opencode:workspace", harness: "opencode", kind: "leaf",
+        displayName: "workspace", parentKey: null, workspacePath: "/workspace",
+        capabilities: ["health", "acp"], adopted: false,
+      },
+    ]);
+
+    await enrollNode(token, HOST_INFO);
+
+    const rows = await rawSql`
+      SELECT station_key, capabilities FROM stations WHERE node_id = ${nodeId}
+    ` as Array<{ station_key: string; capabilities: string[] }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.station_key).toBe("opencode:workspace");
+  });
+```
+
+Add the import at the top of the file, beside the other service imports:
+
+```ts
+import { adoptStations } from "../../src/services/station-registry";
+```
+
+Add `stations` to the `afterAll` cleanup, deleted before `nodes` (stations reference nodes).
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test tests/integration/enrollment.test.ts
+```
+
+Expected: PASS with Task 2 in place. Run it anyway — if it fails, re-enrolment is deleting or re-creating the node rather than updating it, which the row-count test in Task 2 would not necessarily catch.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/hub/tests/integration/enrollment.test.ts
+git commit -m "test(hub): adopted stations survive a runtime re-enrolment"
+```
+
+---
+
+## Task 4: Full verification and PR
+
+- [ ] **Step 1: Run every suite**
+
+```bash
+cd packages/contract && bun test
+cd ../../apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+cd ../node-agent && go vet ./... && go test -race ./...
+cd ../console && pnpm check && pnpm test && pnpm build
+```
+
+Expected: all four green — the required checks on `main`.
+
+- [ ] **Step 2: Verify live against the deployed hub**
+
+Unit tests use a seeded runtime row. This exercises the deployed code against a runtime
+created by the real provisioning path — the discipline that found #243 and the dead
+Cloudflare worker.
+
+Deploy the branch:
+
+```bash
+ssh root@178.105.68.68 'cd /opt/agentpod && git fetch -q origin runtime-identity-persistence && git checkout -q FETCH_HEAD && export PATH="$PATH:/root/.bun/bin" && pnpm install --frozen-lockfile >/dev/null 2>&1 && systemctl restart agentpod-hub && sleep 8 && systemctl is-active agentpod-hub'
+```
+
+Then provision a runtime and simulate the restart at the enrolment boundary. The raw
+enrolment token is not recoverable after provisioning (only its hash is stored), so mint a
+second runtime-bound token for the same runtime — which is exactly what re-presentation
+looks like to the hub:
+
+```bash
+ssh root@178.105.68.68 'cd /opt/agentpod/apps/hub && set -a && . /etc/agentpod/hub.env && set +a && /root/.bun/bin/bun -e "
+import { createRuntime } from \"./src/services/runtimes.ts\";
+import { registerEnabledProvisioners } from \"./src/services/provisioner/bootstrap.ts\";
+import { mintEnrollmentToken, enrollNode } from \"./src/services/enrollment.ts\";
+import { db } from \"./src/db/drizzle.ts\";
+registerEnabledProvisioners();
+const u = (await db.query.user.findMany({ limit: 1 }))[0];
+const rt = await createRuntime(u.id, { provider: \"docker\", name: \"identity-check\", resourceTier: \"small\", harness: \"opencode\" }, \"https://hub.agentpod.dev\");
+await new Promise(r => setTimeout(r, 20000));
+const before = (await db.query.provisionedRuntimes.findFirst({ where: (t,{eq}) => eq(t.id, rt.id) }));
+const { token } = await mintEnrollmentToken(u.id, { provisionedRuntimeId: rt.id });
+const again = await enrollNode(token, { hostname: \"identity-check\", os: \"linux\", arch: \"amd64\", cpuCount: 2 });
+console.log(\"RESULT runtime=\" + rt.id + \" before=\" + before?.nodeId + \" after=\" + again.nodeId + \" same=\" + (before?.nodeId === again.nodeId));
+process.exit(0);
+"'
+```
+
+Expected: `same=true`. On `main` this would print two different node ids.
+
+Clean up the runtime and its container afterwards, and return the hub to `main`.
+
+> The full container-level test — kill the container, let it re-enrol on a fresh disk, confirm
+> it returns as the same node — lands with the Cloudflare driver, where an ephemeral-disk
+> restart is native. Docker preserves its writable layer across restarts, so it cannot
+> reproduce the failure this fixes without artificially recreating the container.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin runtime-identity-persistence
+gh pr create --title "feat: a restarted runtime keeps its node identity" --body "$(cat <<'EOF'
+Implements `docs/superpowers/specs/2026-08-12-runtime-identity-persistence-design.md`.
+
+A provisioned runtime that restarts currently becomes a **different node**. Its
+identity lives on container disk; on an ephemeral-disk substrate a restart
+destroys it, the entrypoint re-enrols, and `enrollNode` mints a brand new node —
+orphaning the runtime's stations, capabilities and history.
+
+Verified on a real Cloudflare container 2026-08-12: stopped, woken, restarted
+cleanly, node never came back.
+
+**Not Cloudflare-specific.** Any restart on any ephemeral-disk substrate —
+eviction, redeploy, crash. Docker escapes it today only because container
+restarts preserve the writable layer, which is a property of that substrate
+rather than a guarantee of the design.
+
+## The fix is smaller than the problem
+
+No node-agent change: it is already idempotent (`decideEnroll`,
+`enroll_idempotent_test.go`), and the schema already links tokens to runtimes via
+`enrollment_tokens.provisionedRuntimeId`. The whole gap was that `enrollNode`
+mints unconditionally.
+
+Now, when a token's runtime already has a node, enrolment **returns that node
+with a rotated secret**. Three properties fall out: identity survives, the secret
+rotates on every restart, and nothing durable needs storing in the container.
+
+## The trade, stated plainly
+
+**Runtime-bound tokens become reusable and non-expiring.** That turns a one-shot
+bearer credential into a durable one, which is exactly the kind of thing `apn
+scan` exists to complain about. It is bounded three ways: it resolves to exactly
+one runtime and can create nothing else, it is already in that container's
+environment today, and destroying the runtime revokes it.
+
+**Unbound tokens are unchanged** — strictly one-time, one-hour expiry — and a
+test pins that, because it is the property this must not erode. The existing
+atomic-consume TOCTOU protection is untouched on that path.
+
+## Rejected deliberately
+
+- **Substrate-side storage** (Durable Objects, R2) — would duplicate per driver.
+- **Injecting the node secret as env** — a long-lived secret in a process listing.
+- **Sleep/wake as a station state** — the spike showed containers can stay alive
+  indefinitely, so scale-to-zero is a cost optimisation, not a prerequisite.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for the four required checks**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: `contract`, `hub`, `node-agent`, `console` all green.

--- a/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md
@@ -1,0 +1,126 @@
+# Cloudflare Sandbox driver — design
+
+**Status:** approved 2026-08-12
+**Horizon:** 1 — step 3 of the re-planned driver wave
+**Depends on:** `2026-08-12-runtime-identity-persistence-design.md` (hard dependency)
+**Evidence:** `2026-08-12-cloudflare-sandbox-spike-findings.md`
+
+## Problem
+
+There is one substrate today — Docker on the hub box. Every provisioned runtime shares a
+machine with the control plane, and the fleet has nowhere else to run.
+
+Cloudflare gives a second substrate with real geographic reach and no machine to operate.
+The existing driver and worker cannot deliver it: both are OpenCode-era and marked dead
+(`cloudflare/worker/DEAD.md`). The worker has no `agentpod-node` in its image and discards
+the `env` the driver sends, so a provision would return 2xx and produce a runtime that
+never enrols.
+
+## What the spike established
+
+Verified against the production hub, then torn down:
+
+| | |
+|---|---|
+| A Cloudflare container running `agentpod-node` **enrols and connects** | online in ~20s, `hostname=cloudchamber` |
+| It **survives `sleepAfter`** | 9 minutes at a 2-minute timeout, one continuous process |
+| **Because `onActivityExpired()` fires and the override renews the timer** | observed in the tail, exactly as documented |
+| **Identity does not survive a restart** | container restarted cleanly, node never returned |
+| **The wake path works** | `stop` then `start` reliably restarts the container |
+
+So the substrate is viable. The single blocker is identity, which is why this spec depends
+on the one above and must not ship before it.
+
+## Design
+
+### Always-on, not scale-to-zero
+
+Containers keep themselves alive by overriding `onActivityExpired()` and declining to stop.
+
+The alternative — letting them sleep and waking on demand — is a **cost optimisation**, and
+the spike showed it is not needed for correctness. Deferring it keeps this driver small and
+keeps "asleep" out of the station state machine until someone wants the saving.
+
+The cost is stated plainly so the choice is informed: roughly **$28/month per always-on
+4 GiB station**, about **$1,090/month across 39**, against ~€46/month for a Hetzner box
+that would run the fleet. Cloudflare earns burst, untrusted code and geography — it is not
+the default substrate for standing stations, and the roadmap already says so.
+
+### Two pieces
+
+**A new worker** (`cloudflare/worker-v2/`, alongside the dead one until it is deleted),
+built on `@cloudflare/containers`. It exposes exactly what the driver needs:
+
+| Route | Purpose |
+|---|---|
+| `POST /sandbox` | Start a container for a runtime, with hub URL and enrolment token in its environment |
+| `DELETE /sandbox/:id` | Destroy it |
+| `POST /sandbox/:id/stop` · `/start` | Lifecycle, mapping to the driver's optional `stop`/`start` |
+| `GET /health` | Liveness, for the driver to fail fast on a misconfigured URL |
+
+Authenticated with a shared bearer token, as the old one was.
+
+**A new image**, `agentpod-node` on a slim base with the standard entrypoint — the same
+enrol-then-run contract every other runtime image uses. Not the OpenCode image: harness
+selection is `imageForHarness`'s job, and baking one harness into the substrate is what
+made the old worker unusable.
+
+Because Cloudflare bakes the image at deploy time rather than per request, **`ProvisionSpec.image`
+cannot be honoured.** The driver must reject a spec whose image is not the one the worker
+was deployed with, rather than silently ignoring it — silently ignoring inputs is precisely
+how the old driver would have failed.
+
+### The driver
+
+`CloudflareSandboxProvisioner`, replacing the dead `CloudflareRuntimeProvisioner`:
+
+- `provision` → `POST /sandbox`, returns the sandbox id as `externalId`
+- `destroy` → `DELETE /sandbox/:id`
+- `start` / `stop` → the lifecycle routes
+- `runtime` → reports `"cloudflare-container"`, so the console's Isolation column says
+  something true rather than nothing
+
+Every response is validated against an expected shape. The dead driver's failure was an
+`ASSUMPTION` comment about the worker's contract that nobody checked; this one asserts it
+and fails loudly when it does not hold.
+
+### Registration
+
+Keeps the existing `ENABLE_CLOUDFLARE_SANDBOXES` flag and registry entry, so no registry
+work is needed — the provider name is already in the union. `CLOUDFLARE_WORKER_URL` and
+`CLOUDFLARE_API_TOKEN` are read through the same env path as today.
+
+## Out of scope
+
+- **Sleep/wake as a station state** — deferred, see above.
+- **Opening the registry** — `cloudflare` is already a known provider; nothing here needs
+  dynamic names or capability manifests.
+- **Deleting the old worker and driver** — they stay marked dead until this replaces them
+  in production, so there is always a working reference during the transition.
+- **Preview URLs, R2 workspace storage, Workflows** — all OpenCode-era concepts with no
+  place in the fleet model.
+
+## Testing
+
+- **Driver unit tests against a fake fetch**, mirroring the existing cloudflare tests:
+  provision posts the right body, destroy targets the right id, lifecycle maps correctly.
+- **A response that does not match the expected shape fails the provision** — the specific
+  bug the dead driver would have had.
+- **A spec whose image differs from the deployed one is rejected**, not ignored.
+- **Worker tests** with `vitest` + `@cloudflare/vitest-pool-workers` for routing and auth.
+- **Live verification, through `createRuntime` rather than by hand** — the discipline that
+  found #243 and would have caught the dead worker. A provisioned Cloudflare runtime must
+  reach `status=online` with a real node heartbeating, then survive a restart with the same
+  `nodeId`, which is what proves the dependency above actually works.
+
+## Known limits
+
+**Image is fixed at worker deploy time.** Changing harness image means redeploying the
+worker. That is a platform property, not a design choice, and it makes Cloudflare a poor
+fit for per-runtime harness selection.
+
+**Always-on costs real money.** Documented above. Not the default substrate.
+
+**Ephemeral disk means a restarted station loses its workspace**, not just its identity.
+Identity is solved by the dependency; workspace persistence is not, and a Cloudflare
+station should be treated as disposable until it is.

--- a/docs/superpowers/specs/2026-08-12-runtime-identity-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-12-runtime-identity-persistence-design.md
@@ -1,0 +1,162 @@
+# Runtime identity persistence — design
+
+**Status:** approved 2026-08-12
+**Horizon:** 1 — prerequisite for the Cloudflare driver, but not specific to it
+**Evidence:** `docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md`
+
+## Problem
+
+A provisioned runtime that restarts **silently becomes a different node, or no node at all.**
+
+Node identity — `nodeId` and secret — lives at `/root/.config/agentpod-node/config.json`
+inside the container. On a substrate with ephemeral disk, a restart destroys it. The
+container's entrypoint then runs `agentpod-node enroll` again, and `enrollNode` mints a
+**brand new node**, orphaning the runtime's original one.
+
+Verified 2026-08-12 on a real Cloudflare container: stopped, woken, container restarted
+cleanly, node never came back online.
+
+**This is not Cloudflare-specific.** It applies to any restart on any ephemeral-disk
+substrate — eviction, redeploy, crash, platform maintenance. Cloudflare merely makes it
+routine rather than rare.
+
+Docker is currently unaffected only because container restarts preserve the writable
+layer. That is a property of the substrate, not a guarantee of the design, and it will not
+hold for the next driver either.
+
+## What already works — do not rebuild it
+
+**The node-agent is already idempotent.** `decideEnroll` / `alreadyEnrolled` in
+`cmd/agentpod-node/main.go` make a bare `enroll` a friendly no-op when config is present,
+and there is an `enroll_idempotent_test.go` covering it. The runtime image's entrypoint
+already calls `enroll` unconditionally on every start.
+
+**The schema already links the pieces.** `enrollment_tokens.provisionedRuntimeId` exists,
+and `enrollNode` already writes `nodeId` back onto the runtime row on success.
+
+So this needs **no node-agent change at all.** The entire gap is one behaviour in the hub.
+
+## The gap
+
+`enrollNode` does two things unconditionally:
+
+1. **Consumes the token** — sets `usedAt`, so it can never be presented again.
+2. **Mints a new node** — a fresh `nodeId` and secret every time.
+
+For a provisioned runtime, both are wrong. The runtime *has* an identity; a restart should
+resume it, not replace it.
+
+## Design
+
+### Runtime-bound re-enrolment
+
+When a token carries a `provisionedRuntimeId` **and** that runtime already has a `nodeId`,
+`enrollNode` returns **that node**, with a freshly rotated secret, instead of creating a
+new one.
+
+Three properties fall out, and each matters:
+
+**The node keeps its identity.** Stations, adopted capabilities, audit history and console
+links all survive a restart. Today they are orphaned.
+
+**The secret rotates on every restart.** The container never needs durable storage for it,
+and a secret that leaked from a previous incarnation stops working. Rotation is a
+consequence of the design rather than an extra feature.
+
+**Nothing is stored substrate-side.** No Durable Object storage, no R2, no per-driver
+persistence code. The hub is already the authority on identity; this makes it act like it.
+
+### Token reuse, scoped
+
+Runtime-bound tokens become **reusable**; unbound tokens stay strictly one-time.
+
+That asymmetry is the whole security argument, so it is worth stating plainly. A one-time
+token is a bearer credential that stops mattering the moment it is used. A reusable one is
+a durable credential, and a durable credential in a container's environment is exactly the
+kind of thing `apn scan` exists to complain about.
+
+It is acceptable here because it is **bounded three ways**:
+
+- It resolves to exactly one runtime, and therefore one node — presenting it cannot create
+  anything new or reach anything else.
+- It is already in that container's environment today; this changes its lifetime, not its
+  exposure.
+- Destroying the runtime revokes it, and that is an action the console already offers.
+
+`usedAt` is still stamped on first use, for audit. It stops being a *gate* for
+runtime-bound tokens and remains one for everything else.
+
+### Expiry
+
+A runtime-bound token must outlive its runtime, so it is minted with no expiry.
+
+An unbound token keeps its current short expiry, because it is handed to a human who is
+about to paste it into a shell.
+
+The two now differ in both reuse and lifetime, which is why the code path branches on
+`provisionedRuntimeId` rather than on a flag someone can set independently — there is
+exactly one kind of token that gets the durable treatment, and it is the kind the hub
+mints for itself.
+
+### What happens on each path
+
+| Situation | Behaviour |
+|---|---|
+| Unbound token, unused | Mint a new node. Consume the token. *(unchanged)* |
+| Unbound token, already used | Reject. *(unchanged)* |
+| Unbound token, expired | Reject. *(unchanged)* |
+| Runtime-bound token, runtime has no node yet | Mint a new node, link it to the runtime, stamp `usedAt`. *(first boot)* |
+| Runtime-bound token, runtime already has a node | **Return that node with a rotated secret.** *(restart — new)* |
+| Runtime-bound token, runtime row deleted | Reject. The runtime is gone; its identity should not be resurrectable. |
+
+That last row is deliberate. `provisionedRuntimeId` is `on delete set null`, so a destroyed
+runtime leaves a token pointing at nothing — and a token that once meant "this runtime"
+must not silently degrade into "mint me anything".
+
+### Concurrency
+
+The current implementation is careful about this and the change must not weaken it: a
+single atomic `UPDATE ... RETURNING` consumes the token, deliberately closing a TOCTOU race
+where two concurrent enrolments could both pass a `SELECT` guard.
+
+Runtime-bound re-enrolment cannot use that trick, because it must *not* gate on `usedAt`.
+Two containers starting at once must therefore not produce two nodes. The rotation is
+performed as a conditional update against the runtime's existing `nodeId`, so concurrent
+re-enrolments converge on one node; the loser sees the winner's secret rotation and its
+credential simply fails, which the node-agent already handles by reconnecting.
+
+## Out of scope
+
+- **Sleep/wake as a station state.** The spike showed a container can stay alive
+  indefinitely via `onActivityExpired`, so scale-to-zero is a cost optimisation, not a
+  correctness requirement.
+- **Any node-agent change.** It is already idempotent.
+- **Substrate-side storage.** Explicitly rejected: it would duplicate per driver.
+- **Re-enrolment for non-provisioned nodes.** A hand-enrolled VPS keeps its config on disk;
+  there is no runtime row to bind to and no problem to solve.
+
+## Testing
+
+- **A runtime-bound token used twice returns the same `nodeId`** — the headline behaviour,
+  and the one that currently fails.
+- **The secret rotates**: the second enrolment's secret verifies, the first no longer does.
+- **An unbound token is still strictly one-time** — the security property this change must
+  not erode.
+- **A runtime-bound token whose runtime row is gone is rejected**, not treated as unbound.
+- **First boot still mints and links**, so the existing provisioning path is untouched.
+- **Concurrent re-enrolment converges on one node** — two overlapping calls, one `nodeId`.
+- **Station rows survive** a re-enrolment: adopted stations still point at the same node.
+- Existing enrolment tests must pass unchanged.
+
+Per repo convention, every test is written failing first.
+
+## Known limits
+
+**A reusable token is a longer-lived credential than before.** Bounded as described, and
+already present in the container's environment, but it is a real change in exposure and is
+recorded here rather than buried.
+
+**Rotation invalidates any concurrently-connected old incarnation.** If a previous
+container is somehow still running when a new one enrols, the old one's credential stops
+working and it drops. That is the correct outcome — one runtime, one live node — but it
+means a restart is not gentle to a lingering predecessor.


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-12-runtime-identity-persistence-design.md`.

A provisioned runtime that restarts currently becomes a **different node**. Its
identity lives on container disk; on an ephemeral-disk substrate a restart
destroys it, the entrypoint re-enrols, and `enrollNode` mints a brand new node —
orphaning the runtime's stations, capabilities and history.

Verified on a real Cloudflare container 2026-08-12: stopped, woken, restarted
cleanly, node never came back.

**Not Cloudflare-specific.** Any restart on any ephemeral-disk substrate —
eviction, redeploy, crash. Docker escapes it today only because container
restarts preserve the writable layer, which is a property of that substrate
rather than a guarantee of the design.

## The fix is smaller than the problem

No node-agent change: it is already idempotent (`decideEnroll`,
`enroll_idempotent_test.go`), and the schema already links tokens to runtimes via
`enrollment_tokens.provisionedRuntimeId`. The whole gap was that `enrollNode`
mints unconditionally.

Now, when a token's runtime already has a node, enrolment **returns that node
with a rotated secret**. Three properties fall out: identity survives, the secret
rotates on every restart, and nothing durable needs storing in the container.

## The trade, stated plainly

**Runtime-bound tokens become reusable and non-expiring.** That turns a one-shot
bearer credential into a durable one, which is exactly the kind of thing `apn
scan` exists to complain about. It is bounded three ways: it resolves to exactly
one runtime and can create nothing else, it is already in that container's
environment today, and destroying the runtime revokes it.

**Unbound tokens are unchanged** — strictly one-time, one-hour expiry — with a
test pinning it, because that is the property this must not erode. The existing
atomic-consume TOCTOU protection is untouched on that path, and its pre-existing
concurrency test still passes.

## Verified live, not just in tests

Deployed to the hub and run through `createRuntime` — the discipline that found
#243 and the dead Cloudflare worker:

```
RESULT runtime=rt_5d99...  before=node_b12d...  after=node_b12d...  same=true
```

On `main` that prints two different ids. Cleaned up afterwards; hub returned to
`main`.

## Rejected deliberately

- **Substrate-side storage** (Durable Objects, R2) — would duplicate per driver.
- **Injecting the node secret as env** — a long-lived secret in a process listing.
- **Sleep/wake as a station state** — the spike showed containers can stay alive
  indefinitely via `onActivityExpired`, so scale-to-zero is a cost optimisation,
  not a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW