### PR TITLE
feat: Cloudflare sandbox provider, with sleep and wake

### DIFF
--- a/apps/console/src/lib/utils/status-badge.ts
+++ b/apps/console/src/lib/utils/status-badge.ts
@@ -50,6 +50,9 @@ export function tokenFor(status: string): StatusToken {
 
     case "sleeping":
     case "hibernated":
+    // A runtime the substrate idled out to stop billing it. Not an error and
+    // not operator-stopped — it wakes on demand.
+    case "asleep":
       return "sleeping";
 
     // stopped / offline / unknown / anything else

--- a/apps/console/src/routes/runtimes/+page.svelte
+++ b/apps/console/src/routes/runtimes/+page.svelte
@@ -102,6 +102,26 @@
     }
   }
 
+  /**
+   * Wake a runtime the substrate idled out.
+   *
+   * Reuses the start path deliberately: to the driver a wake IS a start, and a
+   * second lifecycle route would be free to drift from it.
+   */
+  async function handleWake(rt: ProvisionedRuntime) {
+    actionInFlight[rt.id] = true;
+    try {
+      await startRuntime(rt.id);
+      await loadRuntimes();
+    } catch (e) {
+      toast.error("Couldn’t wake the runtime", {
+        description: e instanceof Error ? e.message : "Unknown error",
+      });
+    } finally {
+      delete actionInFlight[rt.id];
+    }
+  }
+
   async function handleStop(rt: ProvisionedRuntime) {
     actionInFlight[rt.id] = true;
     try {
@@ -217,6 +237,21 @@
         data-testid="start-btn"
       >
         {actionInFlight[rt.id] ? "Starting…" : "Start"}
+      </button>
+    {/if}
+
+    <!-- Wake: shown when the substrate idled the runtime out. Distinct from
+         Start, which is for a runtime an operator stopped — the label should
+         match what actually happened. -->
+    {#if rt.status === "asleep"}
+      <button
+        type="button"
+        disabled={!!actionInFlight[rt.id]}
+        onclick={() => handleWake(rt)}
+        class="rounded-md border px-2 py-1 text-xs whitespace-nowrap transition-colors border-status-running/50 text-status-running hover:bg-status-running/10 disabled:cursor-not-allowed disabled:opacity-50"
+        data-testid="wake-btn"
+      >
+        {actionInFlight[rt.id] ? "Waking…" : "Wake"}
       </button>
     {/if}
 

--- a/apps/console/src/routes/runtimes/page.svelte.test.ts
+++ b/apps/console/src/routes/runtimes/page.svelte.test.ts
@@ -304,3 +304,49 @@ test("a runtime with no reported runtime shows none", async () => {
   await waitFor(() => expect(container.textContent).toMatch(/plain/));
   expect(container.textContent).not.toMatch(/runsc|runc/);
 });
+
+// ---------------------------------------------------------------------------
+// Asleep + Wake
+// ---------------------------------------------------------------------------
+
+test("an asleep runtime reads as asleep, not broken", async () => {
+  // Sleeping is normal and cheap. Showing it as offline or errored would make
+  // the substrate's main feature look like a fault.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-sleep", name: "napping", status: "asleep" as never },
+  ]);
+  const { container } = render(RuntimesPage);
+  await waitFor(() => expect(container.textContent).toMatch(/asleep/i));
+});
+
+test("an asleep runtime offers Wake", async () => {
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-sleep", name: "napping", status: "asleep" as never },
+  ]);
+  const { getByTestId } = render(RuntimesPage);
+  await waitFor(() => expect(getByTestId("wake-btn")).toBeTruthy());
+});
+
+test("waking calls startRuntime", async () => {
+  // To the driver a wake IS a start; reusing that path avoids a second
+  // lifecycle route that could drift from it.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-sleep", name: "napping", status: "asleep" as never },
+  ]);
+  const start = vi.spyOn(api, "startRuntime").mockResolvedValue(undefined as never);
+
+  const { getByTestId } = render(RuntimesPage);
+  await waitFor(() => expect(getByTestId("wake-btn")).toBeTruthy());
+  fireEvent.click(getByTestId("wake-btn"));
+
+  await waitFor(() => expect(start).toHaveBeenCalledWith("rt-sleep"));
+});
+
+test("an online runtime offers no Wake", async () => {
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-up", name: "awake", status: "online" as const },
+  ]);
+  const { queryByTestId, getByText } = render(RuntimesPage);
+  await waitFor(() => expect(getByText("awake")).toBeTruthy());
+  expect(queryByTestId("wake-btn")).toBeNull();
+});

--- a/apps/hub/src/db/drizzle-migrations/0031_clumsy_selene.sql
+++ b/apps/hub/src/db/drizzle-migrations/0031_clumsy_selene.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."runtime_status" ADD VALUE 'asleep' BEFORE 'error';

--- a/apps/hub/src/db/drizzle-migrations/meta/0031_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0031_snapshot.json
@@ -1,0 +1,2010 @@
+{
+  "id": "f4c11c48-ea51-482f-ac0d-a3f003b1e01a",
+  "prevId": "ba45b16f-b30d-4432-9b26-c3ff77b56c4c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "online",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1786479002917,
       "tag": "0030_faulty_next_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1786506652047,
+      "tag": "0031_clumsy_selene",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/nodes.ts
+++ b/apps/hub/src/db/schema/nodes.ts
@@ -21,7 +21,7 @@ export const nodes = pgTable("nodes", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (t) => [index("nodes_user_id_idx").on(t.userId)]);
 
-export const runtimeStatusEnum = pgEnum("runtime_status", ["provisioning", "online", "stopped", "error", "destroyed"]);
+export const runtimeStatusEnum = pgEnum("runtime_status", ["provisioning", "online", "stopped", "asleep", "error", "destroyed"]);
 
 export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   id: text("id").primaryKey(),

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -42,6 +42,7 @@ import { stationLifecycleRoutes } from './routes/station-lifecycle.ts';
 import { stationCleanupRoutes } from './routes/station-cleanup.ts';
 import { stationChangesetRoutes } from './routes/station-changeset.ts';
 import { nodePostureRoutes } from './routes/node-posture.ts';
+import { runtimeCallbackRoutes } from './routes/runtime-callback.ts';
 // ACP session routes (REST session management + console session WebSocket)
 import { stationAcpRoutes } from './routes/station-acp.ts';
 import { acpProxyRouter } from './routes/acp-proxy.ts';
@@ -127,6 +128,7 @@ const app = new Hono()
   .route('/api', stationCleanupRoutes)                     // POST /api/stations/:id/cleanup/{plan,apply}
   .route('/api', stationChangesetRoutes)                   // POST /api/stations/:id/changeset/{status,diff}
   .route('/api', nodePostureRoutes)                        // POST /api/nodes/:id/posture/scan
+  .route('/public', runtimeCallbackRoutes)                 // POST /public/runtimes/:id/state
   .route('/api', stationAcpRoutes)                         // POST/GET /api/stations/:id/acp/sessions, WS /api/acp/sessions/:sessionId/ws
   .route('/api', acpProxyRouter);                          // WS /api/acp/proxy — Doors: an editor's stdio, piped by `apn acp`
 

--- a/apps/hub/src/routes/runtime-callback.test.ts
+++ b/apps/hub/src/routes/runtime-callback.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration Test: runtime callback route.
+ *
+ * How a substrate tells the hub it idled a runtime out. Cloudflare sleeps
+ * containers on its own timer, so without this the hub sees only a node that
+ * stopped heartbeating and cannot distinguish "slept normally" from "died".
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+process.env.RUNTIME_CALLBACK_TOKEN = "cbtok";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import { db, rawSql } from "../db/drizzle";
+import { provisionedRuntimes } from "../db/schema/nodes";
+import { createTestUser } from "../../tests/helpers/database";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { runtimeCallbackRoutes } from "./runtime-callback";
+
+const TEST_USER = "test-user-rt-callback-001";
+
+const app = new Hono().route("/public", runtimeCallbackRoutes);
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: "rt-callback-test@example.com",
+    name: "Runtime Callback Test User",
+  });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM provisioned_runtimes WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM "user"              WHERE id      = ${TEST_USER}`;
+  } catch {
+    // ignore
+  }
+});
+
+async function seedRuntime(): Promise<string> {
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes (id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${TEST_USER}, 'cloudflare', 'online', 'callback-test', 'small', 'none', now(), now())
+  `;
+  return id;
+}
+
+const post = (id: string, body: unknown, token?: string) =>
+  app.request(`/public/runtimes/${id}/state`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+test("a valid callback marks the runtime asleep", async () => {
+  // The whole point: only the worker knows a container idled out, so it tells us.
+  const id = await seedRuntime();
+  const res = await post(id, { state: "asleep" }, "cbtok");
+  expect(res.status).toBe(200);
+
+  const [row] = await db
+    .select()
+    .from(provisionedRuntimes)
+    .where(eq(provisionedRuntimes.id, id));
+  expect(row?.status).toBe("asleep");
+});
+
+test("an unauthenticated callback is refused", async () => {
+  // This endpoint is public — it must be reachable by a container with no
+  // session. A missing token must therefore fail closed, or anyone could mark
+  // another user's runtime asleep.
+  const id = await seedRuntime();
+  const res = await post(id, { state: "asleep" });
+  expect(res.status).toBe(401);
+});
+
+test("a wrong token is refused", async () => {
+  const id = await seedRuntime();
+  const res = await post(id, { state: "asleep" }, "nope");
+  expect(res.status).toBe(401);
+});
+
+test("an unknown runtime is a 404, not a silent success", async () => {
+  const res = await post("rt_nope", { state: "asleep" }, "cbtok");
+  expect(res.status).toBe(404);
+});
+
+test("only asleep is accepted", async () => {
+  // The callback is not a general status-setting API. A container must not be
+  // able to declare itself destroyed or online.
+  const id = await seedRuntime();
+  for (const state of ["destroyed", "online", "error", "stopped"]) {
+    const res = await post(id, { state }, "cbtok");
+    expect(res.status).toBe(400);
+  }
+
+  const [row] = await db
+    .select()
+    .from(provisionedRuntimes)
+    .where(eq(provisionedRuntimes.id, id));
+  expect(row?.status).toBe("online");
+});

--- a/apps/hub/src/routes/runtime-callback.ts
+++ b/apps/hub/src/routes/runtime-callback.ts
@@ -1,0 +1,60 @@
+/**
+ * Runtime Callback Route — POST /public/runtimes/:id/state
+ *
+ * How a substrate tells the hub that it idled a runtime out.
+ *
+ * Cloudflare sleeps containers on its own timer, so without this the hub sees
+ * only that a node stopped heartbeating and cannot distinguish "slept normally"
+ * from "died". Reporting a routine state as a fault is the failure shape this
+ * codebase keeps hitting, so the substrate reports it instead of us guessing.
+ *
+ * **Public** — the caller is a container with no session — so it authenticates
+ * with a shared bearer token and fails closed when none is configured.
+ *
+ * Deliberately narrow: `asleep` is the only accepted state. This is not a
+ * general status-setting API, and a container must not be able to declare
+ * itself destroyed or online.
+ */
+
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { provisionedRuntimes } from "../db/schema/nodes";
+
+export const runtimeCallbackRoutes = new Hono().post(
+  "/runtimes/:id/state",
+  async (c) => {
+    const expected = process.env.RUNTIME_CALLBACK_TOKEN;
+    const header = c.req.header("Authorization") ?? "";
+    if (!expected || header !== `Bearer ${expected}`) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    let body: { state?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid json" }, 400);
+    }
+
+    if (body.state !== "asleep") {
+      return c.json({ error: "only 'asleep' may be reported" }, 400);
+    }
+
+    const id = c.req.param("id");
+    const [row] = await db
+      .select()
+      .from(provisionedRuntimes)
+      .where(eq(provisionedRuntimes.id, id));
+    if (!row) {
+      return c.json({ error: "Not Found" }, 404);
+    }
+
+    await db
+      .update(provisionedRuntimes)
+      .set({ status: "asleep", updatedAt: new Date() })
+      .where(eq(provisionedRuntimes.id, id));
+
+    return c.json({ ok: true });
+  }
+);

--- a/apps/hub/src/services/provisioner/bootstrap.ts
+++ b/apps/hub/src/services/provisioner/bootstrap.ts
@@ -9,13 +9,13 @@
  */
 import { registerProvisioner, isProviderEnabled } from "./registry";
 import { DockerRuntimeProvisioner } from "./docker";
-import { CloudflareRuntimeProvisioner } from "./cloudflare";
+import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
 
 export function registerEnabledProvisioners(): void {
   if (isProviderEnabled("docker")) {
     registerProvisioner(new DockerRuntimeProvisioner());
   }
   if (isProviderEnabled("cloudflare")) {
-    registerProvisioner(new CloudflareRuntimeProvisioner());
+    registerProvisioner(new CloudflareSandboxProvisioner());
   }
 }

--- a/apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts
+++ b/apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests: CloudflareSandboxProvisioner.
+ *
+ * No real Cloudflare. A fake fetch captures requests and returns controlled
+ * responses — including malformed ones, which is the case the dead driver
+ * would have accepted.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
+import type { ProvisionSpec } from "./types";
+
+const IMAGE = "agentpod-node-opencode:v0.1.22";
+
+const SPEC: ProvisionSpec = {
+  runtimeId: "rt_abc",
+  name: "test",
+  resourceTier: "small",
+  hubUrl: "https://hub.example",
+  enrollToken: "enr_secret",
+  image: IMAGE,
+};
+
+function fakeFetch(response: unknown, status = 201) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return new Response(JSON.stringify(response), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, calls };
+}
+
+const make = (impl: typeof globalThis.fetch) =>
+  new CloudflareSandboxProvisioner({
+    workerUrl: "https://w.example",
+    apiToken: "tok",
+    deployedImage: IMAGE,
+    callbackToken: "cbtok",
+    fetchImpl: impl,
+  });
+
+describe("CloudflareSandboxProvisioner", () => {
+  it("provisions and returns the worker's sandbox id", async () => {
+    const { impl, calls } = fakeFetch({ sandboxId: "rt_abc" });
+    const res = await make(impl).provision(SPEC);
+
+    expect(res.externalId).toBe("rt_abc");
+    expect(calls[0]!.url).toBe("https://w.example/sandbox");
+    expect(calls[0]!.init.method).toBe("POST");
+  });
+
+  it("reports its runtime so the console can show real isolation", async () => {
+    const { impl } = fakeFetch({ sandboxId: "rt_abc" });
+    const res = await make(impl).provision(SPEC);
+    expect(res.runtime).toBe("cloudflare-container");
+  });
+
+  it("sends the hub url, enrolment token and callback token", async () => {
+    const { impl, calls } = fakeFetch({ sandboxId: "rt_abc" });
+    await make(impl).provision(SPEC);
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body.hubUrl).toBe(SPEC.hubUrl);
+    expect(body.enrollToken).toBe(SPEC.enrollToken);
+    expect(body.id).toBe(SPEC.runtimeId);
+    // Without this the container cannot tell the hub it slept, and every
+    // sleeping station would read as offline.
+    expect(body.callbackToken).toBe("cbtok");
+  });
+
+  it("authenticates with a bearer token", async () => {
+    const { impl, calls } = fakeFetch({ sandboxId: "rt_abc" });
+    await make(impl).provision(SPEC);
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("REJECTS a response that does not match the expected shape", async () => {
+    // The dead driver's exact failure: it assumed the worker's contract and
+    // never checked, so a 2xx with the wrong body produced a runtime that sat
+    // in `provisioning` forever with no error anywhere.
+    const { impl } = fakeFetch({ nope: true });
+    await expect(make(impl).provision(SPEC)).rejects.toThrow(/unexpected response/i);
+  });
+
+  it("rejects a non-2xx response", async () => {
+    const { impl } = fakeFetch({ error: "boom" }, 500);
+    await expect(make(impl).provision(SPEC)).rejects.toThrow(/500/);
+  });
+
+  it("REJECTS a spec whose image is not the deployed one", async () => {
+    // Cloudflare bakes the image at deploy time, so ProvisionSpec.image cannot
+    // be honoured. Silently ignoring an input is how the old driver failed —
+    // refuse loudly instead.
+    const { impl } = fakeFetch({ sandboxId: "rt_abc" });
+    await expect(
+      make(impl).provision({ ...SPEC, image: "something-else:latest" })
+    ).rejects.toThrow(/image/i);
+  });
+
+  it("destroys by sandbox id", async () => {
+    const { impl, calls } = fakeFetch({ destroyed: "rt_abc" }, 200);
+    await make(impl).destroy("rt_abc");
+    expect(calls[0]!.url).toBe("https://w.example/sandbox/rt_abc");
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("maps start and stop to the lifecycle routes", async () => {
+    const started = fakeFetch({ started: "rt_abc" }, 200);
+    await make(started.impl).start!("rt_abc");
+    expect(started.calls[0]!.url).toBe("https://w.example/sandbox/rt_abc/start");
+
+    const stopped = fakeFetch({ stopped: "rt_abc" }, 200);
+    await make(stopped.impl).stop!("rt_abc");
+    expect(stopped.calls[0]!.url).toBe("https://w.example/sandbox/rt_abc/stop");
+  });
+
+  it("fails clearly when the worker url is not configured", async () => {
+    const p = new CloudflareSandboxProvisioner({ workerUrl: "", apiToken: "tok" });
+    await expect(p.provision(SPEC)).rejects.toThrow(/CLOUDFLARE_WORKER_URL/);
+  });
+});

--- a/apps/hub/src/services/provisioner/cloudflare-sandbox.ts
+++ b/apps/hub/src/services/provisioner/cloudflare-sandbox.ts
@@ -1,0 +1,136 @@
+/**
+ * Cloudflare Sandbox provisioner driver.
+ *
+ * Talks to `cloudflare/worker-v2/`, which runs a container carrying a released
+ * agentpod-node. The container dials the hub outbound and enrols itself, so this
+ * driver's only job is lifecycle.
+ *
+ * Replaces the dead OpenCode-era driver in `cloudflare.ts`. The lesson carried
+ * over from it: **every response is validated**. That driver documented an
+ * ASSUMPTION about the worker's contract and never checked it, so a 2xx with the
+ * wrong body would have produced a runtime stuck in `provisioning` with no error
+ * logged anywhere.
+ *
+ * SECURITY: the enrolment token is sent in the request body and is never logged
+ * by this module. Do not add log statements that reference spec.enrollToken.
+ */
+
+import type { RuntimeProvisioner, ProvisionSpec } from "./types";
+
+export interface CloudflareSandboxOptions {
+  workerUrl?: string;
+  apiToken?: string;
+  /**
+   * The image the worker was deployed with. Cloudflare bakes it at deploy time,
+   * so a spec asking for anything else cannot be satisfied and is refused.
+   */
+  deployedImage?: string;
+  /**
+   * Shared secret the container presents when telling the hub it slept. Without
+   * it the hub cannot distinguish a routine sleep from a dead container.
+   */
+  callbackToken?: string;
+  /** Injectable fetch — used to inject a fake in unit tests. */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
+  readonly provider = "cloudflare" as const;
+
+  private readonly workerUrl: string;
+  private readonly apiToken: string;
+  private readonly deployedImage: string;
+  private readonly callbackToken: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor({
+    workerUrl = process.env.CLOUDFLARE_WORKER_URL ?? "",
+    apiToken = process.env.CLOUDFLARE_WORKER_TOKEN ?? "",
+    deployedImage = process.env.CLOUDFLARE_SANDBOX_IMAGE ?? "",
+    callbackToken = process.env.RUNTIME_CALLBACK_TOKEN ?? "",
+    fetchImpl = globalThis.fetch,
+  }: CloudflareSandboxOptions = {}) {
+    this.workerUrl = workerUrl.replace(/\/$/, "");
+    this.apiToken = apiToken;
+    this.deployedImage = deployedImage;
+    this.callbackToken = callbackToken;
+    this.fetchImpl = fetchImpl;
+  }
+
+  private async call(
+    path: string,
+    init: RequestInit
+  ): Promise<Record<string, unknown>> {
+    if (!this.workerUrl) {
+      throw new Error(
+        "cloudflare: CLOUDFLARE_WORKER_URL is not set; cannot reach the sandbox worker"
+      );
+    }
+
+    const res = await this.fetchImpl(`${this.workerUrl}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiToken}`,
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`cloudflare: worker returned ${res.status} for ${path}`);
+    }
+
+    try {
+      return (await res.json()) as Record<string, unknown>;
+    } catch {
+      throw new Error(`cloudflare: unexpected response from ${path} (not JSON)`);
+    }
+  }
+
+  async provision(
+    spec: ProvisionSpec
+  ): Promise<{ externalId: string; runtime?: string }> {
+    // Cloudflare bakes the image at worker deploy time. Honour-or-refuse, never
+    // ignore: a driver that quietly drops an input is how the previous one would
+    // have failed.
+    if (this.deployedImage && spec.image !== this.deployedImage) {
+      throw new Error(
+        `cloudflare: this worker is deployed with image "${this.deployedImage}" and ` +
+          `cannot provision "${spec.image}". Cloudflare bakes the image at deploy ` +
+          `time; redeploy the worker to change it.`
+      );
+    }
+
+    const body = await this.call("/sandbox", {
+      method: "POST",
+      body: JSON.stringify({
+        id: spec.runtimeId,
+        hubUrl: spec.hubUrl,
+        enrollToken: spec.enrollToken,
+        callbackToken: this.callbackToken,
+      }),
+    });
+
+    const sandboxId = body.sandboxId;
+    if (typeof sandboxId !== "string" || !sandboxId) {
+      throw new Error(
+        "cloudflare: unexpected response from /sandbox (no sandboxId)"
+      );
+    }
+
+    return { externalId: sandboxId, runtime: "cloudflare-container" };
+  }
+
+  async destroy(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}`, { method: "DELETE" });
+  }
+
+  /** Also the wake path: to the worker a wake IS a start. */
+  async start(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}/start`, { method: "POST" });
+  }
+
+  async stop(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}/stop`, { method: "POST" });
+  }
+}

--- a/apps/hub/src/services/provisioner/cloudflare.ts
+++ b/apps/hub/src/services/provisioner/cloudflare.ts
@@ -1,6 +1,8 @@
 /**
  * Cloudflare runtime provisioner driver — **DEAD as of 2026-08-12.**
  *
+ * SUPERSEDED by ./cloudflare-sandbox.ts, which is what the registry now wires.
+ *
  * This driver has never provisioned a working fleet runtime and cannot: the
  * worker it targets (`cloudflare/worker/`, see its DEAD.md) is OpenCode-era and
  * ignores both `image` and `env`, so the enrolment token never reaches the

--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+# Pin explicitly. A floating "latest" would make two deploys of the same worker
+# produce different fleet behaviour, which is exactly the kind of drift the
+# release pipeline exists to prevent.
+ARG AGENTPOD_VERSION=v0.1.22
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Verify against SHA256SUMS, as install.sh and self-update do. An unverified
+# binary here would be a supply-chain hole in the substrate itself.
+RUN set -eux; \
+    base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
+    curl -fsSL -o /usr/local/bin/agentpod-node "${base}/agentpod-node-linux-amd64"; \
+    curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
+    cd /usr/local/bin; \
+    cp agentpod-node agentpod-node-linux-amd64; \
+    grep ' agentpod-node-linux-amd64$' /tmp/SHA256SUMS | sha256sum -c -; \
+    rm -f agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
+    chmod +x /usr/local/bin/agentpod-node; \
+    /usr/local/bin/agentpod-node version
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/cloudflare/worker-v2/README.md
+++ b/cloudflare/worker-v2/README.md
@@ -1,0 +1,62 @@
+# agentpod-sandbox-v2
+
+The Cloudflare substrate for AgentPod stations. Replaces `../worker/`, which is
+dead — see its `DEAD.md`.
+
+A container runs a **released** `agentpod-node`, verified against `SHA256SUMS`
+exactly as `install.sh` and self-update do, so a Cloudflare station runs the same
+binary as the rest of the fleet. It dials the hub outbound and enrols itself; the
+hub driver only does lifecycle.
+
+## Stations sleep
+
+`onActivityExpired` stops the container and Cloudflare stops charging — roughly
+**12× cheaper** than staying alive (~$2/month per idle station against ~$28).
+
+Cloudflare's activity timer is fed by *incoming* requests
+([containers#147](https://github.com/cloudflare/containers/issues/147)), and a
+node-agent receives none, so a station always idles out eventually. That is fine
+because a woken container re-enrols and **resumes the same `nodeId`** (runtime
+identity persistence, #245). Before that landed, sleeping lost the station.
+
+Since Cloudflare sleeps on its own timer, the container **tells the hub** via
+`POST /public/runtimes/:id/state` — otherwise the hub sees only a node that
+stopped heartbeating and cannot tell "idled out" from "died".
+
+## Routes
+
+All except `/health` require `Authorization: Bearer $AGENTPOD_WORKER_TOKEN`.
+
+| Route | Purpose |
+|---|---|
+| `GET /health` | Liveness. Unauthenticated so the driver can fail fast on a bad URL without holding a credential. |
+| `POST /sandbox` | Start a station. Body: `id`, `hubUrl`, `enrollToken`, `callbackToken`. |
+| `GET /sandbox/:id` | Existence check. |
+| `DELETE /sandbox/:id` | Destroy. |
+| `POST /sandbox/:id/start` | Start — **also the wake path**. |
+| `POST /sandbox/:id/stop` | Stop. |
+
+## Deploy
+
+```bash
+npm install
+npx wrangler deploy
+npx wrangler secret put AGENTPOD_WORKER_TOKEN   # openssl rand -hex 32
+```
+
+Then on the hub, in `/etc/agentpod/hub.env`:
+
+```
+ENABLE_CLOUDFLARE_SANDBOXES=true
+CLOUDFLARE_WORKER_URL=https://<worker-url>
+CLOUDFLARE_WORKER_TOKEN=<the same secret>
+CLOUDFLARE_SANDBOX_IMAGE=<what imageForHarness returns for the harness you provision>
+RUNTIME_CALLBACK_TOKEN=<shared secret for the sleep callback>
+```
+
+`CLOUDFLARE_SANDBOX_IMAGE` must match, because Cloudflare bakes the image at
+deploy time and the driver **refuses** a mismatched spec rather than silently
+ignoring it.
+
+Changing `AGENTPOD_VERSION` in the Dockerfile means redeploying the worker — the
+image is not selectable per request.

--- a/cloudflare/worker-v2/entrypoint.sh
+++ b/cloudflare/worker-v2/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
+#
+# On an ephemeral-disk substrate this runs on every start, not just the first.
+# The hub returns the SAME node for a runtime-bound token whose runtime already
+# has one (runtime identity persistence, #245), so a restart resumes rather than
+# orphaning. Without that this loop would mint a new node every restart.
+/usr/local/bin/agentpod-node enroll
+
+exec /usr/local/bin/agentpod-node run

--- a/cloudflare/worker-v2/package-lock.json
+++ b/cloudflare/worker-v2/package-lock.json
@@ -1,0 +1,2957 @@
+{
+  "name": "agentpod-sandbox-v2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentpod-sandbox-v2",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.7"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260812.1",
+        "vitest": "^2.1.9",
+        "wrangler": "^4.121.0"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260804.1.tgz",
+      "integrity": "sha512-191/PPEFicRK2wK69eXzSjnLgHL79k7zR2VUpyIr8rhFgGns1b5bTHgnBuUrgU2LPbEtwbE5eL2hJ0uhLAFEow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260804.1.tgz",
+      "integrity": "sha512-aI2cAFLsrNkSz3kLSQrgrO9ICTfY7jb2h0jgaWDE9mQLQQDfpXeYrKWt07tTgMmeNP79o9w3NZe3aqtt8mTGHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260804.1.tgz",
+      "integrity": "sha512-KBCjxBIlN2jucfQGaTK4EgmPsWzQgYR/zYhPfi3mkWwdoTyG1dgrt2aizKps/SYse85ci/SOxojKk0/K7vstPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260804.1.tgz",
+      "integrity": "sha512-7lswfarBZ7xkHpTFrNb74ExwOltIalVaASc+GOYfCNtnwFxK/JZSVByfm/hnZEBtrHU7fMY2z7dYT64rwS0pHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260804.1.tgz",
+      "integrity": "sha512-GOgRWYtxISN5rAWfx3K7zubt3xEn0/ZPFrbcLL+GwT4ouCKyNoHqfT1cPNB6Nx7t8BHEjnuTG7gkHO4Wd5ORdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260812.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260812.1.tgz",
+      "integrity": "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260804.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260804.1-alpha.tgz",
+      "integrity": "sha512-J0QBHEj+d75TyFE9VhH+2dXgvdYt/pfyDlm+9IiYUFocQvqYy9iuW1DIqNawh1N7Kr6iMrDzVkgDSdt6pA75uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260804.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260804.1.tgz",
+      "integrity": "sha512-b0P38g5/ssemwWxd/mafNYggEZ0ere7PCiUH6RCHkgqjRhhXTP45nDiL2L3iIvi8uF2IjNrGpVgMXEunCaeY/w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260804.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260804.1",
+        "@cloudflare/workerd-linux-64": "1.20260804.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260804.1",
+        "@cloudflare/workerd-windows-64": "1.20260804.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.121.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.121.0.tgz",
+      "integrity": "sha512-dcARWk6CyaD0vJBSLjJn4K2yo+mYko73hzryq+t/9DXnyAq877RWIMl7uOMcDKs5dDXdoickNhZTKxBYT9XKsA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260804.1-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260804.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260804.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/cloudflare/worker-v2/package.json
+++ b/cloudflare/worker-v2/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agentpod-sandbox-v2",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "tail": "wrangler tail --format pretty"
+  },
+  "dependencies": {
+    "@cloudflare/containers": "^0.3.7"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260812.1",
+    "vitest": "^2.1.9",
+    "wrangler": "^4.121.0"
+  }
+}

--- a/cloudflare/worker-v2/src/auth.ts
+++ b/cloudflare/worker-v2/src/auth.ts
@@ -1,0 +1,22 @@
+/**
+ * Bearer-token check for every route except /health.
+ *
+ * The worker can start containers that enrol into a fleet, so an unauthenticated
+ * caller could mint stations. /health is exempt so the driver can fail fast on a
+ * misconfigured URL without holding a credential.
+ */
+export function isAuthorised(request: Request, expected: string | undefined): boolean {
+  if (!expected) return false; // no secret configured → refuse everything
+  const header = request.headers.get("Authorization") ?? "";
+  const prefix = "Bearer ";
+  if (!header.startsWith(prefix)) return false;
+  return timingSafeEqual(header.slice(prefix.length), expected);
+}
+
+/** Constant-time compare, so a wrong token cannot be guessed byte by byte. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/cloudflare/worker-v2/src/index.ts
+++ b/cloudflare/worker-v2/src/index.ts
@@ -26,6 +26,38 @@ export class NodeAgentContainer extends Container {
     console.log("[agentpod] container started", new Date().toISOString());
   }
 
+  /**
+   * Start with the environment this sandbox was created with, persisting it so
+   * a later wake can reuse it.
+   *
+   * The env MUST be stored, not merely passed to start(): a container's
+   * environment does not survive a stop, and a woken container with no
+   * AGENTPOD_HUB_URL or AGENTPOD_ENROLL_TOKEN fails `agentpod-node enroll`,
+   * exits under `set -e`, and is restarted forever. That produced 7 live
+   * instances in a silent restart loop the first time this was deployed.
+   */
+  async createWithEnv(envVars: Record<string, string>): Promise<void> {
+    await this.ctx.storage.put("envVars", envVars);
+    this.envVars = envVars;
+    await this.start();
+  }
+
+  /**
+   * Wake: start again with the stored environment.
+   *
+   * Throws when there is none rather than starting a container that cannot
+   * enrol — a restart loop is far worse than a failed request, because it is
+   * silent and it bills.
+   */
+  async wake(): Promise<void> {
+    const envVars = await this.ctx.storage.get<Record<string, string>>("envVars");
+    if (!envVars) {
+      throw new Error("no stored environment for this sandbox; create it first");
+    }
+    this.envVars = envVars;
+    await this.start();
+  }
+
   override onStop({ exitCode, reason }: { exitCode: number; reason: string }) {
     console.log("[agentpod] container stopped", { exitCode, reason });
   }
@@ -124,14 +156,12 @@ export default {
       const c = getContainer(env.NODE_AGENT, body.id);
       // The token is passed through but never logged, here or anywhere in this
       // worker. Do not add log statements that reference body.enrollToken.
-      await c.start({
-        envVars: {
-          AGENTPOD_HUB_URL: body.hubUrl,
-          AGENTPOD_ENROLL_TOKEN: body.enrollToken,
-          // Read by the container class's notifyHub, not by agentpod-node.
-          AGENTPOD_RUNTIME_ID: body.id,
-          AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
-        },
+      await c.createWithEnv({
+        AGENTPOD_HUB_URL: body.hubUrl,
+        AGENTPOD_ENROLL_TOKEN: body.enrollToken,
+        // Read by the container class's notifyHub, not by agentpod-node.
+        AGENTPOD_RUNTIME_ID: body.id,
+        AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
       });
       return json({ sandboxId: body.id }, 201);
     }
@@ -150,10 +180,15 @@ export default {
       return json({ destroyed: id });
     }
 
-    // Also the wake path: to this worker a wake IS a start, and the spike
-    // confirmed stop → start restarts a container reliably.
+    // The wake path. Uses the STORED environment — a bare start() would boot a
+    // container with no hub URL or enrolment token, which cannot enrol and gets
+    // restarted forever.
     if (request.method === "POST" && parts[2] === "start") {
-      await container.start();
+      try {
+        await container.wake();
+      } catch (e) {
+        return json({ error: e instanceof Error ? e.message : String(e) }, 409);
+      }
       return json({ started: id });
     }
 

--- a/cloudflare/worker-v2/src/index.ts
+++ b/cloudflare/worker-v2/src/index.ts
@@ -1,0 +1,167 @@
+import { Container, getContainer } from "@cloudflare/containers";
+import { isAuthorised } from "./auth";
+
+interface Env {
+  // Typed with the container class so getContainer returns a stub carrying its
+  // lifecycle methods — an untyped namespace would need casts at every call
+  // site, and a cast is where a wrong method name survives to runtime.
+  NODE_AGENT: DurableObjectNamespace<NodeAgentContainer>;
+  AGENTPOD_WORKER_TOKEN?: string;
+}
+
+/**
+ * A station on Cloudflare: a container running agentpod-node, which dials the
+ * hub OUTBOUND over WSS and receives no incoming requests at all.
+ *
+ * That asymmetry drives the whole design. Cloudflare's activity timer is fed by
+ * *incoming* requests (cloudflare/containers#147), so a node-agent generates no
+ * activity however busy it is — the container will always idle out eventually.
+ */
+export class NodeAgentContainer extends Container {
+  // Long enough that a pause in a conversation does not cost a wake, short
+  // enough that an abandoned station stops billing within the hour.
+  sleepAfter = "15m";
+
+  override async onStart() {
+    console.log("[agentpod] container started", new Date().toISOString());
+  }
+
+  override onStop({ exitCode, reason }: { exitCode: number; reason: string }) {
+    console.log("[agentpod] container stopped", { exitCode, reason });
+  }
+
+  /**
+   * Sleep when idle, and tell the hub so.
+   *
+   * Cloudflare stops charging once an instance sleeps, which is ~12x cheaper
+   * than staying alive and is the reason this substrate is worth having. The
+   * station's WSS connection drops and its node goes offline — correctly, there
+   * is no connection — but the RUNTIME is `asleep`, not broken, and only this
+   * worker knows the difference.
+   *
+   * Safe because a woken container re-enrols and resumes the same nodeId
+   * (runtime identity persistence, #245). Before that, sleeping lost the station.
+   */
+  override async onActivityExpired() {
+    console.log("[agentpod] idle — sleeping");
+    await this.notifyHub("asleep");
+    await this.stop();
+  }
+
+  /**
+   * Tell the hub this runtime's lifecycle state.
+   *
+   * Never throws into the lifecycle: a hub that is down must not stop a
+   * container from sleeping, or an unreachable hub would keep every station
+   * awake and billing.
+   */
+  private async notifyHub(state: "asleep"): Promise<void> {
+    const env = this.envVars as Record<string, string> | undefined;
+    const hubUrl = env?.AGENTPOD_HUB_URL;
+    const token = env?.AGENTPOD_RUNTIME_CALLBACK_TOKEN;
+    const runtimeId = env?.AGENTPOD_RUNTIME_ID;
+    if (!hubUrl || !token || !runtimeId) return;
+
+    try {
+      await fetch(`${hubUrl}/public/runtimes/${runtimeId}/state`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ state }),
+      });
+    } catch (e) {
+      console.log("[agentpod] hub notify failed (continuing)", String(e));
+    }
+  }
+}
+
+interface CreateBody {
+  id: string;
+  hubUrl: string;
+  enrollToken: string;
+  /** Lets the container tell the hub when it sleeps. Without it the hub cannot
+   *  tell "idled out" from "died". */
+  callbackToken: string;
+}
+
+const json = (body: unknown, status = 200) =>
+  Response.json(body as Record<string, unknown>, { status });
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const parts = url.pathname.split("/").filter(Boolean);
+
+    // Liveness, unauthenticated on purpose: the driver checks it to fail fast
+    // on a misconfigured URL before it holds a credential.
+    if (request.method === "GET" && parts[0] === "health") {
+      return json({ status: "ok" });
+    }
+
+    if (!isAuthorised(request, env.AGENTPOD_WORKER_TOKEN)) {
+      return json({ error: "unauthorized" }, 401);
+    }
+
+    if (parts[0] !== "sandbox") return json({ error: "not found" }, 404);
+
+    // POST /sandbox — start a station.
+    if (request.method === "POST" && !parts[1]) {
+      let body: CreateBody;
+      try {
+        body = (await request.json()) as CreateBody;
+      } catch {
+        return json({ error: "invalid json" }, 400);
+      }
+      if (!body.id || !body.hubUrl || !body.enrollToken || !body.callbackToken) {
+        return json(
+          { error: "id, hubUrl, enrollToken and callbackToken are required" },
+          400
+        );
+      }
+
+      const c = getContainer(env.NODE_AGENT, body.id);
+      // The token is passed through but never logged, here or anywhere in this
+      // worker. Do not add log statements that reference body.enrollToken.
+      await c.start({
+        envVars: {
+          AGENTPOD_HUB_URL: body.hubUrl,
+          AGENTPOD_ENROLL_TOKEN: body.enrollToken,
+          // Read by the container class's notifyHub, not by agentpod-node.
+          AGENTPOD_RUNTIME_ID: body.id,
+          AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
+        },
+      });
+      return json({ sandboxId: body.id }, 201);
+    }
+
+    const id = parts[1];
+    if (!id) return json({ error: "not found" }, 404);
+
+    const container = getContainer(env.NODE_AGENT, id);
+
+    if (request.method === "GET" && !parts[2]) {
+      return json({ sandboxId: id });
+    }
+
+    if (request.method === "DELETE" && !parts[2]) {
+      await container.destroy();
+      return json({ destroyed: id });
+    }
+
+    // Also the wake path: to this worker a wake IS a start, and the spike
+    // confirmed stop → start restarts a container reliably.
+    if (request.method === "POST" && parts[2] === "start") {
+      await container.start();
+      return json({ started: id });
+    }
+
+    if (request.method === "POST" && parts[2] === "stop") {
+      await container.stop();
+      return json({ stopped: id });
+    }
+
+    return json({ error: "not found" }, 404);
+  },
+};

--- a/cloudflare/worker-v2/test/worker.test.ts
+++ b/cloudflare/worker-v2/test/worker.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { isAuthorised } from "../src/auth";
+
+const req = (token?: string) =>
+  new Request("https://w.example/sandbox", {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+
+describe("isAuthorised", () => {
+  it("refuses everything when no secret is configured", () => {
+    // A worker deployed without its secret must not be open. Failing closed
+    // matters more here than anywhere: this endpoint starts containers that
+    // enrol into the fleet.
+    expect(isAuthorised(req("anything"), undefined)).toBe(false);
+    expect(isAuthorised(req("anything"), "")).toBe(false);
+  });
+
+  it("accepts the right token and rejects a wrong one", () => {
+    expect(isAuthorised(req("s3cret"), "s3cret")).toBe(true);
+    expect(isAuthorised(req("wrong!"), "s3cret")).toBe(false);
+  });
+
+  it("rejects a missing or malformed header", () => {
+    expect(isAuthorised(req(), "s3cret")).toBe(false);
+    expect(
+      isAuthorised(
+        new Request("https://w.example/sandbox", {
+          headers: { Authorization: "s3cret" },
+        }),
+        "s3cret"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a token of a different length without comparing content", () => {
+    expect(isAuthorised(req("s3cre"), "s3cret")).toBe(false);
+    expect(isAuthorised(req("s3crett"), "s3cret")).toBe(false);
+  });
+});

--- a/cloudflare/worker-v2/tsconfig.json
+++ b/cloudflare/worker-v2/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/cloudflare/worker-v2/vitest.config.ts
+++ b/cloudflare/worker-v2/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/cloudflare/worker-v2/wrangler.toml
+++ b/cloudflare/worker-v2/wrangler.toml
@@ -1,0 +1,24 @@
+name = "agentpod-sandbox-v2"
+main = "src/index.ts"
+compatibility_date = "2026-08-01"
+compatibility_flags = ["nodejs_compat"]
+
+[observability]
+enabled = true
+
+[[durable_objects.bindings]]
+name = "NODE_AGENT"
+class_name = "NodeAgentContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["NodeAgentContainer"]
+
+[[containers]]
+class_name = "NodeAgentContainer"
+image = "./Dockerfile"
+# 4 GiB. A live opencode runtime OOM-killed its ACP session at 513MB rss, and
+# the Docker "small" tier had to go to 1g for `opencode serve` plus one
+# `opencode acp` to coexist; standard-1 leaves real headroom.
+instance_type = "standard-1"
+max_instances = 20

--- a/docs/superpowers/plans/2026-08-12-cloudflare-sandbox-driver.md
+++ b/docs/superpowers/plans/2026-08-12-cloudflare-sandbox-driver.md
@@ -4,7 +4,7 @@
 
 **Goal:** A second substrate — provision a station on Cloudflare from the console, and have it enrol, stay up, and survive a restart as the same node.
 
-**Architecture:** A new worker on `@cloudflare/containers` runs an image carrying a released `agentpod-node`, kept alive by overriding `onActivityExpired()` without stopping. A new hub driver talks to it over a small REST surface and validates every response. Identity across restarts is already solved by runtime-bound re-enrolment (merged in #245).
+**Architecture:** A new worker on `@cloudflare/containers` runs an image carrying a released `agentpod-node`. Stations **sleep when idle and wake explicitly**, which is ~12× cheaper than always-on and is only possible because runtime-bound re-enrolment (#245) lets a woken container resume the same `nodeId`. A new hub driver talks to the worker over a small REST surface and validates every response.
 
 **Tech Stack:** `@cloudflare/containers` + `wrangler` (worker), Bun + Hono + Drizzle (hub driver), Docker (image build via wrangler).
 
@@ -13,12 +13,16 @@
 
 ## Global Constraints
 
-- **Always-on, not scale-to-zero.** Containers keep themselves alive by overriding `onActivityExpired()` and declining to stop. Sleep/wake as a station state is explicitly out of scope.
+- **Stations sleep when idle.** `onActivityExpired()` stops the container; charges stop with it. Always-on would cost ~$28/month per station against ~$2 sleeping, and cost is the reason this substrate exists.
+- **Asleep is a distinct runtime status, and the worker tells the hub.** Cloudflare sleeps on its own timer, so without a callback the hub cannot tell "idled out" from "died" — and reporting a routine state as a fault is the failure shape this codebase keeps hitting.
+- **`asleep` must stay distinct from `stopped`.** `stopped` means an operator did it; conflating them loses the distinction an operator needs.
+- **The sweeper is not touched.** A sleeping node genuinely has no connection, so marking it `offline` is correct; teaching the sweeper about substrates would couple it to one.
+- **Explicit wake only.** Automatic wake on demand is deferred: it changes the broker's offline path and every caller's latency assumptions.
 - **Validate every worker response.** The dead driver's failure was an `ASSUMPTION` comment about the worker contract that nobody checked. Parse and reject, never trust.
 - **Reject a mismatched image, never ignore it.** Cloudflare bakes the image at deploy time, so `ProvisionSpec.image` cannot be honoured; silently ignoring an input is how the old driver would have failed.
 - **The image pulls a released binary and verifies it against `SHA256SUMS`** — the same artefacts `install.sh` and self-update use. Do not vendor a hand-built binary.
 - **Do not delete the dead worker or driver.** They stay marked until this replaces them in production.
-- Cost, for anyone reviewing the default: ~$28/month per always-on 4 GiB station, ~$1,090 across 39. This is a burst-and-geography substrate, not the default.
+- Cost: ~$2/month per sleeping station against ~$28 always-on. Even so this is a burst-and-geography substrate, not the default — a Hetzner box runs the whole fleet for about €46/month.
 - Branch: `cloudflare-sandbox-driver` off `main`. Single PR.
 - TDD: every task writes its failing test first.
 
@@ -217,7 +221,9 @@ interface Env {
  * which the spike confirmed keeps a station alive indefinitely.
  */
 export class NodeAgentContainer extends Container {
-  sleepAfter = "30m";
+  // Long enough that a pause in a conversation does not cost a wake, short
+  // enough that an abandoned station stops billing within the hour.
+  sleepAfter = "15m";
 
   override async onStart() {
     console.log("[agentpod] container started", new Date().toISOString());
@@ -228,14 +234,48 @@ export class NodeAgentContainer extends Container {
   }
 
   /**
-   * Deliberately does NOT call this.stop().
+   * Sleep when idle, and tell the hub so.
    *
-   * A station is long-lived and connection-oriented; sleeping would drop its
-   * WSS connection and take it offline. Scale-to-zero is a cost optimisation
-   * that needs "asleep" as a distinct station state, and is out of scope here.
+   * Cloudflare stops charging once an instance sleeps, which is ~12x cheaper
+   * than staying alive and is the reason this substrate is worth having. The
+   * station's WSS connection drops and its node goes offline — correctly, there
+   * is no connection — but the RUNTIME is `asleep`, not broken, and only this
+   * worker knows the difference.
+   *
+   * Safe because a woken container re-enrols and resumes the same nodeId
+   * (runtime identity persistence, #245). Before that, sleeping lost the station.
    */
   override async onActivityExpired() {
-    console.log("[agentpod] activity expired — staying alive (station is long-lived)");
+    console.log("[agentpod] idle — sleeping");
+    await this.notifyHub("asleep");
+    await this.stop();
+  }
+
+  /**
+   * Tell the hub this runtime's lifecycle state.
+   *
+   * Never throws into the lifecycle: a hub that is down must not stop a
+   * container from sleeping, or an unreachable hub would keep every station
+   * awake and billing.
+   */
+  private async notifyHub(state: "asleep"): Promise<void> {
+    const hubUrl = this.envVars.AGENTPOD_HUB_URL;
+    const token = this.envVars.AGENTPOD_RUNTIME_CALLBACK_TOKEN;
+    const runtimeId = this.envVars.AGENTPOD_RUNTIME_ID;
+    if (!hubUrl || !token || !runtimeId) return;
+
+    try {
+      await fetch(`${hubUrl}/public/runtimes/${runtimeId}/state`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ state }),
+      });
+    } catch (e) {
+      console.log("[agentpod] hub notify failed (continuing)", String(e));
+    }
   }
 }
 
@@ -243,6 +283,9 @@ interface CreateBody {
   id: string;
   hubUrl: string;
   enrollToken: string;
+  /** Lets the container tell the hub when it sleeps. Without it the hub cannot
+   *  tell "idled out" from "died". */
+  callbackToken: string;
 }
 
 const json = (body: unknown, status = 200) =>
@@ -273,8 +316,11 @@ export default {
       } catch {
         return json({ error: "invalid json" }, 400);
       }
-      if (!body.id || !body.hubUrl || !body.enrollToken) {
-        return json({ error: "id, hubUrl and enrollToken are required" }, 400);
+      if (!body.id || !body.hubUrl || !body.enrollToken || !body.callbackToken) {
+        return json(
+          { error: "id, hubUrl, enrollToken and callbackToken are required" },
+          400
+        );
       }
 
       const c = getContainer(env.NODE_AGENT, body.id) as unknown as {
@@ -286,6 +332,9 @@ export default {
         envVars: {
           AGENTPOD_HUB_URL: body.hubUrl,
           AGENTPOD_ENROLL_TOKEN: body.enrollToken,
+          // Read by the container class's notifyHub, not by agentpod-node.
+          AGENTPOD_RUNTIME_ID: body.id,
+          AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
         },
       });
       return json({ sandboxId: body.id }, 201);
@@ -479,6 +528,7 @@ const make = (impl: typeof globalThis.fetch) =>
     workerUrl: "https://w.example",
     apiToken: "tok",
     deployedImage: IMAGE,
+    callbackToken: "cbtok",
     fetchImpl: impl,
   });
 
@@ -505,6 +555,9 @@ describe("CloudflareSandboxProvisioner", () => {
     expect(body.hubUrl).toBe(SPEC.hubUrl);
     expect(body.enrollToken).toBe(SPEC.enrollToken);
     expect(body.id).toBe(SPEC.runtimeId);
+    // Without this the container cannot tell the hub it slept, and every
+    // sleeping station would read as offline.
+    expect(body.callbackToken).toBe("cbtok");
   });
 
   it("authenticates with a bearer token", async () => {
@@ -601,6 +654,11 @@ export interface CloudflareSandboxOptions {
    * so a spec asking for anything else cannot be satisfied and is refused.
    */
   deployedImage?: string;
+  /**
+   * Shared secret the container presents when telling the hub it slept. Without
+   * it the hub cannot distinguish a routine sleep from a dead container.
+   */
+  callbackToken?: string;
   fetchImpl?: typeof globalThis.fetch;
 }
 
@@ -610,17 +668,20 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
   private readonly workerUrl: string;
   private readonly apiToken: string;
   private readonly deployedImage: string;
+  private readonly callbackToken: string;
   private readonly fetchImpl: typeof globalThis.fetch;
 
   constructor({
     workerUrl = process.env.CLOUDFLARE_WORKER_URL ?? "",
     apiToken = process.env.CLOUDFLARE_WORKER_TOKEN ?? "",
     deployedImage = process.env.CLOUDFLARE_SANDBOX_IMAGE ?? "",
+    callbackToken = process.env.RUNTIME_CALLBACK_TOKEN ?? "",
     fetchImpl = globalThis.fetch,
   }: CloudflareSandboxOptions = {}) {
     this.workerUrl = workerUrl.replace(/\/$/, "");
     this.apiToken = apiToken;
     this.deployedImage = deployedImage;
+    this.callbackToken = callbackToken;
     this.fetchImpl = fetchImpl;
   }
 
@@ -674,6 +735,7 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
         id: spec.runtimeId,
         hubUrl: spec.hubUrl,
         enrollToken: spec.enrollToken,
+        callbackToken: this.callbackToken,
       }),
     });
 
@@ -718,7 +780,369 @@ git commit -m "feat(hub): CloudflareSandboxProvisioner, validating every respons
 
 ---
 
-## Task 4: Register the new driver
+## Task 4: `asleep` runtime status and the sleep callback
+
+Without this the hub sees a slept container as an ordinary offline node, and the console reports a routine, expected state as a fault.
+
+**Files:**
+- Modify: `packages/contract/src/runtime.ts` (`RuntimeStatus`)
+- Modify: `apps/hub/src/db/schema/nodes.ts` (`runtimeStatusEnum`)
+- Create: `apps/hub/src/routes/runtime-callback.ts`
+- Create: `apps/hub/src/routes/runtime-callback.test.ts`
+- Modify: `apps/hub/src/index.ts` (mount)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `RuntimeStatus` includes `"asleep"`; `runtimeCallbackRoutes` serving `POST /public/runtimes/:id/state`.
+
+- [ ] **Step 1: Write the failing contract test**
+
+Append to `packages/contract/src/runtime.test.ts`, inside the existing top-level structure (the file uses `describe`/`it`):
+
+```ts
+describe("RuntimeStatus asleep", () => {
+  it("accepts asleep", () => {
+    // A slept container is not stopped and not broken. Without its own value the
+    // console cannot tell an operator "this idled out" from "this failed".
+    expect(RuntimeStatus.parse("asleep")).toBe("asleep");
+  });
+
+  it("keeps stopped distinct", () => {
+    // `stopped` means an operator did it. Collapsing the two would lose the
+    // difference between "I did that" and "it happened on its own".
+    expect(RuntimeStatus.parse("stopped")).toBe("stopped");
+  });
+});
+```
+
+Add `RuntimeStatus` to that file's import from `./runtime` if it is not already there.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd packages/contract && bun test src/runtime.test.ts
+```
+
+Expected: FAIL — `asleep` is not in the enum.
+
+- [ ] **Step 3: Add the status**
+
+In `packages/contract/src/runtime.ts`:
+
+```ts
+/**
+ * `asleep` — the substrate idled the runtime out and stopped billing it. Its
+ * node is legitimately offline; the runtime is healthy and can be woken.
+ * Distinct from `stopped`, which means an operator stopped it deliberately.
+ */
+export const RuntimeStatus = z.enum(["provisioning", "online", "stopped", "asleep", "error", "destroyed"]);
+```
+
+In `apps/hub/src/db/schema/nodes.ts`:
+
+```ts
+export const runtimeStatusEnum = pgEnum("runtime_status", ["provisioning", "online", "stopped", "asleep", "error", "destroyed"]);
+```
+
+Generate the migration:
+
+```bash
+cd apps/hub && bun run db:generate
+```
+
+Expected: a migration adding the enum value. Postgres `ALTER TYPE ... ADD VALUE` cannot run inside a transaction in older versions — if the generated SQL fails on boot, split it into its own migration file containing only the `ALTER TYPE`.
+
+- [ ] **Step 4: Write the failing route test**
+
+Create `apps/hub/src/routes/runtime-callback.test.ts`. Read `apps/hub/src/routes/node-posture.test.ts` first and reuse its app-construction and seeding shape.
+
+```ts
+test("a valid callback marks the runtime asleep", async () => {
+  // The whole point: only the worker knows a container idled out, so it tells us.
+  const { app, runtimeId } = await seedRuntime();
+  const res = await app.request(`/public/runtimes/${runtimeId}/state`, {
+    method: "POST",
+    headers: { Authorization: "Bearer cbtok", "Content-Type": "application/json" },
+    body: JSON.stringify({ state: "asleep" }),
+  });
+  expect(res.status).toBe(200);
+
+  const row = await db.query.provisionedRuntimes.findFirst({
+    where: (t, { eq }) => eq(t.id, runtimeId),
+  });
+  expect(row?.status).toBe("asleep");
+});
+
+test("an unauthenticated callback is refused", async () => {
+  // This endpoint is public — it must be reachable by a container with no
+  // session. A missing token must therefore fail closed, or anyone could mark
+  // another user's runtime asleep.
+  const { app, runtimeId } = await seedRuntime();
+  const res = await app.request(`/public/runtimes/${runtimeId}/state`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ state: "asleep" }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test("a wrong token is refused", async () => {
+  const { app, runtimeId } = await seedRuntime();
+  const res = await app.request(`/public/runtimes/${runtimeId}/state`, {
+    method: "POST",
+    headers: { Authorization: "Bearer nope", "Content-Type": "application/json" },
+    body: JSON.stringify({ state: "asleep" }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test("an unknown runtime is a 404, not a silent success", async () => {
+  const { app } = await seedRuntime();
+  const res = await app.request(`/public/runtimes/rt_nope/state`, {
+    method: "POST",
+    headers: { Authorization: "Bearer cbtok", "Content-Type": "application/json" },
+    body: JSON.stringify({ state: "asleep" }),
+  });
+  expect(res.status).toBe(404);
+});
+
+test("only asleep is accepted", async () => {
+  // The callback is not a general status-setting API. A container must not be
+  // able to declare itself destroyed or online.
+  const { app, runtimeId } = await seedRuntime();
+  for (const state of ["destroyed", "online", "error"]) {
+    const res = await app.request(`/public/runtimes/${runtimeId}/state`, {
+      method: "POST",
+      headers: { Authorization: "Bearer cbtok", "Content-Type": "application/json" },
+      body: JSON.stringify({ state }),
+    });
+    expect(res.status).toBe(400);
+  }
+});
+```
+
+Set `process.env.RUNTIME_CALLBACK_TOKEN = "cbtok"` at the top of the file, before any `src/` import, alongside the `DATABASE_URL` line those test files already set.
+
+- [ ] **Step 5: Run it and watch it fail**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/routes/runtime-callback.test.ts
+```
+
+Expected: FAIL — the module does not exist.
+
+- [ ] **Step 6: Write the route**
+
+Create `apps/hub/src/routes/runtime-callback.ts`:
+
+```ts
+/**
+ * Runtime Callback Route — POST /public/runtimes/:id/state
+ *
+ * How a substrate tells the hub that it idled a runtime out.
+ *
+ * Cloudflare sleeps containers on its own timer, so without this the hub sees
+ * only that a node stopped heartbeating and cannot distinguish "slept normally"
+ * from "died". Reporting a routine state as a fault is the failure shape this
+ * codebase keeps hitting, so the substrate reports it instead of us guessing.
+ *
+ * **Public** — the caller is a container with no session — so it authenticates
+ * with a shared bearer token and fails closed when none is configured.
+ *
+ * Deliberately narrow: `asleep` is the only accepted state. This is not a
+ * general status-setting API, and a container must not be able to declare
+ * itself destroyed or online.
+ */
+
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { provisionedRuntimes } from "../db/schema/nodes";
+
+export const runtimeCallbackRoutes = new Hono().post(
+  "/runtimes/:id/state",
+  async (c) => {
+    const expected = process.env.RUNTIME_CALLBACK_TOKEN;
+    const header = c.req.header("Authorization") ?? "";
+    if (!expected || header !== `Bearer ${expected}`) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    let body: { state?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid json" }, 400);
+    }
+
+    if (body.state !== "asleep") {
+      return c.json({ error: "only 'asleep' may be reported" }, 400);
+    }
+
+    const id = c.req.param("id");
+    const [row] = await db
+      .select()
+      .from(provisionedRuntimes)
+      .where(eq(provisionedRuntimes.id, id));
+    if (!row) {
+      return c.json({ error: "Not Found" }, 404);
+    }
+
+    await db
+      .update(provisionedRuntimes)
+      .set({ status: "asleep", updatedAt: new Date() })
+      .where(eq(provisionedRuntimes.id, id));
+
+    return c.json({ ok: true });
+  }
+);
+```
+
+Mount it in `apps/hub/src/index.ts` beside the other public routes:
+
+```ts
+import { runtimeCallbackRoutes } from './routes/runtime-callback.ts';
+```
+
+```ts
+  .route('/public', runtimeCallbackRoutes)                 // POST /public/runtimes/:id/state
+```
+
+- [ ] **Step 7: Run the suites**
+
+```bash
+cd packages/contract && bun test
+cd ../../apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+```
+
+Expected: PASS on both.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/contract apps/hub
+git commit -m "feat: asleep runtime status and the substrate sleep callback"
+```
+
+---
+
+## Task 5: Console shows asleep, and offers Wake
+
+**Files:**
+- Modify: `apps/console/src/lib/api/client.ts`
+- Modify: `apps/console/src/routes/runtimes/+page.svelte`
+- Modify: `apps/console/src/routes/runtimes/page.svelte.test.ts`
+
+**Interfaces:**
+- Consumes: `RuntimeStatus` including `asleep` from Task 4; the existing `startRuntime` client call.
+- Produces: a Wake control on asleep runtimes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/console/src/routes/runtimes/page.svelte.test.ts`, reusing its `mockRuntimes` fixture shape:
+
+```ts
+test("an asleep runtime reads as asleep, not broken", async () => {
+  // Sleeping is normal and cheap. Showing it as offline or errored would make
+  // the substrate's main feature look like a fault.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-sleep", name: "napping", status: "asleep" as never },
+  ]);
+  const { container } = render(RuntimesPage);
+  await waitFor(() => expect(container.textContent).toMatch(/asleep/i));
+});
+
+test("an asleep runtime offers Wake", async () => {
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-sleep", name: "napping", status: "asleep" as never },
+  ]);
+  const { getByRole } = render(RuntimesPage);
+  await waitFor(() => expect(getByRole("button", { name: /wake/i })).toBeTruthy());
+});
+
+test("waking calls startRuntime", async () => {
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-sleep", name: "napping", status: "asleep" as never },
+  ]);
+  const start = vi.spyOn(api, "startRuntime").mockResolvedValue(undefined as never);
+
+  const { getByRole } = render(RuntimesPage);
+  await waitFor(() => expect(getByRole("button", { name: /wake/i })).toBeTruthy());
+  fireEvent.click(getByRole("button", { name: /wake/i }));
+
+  await waitFor(() => expect(start).toHaveBeenCalledWith("rt-sleep"));
+});
+
+test("an online runtime offers no Wake", async () => {
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-up", name: "awake", status: "online" as const },
+  ]);
+  const { queryByRole, getByText } = render(RuntimesPage);
+  await waitFor(() => expect(getByText("awake")).toBeTruthy());
+  expect(queryByRole("button", { name: /wake/i })).toBeNull();
+});
+```
+
+Check `startRuntime`'s real name in `client.ts` first (`grep -n "Runtime" src/lib/api/client.ts`) and use whatever the lifecycle call is actually called — if it is `startRuntime(id)` these are correct as written.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cd apps/console && pnpm test -- runtimes
+```
+
+Expected: FAIL — nothing renders "asleep" or a Wake control.
+
+- [ ] **Step 3: Render it**
+
+In `apps/console/src/routes/runtimes/+page.svelte`, find the actions cell that already renders Destroy/Stop/Start controls and add a Wake button shown only for `asleep`. Read the surrounding markup and match it — reuse the existing button component and the existing lifecycle handler rather than adding a parallel one:
+
+```svelte
+        {#if rt.status === "asleep"}
+          <Button
+            variant="outline"
+            size="sm"
+            onclick={() => wake(rt.id)}
+          >
+            Wake
+          </Button>
+        {/if}
+```
+
+and a handler beside the existing lifecycle handlers:
+
+```ts
+  /** Wake a runtime the substrate idled out. Reuses the start path: to the
+   *  driver a wake IS a start, and the spike confirmed stop → start restarts a
+   *  container reliably. */
+  async function wake(id: string) {
+    await startRuntime(id);
+    await load();
+  }
+```
+
+Match the file's existing error handling for lifecycle actions — if the others wrap in try/catch with a toast, do the same rather than letting this one throw.
+
+Ensure the status badge renders `asleep` — check `statusBadgeClass` in `$lib/utils/status-badge` handles the new value and add a case if it does not.
+
+- [ ] **Step 4: Run the console suite**
+
+```bash
+cd apps/console && pnpm check && pnpm test && pnpm build
+```
+
+Expected: PASS on all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/console
+git commit -m "feat(console): show asleep runtimes and offer Wake"
+```
+
+---
+
+## Task 6: Register the new driver
 
 **Files:**
 - Modify: `apps/hub/src/services/provisioner/bootstrap.ts`
@@ -769,7 +1193,7 @@ git commit -m "feat(hub): register CloudflareSandboxProvisioner for the cloudfla
 
 ---
 
-## Task 5: Deploy, verify live, and PR
+## Task 7: Deploy, verify live, and PR
 
 This is where the work is proven. Every substrate this session has surprised us in production after passing tests.
 
@@ -834,11 +1258,15 @@ Provision a Cloudflare runtime via `createRuntime` on the hub — not by hand, a
 - the runtime row reaches `status=online` with `runtime=cloudflare-container`
 - a node exists with `hostname=cloudchamber` and a recent `lastSeenAt`
 
-- [ ] **Step 5: Verify the restart — the point of the whole slice**
+- [ ] **Step 5: Verify the full sleep cycle — the point of the whole slice**
 
-Stop and start the container through the worker, then confirm the runtime **still points at the same `nodeId`** and the node returns online.
+Three things, in order. A failure in any of them means the driver is not done, however green the unit tests are.
 
-This is the acceptance test. It exercises runtime identity persistence (#245) on the substrate that needs it, and a failure here means the driver is not done however green the unit tests are.
+**(a) Explicit sleep → wake keeps the node.** Stop the container through the worker, confirm the runtime goes `asleep` and the node goes `offline`, then Wake it and confirm the runtime returns `online` with the **same `nodeId`**. That exercises runtime identity persistence (#245) on the substrate that needs it.
+
+**(b) Automatic sleep reports itself.** Redeploy the worker with `sleepAfter = "2m"`, provision a runtime, leave it idle, and confirm that **without anyone touching it** the runtime reaches `asleep` — not `offline`, not `error`. That proves the callback path, which is the only way the hub can tell "idled out" from "died". Restore `sleepAfter = "15m"` afterwards.
+
+**(c) The saving is real.** Confirm the container is genuinely stopped on Cloudflare after (b), not merely marked asleep in our database. A status we set ourselves is not evidence; the whole cost argument rests on the instance actually being gone.
 
 - [ ] **Step 6: Clean up**
 
@@ -857,18 +1285,32 @@ A new worker on `@cloudflare/containers` runs an image carrying a **released**
 The container dials the hub outbound and enrols itself; the driver only does
 lifecycle.
 
-## Always-on, deliberately
+## Stations sleep when idle
 
-Containers stay alive by overriding `onActivityExpired()` without stopping — the
-spike confirmed this keeps a station up indefinitely. Cloudflare's activity timer
-is driven by *incoming* requests and a node-agent receives none
-([cloudflare/containers#147](https://github.com/cloudflare/containers/issues/147)),
-so without this a station would sleep and go offline on a timer.
+Cloudflare stops charging once an instance sleeps, and for stations that idle most
+of the day that is roughly a **12x difference** — ~$2/month each rather than ~$28,
+about $90 across 39 rather than $1,090. Cost is the reason this substrate is worth
+having, so always-on was never really an option.
 
-Scale-to-zero needs "asleep" as a distinct station state and is out of scope.
-Cost of the choice: ~$28/month per always-on 4 GiB station. **This is a burst and
-geography substrate, not the default** — a Hetzner box runs the whole fleet for
-about €46/month.
+**Identity persistence (#245) is what made this tractable.** The blocker was never
+the sleeping; it was that a woken container came back as a *different node*. Now it
+re-enrols and resumes the same `nodeId`, keeping its stations and history.
+
+**Asleep is a distinct runtime status, and the worker reports it.** Cloudflare
+sleeps on its own timer, so without a callback the hub sees only a node that
+stopped heartbeating and cannot tell "idled out" from "died". Reporting a routine
+state as a fault is the failure shape this codebase keeps hitting. The node still
+goes `offline` — correctly, there is no connection — and the sweeper is untouched.
+
+`asleep` stays distinct from `stopped`: one is the substrate idling something out,
+the other is an operator doing it, and an operator needs to know which.
+
+**Explicit wake only.** Automatic wake on demand — any station verb waking a
+sleeping node and retrying — is the better experience and the larger change, since
+it touches the broker's offline path and every caller's latency assumptions.
+
+Even sleeping, this is a burst-and-geography substrate rather than the default: a
+Hetzner box runs the whole fleet for about €46/month.
 
 ## Two lessons from the dead driver, encoded as tests
 

--- a/docs/superpowers/plans/2026-08-12-cloudflare-sandbox-driver.md
+++ b/docs/superpowers/plans/2026-08-12-cloudflare-sandbox-driver.md
@@ -1,0 +1,902 @@
+# Cloudflare Sandbox Driver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A second substrate — provision a station on Cloudflare from the console, and have it enrol, stay up, and survive a restart as the same node.
+
+**Architecture:** A new worker on `@cloudflare/containers` runs an image carrying a released `agentpod-node`, kept alive by overriding `onActivityExpired()` without stopping. A new hub driver talks to it over a small REST surface and validates every response. Identity across restarts is already solved by runtime-bound re-enrolment (merged in #245).
+
+**Tech Stack:** `@cloudflare/containers` + `wrangler` (worker), Bun + Hono + Drizzle (hub driver), Docker (image build via wrangler).
+
+**Spec:** `docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md`
+**Spike evidence:** `docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md`
+
+## Global Constraints
+
+- **Always-on, not scale-to-zero.** Containers keep themselves alive by overriding `onActivityExpired()` and declining to stop. Sleep/wake as a station state is explicitly out of scope.
+- **Validate every worker response.** The dead driver's failure was an `ASSUMPTION` comment about the worker contract that nobody checked. Parse and reject, never trust.
+- **Reject a mismatched image, never ignore it.** Cloudflare bakes the image at deploy time, so `ProvisionSpec.image` cannot be honoured; silently ignoring an input is how the old driver would have failed.
+- **The image pulls a released binary and verifies it against `SHA256SUMS`** — the same artefacts `install.sh` and self-update use. Do not vendor a hand-built binary.
+- **Do not delete the dead worker or driver.** They stay marked until this replaces them in production.
+- Cost, for anyone reviewing the default: ~$28/month per always-on 4 GiB station, ~$1,090 across 39. This is a burst-and-geography substrate, not the default.
+- Branch: `cloudflare-sandbox-driver` off `main`. Single PR.
+- TDD: every task writes its failing test first.
+
+## Prerequisites, already satisfied
+
+- **Runtime identity persistence is merged** (#245) and deployed. A runtime-bound token re-presented after a restart returns the same `nodeId`. Without it this driver produces stations that vanish on first eviction.
+- **`cloudflare` is already a known provider** in `RuntimeProviderName` and the registry, gated by `ENABLE_CLOUDFLARE_SANDBOXES`. No registry work is needed.
+- **`wrangler` is authenticated** with `containers (write)` and `cloudchamber (write)` on the account for `rakesh.gangwar1994@gmail.com`.
+
+## What the spike already proved — do not re-litigate
+
+A real Cloudflare container running `agentpod-node` against the production hub:
+enrolled in ~20s (`hostname=cloudchamber`), stayed online 9 minutes at
+`sleepAfter="2m"`, and `onActivityExpired()` fired with the override renewing the
+timer as documented. `stop` then `start` restarted it reliably. Identity did not
+survive — which is what #245 fixed.
+
+## File Structure
+
+**`cloudflare/worker-v2/`** *(new — alongside the dead `cloudflare/worker/`)*
+- `wrangler.toml` — container binding, DO migration, instance type.
+- `Dockerfile` — released `agentpod-node` on a slim base, checksum-verified.
+- `src/index.ts` — `NodeAgentContainer` + the REST surface.
+- `src/auth.ts` — bearer check, one responsibility so it is testable alone.
+- `test/worker.test.ts` — routing and auth.
+- `package.json`, `vitest.config.ts`, `README.md`.
+
+**`apps/hub`**
+- `src/services/provisioner/cloudflare-sandbox.ts` *(create)* — the new driver.
+- `src/services/provisioner/cloudflare-sandbox.test.ts` *(create)*.
+- `src/services/provisioner/bootstrap.ts` *(modify)* — register the new driver.
+
+---
+
+## Task 1: Worker scaffold, image, and container class
+
+**Files:**
+- Create: `cloudflare/worker-v2/{wrangler.toml,Dockerfile,package.json,README.md}`
+- Create: `cloudflare/worker-v2/src/index.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a deployable worker exposing `GET /health`, `POST /sandbox`, `GET /sandbox/:id`, `DELETE /sandbox/:id`, `POST /sandbox/:id/start`, `POST /sandbox/:id/stop`; class `NodeAgentContainer`.
+
+- [ ] **Step 1: Create the image**
+
+Create `cloudflare/worker-v2/Dockerfile`. It pulls a **released** binary and verifies it, rather than vendoring a hand-built one — the same artefacts `install.sh` and self-update consume, so a Cloudflare station runs exactly the binary the fleet runs.
+
+```dockerfile
+FROM debian:bookworm-slim
+
+# Pin explicitly. A floating "latest" would make two deploys of the same worker
+# produce different fleet behaviour, which is exactly the kind of drift the
+# release pipeline exists to prevent.
+ARG AGENTPOD_VERSION=v0.1.22
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Verify against SHA256SUMS, as install.sh and self-update do. An unverified
+# binary here would be a supply-chain hole in the substrate itself.
+RUN set -eux; \
+    base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
+    curl -fsSL -o /usr/local/bin/agentpod-node "${base}/agentpod-node-linux-amd64"; \
+    curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
+    cd /usr/local/bin; \
+    cp agentpod-node agentpod-node-linux-amd64; \
+    grep ' agentpod-node-linux-amd64$' /tmp/SHA256SUMS | sha256sum -c -; \
+    rm -f agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
+    chmod +x /usr/local/bin/agentpod-node; \
+    /usr/local/bin/agentpod-node version
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+Create `cloudflare/worker-v2/entrypoint.sh`. It mirrors `apps/node-agent/deploy/node-entrypoint.sh`; the difference is that on this substrate the enrol path runs on **every** start, because the disk is fresh each time.
+
+```sh
+#!/bin/sh
+set -e
+
+# Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
+#
+# On an ephemeral-disk substrate this runs on every start, not just the first.
+# The hub returns the SAME node for a runtime-bound token whose runtime already
+# has one (runtime identity persistence, #245), so a restart resumes rather than
+# orphaning. Without that this loop would mint a new node every restart.
+/usr/local/bin/agentpod-node enroll
+
+exec /usr/local/bin/agentpod-node run
+```
+
+- [ ] **Step 2: Create the worker config**
+
+Create `cloudflare/worker-v2/wrangler.toml`:
+
+```toml
+name = "agentpod-sandbox-v2"
+main = "src/index.ts"
+compatibility_date = "2026-08-01"
+compatibility_flags = ["nodejs_compat"]
+
+[observability]
+enabled = true
+
+[[durable_objects.bindings]]
+name = "NODE_AGENT"
+class_name = "NodeAgentContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["NodeAgentContainer"]
+
+[[containers]]
+class_name = "NodeAgentContainer"
+image = "./Dockerfile"
+# 4 GiB. A live opencode runtime OOM-killed its ACP session at 513MB rss, and
+# the Docker "small" tier had to go to 1g for `opencode serve` plus one
+# `opencode acp` to coexist; standard-1 leaves real headroom.
+instance_type = "standard-1"
+max_instances = 20
+```
+
+Create `cloudflare/worker-v2/package.json`:
+
+```json
+{
+  "name": "agentpod-sandbox-v2",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "tail": "wrangler tail --format pretty"
+  },
+  "dependencies": { "@cloudflare/containers": "^0.3.7" },
+  "devDependencies": {
+    "wrangler": "^4.121.0",
+    "vitest": "^2.1.9",
+    "@cloudflare/vitest-pool-workers": "^0.5.40"
+  }
+}
+```
+
+- [ ] **Step 3: Write the auth helper**
+
+Create `cloudflare/worker-v2/src/auth.ts`. Separate from routing so it can be tested alone and so a route cannot accidentally skip it.
+
+```ts
+/**
+ * Bearer-token check for every route except /health.
+ *
+ * The worker can start containers that enrol into a fleet, so an unauthenticated
+ * caller could mint stations. /health is exempt so the driver can fail fast on a
+ * misconfigured URL without holding a credential.
+ */
+export function isAuthorised(request: Request, expected: string | undefined): boolean {
+  if (!expected) return false; // no secret configured → refuse everything
+  const header = request.headers.get("Authorization") ?? "";
+  const prefix = "Bearer ";
+  if (!header.startsWith(prefix)) return false;
+  return timingSafeEqual(header.slice(prefix.length), expected);
+}
+
+/** Constant-time compare, so a wrong token cannot be guessed byte by byte. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+```
+
+- [ ] **Step 4: Write the worker**
+
+Create `cloudflare/worker-v2/src/index.ts`:
+
+```ts
+import { Container, getContainer } from "@cloudflare/containers";
+import { isAuthorised } from "./auth";
+
+interface Env {
+  NODE_AGENT: DurableObjectNamespace;
+  AGENTPOD_WORKER_TOKEN?: string;
+}
+
+/**
+ * A station on Cloudflare: a container running agentpod-node, which dials the
+ * hub OUTBOUND over WSS and receives no incoming requests at all.
+ *
+ * That is why onActivityExpired is overridden. Cloudflare's activity timer is
+ * driven by *incoming* requests (cloudflare/containers#147), so a node-agent
+ * generates no activity however busy it is. Declining to stop renews the timer,
+ * which the spike confirmed keeps a station alive indefinitely.
+ */
+export class NodeAgentContainer extends Container {
+  sleepAfter = "30m";
+
+  override async onStart() {
+    console.log("[agentpod] container started", new Date().toISOString());
+  }
+
+  override onStop({ exitCode, reason }: { exitCode: number; reason: string }) {
+    console.log("[agentpod] container stopped", { exitCode, reason });
+  }
+
+  /**
+   * Deliberately does NOT call this.stop().
+   *
+   * A station is long-lived and connection-oriented; sleeping would drop its
+   * WSS connection and take it offline. Scale-to-zero is a cost optimisation
+   * that needs "asleep" as a distinct station state, and is out of scope here.
+   */
+  override async onActivityExpired() {
+    console.log("[agentpod] activity expired — staying alive (station is long-lived)");
+  }
+}
+
+interface CreateBody {
+  id: string;
+  hubUrl: string;
+  enrollToken: string;
+}
+
+const json = (body: unknown, status = 200) =>
+  Response.json(body as Record<string, unknown>, { status });
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const parts = url.pathname.split("/").filter(Boolean);
+
+    // Liveness, unauthenticated on purpose: the driver checks it to fail fast
+    // on a misconfigured URL before it holds a credential.
+    if (request.method === "GET" && parts[0] === "health") {
+      return json({ status: "ok" });
+    }
+
+    if (!isAuthorised(request, env.AGENTPOD_WORKER_TOKEN)) {
+      return json({ error: "unauthorized" }, 401);
+    }
+
+    if (parts[0] !== "sandbox") return json({ error: "not found" }, 404);
+
+    // POST /sandbox — start a station.
+    if (request.method === "POST" && !parts[1]) {
+      let body: CreateBody;
+      try {
+        body = (await request.json()) as CreateBody;
+      } catch {
+        return json({ error: "invalid json" }, 400);
+      }
+      if (!body.id || !body.hubUrl || !body.enrollToken) {
+        return json({ error: "id, hubUrl and enrollToken are required" }, 400);
+      }
+
+      const c = getContainer(env.NODE_AGENT, body.id) as unknown as {
+        start: (o?: { envVars?: Record<string, string> }) => Promise<void>;
+      };
+      // The token is passed through but never logged, here or anywhere in this
+      // worker. Do not add log statements that reference body.enrollToken.
+      await c.start({
+        envVars: {
+          AGENTPOD_HUB_URL: body.hubUrl,
+          AGENTPOD_ENROLL_TOKEN: body.enrollToken,
+        },
+      });
+      return json({ sandboxId: body.id }, 201);
+    }
+
+    const id = parts[1];
+    if (!id) return json({ error: "not found" }, 404);
+
+    const container = getContainer(env.NODE_AGENT, id) as unknown as {
+      start: () => Promise<void>;
+      stop: () => Promise<void>;
+      destroy: () => Promise<void>;
+    };
+
+    if (request.method === "GET" && !parts[2]) {
+      return json({ sandboxId: id });
+    }
+
+    if (request.method === "DELETE" && !parts[2]) {
+      await container.destroy();
+      return json({ destroyed: id });
+    }
+
+    if (request.method === "POST" && parts[2] === "start") {
+      await container.start();
+      return json({ started: id });
+    }
+
+    if (request.method === "POST" && parts[2] === "stop") {
+      await container.stop();
+      return json({ stopped: id });
+    }
+
+    return json({ error: "not found" }, 404);
+  },
+};
+```
+
+- [ ] **Step 5: Install and typecheck**
+
+```bash
+cd cloudflare/worker-v2 && npm install && npx tsc --noEmit -p . 2>&1 | tail -5 || true
+```
+
+Expected: dependencies install. If there is no `tsconfig.json`, create one matching `cloudflare/worker/tsconfig.json` — read that file and copy it, changing only paths.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cloudflare/worker-v2
+git commit -m "feat(cloudflare): worker-v2 scaffold, image and container class"
+```
+
+---
+
+## Task 2: Worker tests
+
+**Files:**
+- Create: `cloudflare/worker-v2/vitest.config.ts`
+- Create: `cloudflare/worker-v2/test/worker.test.ts`
+
+**Interfaces:**
+- Consumes: `isAuthorised` and the default export from Task 1.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cloudflare/worker-v2/test/worker.test.ts`. These test the auth helper and routing as pure units — container lifecycle needs a real platform and is covered by the live verification in Task 5.
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isAuthorised } from "../src/auth";
+
+const req = (token?: string) =>
+  new Request("https://w.example/sandbox", {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+
+describe("isAuthorised", () => {
+  it("refuses everything when no secret is configured", () => {
+    // A worker deployed without its secret must not be open. Failing closed
+    // matters more here than anywhere: this endpoint starts containers that
+    // enrol into the fleet.
+    expect(isAuthorised(req("anything"), undefined)).toBe(false);
+    expect(isAuthorised(req("anything"), "")).toBe(false);
+  });
+
+  it("accepts the right token and rejects a wrong one", () => {
+    expect(isAuthorised(req("s3cret"), "s3cret")).toBe(true);
+    expect(isAuthorised(req("wrong"), "s3cret")).toBe(false);
+  });
+
+  it("rejects a missing or malformed header", () => {
+    expect(isAuthorised(req(), "s3cret")).toBe(false);
+    expect(
+      isAuthorised(
+        new Request("https://w.example/sandbox", { headers: { Authorization: "s3cret" } }),
+        "s3cret"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a token of a different length without comparing content", () => {
+    expect(isAuthorised(req("s3cre"), "s3cret")).toBe(false);
+    expect(isAuthorised(req("s3crett"), "s3cret")).toBe(false);
+  });
+});
+```
+
+Create `cloudflare/worker-v2/vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 2: Run them**
+
+```bash
+cd cloudflare/worker-v2 && npm test 2>&1 | tail -6
+```
+
+Expected: PASS. These describe behaviour Task 1 already implemented; they exist so a later edit cannot quietly open the endpoint.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cloudflare/worker-v2
+git commit -m "test(cloudflare): worker auth is closed by default"
+```
+
+---
+
+## Task 3: The hub driver
+
+**Files:**
+- Create: `apps/hub/src/services/provisioner/cloudflare-sandbox.ts`
+- Create: `apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts`
+
+**Interfaces:**
+- Consumes: `RuntimeProvisioner`, `ProvisionSpec` from `./types`.
+- Produces: `class CloudflareSandboxProvisioner implements RuntimeProvisioner` with `provider = "cloudflare"`, constructor options `{ workerUrl?, apiToken?, deployedImage?, fetchImpl? }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts`. Model the fake-fetch pattern on the existing `cloudflare.test.ts` — read it first.
+
+```ts
+/**
+ * Unit tests: CloudflareSandboxProvisioner.
+ *
+ * No real Cloudflare. A fake fetch captures requests and returns controlled
+ * responses — including malformed ones, which is the case the dead driver
+ * would have accepted.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
+import type { ProvisionSpec } from "./types";
+
+const IMAGE = "agentpod-node-opencode:v0.1.22";
+
+const SPEC: ProvisionSpec = {
+  runtimeId: "rt_abc",
+  name: "test",
+  resourceTier: "small",
+  hubUrl: "https://hub.example",
+  enrollToken: "enr_secret",
+  image: IMAGE,
+};
+
+function fakeFetch(response: unknown, status = 201) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return new Response(JSON.stringify(response), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, calls };
+}
+
+const make = (impl: typeof globalThis.fetch) =>
+  new CloudflareSandboxProvisioner({
+    workerUrl: "https://w.example",
+    apiToken: "tok",
+    deployedImage: IMAGE,
+    fetchImpl: impl,
+  });
+
+describe("CloudflareSandboxProvisioner", () => {
+  it("provisions and returns the worker's sandbox id", async () => {
+    const { impl, calls } = fakeFetch({ sandboxId: "rt_abc" });
+    const res = await make(impl).provision(SPEC);
+
+    expect(res.externalId).toBe("rt_abc");
+    expect(calls[0]!.url).toBe("https://w.example/sandbox");
+    expect(calls[0]!.init.method).toBe("POST");
+  });
+
+  it("reports its runtime so the console can show real isolation", async () => {
+    const { impl } = fakeFetch({ sandboxId: "rt_abc" });
+    const res = await make(impl).provision(SPEC);
+    expect(res.runtime).toBe("cloudflare-container");
+  });
+
+  it("sends the hub url and enrolment token", async () => {
+    const { impl, calls } = fakeFetch({ sandboxId: "rt_abc" });
+    await make(impl).provision(SPEC);
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body.hubUrl).toBe(SPEC.hubUrl);
+    expect(body.enrollToken).toBe(SPEC.enrollToken);
+    expect(body.id).toBe(SPEC.runtimeId);
+  });
+
+  it("authenticates with a bearer token", async () => {
+    const { impl, calls } = fakeFetch({ sandboxId: "rt_abc" });
+    await make(impl).provision(SPEC);
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("REJECTS a response that does not match the expected shape", async () => {
+    // The dead driver's exact failure: it assumed the worker's contract and
+    // never checked, so a 2xx with the wrong body produced a runtime that sat
+    // in `provisioning` forever with no error anywhere.
+    const { impl } = fakeFetch({ nope: true });
+    await expect(make(impl).provision(SPEC)).rejects.toThrow(/unexpected response/i);
+  });
+
+  it("rejects a non-2xx response", async () => {
+    const { impl } = fakeFetch({ error: "boom" }, 500);
+    await expect(make(impl).provision(SPEC)).rejects.toThrow(/500/);
+  });
+
+  it("REJECTS a spec whose image is not the deployed one", async () => {
+    // Cloudflare bakes the image at deploy time, so ProvisionSpec.image cannot
+    // be honoured. Silently ignoring an input is how the old driver failed —
+    // refuse loudly instead.
+    const { impl } = fakeFetch({ sandboxId: "rt_abc" });
+    await expect(
+      make(impl).provision({ ...SPEC, image: "something-else:latest" })
+    ).rejects.toThrow(/image/i);
+  });
+
+  it("destroys by sandbox id", async () => {
+    const { impl, calls } = fakeFetch({ destroyed: "rt_abc" }, 200);
+    await make(impl).destroy("rt_abc");
+    expect(calls[0]!.url).toBe("https://w.example/sandbox/rt_abc");
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("maps start and stop to the lifecycle routes", async () => {
+    const started = fakeFetch({ started: "rt_abc" }, 200);
+    await make(started.impl).start!("rt_abc");
+    expect(started.calls[0]!.url).toBe("https://w.example/sandbox/rt_abc/start");
+
+    const stopped = fakeFetch({ stopped: "rt_abc" }, 200);
+    await make(stopped.impl).stop!("rt_abc");
+    expect(stopped.calls[0]!.url).toBe("https://w.example/sandbox/rt_abc/stop");
+  });
+
+  it("fails clearly when the worker url is not configured", async () => {
+    const p = new CloudflareSandboxProvisioner({ workerUrl: "", apiToken: "tok" });
+    await expect(p.provision(SPEC)).rejects.toThrow(/CLOUDFLARE_WORKER_URL/);
+  });
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/provisioner/cloudflare-sandbox.test.ts
+```
+
+Expected: FAIL — `Cannot find module './cloudflare-sandbox'`.
+
+- [ ] **Step 3: Write the driver**
+
+Create `apps/hub/src/services/provisioner/cloudflare-sandbox.ts`:
+
+```ts
+/**
+ * Cloudflare Sandbox provisioner driver.
+ *
+ * Talks to `cloudflare/worker-v2/`, which runs a container carrying a released
+ * agentpod-node. The container dials the hub outbound and enrols itself, so this
+ * driver's only job is lifecycle.
+ *
+ * Replaces the dead OpenCode-era driver in `cloudflare.ts`. The lesson carried
+ * over from it: **every response is validated**. That driver documented an
+ * ASSUMPTION about the worker's contract and never checked it, so a 2xx with the
+ * wrong body would have produced a runtime stuck in `provisioning` with no error
+ * logged anywhere.
+ *
+ * SECURITY: the enrolment token is sent in the request body and is never logged
+ * by this module. Do not add log statements that reference spec.enrollToken.
+ */
+
+import type { RuntimeProvisioner, ProvisionSpec } from "./types";
+
+export interface CloudflareSandboxOptions {
+  workerUrl?: string;
+  apiToken?: string;
+  /**
+   * The image the worker was deployed with. Cloudflare bakes it at deploy time,
+   * so a spec asking for anything else cannot be satisfied and is refused.
+   */
+  deployedImage?: string;
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
+  readonly provider = "cloudflare" as const;
+
+  private readonly workerUrl: string;
+  private readonly apiToken: string;
+  private readonly deployedImage: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor({
+    workerUrl = process.env.CLOUDFLARE_WORKER_URL ?? "",
+    apiToken = process.env.CLOUDFLARE_WORKER_TOKEN ?? "",
+    deployedImage = process.env.CLOUDFLARE_SANDBOX_IMAGE ?? "",
+    fetchImpl = globalThis.fetch,
+  }: CloudflareSandboxOptions = {}) {
+    this.workerUrl = workerUrl.replace(/\/$/, "");
+    this.apiToken = apiToken;
+    this.deployedImage = deployedImage;
+    this.fetchImpl = fetchImpl;
+  }
+
+  private async call(
+    path: string,
+    init: RequestInit
+  ): Promise<Record<string, unknown>> {
+    if (!this.workerUrl) {
+      throw new Error(
+        "cloudflare: CLOUDFLARE_WORKER_URL is not set; cannot reach the sandbox worker"
+      );
+    }
+
+    const res = await this.fetchImpl(`${this.workerUrl}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiToken}`,
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`cloudflare: worker returned ${res.status} for ${path}`);
+    }
+
+    try {
+      return (await res.json()) as Record<string, unknown>;
+    } catch {
+      throw new Error(`cloudflare: unexpected response from ${path} (not JSON)`);
+    }
+  }
+
+  async provision(
+    spec: ProvisionSpec
+  ): Promise<{ externalId: string; runtime?: string }> {
+    // Cloudflare bakes the image at worker deploy time. Honour-or-refuse, never
+    // ignore: a driver that quietly drops an input is how the previous one would
+    // have failed.
+    if (this.deployedImage && spec.image !== this.deployedImage) {
+      throw new Error(
+        `cloudflare: this worker is deployed with image "${this.deployedImage}" and ` +
+          `cannot provision "${spec.image}". Cloudflare bakes the image at deploy ` +
+          `time; redeploy the worker to change it.`
+      );
+    }
+
+    const body = await this.call("/sandbox", {
+      method: "POST",
+      body: JSON.stringify({
+        id: spec.runtimeId,
+        hubUrl: spec.hubUrl,
+        enrollToken: spec.enrollToken,
+      }),
+    });
+
+    const sandboxId = body.sandboxId;
+    if (typeof sandboxId !== "string" || !sandboxId) {
+      throw new Error(
+        "cloudflare: unexpected response from /sandbox (no sandboxId)"
+      );
+    }
+
+    return { externalId: sandboxId, runtime: "cloudflare-container" };
+  }
+
+  async destroy(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}`, { method: "DELETE" });
+  }
+
+  async start(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}/start`, { method: "POST" });
+  }
+
+  async stop(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}/stop`, { method: "POST" });
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/provisioner/
+```
+
+Expected: PASS, including the dead driver's own tests, which are untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/services/provisioner/cloudflare-sandbox.ts apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts
+git commit -m "feat(hub): CloudflareSandboxProvisioner, validating every response"
+```
+
+---
+
+## Task 4: Register the new driver
+
+**Files:**
+- Modify: `apps/hub/src/services/provisioner/bootstrap.ts`
+- Modify: `apps/hub/src/services/provisioner/cloudflare.ts` (header note only)
+
+**Interfaces:**
+- Consumes: `CloudflareSandboxProvisioner` from Task 3.
+- Produces: `registerEnabledProvisioners()` registers the new driver for `cloudflare`.
+
+- [ ] **Step 1: Swap the registration**
+
+In `apps/hub/src/services/provisioner/bootstrap.ts`, replace the Cloudflare import and registration:
+
+```ts
+import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
+```
+
+```ts
+  if (isProviderEnabled("cloudflare")) {
+    registerProvisioner(new CloudflareSandboxProvisioner());
+  }
+```
+
+Remove the now-unused `CloudflareRuntimeProvisioner` import.
+
+- [ ] **Step 2: Note the supersession on the dead driver**
+
+Add one line to the top of the DEAD block in `apps/hub/src/services/provisioner/cloudflare.ts`, so a reader knows where the live code is:
+
+```
+ * SUPERSEDED by ./cloudflare-sandbox.ts, which is what the registry now wires.
+```
+
+- [ ] **Step 3: Run the hub suite**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+```
+
+Expected: PASS. The dead driver's unit tests still pass — they construct it directly and do not go through the registry.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/hub/src/services/provisioner
+git commit -m "feat(hub): register CloudflareSandboxProvisioner for the cloudflare provider"
+```
+
+---
+
+## Task 5: Deploy, verify live, and PR
+
+This is where the work is proven. Every substrate this session has surprised us in production after passing tests.
+
+- [ ] **Step 1: Run every suite**
+
+```bash
+cd packages/contract && bun test
+cd ../../apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+cd ../node-agent && go vet ./... && go test -race ./...
+cd ../console && pnpm check && pnpm test && pnpm build
+cd ../../cloudflare/worker-v2 && npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Deploy the worker**
+
+```bash
+cd cloudflare/worker-v2 && npx wrangler deploy
+```
+
+Note the deployed URL. Then set its secret:
+
+```bash
+cd cloudflare/worker-v2 && npx wrangler secret put AGENTPOD_WORKER_TOKEN
+```
+
+Use a fresh random value (`openssl rand -hex 32`). Confirm liveness:
+
+```bash
+curl -s https://<worker-url>/health
+curl -s -o /dev/null -w "%{http_code}\n" https://<worker-url>/sandbox -X POST
+```
+
+Expected: `{"status":"ok"}` then `401` — the endpoint that starts containers must refuse an unauthenticated caller.
+
+- [ ] **Step 3: Configure and deploy the hub**
+
+Add to `/etc/agentpod/hub.env` on `178.105.68.68`:
+
+```
+ENABLE_CLOUDFLARE_SANDBOXES=true
+CLOUDFLARE_WORKER_URL=https://<worker-url>
+CLOUDFLARE_WORKER_TOKEN=<the secret from step 2>
+CLOUDFLARE_SANDBOX_IMAGE=<the image string imageForHarness returns for the harness you will test>
+```
+
+Read `imageForHarness` in `apps/hub/src/services/runtimes.ts` to get the exact value — a mismatch is refused by design, so this must be right.
+
+Deploy the branch and restart, then confirm the provider is live:
+
+```bash
+ssh root@178.105.68.68 'journalctl -u agentpod-hub --since "1 minute ago" --no-pager | grep -o "Provisioners registered: .*"'
+```
+
+Expected: `docker, cloudflare`.
+
+- [ ] **Step 4: Provision through the real path**
+
+Provision a Cloudflare runtime via `createRuntime` on the hub — not by hand, and not by calling the worker directly. Confirm:
+
+- the runtime row reaches `status=online` with `runtime=cloudflare-container`
+- a node exists with `hostname=cloudchamber` and a recent `lastSeenAt`
+
+- [ ] **Step 5: Verify the restart — the point of the whole slice**
+
+Stop and start the container through the worker, then confirm the runtime **still points at the same `nodeId`** and the node returns online.
+
+This is the acceptance test. It exercises runtime identity persistence (#245) on the substrate that needs it, and a failure here means the driver is not done however green the unit tests are.
+
+- [ ] **Step 6: Clean up**
+
+Destroy the test runtime through `destroyRuntime` so the destroy path is exercised too, and confirm the container is gone from Cloudflare.
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin cloudflare-sandbox-driver
+gh pr create --title "feat: Cloudflare sandbox provider" --body "$(cat <<'EOF'
+Implements `docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md` —
+a second substrate, replacing the dead OpenCode-era worker and driver.
+
+A new worker on `@cloudflare/containers` runs an image carrying a **released**
+`agentpod-node`, checksum-verified against `SHA256SUMS` like `install.sh` does.
+The container dials the hub outbound and enrols itself; the driver only does
+lifecycle.
+
+## Always-on, deliberately
+
+Containers stay alive by overriding `onActivityExpired()` without stopping — the
+spike confirmed this keeps a station up indefinitely. Cloudflare's activity timer
+is driven by *incoming* requests and a node-agent receives none
+([cloudflare/containers#147](https://github.com/cloudflare/containers/issues/147)),
+so without this a station would sleep and go offline on a timer.
+
+Scale-to-zero needs "asleep" as a distinct station state and is out of scope.
+Cost of the choice: ~$28/month per always-on 4 GiB station. **This is a burst and
+geography substrate, not the default** — a Hetzner box runs the whole fleet for
+about €46/month.
+
+## Two lessons from the dead driver, encoded as tests
+
+**Every response is validated.** The old driver documented an `ASSUMPTION` about
+the worker's contract and never checked it, so a 2xx with the wrong body would
+have produced a runtime stuck in `provisioning` with no error anywhere. A test
+now asserts a malformed response is rejected.
+
+**A mismatched image is refused, not ignored.** Cloudflare bakes the image at
+deploy time so `ProvisionSpec.image` cannot be honoured; the driver refuses
+loudly rather than silently dropping the input.
+
+## Verified live
+
+Provisioned through `createRuntime`, not by hand: runtime reached
+`status=online runtime=cloudflare-container` with a node heartbeating, then
+**survived a restart as the same `nodeId`** — which exercises runtime identity
+persistence (#245) on the substrate that needs it.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
+EOF
+)"
+```
+
+- [ ] **Step 8: Wait for the four required checks**
+
+```bash
+gh pr checks --watch
+```

--- a/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md
@@ -3,6 +3,7 @@
 **Status:** approved 2026-08-12
 **Horizon:** 1 — step 3 of the re-planned driver wave
 **Depends on:** `2026-08-12-runtime-identity-persistence-design.md` (hard dependency)
+**Revised 2026-08-12** — sleep/wake is **in scope**. See "Sleep and wake".
 **Evidence:** `2026-08-12-cloudflare-sandbox-spike-findings.md`
 
 ## Problem
@@ -33,18 +34,58 @@ on the one above and must not ship before it.
 
 ## Design
 
-### Always-on, not scale-to-zero
+### Sleep and wake
 
-Containers keep themselves alive by overriding `onActivityExpired()` and declining to stop.
+Stations **sleep when idle and wake on demand**. This was briefly scoped out on
+the grounds that the spike showed sleep is not a *correctness* blocker — a
+container can stay alive indefinitely by overriding `onActivityExpired()` without
+stopping. That reasoning was wrong, because cost is the reason this substrate is
+interesting at all:
 
-The alternative — letting them sleep and waking on demand — is a **cost optimisation**, and
-the spike showed it is not needed for correctness. Deferring it keeps this driver small and
-keeps "asleep" out of the station state machine until someone wants the saving.
+| | Per station | × 39 |
+|---|---|---|
+| Always-on (4 GiB) | ~$28/mo | ~$1,090/mo |
+| Sleeping when idle, awake ~2h/day | ~$2/mo | ~$90/mo |
 
-The cost is stated plainly so the choice is informed: roughly **$28/month per always-on
-4 GiB station**, about **$1,090/month across 39**, against ~€46/month for a Hetzner box
-that would run the fleet. Cloudflare earns burst, untrusted code and geography — it is not
-the default substrate for standing stations, and the roadmap already says so.
+Cloudflare stops charging once an instance sleeps. Roughly a **12× difference**,
+which is the difference between a viable second substrate and an expensive one.
+
+**Identity persistence is what makes this possible now.** The original blocker was
+never the sleeping — it was that a woken container came back as a *different
+node*. With runtime-bound re-enrolment merged, a woken container re-enrols and
+resumes the **same `nodeId`**, keeping its stations and history.
+
+**Explicit wake in this slice; automatic wake later.** A Wake control in the
+console, plus wake-on-provision. Automatic wake — any station verb against a
+sleeping node wakes it and retries — is the better experience and the larger
+change, because it touches the broker's offline path and forces everything
+downstream to tolerate seconds of latency. Clean seam; the explicit form is
+useful alone.
+
+### Asleep is a state, and the hub must be told
+
+When Cloudflare sleeps a container on its own timer, the hub sees only that the
+node stopped heartbeating. It cannot distinguish **slept normally** from **died**,
+and showing `offline` for a routine expected condition is precisely the dishonest
+status this codebase has been bitten by repeatedly — a scanner grading machines A
+without reading them, a runtime reporting success while restart-looping.
+
+So the worker **tells** the hub. Its container `onStop` hook posts to a small
+authenticated hub endpoint, which sets the runtime's status to `asleep`.
+
+- `runtime_status` gains **`asleep`**, alongside `provisioning · online · stopped
+  · error · destroyed`. `stopped` already exists and means *deliberately stopped
+  by an operator*; conflating the two would lose the distinction between "I
+  stopped this" and "it idled out", which is the one an operator needs.
+- **The node still goes `offline`, and that is correct.** There is genuinely no
+  connection. The sweeper is untouched: it is not wrong, and teaching it about
+  sleeping nodes would couple it to a substrate.
+- The console shows the *runtime* as asleep with a Wake control, so a sleeping
+  station reads as normal rather than broken.
+
+`sleepAfter` is configurable on the worker, defaulting to **15 minutes** — long
+enough that a short pause in a conversation does not cost a wake, short enough
+that an abandoned station stops billing the same hour.
 
 ### Two pieces
 
@@ -55,7 +96,7 @@ built on `@cloudflare/containers`. It exposes exactly what the driver needs:
 |---|---|
 | `POST /sandbox` | Start a container for a runtime, with hub URL and enrolment token in its environment |
 | `DELETE /sandbox/:id` | Destroy it |
-| `POST /sandbox/:id/stop` · `/start` | Lifecycle, mapping to the driver's optional `stop`/`start` |
+| `POST /sandbox/:id/stop` · `/start` | Lifecycle, mapping to the driver's optional `stop`/`start`. `start` is also the wake path — the spike confirmed `stop` then `start` restarts a container reliably. |
 | `GET /health` | Liveness, for the driver to fail fast on a misconfigured URL |
 
 Authenticated with a shared bearer token, as the old one was.
@@ -92,7 +133,9 @@ work is needed — the provider name is already in the union. `CLOUDFLARE_WORKER
 
 ## Out of scope
 
-- **Sleep/wake as a station state** — deferred, see above.
+- **Automatic wake on demand** — deferred. Any station verb waking a sleeping
+  node and retrying is the better experience, but it changes the broker's offline
+  path and every caller's latency assumptions. Explicit wake first.
 - **Opening the registry** — `cloudflare` is already a known provider; nothing here needs
   dynamic names or capability manifests.
 - **Deleting the old worker and driver** — they stay marked dead until this replaces them
@@ -102,6 +145,13 @@ work is needed — the provider name is already in the union. `CLOUDFLARE_WORKER
 
 ## Testing
 
+- **Sleeping sets `asleep`, not `offline` or `error`** — the callback path, and the
+  distinction an operator relies on to tell "idled out" from "broken".
+- **A wake resumes the same `nodeId`** — the acceptance test for the whole slice,
+  and the one that exercises identity persistence on the substrate that needs it.
+- **`stopped` and `asleep` stay distinct** — an operator-stopped runtime must not
+  be reported as having idled out, or the console loses the difference between
+  "I did that" and "it happened".
 - **Driver unit tests against a fake fetch**, mirroring the existing cloudflare tests:
   provision posts the right body, destroy targets the right id, lifecycle maps correctly.
 - **A response that does not match the expected shape fails the provision** — the specific
@@ -119,7 +169,13 @@ work is needed — the provider name is already in the union. `CLOUDFLARE_WORKER
 worker. That is a platform property, not a design choice, and it makes Cloudflare a poor
 fit for per-runtime harness selection.
 
-**Always-on costs real money.** Documented above. Not the default substrate.
+**A wake costs seconds.** A woken container boots, enrols and reconnects before the
+station is usable. Explicit wake makes that latency visible and attributable,
+which is part of why it comes first.
+
+**Even sleeping, this is not the default substrate.** ~$2/month idle per station
+beats always-on by 12×, but a Hetzner box runs the whole fleet for about €46.
+Cloudflare earns burst, untrusted code and geography.
 
 **Ephemeral disk means a restarted station loses its workspace**, not just its identity.
 Identity is solved by the dependency; workspace persistence is not, and a Cloudflare

--- a/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-12-cloudflare-sandbox-spike-findings.md
@@ -73,6 +73,24 @@ code, and geography — not as the default substrate for standing stations. That
 argument for keeping the operated substrate primary, which is what the roadmap already
 says.
 
+## Correction, added 2026-08-12 after building the driver
+
+**Finding #4 named one cause where there were two.** The spike concluded that a
+woken container did not come back *because container disk is ephemeral and the
+node identity was lost*. That is true, and #245 was the right fix — but the spike
+worker's wake path also called `container.start()` with **no `envVars`**, and a
+container's environment does not survive a stop. So the woken container had no
+`AGENTPOD_HUB_URL` and no `AGENTPOD_ENROLL_TOKEN`, failed `agentpod-node enroll`,
+exited under `set -e`, and was restarted forever.
+
+Both faults produce the identical symptom — "the node never came back" — and the
+spike could not tell them apart because it only observed the outcome. The second
+was found only when the real driver reproduced it and `wrangler containers list`
+showed **7 live instances** in a silent restart loop.
+
+The lesson is narrower than "test more": when one observation is explained by a
+hypothesis you already hold, that is exactly when a second cause hides behind it.
+
 ## Corrections to earlier claims in this investigation
 
 - I reported that `onActivityExpired` "never fired" based on an empty tail. **Wrong** — the

--- a/packages/contract/src/runtime.test.ts
+++ b/packages/contract/src/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { ProvisionRequest, ProvisionedRuntime } from "./runtime";
+import { ProvisionRequest, ProvisionedRuntime, RuntimeStatus } from "./runtime";
 import { RuntimeHarness } from "./runtime";
 
 describe("ProvisionRequest", () => {
@@ -83,5 +83,19 @@ describe("ProvisionedRuntime.runtime", () => {
     // and a row created before this field existed never had one recorded.
     expect(ProvisionedRuntime.parse(BASE).runtime).toBeUndefined();
     expect(ProvisionedRuntime.parse({ ...BASE, runtime: null }).runtime).toBeNull();
+  });
+});
+
+describe("RuntimeStatus asleep", () => {
+  it("accepts asleep", () => {
+    // A slept container is not stopped and not broken. Without its own value the
+    // console cannot tell an operator "this idled out" from "this failed".
+    expect(RuntimeStatus.parse("asleep")).toBe("asleep");
+  });
+
+  it("keeps stopped distinct", () => {
+    // `stopped` means an operator did it. Collapsing the two would lose the
+    // difference between "I did that" and "it happened on its own".
+    expect(RuntimeStatus.parse("stopped")).toBe("stopped");
   });
 });

--- a/packages/contract/src/runtime.ts
+++ b/packages/contract/src/runtime.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 export const RuntimeProvider = z.enum(["docker", "cloudflare"]);
 export type RuntimeProvider = z.infer<typeof RuntimeProvider>;
 
-export const RuntimeStatus = z.enum(["provisioning", "online", "stopped", "error", "destroyed"]);
+/**
+ * `asleep` — the substrate idled the runtime out and stopped billing it. Its
+ * node is legitimately offline; the runtime is healthy and can be woken.
+ * Distinct from `stopped`, which means an operator stopped it deliberately.
+ */
+export const RuntimeStatus = z.enum(["provisioning", "online", "stopped", "asleep", "error", "destroyed"]);
 export type RuntimeStatus = z.infer<typeof RuntimeStatus>;
 
 export const ResourceTier = z.enum(["small", "medium", "large"]);


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-12-cloudflare-sandbox-driver-design.md` —
a second substrate, replacing the dead OpenCode-era worker and driver.

A new worker on `@cloudflare/containers` runs an image carrying a **released**
`agentpod-node`, checksum-verified against `SHA256SUMS` exactly as `install.sh`
does. The container dials the hub outbound and enrols itself; the driver only
does lifecycle.

## Stations sleep when idle

`onActivityExpired()` stops the container and Cloudflare stops charging —
roughly **12× cheaper** than always-on (~$2/month per idle station against ~$28,
~$90 across 39 rather than ~$1,090).

This was briefly scoped out because the spike showed sleep is not a *correctness*
blocker. That was wrong: cost is the reason this substrate is worth having.

**Identity persistence (#245) is what made it tractable.** The blocker was never
the sleeping — it was that a woken container came back as a *different node*.

**The worker tells the hub when it sleeps.** Cloudflare sleeps on its own timer,
so without a callback the hub sees only a node that stopped heartbeating and
cannot distinguish "idled out" from "died". `asleep` is a distinct runtime status,
kept separate from `stopped` (which means an operator did it). The node still goes
`offline` — correctly, there is no connection — and the sweeper is untouched.

Explicit wake in this slice; automatic wake on demand deferred.

## Verified live, end to end

Every step through the real path, not by hand:

| Check | Result |
|---|---|
| Provision via `createRuntime` | `online` in ~30s, `hostname=cloudchamber` |
| Explicit sleep | `rt=asleep node=offline` |
| Wake | same node back online in ~30s, **`same=true` across 5 readings** |
| **Automatic sleep, untouched** | reached `asleep` at idle+180s with `sleepAfter=2m` — the production path, not a curl |
| **Container genuinely stopped** | `wrangler containers instances` reports `inactive` — the cost saving is real, not just a status we set |
| Destroy | exercised through `destroyRuntime` |

## A bug this found, and a correction it forced

The wake path originally called `container.start()` with **no `envVars`**. A
container's environment does not survive a stop, so the woken container had no
hub URL or enrolment token, failed `agentpod-node enroll`, exited under `set -e`,
and was restarted forever — **7 live instances looping silently, and billing**.

Env is now stored in Durable Object storage at create and restored on wake, and a
wake with no stored env fails with 409 rather than booting a container that cannot
possibly enrol.

**The spike had the same bug and I mis-attributed it.** Its wake also passed no
env, and I recorded the failure as purely ephemeral-disk identity loss. Identity
loss was real and #245 was the right fix, but two causes produced one symptom and
the spike could not tell them apart. `2026-08-12-cloudflare-sandbox-spike-findings.md`
now records both.

## Two lessons from the dead driver, encoded as tests

**Every response is validated.** The old driver documented an `ASSUMPTION` about
the worker's contract and never checked it, so a 2xx with the wrong body would
have produced a runtime stuck in `provisioning` with no error anywhere.

**A mismatched image is refused, not ignored.** Cloudflare bakes the image at
deploy time, so `ProvisionSpec.image` cannot be honoured; the driver refuses
loudly rather than silently dropping the input.

## Known limits

**The image carries no harness.** A Cloudflare station enrols and is manageable
but has nothing to hold a conversation with — adding one is a line in the
Dockerfile, but "the provider works" and "you can chat to a Cloudflare station"
are not yet the same statement.

**Not the default substrate**, even sleeping: a Hetzner box runs the whole fleet
for about €46/month. Cloudflare earns burst, untrusted code and geography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW