### PR TITLE
docs: mark the OpenCode-era Cloudflare worker dead, and record the sandbox spike

### DIFF
--- a/apps/hub/src/services/provisioner/cloudflare.ts
+++ b/apps/hub/src/services/provisioner/cloudflare.ts
@@ -1,4 +1,25 @@
 /**
+ * Cloudflare runtime provisioner driver — **DEAD as of 2026-08-12.**
+ *
+ * This driver has never provisioned a working fleet runtime and cannot: the
+ * worker it targets (`cloudflare/worker/`, see its DEAD.md) is OpenCode-era and
+ * ignores both `image` and `env`, so the enrolment token never reaches the
+ * container and the container has no `agentpod-node` binary to use it.
+ *
+ * **The dangerous part is that it would look like it worked.** The worker's
+ * routes match what the ASSUMPTION block below describes, so a provision
+ * returns 2xx, this driver reports success and persists an externalId, and the
+ * runtime row then sits in `provisioning` forever with no error logged
+ * anywhere. That is the same silent-success failure as #243.
+ *
+ * It is left in place, still unregistered (`ENABLE_CLOUDFLARE_SANDBOXES` is
+ * unset everywhere), because its tests pin the RuntimeProvisioner interface for
+ * a non-Docker provider. Do not enable it. A replacement built on the modern
+ * `@cloudflare/sandbox` SDK is tracked separately.
+ *
+ * ── Original header, preserved because the ASSUMPTION is exactly what went
+ *    wrong: the routes were verified, the semantics never were ───────────────
+ *
  * Cloudflare runtime provisioner driver (P4 Task 6).
  *
  * Creates and destroys node-agent sandboxes via the Cloudflare Worker REST API.

--- a/cloudflare/worker/DEAD.md
+++ b/cloudflare/worker/DEAD.md
@@ -1,0 +1,39 @@
+# This worker is dead — do not use it as a reference
+
+**Status: dead as of 2026-08-12.** It is kept in the tree for the SDK usage
+patterns only. It cannot provision a fleet runtime and never could.
+
+It was written in the **OpenCode era**, when the hub drove OpenCode over HTTP
+inside a sandbox. The fleet architecture is the inverse: a `agentpod-node`
+binary runs in the sandbox, dials the hub outbound over WSS, and enrols itself.
+Nothing here does that.
+
+## Why it cannot work, checked 2026-08-12
+
+| Blocker | Detail |
+|---|---|
+| **Wrong image** | `Dockerfile` is `cloudflare/sandbox:0.6.7` + OpenCode. There is no `agentpod-node` binary, so nothing can ever enrol. |
+| **Image is not per-request** | `wrangler.toml` bakes it: `[[containers]] image = "./Dockerfile"`. `ProvisionSpec.image`, which the hub driver dutifully sends, is structurally meaningless here. |
+| **Enrolment token is dropped** | `CreateSandboxBody` has no `env` field. The driver sends `env: { AGENTPOD_HUB_URL, AGENTPOD_ENROLL_TOKEN }` and the worker ignores it. Zero occurrences of either variable in `src/`. |
+| **Wrong architecture** | `handleCreateSandbox` calls `createOpencodeServer`, and `AGENTPOD_API_URL` points at `https://api.agentpod.app` — a domain that no longer exists. The hub is `hub.agentpod.dev`. |
+
+## The trap it sets
+
+The **routes match** what `apps/hub/src/services/provisioner/cloudflare.ts`
+assumes — `POST /sandbox`, `DELETE /sandbox/:id`. So a provision would return
+2xx, the driver would report success and persist an `externalId`, and the
+runtime row would sit in `provisioning` forever with no error anywhere.
+
+That silent-success shape is the same one that produced
+[#243](https://github.com/rakeshgangwar/agentpod/issues/243). Code that returns
+2xx while doing the wrong thing is worse than code that fails.
+
+## What replaces it
+
+A new worker built on the modern `@cloudflare/sandbox` SDK (Sandboxes reached GA
+in April 2026), carrying `agentpod-node` and passing the hub URL and enrolment
+token into the sandbox environment.
+
+Also relevant: this worker already has a `POST /sandbox/:id/wake` route. Sandboxes
+sleep on inactivity, and under our dial-out model **a slept sandbox is an offline
+station** — so wake is not an optimisation here, it is a requirement.

--- a/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md
@@ -1,0 +1,83 @@
+# Cloudflare Sandbox spike — findings
+
+**Date:** 2026-08-12
+**Question:** can a Cloudflare container host an AgentPod station, and what does sleep do to it?
+**Verdict: yes, with one mandatory design consequence.** Build it, and persist node identity outside the container.
+
+Run against the production hub with a real `agentpod-node` binary in a purpose-built
+image, deployed to Cloudflare with `wrangler`. Torn down afterwards: worker deleted,
+node row removed, no residue.
+
+## What was tested
+
+A minimal worker (`@cloudflare/containers@0.3.7`) with a `Container` subclass at
+`sleepAfter = "2m"`, and a Debian image carrying `agentpod-node` plus an entrypoint that
+enrols on first boot and then runs. `POST /spawn` started it with `AGENTPOD_HUB_URL` and
+a one-time enrolment token in the container environment.
+
+## Results
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | Does a Cloudflare container enrol and connect at all? | **Yes.** Online in ~20s, `hostname=cloudchamber`, heartbeating. |
+| 2 | Does it survive `sleepAfter`? | **Yes.** Online across a full 9-minute window at `sleepAfter="2m"` — 4.5× the timeout, one continuous process, one enrolment, zero restarts. |
+| 3 | *Why* does it survive? | **`onActivityExpired()` fires and the override renews the timer**, exactly as documented. Observed in the tail: `[spike] activity expired — NOT stopping` at 02:49:52, container still running after. |
+| 4 | Does identity survive a restart? | **No.** After an explicit stop and a wake with no token, the container restarted cleanly (`NodeAgentContainer.start - Ok`, `[spike] container started`) and the node **never came back online** — still offline 135s later. |
+| 5 | Does the wake path work? | **Yes**, at the platform level. `POST /wake/:id` restarted the container reliably. |
+
+## The one mandatory consequence
+
+**Node identity must live outside the container.**
+
+Cloudflare documents container disk as ephemeral: a restart gets "a fresh disk as defined
+by its container image". AgentPod persists its identity — `nodeId` and secret — to
+`/root/.config/agentpod-node/config.json`. So a restart destroys it, and because enrolment
+tokens are one-time, the node cannot simply enrol again.
+
+**This is not a sleep workaround.** It applies to every restart: eviction, deploy, crash,
+platform maintenance. Any ephemeral-disk substrate needs it. Sleep is merely the most
+frequent trigger.
+
+Result #2 makes this *less* urgent than feared — a station can stay up indefinitely — but
+not optional, because "indefinitely" still ends at the first eviction.
+
+## What this changes about the plan
+
+**Sleep is a solved problem, not a blocker.** The original concern — that Cloudflare's
+activity timer is driven by incoming requests, and a node-agent receives none
+([cloudflare/containers#147](https://github.com/cloudflare/containers/issues/147)) — is
+real but has a documented, verified lever. A station can be kept alive by declining to
+stop on expiry.
+
+**That means the sleep/wake state machine is a cost optimisation, not a correctness
+requirement.** A first Cloudflare driver can ship with always-on containers and be
+correct. Scale-to-zero — "asleep" as a state distinct from "offline", waking on demand —
+becomes a later, optional economic win rather than a prerequisite.
+
+**Identity persistence moves from "nice" to "required", and moves first.** It is the only
+thing standing between a working driver and a fleet that silently loses stations.
+
+Suggested order, revised from "sleep/wake and Cloudflare together":
+
+1. **Identity persistence** — a node resumes an existing `nodeId` after a restart rather
+   than re-enrolling. Needed by any ephemeral substrate; not Cloudflare-specific.
+2. **The Cloudflare driver** — new worker, new image, always-on containers.
+3. **Sleep/wake as a state** — only once someone wants the cost saving.
+
+## Cost, for the decision
+
+At `standard-1` (½ vCPU, 4 GiB), always-on, memory is billed on provisioned resources:
+roughly **$28/month per station**, about **$1,090/month across 39**. A Hetzner AX41 is
+about €46/month and would run that fleet. Cloudflare earns its place for burst, untrusted
+code, and geography — not as the default substrate for standing stations. That is an
+argument for keeping the operated substrate primary, which is what the roadmap already
+says.
+
+## Corrections to earlier claims in this investigation
+
+- I reported that `onActivityExpired` "never fired" based on an empty tail. **Wrong** — the
+  tail had simply started after the firing. It fires, and the override works. This matters:
+  the survival is a documented mechanism, not unexplained behaviour, and can be designed
+  around.
+- A worker redeploy does **not** restart a running container when the image digest is
+  unchanged. Forcing a restart needs an explicit stop.


### PR DESCRIPTION
Documentation only. No behaviour change — the Cloudflare driver stays unregistered
(`ENABLE_CLOUDFLARE_SANDBOXES` is unset everywhere) and 62 provisioner tests pass
unchanged.

## Why this should land before the replacement, not with it

The existing `cloudflare/worker/` and `apps/hub/src/services/provisioner/cloudflare.ts`
**read like a working reference and are not one.** I nearly designed capability
manifests against them before checking. A `DEAD.md` that sits on an unmerged
branch cannot do its job, which is to be found *before* someone spends an
afternoon on the code it describes.

## What was actually wrong with it

Checked 2026-08-12, not inferred:

| Blocker | Detail |
|---|---|
| Wrong image | `Dockerfile` is `cloudflare/sandbox` + OpenCode. No `agentpod-node`, so nothing can enrol. |
| Image is not per-request | `wrangler.toml` bakes it at deploy time, so `ProvisionSpec.image` is structurally meaningless. |
| Enrolment token dropped | `CreateSandboxBody` has no `env` field. Zero occurrences of `AGENTPOD_ENROLL_TOKEN` in `src/`. |
| Wrong architecture | Calls `createOpencodeServer`; `AGENTPOD_API_URL` points at `api.agentpod.app`, a dead domain. |

**The trap:** the *routes* match what the driver assumes, so a provision would
return 2xx, the driver would report success and persist an `externalId`, and the
runtime would sit in `provisioning` forever with no error anywhere. That is the
same silent-success shape as #243.

## The spike findings

Also included: `docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md`,
recording a real Cloudflare container running `agentpod-node` against the
production hub.

- **Enrols and connects** — online in ~20s, `hostname=cloudchamber`
- **Survives `sleepAfter`** — 9 minutes at a 2-minute timeout, one continuous process
- **Because `onActivityExpired()` fires and the override renews the timer**, as documented
- **Identity does not survive a restart** — the finding that produced #245
- **Wake works** — `stop` then `start` restarts it reliably

That reordered the work: identity persistence first (now merged), driver second,
sleep/wake later as a cost optimisation rather than a prerequisite.

The dead code stays in the tree, marked, until its replacement lands — so there is
always a working reference for the SDK usage patterns during the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW