### PR TITLE
feat: offer only the resource tiers the selected provider supports

### DIFF
--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -80,7 +80,11 @@ export const provisionRuntime = (req: {
 export const listRuntimes = () => http<ProvisionedRuntime[]>("/api/runtimes");
 
 export const listRuntimeProviders = () =>
-  http<{ providers: string[] }>("/api/runtimes/providers");
+  http<{
+    providers: string[];
+    /** Tiers each provider can satisfy — the dialog builds its form from this. */
+    capabilities?: Array<{ provider: string; tiers: string[] }>;
+  }>("/api/runtimes/providers");
 
 export const destroyRuntime = (id: string) =>
   http<void>(`/api/runtimes/${id}`, { method: "DELETE" });

--- a/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte
+++ b/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte
@@ -15,13 +15,27 @@
   interface Props {
     open: boolean;
     providers: string[];
+    /**
+     * Which tiers each provider can actually satisfy. Read from the hub rather
+     * than hardcoded here: Cloudflare fixes instance_type at worker deploy
+     * time, and a map baked into the UI would rot the moment a worker is
+     * redeployed at a different instance type.
+     */
+    capabilities?: Array<{ provider: string; tiers: string[] }>;
     onClose: () => void;
     onCreated?: () => void;
   }
 
-  let { open, providers, onClose, onCreated }: Props = $props();
+  let { open, providers, capabilities = [], onClose, onCreated }: Props = $props();
 
-  const tiers = ["small", "medium", "large"];
+  const ALL_TIERS = ["small", "medium", "large"];
+
+  // Only the tiers the selected provider can satisfy. Offering one it cannot
+  // means the driver refuses the request and the user sees a backend error for
+  // a choice the form invited them to make.
+  const tiers = $derived(
+    capabilities.find((c) => c.provider === provider)?.tiers ?? ALL_TIERS,
+  );
   const harnessOptions = [
     { value: "none", label: "Generic" },
     { value: "opencode", label: "OpenCode" },
@@ -40,9 +54,16 @@
     if (open) {
       name = "";
       error = null;
-      resourceTier = "small";
       harness = "none";
       provider = providers[0] ?? "docker";
+    }
+  });
+
+  // Keep the selected tier valid: on open, and whenever the provider changes to
+  // one that does not offer the current selection.
+  $effect(() => {
+    if (!tiers.includes(resourceTier)) {
+      resourceTier = tiers[0] ?? "small";
     }
   });
 

--- a/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte.test.ts
@@ -179,3 +179,52 @@ test("failed provisionRuntime shows inline error and does NOT call onClose", asy
     expect(onCreated).not.toHaveBeenCalled();
   });
 });
+
+test("offers only the tiers the selected provider can actually satisfy", async () => {
+  // Cloudflare fixes instance_type at worker deploy time, so it supports one
+  // tier. Offering small/medium/large made provisioning fail with a backend
+  // error as the only feedback — the dialog must not present a doomed choice.
+  const { getByText, queryByText } = render(NewRuntimeDialog, {
+    props: {
+      open: true,
+      providers: ["cloudflare"],
+      capabilities: [{ provider: "cloudflare", tiers: ["large"] }],
+      onClose: () => {},
+      onCreated: () => {},
+    },
+  });
+
+  // The trigger shows the selected tier, which must already be a supported one.
+  expect(getByText("large")).toBeTruthy();
+  expect(queryByText("small")).toBeNull();
+  expect(queryByText("medium")).toBeNull();
+});
+
+test("defaults the tier to one the provider supports", async () => {
+  // The default was hardcoded to "small", which cloudflare refuses.
+  const spy = vi.spyOn(api, "provisionRuntime").mockResolvedValue({
+    ...mockRuntime,
+    provider: "cloudflare" as const,
+    resourceTier: "large" as const,
+  });
+
+  const { getByRole, getByPlaceholderText } = render(NewRuntimeDialog, {
+    props: {
+      open: true,
+      providers: ["cloudflare"],
+      capabilities: [{ provider: "cloudflare", tiers: ["large"] }],
+      onClose: () => {},
+      onCreated: () => {},
+    },
+  });
+
+  const input = getByPlaceholderText(/my-runtime|name/i);
+  await fireEvent.input(input, { target: { value: "cf-box" } });
+  await fireEvent.click(getByRole("button", { name: /^create runtime$/i }));
+
+  await waitFor(() =>
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "cloudflare", resourceTier: "large" })
+    )
+  );
+});

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte
@@ -48,6 +48,7 @@
   // Runtime provisioning state
   let runtimes = $state<ProvisionedRuntime[]>([]);
   let providers = $state<string[]>(["docker", "cloudflare"]);
+  let capabilities = $state<Array<{ provider: string; tiers: string[] }>>([]);
   let showNewRuntimeDialog = $state(false);
 
   // Provisioning runtimes: status==="provisioning" with no matching online node yet
@@ -106,6 +107,7 @@
       try {
         const res = await listRuntimeProviders();
         if (res.providers.length > 0) providers = res.providers;
+        if (res.capabilities) capabilities = res.capabilities;
       } catch {
         // keep fallback ["docker", "cloudflare"]
       }
@@ -413,6 +415,7 @@
 <NewRuntimeDialog
   open={showNewRuntimeDialog}
   {providers}
+  {capabilities}
   onClose={() => (showNewRuntimeDialog = false)}
   onCreated={handleRuntimeCreated}
 />

--- a/apps/console/src/routes/runtimes/+page.svelte
+++ b/apps/console/src/routes/runtimes/+page.svelte
@@ -26,6 +26,7 @@
   // ── State ───────────────────────────────────────────────────────────────────
   let runtimes = $state<ProvisionedRuntime[]>([]);
   let providers = $state<string[]>(["docker", "cloudflare"]);
+  let capabilities = $state<Array<{ provider: string; tiers: string[] }>>([]);
   let isLoading = $state(true);
   let error = $state<string | null>(null);
   let showNewRuntimeDialog = $state(false);
@@ -56,6 +57,7 @@
     try {
       const res = await listRuntimeProviders();
       if (res.providers.length > 0) providers = res.providers;
+      if (res.capabilities) capabilities = res.capabilities;
     } catch {
       // keep ["docker", "cloudflare"]
     }
@@ -337,6 +339,7 @@
 <NewRuntimeDialog
   open={showNewRuntimeDialog}
   {providers}
+  {capabilities}
   onClose={() => (showNewRuntimeDialog = false)}
   onCreated={handleRuntimeCreated}
 />

--- a/apps/hub/src/routes/runtimes.ts
+++ b/apps/hub/src/routes/runtimes.ts
@@ -32,6 +32,7 @@ import {
   startRuntime,
   stopRuntime,
   enabledProviders,
+  providerCapabilities,
 } from "../services/runtimes";
 
 export const runtimeRoutes = new Hono()
@@ -67,7 +68,7 @@ export const runtimeRoutes = new Hono()
   // ── GET /api/runtimes/providers ───────────────────────────────────────────
   // Must be registered BEFORE /:id to avoid being shadowed.
   .get("/providers", (c) => {
-    return c.json({ providers: enabledProviders() });
+    return c.json({ providers: enabledProviders(), capabilities: providerCapabilities() });
   })
 
   // ── GET /api/runtimes ─────────────────────────────────────────────────────

--- a/apps/hub/src/services/provisioner/cloudflare-sandbox.ts
+++ b/apps/hub/src/services/provisioner/cloudflare-sandbox.ts
@@ -15,7 +15,7 @@
  * by this module. Do not add log statements that reference spec.enrollToken.
  */
 
-import type { RuntimeProvisioner, ProvisionSpec } from "./types";
+import type { RuntimeProvisioner, ProvisionSpec, ResourceTier } from "./types";
 
 export interface CloudflareSandboxOptions {
   workerUrl?: string;
@@ -43,6 +43,14 @@ export interface CloudflareSandboxOptions {
 export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
   readonly provider = "cloudflare" as const;
 
+  /**
+   * Exactly one tier: Cloudflare fixes instance_type per container class, so
+   * this worker provides the tier it was deployed with and nothing else. The
+   * console reads this to build its form, which is why provisioning can no
+   * longer be offered in a shape this driver would refuse.
+   */
+  readonly supportedTiers: ResourceTier[];
+
   private readonly workerUrl: string;
   private readonly apiToken: string;
   private readonly deployedImage: string;
@@ -64,6 +72,7 @@ export class CloudflareSandboxProvisioner implements RuntimeProvisioner {
     this.deployedImage = deployedImage;
     this.callbackToken = callbackToken;
     this.deployedTier = deployedTier;
+    this.supportedTiers = [deployedTier as ResourceTier];
     this.fetchImpl = fetchImpl;
   }
 

--- a/apps/hub/src/services/provisioner/registry.test.ts
+++ b/apps/hub/src/services/provisioner/registry.test.ts
@@ -7,10 +7,11 @@
  * No DB or external I/O — pure unit test.
  */
 
-import { test, expect, beforeEach, afterEach, describe } from "bun:test";
+import { test, it, expect, beforeEach, afterEach, describe } from "bun:test";
 import {
   registerProvisioner,
   enabledProviders,
+  providerCapabilities,
   getProvisioner,
   resetProvisioners,
 } from "./registry";
@@ -169,5 +170,42 @@ describe("resetProvisioners (test isolation)", () => {
     registerProvisioner(fakeDockerProvisioner());
     resetProvisioners();
     expect(() => getProvisioner("docker")).toThrow("provider not registered: docker");
+  });
+});
+
+// ─── Provider capabilities ────────────────────────────────────────────────────
+
+
+describe("providerCapabilities", () => {
+  it("reports the tiers a provider can actually satisfy", () => {
+    // The console must not offer a choice the driver will refuse. Cloudflare
+    // fixes instance_type at worker deploy time, so it supports exactly one
+    // tier — offering "small" produced a guaranteed provisioning failure.
+    process.env.ENABLE_CLOUDFLARE_SANDBOXES = "true";
+    registerProvisioner({
+      provider: "cloudflare",
+      supportedTiers: ["large"],
+      provision: async () => ({ externalId: "x" }),
+      destroy: async () => {},
+    } as never);
+
+    const caps = providerCapabilities();
+    const cf = caps.find((c) => c.provider === "cloudflare");
+    expect(cf?.tiers).toEqual(["large"]);
+  });
+
+  it("defaults to every tier for a driver that does not restrict them", () => {
+    // Docker maps all three tiers to real cpu/memory limits, so a driver that
+    // says nothing must keep offering all of them.
+    process.env.ENABLE_DOCKER_PROVISIONING = "true";
+    registerProvisioner({
+      provider: "docker",
+      provision: async () => ({ externalId: "x" }),
+      destroy: async () => {},
+    } as never);
+
+    const caps = providerCapabilities();
+    const docker = caps.find((c) => c.provider === "docker");
+    expect(docker?.tiers).toEqual(["small", "medium", "large"]);
   });
 });

--- a/apps/hub/src/services/provisioner/registry.ts
+++ b/apps/hub/src/services/provisioner/registry.ts
@@ -11,7 +11,7 @@
  *     (reuses the existing Cloudflare feature-flag name from config.ts)
  */
 
-import type { RuntimeProvisioner, RuntimeProviderName } from "./types";
+import type { RuntimeProvisioner, RuntimeProviderName, ResourceTier } from "./types";
 
 // ─── Known provider names (type-checked set) ──────────────────────────────────
 
@@ -58,6 +58,31 @@ export function enabledProviders(): RuntimeProviderName[] {
     }
   }
   return result;
+}
+
+/** Every tier, for a driver that does not restrict them. */
+const ALL_TIERS: ResourceTier[] = ["small", "medium", "large"];
+
+/**
+ * What each enabled provider can actually do, for the UI to build its form from.
+ *
+ * Exists so the console never offers a choice the driver will refuse. Cloudflare
+ * fixes `instance_type` at worker deploy time and supports exactly one tier, so
+ * a dialog offering small/medium/large produced a guaranteed provisioning
+ * failure with a backend error as the only feedback.
+ *
+ * The capability is read from the driver rather than hardcoded in the console:
+ * a hardcoded map in the UI would silently rot the moment a worker is redeployed
+ * at a different instance type.
+ */
+export function providerCapabilities(): Array<{
+  provider: RuntimeProviderName;
+  tiers: ResourceTier[];
+}> {
+  return enabledProviders().map((provider) => {
+    const driver = _registry.get(provider);
+    return { provider, tiers: driver?.supportedTiers ?? ALL_TIERS };
+  });
 }
 
 /**

--- a/apps/hub/src/services/provisioner/types.ts
+++ b/apps/hub/src/services/provisioner/types.ts
@@ -7,6 +7,9 @@
 
 export type RuntimeProviderName = "docker" | "cloudflare";
 
+/** Resource tier controlling CPU/memory allocation. */
+export type ResourceTier = "small" | "medium" | "large";
+
 /**
  * The spec passed to a provisioner when creating a new runtime.
  * Contains everything the container/sandbox needs to boot and self-enroll.
@@ -35,6 +38,16 @@ export interface ProvisionSpec {
  */
 export interface RuntimeProvisioner {
   readonly provider: RuntimeProviderName;
+
+  /**
+   * Tiers this driver can actually satisfy. Omit when the driver supports all
+   * of them (Docker maps each to real cpu/memory limits).
+   *
+   * Cloudflare fixes instance_type at worker deploy time, so it supports
+   * exactly one — and the console reads this rather than hardcoding a map that
+   * would rot the moment a worker is redeployed at a different instance type.
+   */
+  readonly supportedTiers?: ResourceTier[];
 
   /**
    * Create and start a new runtime for the given spec.

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -22,6 +22,7 @@ import {
   getProvisioner,
   getProvisionerUnguarded,
   enabledProviders,
+  providerCapabilities,
   isProviderEnabled,
 } from "./provisioner/registry";
 import type { ProvisionedRuntime } from "@agentpod/contract";
@@ -340,4 +341,4 @@ export async function stopRuntime(userId: string, id: string): Promise<void> {
 }
 
 // Re-export for convenience (routes use this)
-export { enabledProviders };
+export { enabledProviders, providerCapabilities };


### PR DESCRIPTION
## Why

The Cloudflare driver refuses any tier but the one its worker was deployed with (#249). The New Runtime dialog still offered small/medium/large and **defaulted to small**, so the common path was a guaranteed provisioning failure whose only feedback was a backend error.

Refusing in the driver is right; inviting the choice in the UI was not.

## What

- `RuntimeProvisioner` gains an optional `supportedTiers`. Docker omits it and keeps all three; Cloudflare reports exactly the tier it was deployed with.
- `GET /api/runtimes/providers` now also returns `capabilities: [{ provider, tiers }]`.
- The dialog derives its tier list from that, and keeps the selection valid when the provider changes.

The capability is read from the driver rather than hardcoded in the console — a map baked into the UI would rot the moment a worker is redeployed at a different instance type.

## Tests

- Hub: `providerCapabilities` reports a restricted driver's tiers, and defaults to all three for a driver that does not restrict them. **487 pass.**
- Console: the dialog offers only supported tiers and defaults to one the provider accepts. **713 pass**, `pnpm check` clean.

Both console tests were confirmed failing before the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW