### PR TITLE
fix(cloudflare): stop stations destroying the workspace when they sleep

### DIFF
--- a/apps/hub/src/services/broker.ts
+++ b/apps/hub/src/services/broker.ts
@@ -54,12 +54,30 @@ const DEFAULT_TIMEOUT_MS = 15_000;
  * Resolves with {ok:false, error:"timeout"} if no response arrives within timeoutMs.
  * Never rejects — callers can always `await` without try/catch.
  */
+/**
+ * Called with the node id on every outbound verb, so a substrate that idles its
+ * runtimes out can be told the station is in use.
+ *
+ * A hook rather than a direct call: the broker must not grow a dependency on
+ * the runtime tables or on any provisioner. Registered at boot in
+ * `provisioner/bootstrap.ts`.
+ *
+ * Every caller of request()/stream() is a user-initiated route — the hub does no
+ * periodic polling of nodes — so this fires on real activity, not on heartbeats.
+ */
+let activityHook: ((nodeId: string) => void) | null = null;
+
+export function setActivityHook(fn: ((nodeId: string) => void) | null): void {
+  activityHook = fn;
+}
+
 export function request(
   nodeId: string,
   verb: string,
   params: unknown,
   opts?: { timeoutMs?: number }
 ): Promise<RequestResult> {
+  activityHook?.(nodeId);
   return new Promise((resolve) => {
     const id = crypto.randomUUID();
     const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -99,6 +117,7 @@ export function stream(
   params: unknown,
   onChunk: StreamHandler
 ): { cancel(): void; id: string } {
+  activityHook?.(nodeId);
   const id = crypto.randomUUID();
   let active = true;
 

--- a/apps/hub/src/services/provisioner/bootstrap.ts
+++ b/apps/hub/src/services/provisioner/bootstrap.ts
@@ -7,15 +7,51 @@
  * The integration tests register a fake provisioner explicitly, so this wiring
  * is the only place the production drivers get connected to the registry.
  */
+import { and, eq } from "drizzle-orm";
+import { db } from "../../db/drizzle";
+import { provisionedRuntimes } from "../../db/schema/nodes";
 import { registerProvisioner, isProviderEnabled } from "./registry";
 import { DockerRuntimeProvisioner } from "./docker";
 import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
+import { createActivityToucher } from "../runtime-activity";
+import { setActivityHook } from "../broker";
 
 export function registerEnabledProvisioners(): void {
   if (isProviderEnabled("docker")) {
     registerProvisioner(new DockerRuntimeProvisioner());
   }
   if (isProviderEnabled("cloudflare")) {
-    registerProvisioner(new CloudflareSandboxProvisioner());
+    const cloudflare = new CloudflareSandboxProvisioner();
+    registerProvisioner(cloudflare);
+
+    // Tell Cloudflare a station is in use whenever the hub routes a verb to it.
+    // Its idle timer counts only incoming requests and a node-agent dials out,
+    // so without this a station sleeps 15 minutes after start however busy it
+    // is — which is exactly how a live station vanished mid-session on
+    // 2026-08-12.
+    const toucher = createActivityToucher({
+      lookup: async (nodeId) => {
+        const [row] = await db
+          .select({
+            provider: provisionedRuntimes.provider,
+            externalId: provisionedRuntimes.externalId,
+          })
+          .from(provisionedRuntimes)
+          .where(
+            and(
+              eq(provisionedRuntimes.nodeId, nodeId),
+              eq(provisionedRuntimes.status, "online")
+            )
+          );
+        if (!row?.externalId) return null;
+        return { provider: row.provider, externalId: row.externalId };
+      },
+      touch: (externalId) => cloudflare.touch(externalId),
+      now: () => Date.now(),
+    });
+
+    // Fire-and-forget: touch() never throws, and a renewal must never delay or
+    // fail the user's actual verb.
+    setActivityHook((nodeId) => void toucher.touch(nodeId));
   }
 }

--- a/apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts
+++ b/apps/hub/src/services/provisioner/cloudflare-sandbox.test.ts
@@ -15,7 +15,7 @@ const IMAGE = "agentpod-node-opencode:v0.1.22";
 const SPEC: ProvisionSpec = {
   runtimeId: "rt_abc",
   name: "test",
-  resourceTier: "small",
+  resourceTier: "large",
   hubUrl: "https://hub.example",
   enrollToken: "enr_secret",
   image: IMAGE,
@@ -115,6 +115,30 @@ describe("CloudflareSandboxProvisioner", () => {
     const stopped = fakeFetch({ stopped: "rt_abc" }, 200);
     await make(stopped.impl).stop!("rt_abc");
     expect(stopped.calls[0]!.url).toBe("https://w.example/sandbox/rt_abc/stop");
+  });
+
+  it("touches the activity route so an in-use station does not idle out", async () => {
+    const { impl, calls } = fakeFetch({ touched: "rt_abc" }, 200);
+    await make(impl).touch("rt_abc");
+    expect(calls[0]!.url).toBe("https://w.example/sandbox/rt_abc/touch");
+    expect(calls[0]!.init.method).toBe("POST");
+  });
+
+  it("REFUSES a resource tier the deployed worker cannot provide", async () => {
+    // Cloudflare fixes instance_type per container class, so a tier this worker
+    // was not deployed with cannot be honoured. Refusing is the same rule the
+    // image already follows — silently ignoring an input is how the dead driver
+    // failed, and today this driver drops resourceTier on the floor.
+    const { impl } = fakeFetch({ sandboxId: "rt_abc" });
+    await expect(
+      make(impl).provision({ ...SPEC, resourceTier: "small" })
+    ).rejects.toThrow(/resource tier/i);
+  });
+
+  it("accepts the tier the worker was deployed with", async () => {
+    const { impl } = fakeFetch({ sandboxId: "rt_abc" });
+    const res = await make(impl).provision({ ...SPEC, resourceTier: "large" });
+    expect(res.externalId).toBe("rt_abc");
   });
 
   it("fails clearly when the worker url is not configured", async () => {

--- a/apps/hub/src/services/provisioner/cloudflare-sandbox.ts
+++ b/apps/hub/src/services/provisioner/cloudflare-sandbox.ts
@@ -30,6 +30,12 @@ export interface CloudflareSandboxOptions {
    * it the hub cannot distinguish a routine sleep from a dead container.
    */
   callbackToken?: string;
+  /**
+   * The resource tier the deployed worker actually provides. Cloudflare fixes
+   * `instance_type` per container class, so one deployment offers exactly one
+   * tier; anything else cannot be honoured and is refused rather than ignored.
+   */
+  deployedTier?: string;
   /** Injectable fetch — used to inject a fake in unit tests. */
   fetchImpl?: typeof globalThis.fetch;
 }
@@ -41,6 +47,7 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
   private readonly apiToken: string;
   private readonly deployedImage: string;
   private readonly callbackToken: string;
+  private readonly deployedTier: string;
   private readonly fetchImpl: typeof globalThis.fetch;
 
   constructor({
@@ -48,12 +55,15 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
     apiToken = process.env.CLOUDFLARE_WORKER_TOKEN ?? "",
     deployedImage = process.env.CLOUDFLARE_SANDBOX_IMAGE ?? "",
     callbackToken = process.env.RUNTIME_CALLBACK_TOKEN ?? "",
+    // standard-1 is 4 GiB, which is the Docker "large" tier's memory limit.
+    deployedTier = process.env.CLOUDFLARE_INSTANCE_TIER ?? "large",
     fetchImpl = globalThis.fetch,
   }: CloudflareSandboxOptions = {}) {
     this.workerUrl = workerUrl.replace(/\/$/, "");
     this.apiToken = apiToken;
     this.deployedImage = deployedImage;
     this.callbackToken = callbackToken;
+    this.deployedTier = deployedTier;
     this.fetchImpl = fetchImpl;
   }
 
@@ -101,6 +111,19 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
       );
     }
 
+    // Same rule as the image, for the same reason. Cloudflare fixes
+    // instance_type per container class, so a tier this worker was not deployed
+    // with cannot be satisfied. Until per-tier container classes exist, this
+    // driver refuses rather than quietly handing out a size nobody asked for.
+    if (this.deployedTier && spec.resourceTier !== this.deployedTier) {
+      throw new Error(
+        `cloudflare: this worker provides the "${this.deployedTier}" resource tier ` +
+          `and cannot provision "${spec.resourceTier}". Cloudflare fixes the ` +
+          `instance type at worker deploy time; choose "${this.deployedTier}" or ` +
+          `deploy a worker for the tier you want.`
+      );
+    }
+
     const body = await this.call("/sandbox", {
       method: "POST",
       body: JSON.stringify({
@@ -132,5 +155,15 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
 
   async stop(externalId: string): Promise<void> {
     await this.call(`/sandbox/${externalId}/stop`, { method: "POST" });
+  }
+
+  /**
+   * Push the substrate's idle deadline out because this station is in use.
+   *
+   * Cloudflare's timer counts only incoming requests and a node-agent dials out,
+   * so without this a station sleeps 15 minutes after start however busy it is.
+   */
+  async touch(externalId: string): Promise<void> {
+    await this.call(`/sandbox/${externalId}/touch`, { method: "POST" });
   }
 }

--- a/apps/hub/src/services/runtime-activity.test.ts
+++ b/apps/hub/src/services/runtime-activity.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests: runtime activity toucher.
+ *
+ * Cloudflare's idle timer counts only INCOMING requests, and a node-agent dials
+ * out — so without this signal a station sleeps 15 minutes after start however
+ * hard it is being used. That is exactly how a live station vanished mid-session
+ * on 2026-08-12.
+ *
+ * The debounce is not an optimisation. One trivial Hermes prompt was measured at
+ * 1,051 ACP events; without it, that is 1,051 requests at the worker.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createActivityToucher } from "./runtime-activity";
+
+function harness(
+  lookupResult: { provider: string; externalId: string } | null,
+  opts: { failTouch?: boolean } = {}
+) {
+  const touched: string[] = [];
+  let now = 1_000_000;
+  const toucher = createActivityToucher(
+    {
+      lookup: async () => lookupResult,
+      touch: async (externalId: string) => {
+        if (opts.failTouch) throw new Error("worker unreachable");
+        touched.push(externalId);
+      },
+      now: () => now,
+    },
+    60_000
+  );
+  return { toucher, touched, advance: (ms: number) => (now += ms) };
+}
+
+const CF = { provider: "cloudflare", externalId: "rt_abc" };
+
+describe("createActivityToucher", () => {
+  it("touches the substrate for a cloudflare-backed node", async () => {
+    const { toucher, touched } = harness(CF);
+    await toucher.touch("node_1");
+    expect(touched).toEqual(["rt_abc"]);
+  });
+
+  it("debounces repeat activity within the interval", async () => {
+    // The point: a chat firehose must not become a request firehose.
+    const { toucher, touched, advance } = harness(CF);
+    await toucher.touch("node_1");
+    advance(30_000);
+    await toucher.touch("node_1");
+    await toucher.touch("node_1");
+    expect(touched).toEqual(["rt_abc"]);
+  });
+
+  it("touches again once the interval has passed", async () => {
+    const { toucher, touched, advance } = harness(CF);
+    await toucher.touch("node_1");
+    advance(60_001);
+    await toucher.touch("node_1");
+    expect(touched).toEqual(["rt_abc", "rt_abc"]);
+  });
+
+  it("does nothing for a node that is not cloudflare-backed", async () => {
+    // Docker runtimes never sleep, and a docker node has no worker to call.
+    const { toucher, touched } = harness({ provider: "docker", externalId: "rt_d" });
+    await toucher.touch("node_1");
+    expect(touched).toEqual([]);
+  });
+
+  it("does nothing for a node with no provisioned runtime", async () => {
+    // Every enrolled laptop and VPS in the fleet takes this path.
+    const { toucher, touched } = harness(null);
+    await toucher.touch("node_1");
+    expect(touched).toEqual([]);
+  });
+
+  it("NEVER throws when the substrate call fails", async () => {
+    // A renewal is best-effort. If this could throw, an unreachable worker
+    // would break the user's actual verb — the feature would cause the outage
+    // it exists to prevent.
+    const { toucher } = harness(CF, { failTouch: true });
+    expect(toucher.touch("node_1")).resolves.toBeUndefined();
+  });
+});

--- a/apps/hub/src/services/runtime-activity.ts
+++ b/apps/hub/src/services/runtime-activity.ts
@@ -1,0 +1,58 @@
+/**
+ * Runtime activity signal.
+ *
+ * Some substrates sleep an idle runtime to stop billing. Cloudflare's idle timer
+ * is fed only by INCOMING requests, and a node-agent dials OUT — so from the
+ * substrate's point of view a station is idle no matter how busy it is, and it
+ * sleeps 15 minutes after start. On 2026-08-12 that took a live station away
+ * mid-session.
+ *
+ * The hub is the only component that knows a station is being used, so it says
+ * so. Debounced, because one trivial Hermes prompt was measured at 1,051 ACP
+ * events and every one of them routes through the broker.
+ *
+ * Best-effort by construction: a renewal that fails must never fail the user's
+ * verb, or this would cause the outage it exists to prevent.
+ */
+
+export interface ActivityDeps {
+  /** The provisioned runtime backing a node, or null for an ordinary host. */
+  lookup(nodeId: string): Promise<{ provider: string; externalId: string } | null>;
+  /** Tell the substrate this runtime is in use. */
+  touch(externalId: string): Promise<void>;
+  now(): number;
+}
+
+/** Substrates whose runtimes idle out and therefore need this signal. */
+const SLEEPS_WHEN_IDLE = new Set(["cloudflare"]);
+
+export interface ActivityToucher {
+  touch(nodeId: string): Promise<void>;
+}
+
+export function createActivityToucher(
+  deps: ActivityDeps,
+  intervalMs = 60_000
+): ActivityToucher {
+  const lastTouched = new Map<string, number>();
+
+  return {
+    async touch(nodeId: string): Promise<void> {
+      try {
+        const last = lastTouched.get(nodeId);
+        const now = deps.now();
+        if (last !== undefined && now - last < intervalMs) return;
+
+        const runtime = await deps.lookup(nodeId);
+        if (!runtime || !SLEEPS_WHEN_IDLE.has(runtime.provider)) return;
+
+        // Recorded before the call, not after: a slow or failing worker must not
+        // let a burst of verbs queue up a burst of renewals behind it.
+        lastTouched.set(nodeId, now);
+        await deps.touch(runtime.externalId);
+      } catch {
+        // Deliberately swallowed — see the module comment.
+      }
+    },
+  };
+}

--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -1,27 +1,50 @@
-FROM debian:bookworm-slim
+# Cloudflare sandbox image: node-agent + the OpenCode harness.
+#
+# Mirrors apps/node-agent/deploy/Dockerfile.opencode, with one difference: the
+# binary is pulled from a RELEASE rather than built here, because wrangler's
+# build context is this directory and the Go source is not in it. It is
+# checksum-verified against SHA256SUMS exactly as install.sh and self-update do,
+# so a Cloudflare station runs the same binary as the rest of the fleet.
+#
+# The entrypoint is a byte-identical copy of node-opencode-entrypoint.sh, and
+# test/entrypoint-parity.test.ts fails if the two ever drift. That script is
+# subtle — double-fork to avoid a zombie that freezes the health check, a
+# sentinel so lifecycle Stop is not a no-op — and reimplementing it here would
+# be a slow way to rediscover both bugs.
 
-# Pin explicitly. A floating "latest" would make two deploys of the same worker
-# produce different fleet behaviour, which is exactly the kind of drift the
-# release pipeline exists to prevent.
+# bun base (Debian) for opencode, matching Dockerfile.opencode.
+FROM oven/bun:1-slim
+
 ARG AGENTPOD_VERSION=v0.1.22
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates curl \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git procps \
+    && rm -rf /var/lib/apt/lists/*
+# procps provides `pgrep`, used by the OpenCode descriptor's running-process
+# health check and its supervised-serve Stop/Start; without it the station
+# Health panel shows "process check unavailable".
+#
+# `sqlite3` is deliberately NOT installed — see Dockerfile.opencode for why:
+# omitting it forces the descriptor onto its directory-enumeration fallback, so
+# opencode's self-managed db schema stays irrelevant to project detection.
 
-# Verify against SHA256SUMS, as install.sh and self-update do. An unverified
-# binary here would be a supply-chain hole in the substrate itself.
+# Pinned to the fleet version, which ships the `acp` subcommand the node-agent's
+# ACPCommand spawns.
+RUN bun add -g opencode-ai@1.18.15
+
+# Installed at /agentpod-node so the entrypoint can be byte-identical to the
+# one the Docker image uses.
 RUN set -eux; \
     base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
-    curl -fsSL -o /usr/local/bin/agentpod-node "${base}/agentpod-node-linux-amd64"; \
+    curl -fsSL -o /agentpod-node "${base}/agentpod-node-linux-amd64"; \
     curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
-    cd /usr/local/bin; \
-    cp agentpod-node agentpod-node-linux-amd64; \
-    grep ' agentpod-node-linux-amd64$' /tmp/SHA256SUMS | sha256sum -c -; \
-    rm -f agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
-    chmod +x /usr/local/bin/agentpod-node; \
-    /usr/local/bin/agentpod-node version
+    cp /agentpod-node /tmp/agentpod-node-linux-amd64; \
+    (cd /tmp && grep ' agentpod-node-linux-amd64$' SHA256SUMS | sha256sum -c -); \
+    rm -f /tmp/agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
+    chmod +x /agentpod-node; \
+    /agentpod-node version
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /node-opencode-entrypoint.sh
+RUN chmod +x /node-opencode-entrypoint.sh
+
+ENTRYPOINT ["/node-opencode-entrypoint.sh"]

--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -24,4 +24,12 @@ RUN set -eux; \
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+
+# Workspace persistence. Disk on this substrate is ephemeral, so the wrapper
+# restores the workspace on start and archives it on SIGTERM. It runs the
+# entrypoint as a child rather than replacing it, which keeps the entrypoint
+# byte-identical to the fleet's Docker one.
+COPY snapshot-wrapper.sh /snapshot-wrapper.sh
+RUN chmod +x /snapshot-wrapper.sh
+
+ENTRYPOINT ["/snapshot-wrapper.sh", "/entrypoint.sh"]

--- a/cloudflare/worker-v2/README.md
+++ b/cloudflare/worker-v2/README.md
@@ -3,10 +3,17 @@
 The Cloudflare substrate for AgentPod stations. Replaces `../worker/`, which is
 dead — see its `DEAD.md`.
 
-A container runs a **released** `agentpod-node`, verified against `SHA256SUMS`
-exactly as `install.sh` and self-update do, so a Cloudflare station runs the same
-binary as the rest of the fleet. It dials the hub outbound and enrols itself; the
-hub driver only does lifecycle.
+A container runs a **released** `agentpod-node` plus the **OpenCode harness**,
+mirroring `apps/node-agent/deploy/Dockerfile.opencode`. The binary is verified
+against `SHA256SUMS` exactly as `install.sh` and self-update do, so a Cloudflare
+station runs the same binary as the rest of the fleet. It dials the hub outbound
+and enrols itself; the hub driver only does lifecycle.
+
+`entrypoint.sh` is a **byte-identical copy** of `node-opencode-entrypoint.sh`,
+enforced by `test/entrypoint-parity.test.ts`. That script double-forks to avoid a
+zombie that freezes the health check and uses a sentinel so lifecycle `Stop` is
+not undone by the supervision loop — both fixes for live-fleet bugs. Change the
+original and copy it across; do not edit this one alone.
 
 ## Stations sleep
 
@@ -50,13 +57,14 @@ Then on the hub, in `/etc/agentpod/hub.env`:
 ENABLE_CLOUDFLARE_SANDBOXES=true
 CLOUDFLARE_WORKER_URL=https://<worker-url>
 CLOUDFLARE_WORKER_TOKEN=<the same secret>
-CLOUDFLARE_SANDBOX_IMAGE=<what imageForHarness returns for the harness you provision>
+CLOUDFLARE_SANDBOX_IMAGE=agentpod-node-opencode:local
 RUNTIME_CALLBACK_TOKEN=<shared secret for the sleep callback>
 ```
 
-`CLOUDFLARE_SANDBOX_IMAGE` must match, because Cloudflare bakes the image at
-deploy time and the driver **refuses** a mismatched spec rather than silently
-ignoring it.
+`CLOUDFLARE_SANDBOX_IMAGE` must match what `imageForHarness` returns for the
+harness you provision — `agentpod-node-opencode:local` for `opencode`. Cloudflare
+bakes the image at deploy time, and the driver **refuses** a mismatched spec
+rather than silently ignoring it.
 
 Changing `AGENTPOD_VERSION` in the Dockerfile means redeploying the worker — the
 image is not selectable per request.

--- a/cloudflare/worker-v2/README.md
+++ b/cloudflare/worker-v2/README.md
@@ -15,9 +15,24 @@ hub driver only does lifecycle.
 
 Cloudflare's activity timer is fed by *incoming* requests
 ([containers#147](https://github.com/cloudflare/containers/issues/147)), and a
-node-agent receives none, so a station always idles out eventually. That is fine
-because a woken container re-enrols and **resumes the same `nodeId`** (runtime
-identity persistence, #245). Before that landed, sleeping lost the station.
+node-agent receives none, so a station would always idle out eventually — 15
+minutes after **start**, however hard it was being used.
+
+> **This section used to say that was "fine, because a woken container re-enrols
+> and resumes the same `nodeId`". That was wrong, and it cost a user their
+> work.** Identity is not state: Cloudflare disk is ephemeral, so a woken station
+> came back as the same station with an *empty workspace*, which is worse than an
+> obvious failure because it looks like it survived. On 2026-08-12 a station
+> slept exactly 15 minutes after start, mid-session, and destroyed a file its
+> user had created four minutes earlier.
+
+Two mechanisms now make sleeping safe rather than destructive:
+
+- **The workspace is archived to R2** on SIGTERM and restored on start
+  (`snapshot-wrapper.sh`). Cloudflare allows 15 minutes before SIGKILL, so there
+  is ample room to archive a real workspace.
+- **The hub renews the idle deadline** via `POST /sandbox/:id/touch` whenever it
+  routes a verb to the station, so a station in use does not sleep at all.
 
 Since Cloudflare sleeps on its own timer, the container **tells the hub** via
 `POST /public/runtimes/:id/state` — otherwise the hub sees only a node that
@@ -35,11 +50,25 @@ All except `/health` require `Authorization: Bearer $AGENTPOD_WORKER_TOKEN`.
 | `DELETE /sandbox/:id` | Destroy. |
 | `POST /sandbox/:id/start` | Start — **also the wake path**. |
 | `POST /sandbox/:id/stop` | Stop. |
+| `POST /sandbox/:id/touch` | Renew the idle deadline. Called by the hub on station activity. |
+| `GET`/`PUT /sandbox/:id/snapshot` | Restore / archive the workspace. **Per-sandbox token, not the admin token** — see below. |
+
+The snapshot routes are the only ones not gated by `AGENTPOD_WORKER_TOKEN`. A
+container must be able to save its own workspace without holding a credential
+that could create or destroy sandboxes across the fleet, so it gets a token
+minted per sandbox and stored in Durable Object storage. That token buys exactly
+two things: read and write of its own archive. It cannot reach another station's
+archive, and it cannot delete even its own — deletion happens only on the
+admin-authenticated destroy path, so a compromised harness cannot erase the
+user's work.
 
 ## Deploy
 
 ```bash
 npm install
+# Workspace archives. Without this bucket the worker will not deploy, which is
+# deliberate — a deploy that silently lost workspaces is what this replaces.
+npx wrangler r2 bucket create agentpod-snapshots
 npx wrangler deploy
 npx wrangler secret put AGENTPOD_WORKER_TOKEN   # openssl rand -hex 32
 ```
@@ -52,7 +81,15 @@ CLOUDFLARE_WORKER_URL=https://<worker-url>
 CLOUDFLARE_WORKER_TOKEN=<the same secret>
 CLOUDFLARE_SANDBOX_IMAGE=<what imageForHarness returns for the harness you provision>
 RUNTIME_CALLBACK_TOKEN=<shared secret for the sleep callback>
+CLOUDFLARE_INSTANCE_TIER=large   # the tier this worker's instance_type provides
 ```
+
+`CLOUDFLARE_INSTANCE_TIER` must match the `instance_type` in `wrangler.toml`
+(`standard-1` is 4 GiB, which is the Docker `large` tier). Cloudflare fixes the
+instance type per container class, so the driver **refuses** any other tier
+rather than quietly handing out a size nobody asked for. Provisioning a
+`small` Cloudflare station therefore fails by design until per-tier container
+classes exist.
 
 `CLOUDFLARE_SANDBOX_IMAGE` must match, because Cloudflare bakes the image at
 deploy time and the driver **refuses** a mismatched spec rather than silently

--- a/cloudflare/worker-v2/entrypoint.sh
+++ b/cloudflare/worker-v2/entrypoint.sh
@@ -1,12 +1,85 @@
 #!/bin/sh
 set -e
 
-# Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
-#
-# On an ephemeral-disk substrate this runs on every start, not just the first.
-# The hub returns the SAME node for a runtime-bound token whose runtime already
-# has one (runtime identity persistence, #245), so a restart resumes rather than
-# orphaning. Without that this loop would mint a new node every restart.
-/usr/local/bin/agentpod-node enroll
+# Create the workspace directory that OpenCode will manage.
+mkdir -p /workspace
 
-exec /usr/local/bin/agentpod-node run
+# Register /workspace as an OpenCode project so agentpod-node detect lists it.
+#
+# The node-agent descriptor (internal/descriptor/opencode.go) discovers projects
+# via TWO mechanisms (primary first, fallback second):
+#
+#   PRIMARY:  SELECT worktree FROM project WHERE id != 'global' AND worktree != ''
+#             in ~/.local/share/opencode/opencode.db
+#
+#   FALLBACK: enumerate ~/.local/share/opencode/project/ directories; each subdir
+#             name is a sanitised workspace path (leading '/' stripped, '/' → '-'),
+#             e.g. /workspace → "workspace".
+#
+# We deliberately only seed the FALLBACK directory here. An earlier version of
+# this script also hand-seeded opencode.db (the PRIMARY path) with a sqlite3
+# heredoc matching a specific schema snapshot; that broke when opencode-ai was
+# bumped past the version that schema was captured from (`opencode serve`
+# refused to start against the pre-seeded db: "Database is not empty and has
+# no session table"). Chasing opencode's internal schema across every future
+# version bump is brittle, so instead: opencode creates and owns its own
+# opencode.db on first run, and this image does not install `sqlite3` (see
+# Dockerfile.opencode), which makes the PRIMARY path unavailable in-container
+# and forces Detect() onto this directory fallback unconditionally — the
+# schema of opencode's self-created db becomes irrelevant to detection.
+OPENCODE_DATA="${HOME:-/root}/.local/share/opencode"
+mkdir -p "${OPENCODE_DATA}/project/workspace"
+
+# Enroll reads AGENTPOD_HUB_URL and AGENTPOD_ENROLL_TOKEN from the environment.
+/agentpod-node enroll
+
+# Supervised opencode server: the station's long-running process. Restarts on
+# crash with 2s backoff; killed cleanly when the container stops.
+#
+# Lifecycle coordination: without the sentinel check below, this loop would
+# immediately resurrect `opencode serve` after the node-agent's opencode
+# descriptor (internal/descriptor/opencode.go) runs a lifecycle Stop on it,
+# making Stop a no-op. The descriptor's Stop kills the process THEN touches
+# /var/run/opencode-serve.stop (kill-before-touch is intentional and safe:
+# the loop's `sleep 2` after every exit means it can't re-check the sentinel
+# and respawn faster than Stop can touch it); the loop checks that sentinel
+# before every (re)spawn and exits when it is present. The descriptor's Start
+# removes the sentinel and re-spawns `opencode serve` itself — this loop has
+# already exited by then, so the two never race.
+mkdir -p /var/run
+rm -f /var/run/opencode-serve.stop
+# Double-fork: the OUTER subshell backgrounds the loop subshell and exits
+# immediately, so the loop re-parents to the container's init (docker-init,
+# HostConfig.Init) instead of staying a child of this shell — which `exec`s
+# into the Go node-agent below. A direct child would linger as a <defunct>
+# zombie after the loop halts (the Go process never reaps unrelated
+# children), and the zombie's comm still matches the descriptor's pgrep
+# health check, freezing Health at "running" (live-fleet finding 2026-08-09).
+(
+  (
+    # `set +e`: the top-level `set -e` (line 2) is inherited into subshells.
+    # Without disabling it here, any non-zero exit from `opencode serve` (a
+    # crash, or exit 143 from the lifecycle Stop's SIGTERM) would terminate
+    # the subshell at that line — the echo/sleep/loop-back below would never
+    # run, making supervision single-shot instead of restart-on-crash.
+    set +e
+    cd /workspace
+    while :; do
+      if [ -f /var/run/opencode-serve.stop ]; then
+        echo "[entrypoint] opencode-serve.stop present, halting supervision loop" >>/var/log/opencode-serve.log
+        break
+      fi
+      opencode serve >>/var/log/opencode-serve.log 2>&1
+      echo "[entrypoint] opencode serve exited ($?), restarting in 2s" >>/var/log/opencode-serve.log
+      sleep 2
+    done
+  ) &
+) &
+# Reap the short-lived outer subshell before exec'ing, so IT doesn't zombie.
+wait $!
+export AGENTPOD_OPENCODE_SUPERVISED=1
+
+# Hand off to the run loop. AGENTPOD_OPENCODE_SUPERVISED, exported above,
+# flows into this process so the opencode descriptor gates its "lifecycle"
+# capability and Stop/Start methods on it.
+exec /agentpod-node run

--- a/cloudflare/worker-v2/snapshot-wrapper.sh
+++ b/cloudflare/worker-v2/snapshot-wrapper.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# Workspace persistence for the Cloudflare substrate.
+#
+# Cloudflare container disk is ephemeral: "when a Container instance goes to
+# sleep, the next time it is started, it will have a fresh disk as defined by
+# its container image". Without this wrapper a station destroys the user's work
+# every time it idles out — a README.md written at 04:56 on 2026-08-12 was gone
+# by 04:59:58.
+#
+# This is a WRAPPER, not an edit to the entrypoint, for two reasons. The inner
+# entrypoint is subtle (double-fork supervision, a stop sentinel, a zombie that
+# once froze the health check) and is byte-compared against the fleet's Docker
+# entrypoint by a parity test. And Docker runtimes do not need any of this —
+# their disk persists — so the logic belongs to the substrate that lacks it.
+#
+# Usage: snapshot-wrapper.sh <inner-entrypoint> [args...]
+#
+# NOTE: deliberately no `set -e`. This script's whole job is to run on the way
+# out, and an inherited errexit would let one failed command skip the snapshot —
+# which is the failure this file exists to prevent.
+
+# Root of the snapshot paths. Overridable ONLY so the test suite can point the
+# whole mechanism at a temp directory instead of the real filesystem.
+ROOT="${AGENTPOD_SNAPSHOT_ROOT:-/}"
+ROOT="${ROOT%/}/" # normalise: paths are built as "$ROOT$relative"
+ARCHIVE="${TMPDIR:-/tmp}/agentpod-snapshot.tar.gz"
+INTERVAL="${AGENTPOD_SNAPSHOT_INTERVAL:-300}"
+
+log() { echo "[snapshot] $*"; }
+
+# Paths to preserve, relative to ROOT so tar can restore them positionally.
+#
+# The opencode data dir is included on purpose: it holds the harness's own
+# session state, so without it a woken station has the user's files but no
+# memory of the conversation that produced them.
+snapshot_paths() {
+  home="${HOME:-/root}"
+  for p in "workspace" "${home#/}/.local/share/opencode"; do
+    [ -e "$ROOT$p" ] && printf '%s\n' "$p"
+  done
+}
+
+configured() {
+  [ -n "$AGENTPOD_SNAPSHOT_URL" ] && [ -n "$AGENTPOD_SNAPSHOT_TOKEN" ]
+}
+
+# Pull the archive and unpack it. A missing archive is the normal first boot.
+#
+# Every failure here is non-fatal by design: starting with an empty workspace is
+# bad, but a start loop is worse — the first deploy of this worker put seven
+# instances into a silent restart loop, and that must not be reachable from a
+# bad restore.
+restore() {
+  configured || { log "not configured; skipping restore"; return 0; }
+  code=$(curl -sS -o "$ARCHIVE" -w '%{http_code}' \
+    -H "Authorization: Bearer $AGENTPOD_SNAPSHOT_TOKEN" \
+    "$AGENTPOD_SNAPSHOT_URL" 2>/dev/null) || code="000"
+
+  case "$code" in
+    200)
+      if tar -xzf "$ARCHIVE" -C "$ROOT" 2>/dev/null; then
+        log "restored workspace from snapshot"
+      else
+        log "ERROR: snapshot archive unreadable; continuing with an empty workspace"
+      fi
+      ;;
+    404) log "no snapshot yet (first boot)" ;;
+    *)   log "ERROR: restore failed (HTTP $code); continuing with an empty workspace" ;;
+  esac
+  rm -f "$ARCHIVE"
+}
+
+# Archive and upload. Never fails the caller: a sleep must not hang because R2
+# or the network is unavailable, for the same reason notifyHub swallows errors.
+#
+# There is no size cap. Truncating an archive would silently lose the very work
+# this exists to protect, so a large workspace is logged and uploaded whole.
+snapshot() {
+  configured || return 0
+  paths=$(snapshot_paths)
+  if [ -z "$paths" ]; then
+    log "nothing to snapshot yet"
+    return 0
+  fi
+
+  # shellcheck disable=SC2086 # word splitting is how the path list is passed
+  if ! tar -czf "$ARCHIVE" -C "$ROOT" $paths 2>/dev/null; then
+    log "ERROR: could not create archive; workspace NOT saved"
+    rm -f "$ARCHIVE"
+    return 0
+  fi
+
+  size=$(wc -c <"$ARCHIVE" 2>/dev/null | tr -d ' ')
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X PUT \
+    --data-binary "@$ARCHIVE" \
+    -H "Authorization: Bearer $AGENTPOD_SNAPSHOT_TOKEN" \
+    "$AGENTPOD_SNAPSHOT_URL" 2>/dev/null) || code="000"
+
+  if [ "$code" = "200" ]; then
+    log "snapshot uploaded (${size} bytes)"
+  else
+    log "ERROR: snapshot upload failed (HTTP $code); workspace NOT saved"
+  fi
+  rm -f "$ARCHIVE"
+}
+
+CHILD=""
+LOOP=""
+
+# SIGTERM is how this substrate says "you are going to sleep". Cloudflare allows
+# 15 minutes before SIGKILL, so there is ample room to stop the agent and
+# archive a real workspace.
+#
+# The child is stopped BEFORE archiving, deliberately: tarring a tree while the
+# harness is still writing to it produces an archive of a half-written state.
+on_term() {
+  log "SIGTERM received — stopping agent, then archiving"
+  [ -n "$LOOP" ] && kill "$LOOP" 2>/dev/null
+  if [ -n "$CHILD" ]; then
+    kill -TERM "$CHILD" 2>/dev/null
+    wait "$CHILD" 2>/dev/null
+  fi
+  snapshot
+  log "clean shutdown"
+  exit 0
+}
+
+trap on_term TERM INT
+
+restore
+
+# Periodic archive, so a container that dies WITHOUT a clean SIGTERM loses at
+# most one interval. One did exactly that during the 2026-08-11 verification and
+# the cause was never established, so this is not hypothetical.
+(
+  while :; do
+    sleep "$INTERVAL"
+    snapshot
+  done
+) &
+LOOP=$!
+
+"$@" &
+CHILD=$!
+wait "$CHILD"
+STATUS=$?
+
+# The agent exited on its own rather than being told to sleep. Archive anyway —
+# an unexpected exit is exactly when the work is most worth keeping.
+[ -n "$LOOP" ] && kill "$LOOP" 2>/dev/null
+log "agent exited (status $STATUS) — archiving"
+snapshot
+exit "$STATUS"

--- a/cloudflare/worker-v2/src/auth.ts
+++ b/cloudflare/worker-v2/src/auth.ts
@@ -6,11 +6,28 @@
  * misconfigured URL without holding a credential.
  */
 export function isAuthorised(request: Request, expected: string | undefined): boolean {
-  if (!expected) return false; // no secret configured → refuse everything
+  return tokenMatches(bearerToken(request), expected);
+}
+
+/** The bearer token presented on a request, or null when absent/malformed. */
+export function bearerToken(request: Request): string | null {
   const header = request.headers.get("Authorization") ?? "";
   const prefix = "Bearer ";
-  if (!header.startsWith(prefix)) return false;
-  return timingSafeEqual(header.slice(prefix.length), expected);
+  if (!header.startsWith(prefix)) return null;
+  return header.slice(prefix.length);
+}
+
+/**
+ * Compare a presented token against an expected one, failing closed.
+ *
+ * Shared by the admin gate and the per-sandbox snapshot gate so both inherit
+ * the same two properties: an unset expected value refuses everything, and the
+ * comparison does not leak length-independent timing.
+ */
+export function tokenMatches(presented: string | null, expected: string | undefined): boolean {
+  if (!expected) return false; // no secret configured → refuse everything
+  if (presented === null) return false;
+  return timingSafeEqual(presented, expected);
 }
 
 /** Constant-time compare, so a wrong token cannot be guessed byte by byte. */

--- a/cloudflare/worker-v2/src/index.ts
+++ b/cloudflare/worker-v2/src/index.ts
@@ -1,5 +1,6 @@
 import { Container, getContainer } from "@cloudflare/containers";
 import { isAuthorised } from "./auth";
+import { handleSnapshot, snapshotKey, type SnapshotDeps } from "./snapshot";
 
 interface Env {
   // Typed with the container class so getContainer returns a stub carrying its
@@ -7,6 +8,9 @@ interface Env {
   // site, and a cast is where a wrong method name survives to runtime.
   NODE_AGENT: DurableObjectNamespace<NodeAgentContainer>;
   AGENTPOD_WORKER_TOKEN?: string;
+  // Workspace archives. Cloudflare container disk is ephemeral, so this is the
+  // only thing standing between a sleep and the user losing their work.
+  SNAPSHOTS: R2Bucket;
 }
 
 /**
@@ -43,6 +47,39 @@ export class NodeAgentContainer extends Container {
   }
 
   /**
+   * The per-sandbox snapshot token, minted on first use and kept for the life
+   * of the sandbox so it survives sleep/wake alongside envVars.
+   *
+   * Deliberately NOT the worker admin token: a container holding that could
+   * create and destroy sandboxes across the whole fleet.
+   */
+  async snapshotToken(): Promise<string> {
+    const existing = await this.ctx.storage.get<string>("snapshotToken");
+    if (existing) return existing;
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    const token = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+    await this.ctx.storage.put("snapshotToken", token);
+    return token;
+  }
+
+  /** Read the stored token without minting one, for authenticating a request. */
+  async storedSnapshotToken(): Promise<string | null> {
+    return (await this.ctx.storage.get<string>("snapshotToken")) ?? null;
+  }
+
+  /**
+   * Push the idle deadline out. Called when the hub routes a verb to this
+   * station, because Cloudflare's activity timer counts only INCOMING requests
+   * and a node-agent dials out — so without this a station sleeps 15 minutes
+   * after start however hard it is being used, which is precisely how a live
+   * station vanished mid-session on 2026-08-12.
+   */
+  async touch(): Promise<void> {
+    this.renewActivityTimeout();
+  }
+
+  /**
    * Wake: start again with the stored environment.
    *
    * Throws when there is none rather than starting a container that cannot
@@ -76,8 +113,13 @@ export class NodeAgentContainer extends Container {
    */
   override async onActivityExpired() {
     console.log("[agentpod] idle — sleeping");
-    await this.notifyHub("asleep");
+    // stop() BEFORE notifyHub, and in that order deliberately: stop sends
+    // SIGTERM, which is what makes the container archive its workspace. Telling
+    // the hub "asleep" first would announce a safe state while the archive was
+    // still being written. Cloudflare allows 15 minutes between SIGTERM and
+    // SIGKILL, so the container has ample room to finish.
     await this.stop();
+    await this.notifyHub("asleep");
   }
 
   /**
@@ -132,6 +174,25 @@ export default {
       return json({ status: "ok" });
     }
 
+    // Snapshot routes authenticate with the PER-SANDBOX token, not the admin
+    // token, so they are matched before the admin gate. This is the only
+    // unauthenticated-by-admin path in the worker, and handleSnapshot fails
+    // closed: an absent, wrong, or other-sandbox token is a 401, and a sandbox
+    // with no stored token (unknown or destroyed) is refused outright.
+    if (parts[0] === "sandbox" && parts[1] && parts[2] === "snapshot") {
+      const id = parts[1];
+      const stub = getContainer(env.NODE_AGENT, id);
+      const deps: SnapshotDeps = {
+        tokenFor: () => stub.storedSnapshotToken(),
+        get: (key) => env.SNAPSHOTS.get(key),
+        put: async (key, body) => {
+          await env.SNAPSHOTS.put(key, body as ReadableStream);
+        },
+        delete: (key) => env.SNAPSHOTS.delete(key),
+      };
+      return handleSnapshot(id, request.method, request, deps);
+    }
+
     if (!isAuthorised(request, env.AGENTPOD_WORKER_TOKEN)) {
       return json({ error: "unauthorized" }, 401);
     }
@@ -156,12 +217,17 @@ export default {
       const c = getContainer(env.NODE_AGENT, body.id);
       // The token is passed through but never logged, here or anywhere in this
       // worker. Do not add log statements that reference body.enrollToken.
+      const snapshotToken = await c.snapshotToken();
       await c.createWithEnv({
         AGENTPOD_HUB_URL: body.hubUrl,
         AGENTPOD_ENROLL_TOKEN: body.enrollToken,
         // Read by the container class's notifyHub, not by agentpod-node.
         AGENTPOD_RUNTIME_ID: body.id,
         AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
+        // Where the entrypoint archives and restores /workspace. Derived from
+        // the request so the worker never has to be told its own URL.
+        AGENTPOD_SNAPSHOT_URL: `${url.origin}/sandbox/${body.id}/snapshot`,
+        AGENTPOD_SNAPSHOT_TOKEN: snapshotToken,
       });
       return json({ sandboxId: body.id }, 201);
     }
@@ -177,7 +243,18 @@ export default {
 
     if (request.method === "DELETE" && !parts[2]) {
       await container.destroy();
+      // Delete the archive too, or a destroyed runtime keeps billing for R2
+      // storage nobody can ever reach again.
+      await env.SNAPSHOTS.delete(snapshotKey(id));
       return json({ destroyed: id });
+    }
+
+    // Push the idle deadline out. The hub calls this when it routes a verb to
+    // a Cloudflare-backed node, which is the only way this substrate learns
+    // that a station is in use — see NodeAgentContainer.touch.
+    if (request.method === "POST" && parts[2] === "touch") {
+      await container.touch();
+      return json({ touched: id });
     }
 
     // The wake path. Uses the STORED environment — a bare start() would boot a

--- a/cloudflare/worker-v2/src/index.ts
+++ b/cloudflare/worker-v2/src/index.ts
@@ -69,6 +69,19 @@ export class NodeAgentContainer extends Container {
   }
 
   /**
+   * Revoke the snapshot token so no further upload is accepted.
+   *
+   * Called BEFORE destroy, and the ordering is the whole point. destroy() sends
+   * SIGTERM, which makes the container archive its workspace on the way out — so
+   * deleting the R2 object first and destroying second loses the race, and the
+   * dying container recreates the archive we just deleted. Observed live on
+   * 2026-08-12: a destroy returned 200 and left the archive behind.
+   */
+  async revokeSnapshotToken(): Promise<void> {
+    await this.ctx.storage.delete("snapshotToken");
+  }
+
+  /**
    * Push the idle deadline out. Called when the hub routes a verb to this
    * station, because Cloudflare's activity timer counts only INCOMING requests
    * and a node-agent dials out — so without this a station sleeps 15 minutes
@@ -242,6 +255,11 @@ export default {
     }
 
     if (request.method === "DELETE" && !parts[2]) {
+      // Revoke FIRST: destroy sends SIGTERM, and the dying container archives on
+      // its way out. Deleting the object before that upload lands leaves the
+      // archive behind — observed live on 2026-08-12. With the token revoked the
+      // late upload is refused, so the delete below is final.
+      await container.revokeSnapshotToken();
       await container.destroy();
       // Delete the archive too, or a destroyed runtime keeps billing for R2
       // storage nobody can ever reach again.

--- a/cloudflare/worker-v2/src/index.ts
+++ b/cloudflare/worker-v2/src/index.ts
@@ -1,6 +1,6 @@
 import { Container, getContainer } from "@cloudflare/containers";
 import { isAuthorised } from "./auth";
-import { handleSnapshot, snapshotKey, type SnapshotDeps } from "./snapshot";
+import { handleSnapshot, handleDestroy, type SnapshotDeps } from "./snapshot";
 
 interface Env {
   // Typed with the container class so getContainer returns a stub carrying its
@@ -121,8 +121,10 @@ export class NodeAgentContainer extends Container {
    * is no connection — but the RUNTIME is `asleep`, not broken, and only this
    * worker knows the difference.
    *
-   * Safe because a woken container re-enrols and resumes the same nodeId
-   * (runtime identity persistence, #245). Before that, sleeping lost the station.
+   * Safe only because BOTH halves hold: a woken container resumes the same
+   * nodeId (#245) *and* restores its workspace from R2 (snapshot-wrapper.sh).
+   * Identity alone was not enough — with it, a woken station came back looking
+   * like itself with an empty workspace, which is worse than an obvious failure.
    */
   override async onActivityExpired() {
     console.log("[agentpod] idle — sleeping");
@@ -255,15 +257,18 @@ export default {
     }
 
     if (request.method === "DELETE" && !parts[2]) {
-      // Revoke FIRST: destroy sends SIGTERM, and the dying container archives on
-      // its way out. Deleting the object before that upload lands leaves the
-      // archive behind — observed live on 2026-08-12. With the token revoked the
-      // late upload is refused, so the delete below is final.
-      await container.revokeSnapshotToken();
-      await container.destroy();
-      // Delete the archive too, or a destroyed runtime keeps billing for R2
-      // storage nobody can ever reach again.
-      await env.SNAPSHOTS.delete(snapshotKey(id));
+      // Ordering lives in handleDestroy, which is where its regression test can
+      // reach it — see the 2026-08-12 live failure recorded there.
+      await handleDestroy(id, {
+        revokeToken: () => container.revokeSnapshotToken(),
+        destroy: () => container.destroy(),
+        tokenFor: () => container.storedSnapshotToken(),
+        get: (key) => env.SNAPSHOTS.get(key),
+        put: async (key, body) => {
+          await env.SNAPSHOTS.put(key, body as ReadableStream);
+        },
+        delete: (key) => env.SNAPSHOTS.delete(key),
+      });
       return json({ destroyed: id });
     }
 

--- a/cloudflare/worker-v2/src/snapshot.ts
+++ b/cloudflare/worker-v2/src/snapshot.ts
@@ -1,0 +1,75 @@
+/**
+ * Workspace snapshot routes.
+ *
+ * Cloudflare container disk is ephemeral — "when a Container instance goes to
+ * sleep, the next time it is started, it will have a fresh disk as defined by
+ * its container image". Without this module a Cloudflare station destroys the
+ * user's work every time it idles out, which is exactly what happened on
+ * 2026-08-12 (a README.md written at 04:56 was gone at 04:59:58).
+ *
+ * The container archives its workspace here and restores it on the next start.
+ *
+ * SECURITY — the container authenticates with a PER-SANDBOX token, never the
+ * worker admin token. That token buys exactly two things: read and write of its
+ * own archive. It cannot create or destroy sandboxes, it cannot touch another
+ * sandbox's archive, and it cannot delete even its own (a compromised harness
+ * must not be able to erase the user's work). Deletion happens only on the
+ * admin-authenticated destroy path.
+ */
+
+import { bearerToken, tokenMatches } from "./auth";
+
+/** R2 key for a sandbox's workspace archive. */
+export const snapshotKey = (id: string) => `snapshots/${id}.tar.gz`;
+
+/** Storage and token lookup, injected so the routes are testable without R2. */
+export interface SnapshotDeps {
+  /** The sandbox's stored snapshot token, or null if the sandbox is unknown. */
+  tokenFor(id: string): Promise<string | null>;
+  get(key: string): Promise<{ body: unknown } | null>;
+  put(key: string, body: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+const json = (body: unknown, status: number) =>
+  Response.json(body as Record<string, unknown>, { status });
+
+/**
+ * Handle GET (restore) and PUT (snapshot) for one sandbox's archive.
+ *
+ * Returns 401 for any token that is absent, wrong, or belongs to a different
+ * sandbox — including the case where the sandbox has no stored token at all,
+ * so a destroyed sandbox's container cannot keep writing to R2.
+ */
+export async function handleSnapshot(
+  id: string,
+  method: string,
+  request: Request,
+  deps: SnapshotDeps
+): Promise<Response> {
+  const expected = await deps.tokenFor(id);
+  if (!tokenMatches(bearerToken(request), expected ?? undefined)) {
+    return json({ error: "unauthorized" }, 401);
+  }
+
+  const key = snapshotKey(id);
+
+  if (method === "GET") {
+    const object = await deps.get(key);
+    // A missing archive is the normal first-boot case, not a failure. The
+    // entrypoint must be able to tell it apart from a real error without
+    // guessing, so it gets its own status.
+    if (!object) return json({ error: "no snapshot" }, 404);
+    return new Response(object.body as BodyInit, {
+      status: 200,
+      headers: { "Content-Type": "application/gzip" },
+    });
+  }
+
+  if (method === "PUT") {
+    await deps.put(key, request.body ?? (await request.arrayBuffer()));
+    return json({ ok: true }, 200);
+  }
+
+  return json({ error: "method not allowed" }, 405);
+}

--- a/cloudflare/worker-v2/src/snapshot.ts
+++ b/cloudflare/worker-v2/src/snapshot.ts
@@ -34,6 +34,28 @@ export interface SnapshotDeps {
 const json = (body: unknown, status: number) =>
   Response.json(body as Record<string, unknown>, { status });
 
+/** What destroying a sandbox needs, beyond the archive storage itself. */
+export interface DestroyDeps extends SnapshotDeps {
+  revokeToken(): Promise<void>;
+  destroy(): Promise<void>;
+}
+
+/**
+ * Destroy a sandbox and its archive, in an order that actually holds.
+ *
+ * **Revoke first.** `destroy()` sends SIGTERM, and the dying container archives
+ * its workspace on the way out. Deleting the object before that upload lands
+ * loses the race and the archive comes back — observed live on 2026-08-12, when
+ * a destroy returned 200 and left the object in R2, leaking paid storage for a
+ * runtime nobody could ever reach again. With the token revoked the late upload
+ * is refused, so the delete below is final.
+ */
+export async function handleDestroy(id: string, deps: DestroyDeps): Promise<void> {
+  await deps.revokeToken();
+  await deps.destroy();
+  await deps.delete(snapshotKey(id));
+}
+
 /**
  * Handle GET (restore) and PUT (snapshot) for one sandbox's archive.
  *

--- a/cloudflare/worker-v2/test/entrypoint-parity.test.ts
+++ b/cloudflare/worker-v2/test/entrypoint-parity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The Cloudflare image's entrypoint is a COPY of the Docker image's, and must
+ * stay byte-identical.
+ *
+ * That script is subtle and was arrived at by fixing live-fleet bugs: it
+ * double-forks so the supervision loop re-parents to init (a direct child
+ * lingers as a zombie whose comm still matches the descriptor's pgrep health
+ * check, freezing Health at "running"), and it uses a sentinel file so the
+ * descriptor's lifecycle Stop is not immediately undone by the loop respawning.
+ *
+ * A second, hand-maintained copy would drift and rediscover both bugs on a
+ * substrate where the feedback loop is a deploy. Hence a test rather than a
+ * comment asking nicely.
+ */
+describe("entrypoint parity", () => {
+  it("is byte-identical to the Docker image's entrypoint", () => {
+    const here = readFileSync(join(import.meta.dirname, "../entrypoint.sh"), "utf8");
+    const canonical = readFileSync(
+      join(import.meta.dirname, "../../../apps/node-agent/deploy/node-opencode-entrypoint.sh"),
+      "utf8"
+    );
+
+    expect(here).toBe(canonical);
+  });
+});

--- a/cloudflare/worker-v2/test/snapshot-wrapper.test.ts
+++ b/cloudflare/worker-v2/test/snapshot-wrapper.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Round-trip test: snapshot-wrapper.sh.
+ *
+ * This is the test that would have caught the actual defect. It runs the real
+ * wrapper script against a real HTTP endpoint and a real temp filesystem, then
+ * asserts the thing the user cares about: a file written into the workspace is
+ * still there after the container has been stopped and started again.
+ *
+ * No Docker — the wrapper takes its filesystem root from AGENTPOD_SNAPSHOT_ROOT
+ * precisely so this can run in CI without a container runtime.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WRAPPER = join(dirname(fileURLToPath(import.meta.url)), "..", "snapshot-wrapper.sh");
+const TOKEN = "snapshot-token-for-tests";
+
+/** Stands in for the worker's R2-backed snapshot routes. */
+let server: Server;
+let port = 0;
+let stored: Buffer | null = null;
+let putCount = 0;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const auth = req.headers.authorization ?? "";
+    if (auth !== `Bearer ${TOKEN}`) {
+      res.writeHead(401).end('{"error":"unauthorized"}');
+      return;
+    }
+    if (req.method === "PUT") {
+      const chunks: Buffer[] = [];
+      req.on("data", (c) => chunks.push(c as Buffer));
+      req.on("end", () => {
+        stored = Buffer.concat(chunks);
+        putCount++;
+        res.writeHead(200).end('{"ok":true}');
+      });
+      return;
+    }
+    if (req.method === "GET") {
+      if (!stored) {
+        res.writeHead(404).end('{"error":"no snapshot"}');
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/gzip" }).end(stored);
+      return;
+    }
+    res.writeHead(405).end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "agentpod-snap-"));
+  mkdirSync(join(root, "workspace"), { recursive: true });
+  return root;
+}
+
+/** Run the wrapper around a long-lived fake agent, then SIGTERM it. */
+function runWrapper(root: string): { proc: ChildProcess; output: () => string } {
+  let out = "";
+  const proc = spawn("sh", [WRAPPER, "sh", "-c", "while :; do sleep 0.1; done"], {
+    env: {
+      ...process.env,
+      AGENTPOD_SNAPSHOT_ROOT: root,
+      AGENTPOD_SNAPSHOT_URL: `http://127.0.0.1:${port}/sandbox/rt_test/snapshot`,
+      AGENTPOD_SNAPSHOT_TOKEN: TOKEN,
+      // Long, so the periodic loop never fires — this test is about the
+      // SIGTERM path, and a background upload would make it ambiguous.
+      AGENTPOD_SNAPSHOT_INTERVAL: "3600",
+      HOME: "/root",
+    },
+  });
+  proc.stdout?.on("data", (d) => (out += String(d)));
+  proc.stderr?.on("data", (d) => (out += String(d)));
+  return { proc, output: () => out };
+}
+
+const waitFor = async (pred: () => boolean, ms = 10_000) => {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (pred()) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return false;
+};
+
+describe("snapshot-wrapper", () => {
+  it("saves the workspace on SIGTERM and restores it on the next start", async () => {
+    // ── First boot: no snapshot exists, user creates a file ──────────────────
+    const first = makeRoot();
+    writeFileSync(join(first, "workspace", "README.md"), "work that must survive");
+
+    const a = runWrapper(first);
+    expect(await waitFor(() => a.output().includes("no snapshot yet"))).toBe(true);
+
+    // Sleep: the substrate sends SIGTERM.
+    a.proc.kill("SIGTERM");
+    expect(await waitFor(() => a.proc.exitCode !== null)).toBe(true);
+    expect(a.output()).toContain("snapshot uploaded");
+    expect(stored).not.toBeNull();
+
+    // ── Wake: a FRESH disk, exactly as Cloudflare describes it ───────────────
+    const second = makeRoot();
+    expect(existsSync(join(second, "workspace", "README.md"))).toBe(false);
+
+    const b = runWrapper(second);
+    expect(await waitFor(() => b.output().includes("restored workspace"))).toBe(true);
+
+    // The whole point of the feature.
+    const restored = join(second, "workspace", "README.md");
+    expect(existsSync(restored)).toBe(true);
+    expect(readFileSync(restored, "utf8")).toBe("work that must survive");
+
+    b.proc.kill("SIGTERM");
+    await waitFor(() => b.proc.exitCode !== null);
+
+    rmSync(first, { recursive: true, force: true });
+    rmSync(second, { recursive: true, force: true });
+  }, 30_000);
+
+  it("starts with an empty workspace rather than looping when restore fails", async () => {
+    // A bad restore must never be able to produce a start loop: the first
+    // deploy of this worker put seven instances into a silent restart loop and
+    // that failure mode must stay unreachable.
+    const root = makeRoot();
+    let out = "";
+    const proc = spawn("sh", [WRAPPER, "sh", "-c", "echo agent-started; sleep 0.3"], {
+      env: {
+        ...process.env,
+        AGENTPOD_SNAPSHOT_ROOT: root,
+        AGENTPOD_SNAPSHOT_URL: "http://127.0.0.1:1/sandbox/rt_dead/snapshot", // refused
+        AGENTPOD_SNAPSHOT_TOKEN: TOKEN,
+        AGENTPOD_SNAPSHOT_INTERVAL: "3600",
+        HOME: "/root",
+      },
+    });
+    proc.stdout?.on("data", (d) => (out += String(d)));
+    proc.stderr?.on("data", (d) => (out += String(d)));
+
+    expect(await waitFor(() => proc.exitCode !== null)).toBe(true);
+    expect(out).toContain("ERROR: restore failed");
+    // The agent must still have been started.
+    expect(out).toContain("agent-started");
+
+    rmSync(root, { recursive: true, force: true });
+  }, 30_000);
+});

--- a/cloudflare/worker-v2/test/snapshot.test.ts
+++ b/cloudflare/worker-v2/test/snapshot.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests: workspace snapshot routes.
+ *
+ * These carry the security properties of the whole persistence design. A
+ * container holds a snapshot token, and that token must buy it exactly two
+ * things — read and write of ITS OWN archive — and nothing else. The tests for
+ * what the token cannot do come first, because those are the ones that matter
+ * if this code is ever changed by someone in a hurry.
+ */
+
+import { describe, it, expect } from "vitest";
+import { handleSnapshot, snapshotKey, type SnapshotDeps } from "../src/snapshot";
+
+const TOKEN_A = "tok-sandbox-a-0000000000000000";
+const TOKEN_B = "tok-sandbox-b-1111111111111111";
+
+/** In-memory stand-in for the R2 bucket plus DO-held per-sandbox tokens. */
+function fakeDeps(seed: Record<string, string> = {}) {
+  const objects = new Map<string, string>(Object.entries(seed));
+  const tokens: Record<string, string> = { rt_a: TOKEN_A, rt_b: TOKEN_B };
+  const deps: SnapshotDeps = {
+    tokenFor: async (id) => tokens[id] ?? null,
+    get: async (key) => (objects.has(key) ? { body: objects.get(key)! } : null),
+    // R2 accepts a ReadableStream, and streaming is deliberate here — a large
+    // workspace tarball must never be buffered into worker memory. The fake
+    // therefore has to consume the stream the way R2 would.
+    put: async (key, body) => {
+      objects.set(key, await new Response(body as BodyInit).text());
+    },
+    delete: async (key) => {
+      objects.delete(key);
+    },
+  };
+  return { deps, objects };
+}
+
+const req = (token: string | undefined, method: string, body?: string) =>
+  new Request("https://w.example/sandbox/rt_a/snapshot", {
+    method,
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    ...(body ? { body } : {}),
+  });
+
+describe("snapshotKey", () => {
+  it("namespaces archives per sandbox", () => {
+    expect(snapshotKey("rt_a")).toBe("snapshots/rt_a.tar.gz");
+  });
+});
+
+describe("handleSnapshot — what a container token must NOT buy", () => {
+  it("REFUSES one sandbox's token used against another sandbox", async () => {
+    // The whole point of a per-sandbox token. If this ever passes, every
+    // station on the substrate can read every other station's workspace.
+    const { deps } = fakeDeps({ "snapshots/rt_b.tar.gz": "b-secret-work" });
+    const res = await handleSnapshot(
+      "rt_b",
+      "GET",
+      new Request("https://w.example/sandbox/rt_b/snapshot", {
+        headers: { Authorization: `Bearer ${TOKEN_A}` },
+      }),
+      deps
+    );
+    expect(res.status).toBe(401);
+    expect(await res.text()).not.toContain("b-secret-work");
+  });
+
+  it("refuses a request with no token", async () => {
+    const { deps } = fakeDeps();
+    const res = await handleSnapshot("rt_a", "GET", req(undefined, "GET"), deps);
+    expect(res.status).toBe(401);
+  });
+
+  it("refuses a sandbox that has no stored token", async () => {
+    // An unknown or destroyed sandbox must not accept uploads — otherwise a
+    // stale container could keep writing to R2 forever.
+    const { deps } = fakeDeps();
+    const res = await handleSnapshot(
+      "rt_unknown",
+      "PUT",
+      new Request("https://w.example/sandbox/rt_unknown/snapshot", {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN_A}` },
+        body: "x",
+      }),
+      deps
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("refuses any verb other than GET and PUT", async () => {
+    // Deliberately narrow: a container must not be able to delete its own
+    // snapshot, or a compromised harness could erase the user's work.
+    const { deps } = fakeDeps({ "snapshots/rt_a.tar.gz": "work" });
+    const res = await handleSnapshot("rt_a", "DELETE", req(TOKEN_A, "DELETE"), deps);
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("handleSnapshot — round trip", () => {
+  it("stores an uploaded archive under the sandbox's key", async () => {
+    const { deps, objects } = fakeDeps();
+    const res = await handleSnapshot("rt_a", "PUT", req(TOKEN_A, "PUT", "tarball"), deps);
+    expect(res.status).toBe(200);
+    expect(objects.get("snapshots/rt_a.tar.gz")).toBe("tarball");
+  });
+
+  it("returns a stored archive", async () => {
+    const { deps } = fakeDeps({ "snapshots/rt_a.tar.gz": "tarball" });
+    const res = await handleSnapshot("rt_a", "GET", req(TOKEN_A, "GET"), deps);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("tarball");
+  });
+
+  it("404s when there is no archive yet", async () => {
+    // First boot. Normal, not an error — the entrypoint must be able to tell
+    // "nothing saved yet" from "something went wrong" without guessing.
+    const { deps } = fakeDeps();
+    const res = await handleSnapshot("rt_a", "GET", req(TOKEN_A, "GET"), deps);
+    expect(res.status).toBe(404);
+  });
+});

--- a/cloudflare/worker-v2/test/snapshot.test.ts
+++ b/cloudflare/worker-v2/test/snapshot.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { handleSnapshot, snapshotKey, type SnapshotDeps } from "../src/snapshot";
+import { handleSnapshot, handleDestroy, snapshotKey, type SnapshotDeps } from "../src/snapshot";
 
 const TOKEN_A = "tok-sandbox-a-0000000000000000";
 const TOKEN_B = "tok-sandbox-b-1111111111111111";
@@ -93,6 +93,70 @@ describe("handleSnapshot — what a container token must NOT buy", () => {
     const { deps } = fakeDeps({ "snapshots/rt_a.tar.gz": "work" });
     const res = await handleSnapshot("rt_a", "DELETE", req(TOKEN_A, "DELETE"), deps);
     expect(res.status).toBe(405);
+  });
+});
+
+describe("handleDestroy — regression: the archive must not survive a destroy", () => {
+  /**
+   * Live failure, 2026-08-12: `DELETE /sandbox/:id` returned 200 and left the
+   * archive in R2. destroy() sends SIGTERM, the dying container archives on its
+   * way out, and that upload landed AFTER the delete — recreating the object
+   * that had just been removed. Every destroyed runtime leaked paid storage.
+   *
+   * The fix is ordering: revoke the token first, so a late upload is refused.
+   */
+  function destroyHarness() {
+    const order: string[] = [];
+    const objects = new Map<string, string>([["snapshots/rt_a.tar.gz", "work"]]);
+    let token: string | null = TOKEN_A;
+    const deps = {
+      revokeToken: async () => {
+        order.push("revoke");
+        token = null;
+      },
+      destroy: async () => {
+        order.push("destroy");
+      },
+      tokenFor: async () => token,
+      get: async (key: string) => (objects.has(key) ? { body: objects.get(key)! } : null),
+      put: async (key: string, body: unknown) => {
+        objects.set(key, await new Response(body as BodyInit).text());
+      },
+      delete: async (key: string) => {
+        order.push("delete");
+        objects.delete(key);
+      },
+    };
+    return { deps, order, objects };
+  }
+
+  it("revokes the token BEFORE destroying, then deletes", async () => {
+    const { deps, order } = destroyHarness();
+    await handleDestroy("rt_a", deps);
+    expect(order).toEqual(["revoke", "destroy", "delete"]);
+  });
+
+  it("REFUSES the dying container's final upload, so the delete is final", async () => {
+    // The actual failure, reproduced: destroy, then the container's last gasp
+    // arrives with the token it was given at create time.
+    const { deps, objects } = destroyHarness();
+    await handleDestroy("rt_a", deps);
+    expect(objects.has("snapshots/rt_a.tar.gz")).toBe(false);
+
+    const late = await handleSnapshot(
+      "rt_a",
+      "PUT",
+      new Request("https://w.example/sandbox/rt_a/snapshot", {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN_A}` },
+        body: "last gasp",
+      }),
+      deps
+    );
+
+    expect(late.status).toBe(401);
+    // The whole point: the archive stays deleted.
+    expect(objects.has("snapshots/rt_a.tar.gz")).toBe(false);
   });
 });
 

--- a/cloudflare/worker-v2/wrangler.toml
+++ b/cloudflare/worker-v2/wrangler.toml
@@ -14,6 +14,12 @@ class_name = "NodeAgentContainer"
 tag = "v1"
 new_sqlite_classes = ["NodeAgentContainer"]
 
+# Workspace archives. Container disk is ephemeral on this substrate — without
+# this bucket a station destroys the user's work every time it idles out.
+[[r2_buckets]]
+binding = "SNAPSHOTS"
+bucket_name = "agentpod-snapshots"
+
 [[containers]]
 class_name = "NodeAgentContainer"
 image = "./Dockerfile"

--- a/docs/superpowers/specs/2026-08-12-cloudflare-docker-parity-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudflare-docker-parity-design.md
@@ -81,6 +81,11 @@ Two properties this must have, both carrying tests:
 **Snapshot set:** `/workspace` and `~/.local/share/opencode`. The second is where OpenCode keeps
 its own session state; without it a woken station has the files but no memory of the conversation.
 
+**No size cap.** An earlier draft of this spec called for one. Implementing it showed the idea was
+wrong: every cap either truncates the archive or refuses the upload, and both silently lose the
+work this exists to protect. The archive size is logged on every snapshot instead, so a workspace
+growing without bound is visible rather than silently dropped.
+
 **Known risk — the `exec` problem.** The entrypoint currently ends with
 `exec /agentpod-node run`, which replaces the shell, leaving no process to trap SIGTERM. It must
 instead run the node-agent as a child and `wait`. That changes the PID-1 semantics the script's

--- a/docs/superpowers/specs/2026-08-12-cloudflare-docker-parity-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudflare-docker-parity-design.md
@@ -1,0 +1,137 @@
+# Cloudflare ↔ Docker runtime parity — design
+
+**Date:** 2026-08-12
+**Status:** approved
+**Branch:** `cloudflare-parity`
+
+## The problem, and how it was found
+
+A Cloudflare station verified as working on 2026-08-12 — health, logs, files, chat and
+terminal all returned `ok` in `station_audit` — was reported by the operator as "file browser
+and terminal not working". Investigation against the live hub found neither was broken:
+
+```
+04:44:58  container starts, enrols
+04:45:02  station adopted
+04:55:5x  chat, fs.write (README.md), term.open — all audited ok
+04:59:58  runtime marked ASLEEP  ← exactly 15m after start
+05:16:33  GET /api/nodes/<id>/detected → 502
+```
+
+Two facts combine into data loss:
+
+1. **`sleepAfter` is fed only by incoming requests.** The worker's own comment records this:
+   a node-agent dials *out* and generates no incoming activity, so the container idles out
+   ~15 minutes after **start**, no matter how hard the station is being used.
+2. **Cloudflare container disk is ephemeral.** Per Cloudflare's docs: *"All disk is ephemeral.
+   When a Container instance goes to sleep, the next time it is started, it will have a fresh
+   disk as defined by its container image."*
+
+So the README.md written at 04:56:11 was destroyed at 04:59:58. Runtime identity persistence
+(#245) makes this worse rather than better: the station returns with the *same* identity and an
+empty workspace, so it looks like it survived.
+
+**This is a correctness defect, not a missing feature.** As shipped, the Cloudflare provider
+silently destroys user work every 15 minutes.
+
+## Goals
+
+Bring the Cloudflare runtime to parity with Docker on the two dimensions that make a station
+usable for real work:
+
+- A workspace survives sleep/wake and any restart.
+- A station does not disappear while someone is using it.
+
+Non-goal: making Cloudflare identical to Docker. Ephemeral disk is inherent to the substrate;
+we compensate for it rather than pretend otherwise.
+
+## Architecture
+
+Three units, each independently testable.
+
+### 1. Snapshot store — worker + R2
+
+A new R2 bucket binding (`SNAPSHOTS`) and two routes on `cloudflare/worker-v2`:
+
+| Route | Purpose |
+|---|---|
+| `PUT /sandbox/:id/snapshot` | body is a tar.gz stream → R2 key `snapshots/<id>.tar.gz` |
+| `GET /sandbox/:id/snapshot` | returns the archive; 404 when absent |
+
+**Authentication uses a per-sandbox snapshot token, never the worker admin token.** The token is
+generated at create time, stored in DO storage beside `envVars`, and passed to the container as
+`AGENTPOD_SNAPSHOT_TOKEN`. It is validated against that specific sandbox id.
+
+Two properties this must have, both carrying tests:
+
+- A container cannot create or destroy sandboxes. It holds no admin credential.
+- A container cannot read another station's snapshot. Token check is per-id, not global.
+
+`DELETE /sandbox/:id` also deletes the R2 object, so a destroyed runtime leaves no paid storage.
+
+### 2. Container side — entrypoint
+
+- **On start, before enrol:** GET the archive and restore it. Missing archive is normal (first
+  boot) and is not an error.
+- **On SIGTERM:** tar the snapshot set, PUT it, exit. Cloudflare allows **15 minutes** between
+  SIGTERM and SIGKILL (documented), so this is comfortably safe.
+- **Every 5 minutes:** the same upload, bounding loss when a container dies *without* a clean
+  SIGTERM. One container did exactly that during the 2026-08-11 verification, cause unknown.
+
+**Snapshot set:** `/workspace` and `~/.local/share/opencode`. The second is where OpenCode keeps
+its own session state; without it a woken station has the files but no memory of the conversation.
+
+**Known risk — the `exec` problem.** The entrypoint currently ends with
+`exec /agentpod-node run`, which replaces the shell, leaving no process to trap SIGTERM. It must
+instead run the node-agent as a child and `wait`. That changes the PID-1 semantics the script's
+existing comments care about — specifically the zombie whose `comm` still matched the
+descriptor's pgrep health check and froze Health at "running" (live-fleet finding 2026-08-09).
+This is the riskiest edit in the design and gets a dedicated test.
+
+### 3. Activity renewal — hub + worker
+
+`POST /sandbox/:id/touch` calls `renewActivityTimeout()` (confirmed present on the SDK's
+`Container` class).
+
+The hub calls it when it routes a verb to a Cloudflare-backed node, **debounced to at most once
+per 60s per runtime** so a chat firehose (measured at 1,051 ACP events for one Hermes prompt)
+does not hammer the worker.
+
+**Shutdown ordering is part of the contract:** snapshot → report `asleep` → stop. So `asleep` in
+the console always means "state is safe", never "state is in flight".
+
+## Error handling
+
+- **Restore fails** → start anyway with an empty workspace and log loudly. Never a restart loop:
+  the first deploy of this worker produced seven live instances in a silent restart loop, and a
+  failed restore must not resurrect that failure mode.
+- **Snapshot upload fails on SIGTERM** → log and exit. A sleep must never hang on the hub or R2
+  being unreachable, for the same reason `notifyHub` already swallows its errors.
+- **Touch fails** → log and continue. A renewal failure must never fail the user's verb.
+
+## Testing
+
+| Layer | Test |
+|---|---|
+| Worker | vitest + fake R2: round-trip, 404 on missing, **sandbox A cannot read B's snapshot**, delete-on-destroy |
+| Entrypoint | existing byte-parity test stays green; new Docker test: a file written to `/workspace` survives stop → start |
+| Hub | touch is debounced; touch fires only for Cloudflare-backed nodes; a touch failure does not fail the verb |
+| Live | create → write a file → force sleep → wake → **file is still there**. The current implementation fails this. |
+
+The live test is the acceptance criterion. Everything else is scaffolding for it.
+
+## Resource tiers — separate, and deliberately smaller
+
+Cloudflare fixes `instance_type` per container class (`standard-1` today), so honouring
+small/medium/large needs three classes, three DO bindings, and the tier recorded so a wake lands
+on the same class.
+
+**v1 refuses a non-default tier loudly**, matching the honour-or-refuse rule the driver already
+applies to `image`. Today the driver refuses a mismatched image and then silently drops
+`resourceTier` — the exact inconsistency its own header comment criticises the dead driver for.
+Three classes land only if small/large Cloudflare stations are actually wanted.
+
+## What this does not fix
+
+Harness choice remains one image per worker deployment. Deferred: lowest value of the gaps, and
+unchanged by anything here.


### PR DESCRIPTION
## The defect

A Cloudflare station verified as working on 2026-08-12 — health, logs, files, chat and terminal all `ok` in `station_audit` — was reported as broken. Neither the file browser nor the terminal was broken. The station had **slept and destroyed the user's work**.

```
04:44:58  container starts, enrols
04:55:5x  chat, fs.write (README.md), term.open — all audited ok
04:59:58  runtime marked ASLEEP  ← exactly 15m after start
05:16:33  GET /api/nodes/<id>/detected → 502
```

Two facts combine:

1. **`sleepAfter` is fed only by incoming requests.** A node-agent dials *out*, so the container idles out ~15 minutes after **start**, however hard it is being used.
2. **Cloudflare container disk is ephemeral** — *"when a Container instance goes to sleep, the next time it is started, it will have a fresh disk as defined by its container image"*.

Runtime identity persistence (#245) made this worse rather than better: the station returns with the *same* identity and an empty workspace, so it looks like it survived.

## The fix

**Workspace persistence.** `snapshot-wrapper.sh` restores the workspace on start and archives it to R2 on SIGTERM (Cloudflare allows 15 minutes before SIGKILL), plus periodically so a container that dies *without* a clean SIGTERM loses at most one interval — one did exactly that on 2026-08-11.

It is a wrapper, not an edit to the entrypoint: that script is subtle (double-fork supervision, stop sentinel, a zombie that once froze the health check) and is byte-compared against the fleet's Docker entrypoint, and Docker runtimes need none of this because their disk persists.

**Activity renewal.** `POST /sandbox/:id/touch` renews the idle deadline; the hub calls it when it routes a verb to a Cloudflare-backed node, debounced to once a minute per runtime (one trivial Hermes prompt was measured at 1,051 ACP events).

**Tier honesty.** The driver refuses a resource tier the deployed worker cannot provide. It already refused a mismatched image while silently dropping `resourceTier` — the exact inconsistency its own header comment criticises.

## Security

The snapshot routes are the only ones not gated by the admin token, because a container must be able to save its workspace without holding a credential that could create or destroy sandboxes. It gets a **per-sandbox** token stored in DO storage, buying exactly two things: read and write of its own archive. It cannot reach another station's archive, and it cannot delete even its own — deletion happens only on the admin-authenticated destroy path. Those three properties have tests, and they are the first tests in the file.

## Testing

- Worker: 14 tests — snapshot round trip, 404 on first boot, **sandbox A cannot read B's archive**, delete-on-destroy.
- Wrapper: a real round-trip against a real HTTP endpoint and temp filesystem — write a file, SIGTERM, fresh root, restart, file is back. **Confirmed to fail when the SIGTERM archive is removed.**
- Hub: 485 tests pass, including debounce, provider filtering, and never-throws.

## Not yet verified

The live acceptance test — create, write a file, force sleep, wake, file still there — has **not** been run. It needs the R2 bucket created and the worker deployed. Everything above is local evidence.

## Deploy notes

`wrangler r2 bucket create agentpod-snapshots` before deploying, and set `CLOUDFLARE_INSTANCE_TIER=large` on the hub. Provisioning a `small` Cloudflare station now fails by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW