### PR TITLE
feat: add the OpenCode harness to the Cloudflare image

### DIFF
--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -1,27 +1,50 @@
-FROM debian:bookworm-slim
+# Cloudflare sandbox image: node-agent + the OpenCode harness.
+#
+# Mirrors apps/node-agent/deploy/Dockerfile.opencode, with one difference: the
+# binary is pulled from a RELEASE rather than built here, because wrangler's
+# build context is this directory and the Go source is not in it. It is
+# checksum-verified against SHA256SUMS exactly as install.sh and self-update do,
+# so a Cloudflare station runs the same binary as the rest of the fleet.
+#
+# The entrypoint is a byte-identical copy of node-opencode-entrypoint.sh, and
+# test/entrypoint-parity.test.ts fails if the two ever drift. That script is
+# subtle — double-fork to avoid a zombie that freezes the health check, a
+# sentinel so lifecycle Stop is not a no-op — and reimplementing it here would
+# be a slow way to rediscover both bugs.
 
-# Pin explicitly. A floating "latest" would make two deploys of the same worker
-# produce different fleet behaviour, which is exactly the kind of drift the
-# release pipeline exists to prevent.
+# bun base (Debian) for opencode, matching Dockerfile.opencode.
+FROM oven/bun:1-slim
+
 ARG AGENTPOD_VERSION=v0.1.22
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates curl \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git procps \
+    && rm -rf /var/lib/apt/lists/*
+# procps provides `pgrep`, used by the OpenCode descriptor's running-process
+# health check and its supervised-serve Stop/Start; without it the station
+# Health panel shows "process check unavailable".
+#
+# `sqlite3` is deliberately NOT installed — see Dockerfile.opencode for why:
+# omitting it forces the descriptor onto its directory-enumeration fallback, so
+# opencode's self-managed db schema stays irrelevant to project detection.
 
-# Verify against SHA256SUMS, as install.sh and self-update do. An unverified
-# binary here would be a supply-chain hole in the substrate itself.
+# Pinned to the fleet version, which ships the `acp` subcommand the node-agent's
+# ACPCommand spawns.
+RUN bun add -g opencode-ai@1.18.15
+
+# Installed at /agentpod-node so the entrypoint can be byte-identical to the
+# one the Docker image uses.
 RUN set -eux; \
     base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
-    curl -fsSL -o /usr/local/bin/agentpod-node "${base}/agentpod-node-linux-amd64"; \
+    curl -fsSL -o /agentpod-node "${base}/agentpod-node-linux-amd64"; \
     curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
-    cd /usr/local/bin; \
-    cp agentpod-node agentpod-node-linux-amd64; \
-    grep ' agentpod-node-linux-amd64$' /tmp/SHA256SUMS | sha256sum -c -; \
-    rm -f agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
-    chmod +x /usr/local/bin/agentpod-node; \
-    /usr/local/bin/agentpod-node version
+    cp /agentpod-node /tmp/agentpod-node-linux-amd64; \
+    (cd /tmp && grep ' agentpod-node-linux-amd64$' SHA256SUMS | sha256sum -c -); \
+    rm -f /tmp/agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
+    chmod +x /agentpod-node; \
+    /agentpod-node version
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /node-opencode-entrypoint.sh
+RUN chmod +x /node-opencode-entrypoint.sh
+
+ENTRYPOINT ["/node-opencode-entrypoint.sh"]

--- a/cloudflare/worker-v2/README.md
+++ b/cloudflare/worker-v2/README.md
@@ -3,10 +3,17 @@
 The Cloudflare substrate for AgentPod stations. Replaces `../worker/`, which is
 dead — see its `DEAD.md`.
 
-A container runs a **released** `agentpod-node`, verified against `SHA256SUMS`
-exactly as `install.sh` and self-update do, so a Cloudflare station runs the same
-binary as the rest of the fleet. It dials the hub outbound and enrols itself; the
-hub driver only does lifecycle.
+A container runs a **released** `agentpod-node` plus the **OpenCode harness**,
+mirroring `apps/node-agent/deploy/Dockerfile.opencode`. The binary is verified
+against `SHA256SUMS` exactly as `install.sh` and self-update do, so a Cloudflare
+station runs the same binary as the rest of the fleet. It dials the hub outbound
+and enrols itself; the hub driver only does lifecycle.
+
+`entrypoint.sh` is a **byte-identical copy** of `node-opencode-entrypoint.sh`,
+enforced by `test/entrypoint-parity.test.ts`. That script double-forks to avoid a
+zombie that freezes the health check and uses a sentinel so lifecycle `Stop` is
+not undone by the supervision loop — both fixes for live-fleet bugs. Change the
+original and copy it across; do not edit this one alone.
 
 ## Stations sleep
 
@@ -50,13 +57,14 @@ Then on the hub, in `/etc/agentpod/hub.env`:
 ENABLE_CLOUDFLARE_SANDBOXES=true
 CLOUDFLARE_WORKER_URL=https://<worker-url>
 CLOUDFLARE_WORKER_TOKEN=<the same secret>
-CLOUDFLARE_SANDBOX_IMAGE=<what imageForHarness returns for the harness you provision>
+CLOUDFLARE_SANDBOX_IMAGE=agentpod-node-opencode:local
 RUNTIME_CALLBACK_TOKEN=<shared secret for the sleep callback>
 ```
 
-`CLOUDFLARE_SANDBOX_IMAGE` must match, because Cloudflare bakes the image at
-deploy time and the driver **refuses** a mismatched spec rather than silently
-ignoring it.
+`CLOUDFLARE_SANDBOX_IMAGE` must match what `imageForHarness` returns for the
+harness you provision — `agentpod-node-opencode:local` for `opencode`. Cloudflare
+bakes the image at deploy time, and the driver **refuses** a mismatched spec
+rather than silently ignoring it.
 
 Changing `AGENTPOD_VERSION` in the Dockerfile means redeploying the worker — the
 image is not selectable per request.

--- a/cloudflare/worker-v2/entrypoint.sh
+++ b/cloudflare/worker-v2/entrypoint.sh
@@ -1,12 +1,85 @@
 #!/bin/sh
 set -e
 
-# Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
-#
-# On an ephemeral-disk substrate this runs on every start, not just the first.
-# The hub returns the SAME node for a runtime-bound token whose runtime already
-# has one (runtime identity persistence, #245), so a restart resumes rather than
-# orphaning. Without that this loop would mint a new node every restart.
-/usr/local/bin/agentpod-node enroll
+# Create the workspace directory that OpenCode will manage.
+mkdir -p /workspace
 
-exec /usr/local/bin/agentpod-node run
+# Register /workspace as an OpenCode project so agentpod-node detect lists it.
+#
+# The node-agent descriptor (internal/descriptor/opencode.go) discovers projects
+# via TWO mechanisms (primary first, fallback second):
+#
+#   PRIMARY:  SELECT worktree FROM project WHERE id != 'global' AND worktree != ''
+#             in ~/.local/share/opencode/opencode.db
+#
+#   FALLBACK: enumerate ~/.local/share/opencode/project/ directories; each subdir
+#             name is a sanitised workspace path (leading '/' stripped, '/' → '-'),
+#             e.g. /workspace → "workspace".
+#
+# We deliberately only seed the FALLBACK directory here. An earlier version of
+# this script also hand-seeded opencode.db (the PRIMARY path) with a sqlite3
+# heredoc matching a specific schema snapshot; that broke when opencode-ai was
+# bumped past the version that schema was captured from (`opencode serve`
+# refused to start against the pre-seeded db: "Database is not empty and has
+# no session table"). Chasing opencode's internal schema across every future
+# version bump is brittle, so instead: opencode creates and owns its own
+# opencode.db on first run, and this image does not install `sqlite3` (see
+# Dockerfile.opencode), which makes the PRIMARY path unavailable in-container
+# and forces Detect() onto this directory fallback unconditionally — the
+# schema of opencode's self-created db becomes irrelevant to detection.
+OPENCODE_DATA="${HOME:-/root}/.local/share/opencode"
+mkdir -p "${OPENCODE_DATA}/project/workspace"
+
+# Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
+/agentpod-node enroll
+
+# Supervised opencode server: the station's long-running process. Restarts on
+# crash with 2s backoff; killed cleanly when the container stops.
+#
+# Lifecycle coordination: without the sentinel check below, this loop would
+# immediately resurrect `opencode serve` after the node-agent's opencode
+# descriptor (internal/descriptor/opencode.go) runs a lifecycle Stop on it,
+# making Stop a no-op. The descriptor's Stop kills the process THEN touches
+# /var/run/opencode-serve.stop (kill-before-touch is intentional and safe:
+# the loop's `sleep 2` after every exit means it can't re-check the sentinel
+# and respawn faster than Stop can touch it); the loop checks that sentinel
+# before every (re)spawn and exits when it is present. The descriptor's Start
+# removes the sentinel and re-spawns `opencode serve` itself — this loop has
+# already exited by then, so the two never race.
+mkdir -p /var/run
+rm -f /var/run/opencode-serve.stop
+# Double-fork: the OUTER subshell backgrounds the loop subshell and exits
+# immediately, so the loop re-parents to the container's init (docker-init,
+# HostConfig.Init) instead of staying a child of this shell — which `exec`s
+# into the Go node-agent below. A direct child would linger as a <defunct>
+# zombie after the loop halts (the Go process never reaps unrelated
+# children), and the zombie's comm still matches the descriptor's pgrep
+# health check, freezing Health at "running" (live-fleet finding 2026-08-09).
+(
+  (
+    # `set +e`: the top-level `set -e` (line 2) is inherited into subshells.
+    # Without disabling it here, any non-zero exit from `opencode serve` (a
+    # crash, or exit 143 from the lifecycle Stop's SIGTERM) would terminate
+    # the subshell at that line — the echo/sleep/loop-back below would never
+    # run, making supervision single-shot instead of restart-on-crash.
+    set +e
+    cd /workspace
+    while :; do
+      if [ -f /var/run/opencode-serve.stop ]; then
+        echo "[entrypoint] opencode-serve.stop present, halting supervision loop" >>/var/log/opencode-serve.log
+        break
+      fi
+      opencode serve >>/var/log/opencode-serve.log 2>&1
+      echo "[entrypoint] opencode serve exited ($?), restarting in 2s" >>/var/log/opencode-serve.log
+      sleep 2
+    done
+  ) &
+) &
+# Reap the short-lived outer subshell before exec'ing, so IT doesn't zombie.
+wait $!
+export AGENTPOD_OPENCODE_SUPERVISED=1
+
+# Hand off to the run loop. AGENTPOD_OPENCODE_SUPERVISED, exported above,
+# flows into this process so the opencode descriptor gates its "lifecycle"
+# capability and Stop/Start methods on it.
+exec /agentpod-node run

--- a/cloudflare/worker-v2/test/entrypoint-parity.test.ts
+++ b/cloudflare/worker-v2/test/entrypoint-parity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The Cloudflare image's entrypoint is a COPY of the Docker image's, and must
+ * stay byte-identical.
+ *
+ * That script is subtle and was arrived at by fixing live-fleet bugs: it
+ * double-forks so the supervision loop re-parents to init (a direct child
+ * lingers as a zombie whose comm still matches the descriptor's pgrep health
+ * check, freezing Health at "running"), and it uses a sentinel file so the
+ * descriptor's lifecycle Stop is not immediately undone by the loop respawning.
+ *
+ * A second, hand-maintained copy would drift and rediscover both bugs on a
+ * substrate where the feedback loop is a deploy. Hence a test rather than a
+ * comment asking nicely.
+ */
+describe("entrypoint parity", () => {
+  it("is byte-identical to the Docker image's entrypoint", () => {
+    const here = readFileSync(join(import.meta.dirname, "../entrypoint.sh"), "utf8");
+    const canonical = readFileSync(
+      join(import.meta.dirname, "../../../apps/node-agent/deploy/node-opencode-entrypoint.sh"),
+      "utf8"
+    );
+
+    expect(here).toBe(canonical);
+  });
+});


### PR DESCRIPTION
Closes the gap named in #247's Known Limits: a Cloudflare station enrolled and
was manageable, but had no harness and so nothing to converse with.

The image now mirrors `apps/node-agent/deploy/Dockerfile.opencode` — bun base,
`opencode-ai@1.18.15`, `procps` for the descriptor's pgrep health check, and
deliberately **no** `sqlite3` so project detection stays on its directory
fallback rather than depending on opencode's internal schema.

## The entrypoint is a byte-identical copy, enforced by a test

`entrypoint.sh` is `node-opencode-entrypoint.sh`, unchanged, and
`test/entrypoint-parity.test.ts` fails if they drift. The released binary is
installed at `/agentpod-node` specifically so the two *can* be identical.

That script is subtle and was arrived at by fixing live-fleet bugs: it
double-forks so the supervision loop re-parents to init (a direct child lingers
as a zombie whose comm still matches the pgrep health check, freezing Health at
"running"), and it uses a sentinel so the descriptor's lifecycle `Stop` is not
immediately undone by the loop respawning. A hand-maintained second copy would
rediscover both, on a substrate where the feedback loop is a deploy.

I expected this to be the risky part — the script was written against Docker's
`HostConfig.Init: true`, and Cloudflare offers no such setting. It works anyway.

## Verified live

Provisioned through `createRuntime` against the deployed hub:

```
runtime  online   node online
station  opencode:c52ddf65  auto-adopted
caps     health, logs, fs.read, fs.write, terminal, cleanup, acp, lifecycle
```

**`acp` is what gates the Chat tab and `apn acp`.** **`lifecycle` is only
advertised when the entrypoint exports `AGENTPOD_OPENCODE_SUPERVISED`**, so the
supervision loop demonstrably ran.

## One unexplained event, reported rather than explained away

The container **died once**, about two minutes after its first enrol. The runtime
correctly stayed `online` while the node went `offline` — it failed rather than
slept, so the sleep callback rightly did not fire.

After a restart it ran clean for **7 consecutive readings over ~5 minutes** with
no `onStop` logged. I have no evidence for a cause. The tempting story is
"first-boot transient while opencode initialised", and that may be right, but
inventing a cause that fits an observation is exactly the mistake that made the
spike record one cause where there were two. Recorded as: died once, unexplained,
did not recur.

## Deployment note

`CLOUDFLARE_SANDBOX_IMAGE` must now be `agentpod-node-opencode:local` — the image
carries a harness, so `imageForHarness("opencode")` is what a spec will ask for.
The driver refuses a mismatch rather than ignoring it, so this is a required
config change, already applied to the reference hub.

## Still not claimed

A prompt and reply through the Chat tab. That needs an authenticated ACP session
against the running hub, which the verification scripts cannot do — the broker's
connection map lives in the hub process. The station is left running so it can be
tried from the console directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW