### PR TITLE
fix(console): contain pane scrolling and add a file-list refresh

### DIFF
--- a/apps/console/src/lib/components/app-shell.svelte
+++ b/apps/console/src/lib/components/app-shell.svelte
@@ -98,7 +98,13 @@
 </script>
 
 <!-- Outer wrapper: flex row — side nav + content column -->
-<div class={cn("min-h-screen flex", className)}>
+<!--
+  h-screen, not min-h-screen: a floor lets the flex column grow with its content,
+  so panes that set `overflow-y-auto` never engage and the whole PAGE scrolls
+  instead. Capping the shell is what makes inner scroll regions (file tree, file
+  preview, logs, terminal) scroll in place.
+-->
+<div class={cn("h-screen overflow-hidden flex", className)}>
 
   <!-- =========================================================
        Desktop side nav  (hidden on mobile, visible md+)
@@ -179,7 +185,12 @@
     {/if}
 
     <!-- Page content -->
-    <main class="flex-1 flex flex-col">
+    <!--
+      min-h-0 lets flex children shrink below their content height so their own
+      overflow rules apply; overflow-y-auto keeps ordinary long pages scrolling
+      as before, now inside main rather than the document.
+    -->
+    <main class="flex-1 flex flex-col min-h-0 overflow-y-auto">
       {@render children?.()}
     </main>
 

--- a/apps/console/src/lib/components/stations/FileBrowser.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/FileBrowser.svelte.test.ts
@@ -391,3 +391,50 @@ test("FileBrowser: closes a tab with its close button", async () => {
   });
   expect(getByRole("tab", { name: "index.ts" }).getAttribute("aria-selected")).toBe("true");
 });
+
+test("a read-only viewer can still refresh the file list", async () => {
+  // The file list is a cached view of a machine an agent is actively changing.
+  // Before this, a file the agent created only appeared after a full page
+  // reload, and the toolbar holding the action was gated behind canWrite.
+  const spy = vi.spyOn(api, "listFiles").mockResolvedValue([mockDir, mockFile]);
+
+  const { getByRole } = render(FileBrowser, {
+    props: { stationId: "station_1", canWrite: false },
+  });
+
+  await waitFor(() => expect(spy).toHaveBeenCalledWith("station_1", ""));
+  const callsBefore = spy.mock.calls.length;
+
+  await fireEvent.click(getByRole("button", { name: /refresh file list/i }));
+
+  await waitFor(() => expect(spy.mock.calls.length).toBeGreaterThan(callsBefore));
+});
+
+test("refresh re-reads folders that are already expanded", async () => {
+  // Reloading only the root would leave a file the agent created inside an
+  // expanded folder invisible, because that folder's contents are cached.
+  // Per-path, not a blanket mock: returning the same dir for every path makes
+  // mockDir contain itself and the tree recurses forever.
+  const child: FsEntry = { name: "child.txt", path: `${mockDir.path}/child.txt`, type: "file", size: 3 };
+  const spy = vi
+    .spyOn(api, "listFiles")
+    .mockImplementation(async (_id: string, path: string) =>
+      path === "" ? [mockDir, mockFile] : [child],
+    );
+
+  const { getByRole, getByText } = render(FileBrowser, {
+    props: { stationId: "station_1", canWrite: false },
+  });
+
+  await waitFor(() => expect(getByText(mockDir.name)).toBeTruthy());
+  await fireEvent.click(getByText(mockDir.name));
+  await waitFor(() => expect(spy).toHaveBeenCalledWith("station_1", mockDir.path));
+
+  spy.mockClear();
+  await fireEvent.click(getByRole("button", { name: /refresh file list/i }));
+
+  await waitFor(() => {
+    expect(spy).toHaveBeenCalledWith("station_1", "");
+    expect(spy).toHaveBeenCalledWith("station_1", mockDir.path);
+  });
+});

--- a/apps/console/src/lib/components/stations/FileBrowser.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/FileBrowser.svelte.test.ts
@@ -415,7 +415,13 @@ test("refresh re-reads folders that are already expanded", async () => {
   // expanded folder invisible, because that folder's contents are cached.
   // Per-path, not a blanket mock: returning the same dir for every path makes
   // mockDir contain itself and the tree recurses forever.
-  const child: FsEntry = { name: "child.txt", path: `${mockDir.path}/child.txt`, type: "file", size: 3 };
+  const child: FsEntry = {
+    name: "child.txt",
+    path: `${mockDir.path}/child.txt`,
+    type: "file",
+    size: 3,
+    modified: null,
+  };
   const spy = vi
     .spyOn(api, "listFiles")
     .mockImplementation(async (_id: string, path: string) =>

--- a/apps/console/src/lib/components/stations/file-tree.svelte
+++ b/apps/console/src/lib/components/stations/file-tree.svelte
@@ -3,7 +3,7 @@
   import { listFiles, writeFile, mkdir, move, del } from "$lib/api/client";
   import { toast } from "svelte-sonner";
   import type { FsEntry } from "@agentpod/contract";
-  import { ChevronRight, ChevronDown, Loader2, Trash2, FilePlus, FolderPlus, Pencil } from "@lucide/svelte";
+  import { ChevronRight, ChevronDown, Loader2, Trash2, FilePlus, FolderPlus, Pencil, RefreshCw } from "@lucide/svelte";
   import { Button } from "$lib/components/ui/button";
   import TypeToConfirmDialog from "$lib/components/ui/TypeToConfirmDialog.svelte";
   import { autofocus } from "$lib/actions/autofocus";
@@ -83,6 +83,19 @@
     } finally {
       isLoading = false;
     }
+  }
+
+  /**
+   * Reload the tree from the station.
+   *
+   * Reloads every folder already loaded, not just the root: an agent that
+   * creates a file inside an expanded folder would otherwise stay invisible
+   * until a full page reload, because that folder's contents are cached.
+   */
+  async function refreshAll() {
+    const loaded = [...folderContents.keys()];
+    await refresh();
+    await Promise.all(loaded.map((p) => loadDirContents(p)));
   }
 
   async function ensureExpanded(path: string) {
@@ -235,9 +248,23 @@
   }
 </script>
 
-<!-- Write toolbar (always rendered when canWrite so tests can find buttons) -->
-{#if canWrite}
-  <div class="flex shrink-0 items-center gap-1 border-b border-border/60 px-2 py-1.5 bg-muted/5">
+<!-- Toolbar. Refresh is always available: the file list is a cached view of a
+     machine someone else (an agent) is changing, and a read-only viewer needs to
+     re-read it just as much as a writer does. -->
+<div class="flex shrink-0 items-center gap-1 border-b border-border/60 px-2 py-1.5 bg-muted/5">
+  <Button
+    variant="ghost"
+    size="sm"
+    class="h-7 gap-1 px-2 text-xs font-medium text-muted-foreground hover:text-foreground"
+    onclick={refreshAll}
+    disabled={isLoading}
+    title="Refresh file list"
+    aria-label="Refresh file list"
+  >
+    <RefreshCw class="h-3.5 w-3.5 {isLoading ? 'animate-spin' : ''}" />
+    Refresh
+  </Button>
+  {#if canWrite}
     <Button
       variant="ghost"
       size="sm"
@@ -258,8 +285,10 @@
       <FolderPlus class="h-3.5 w-3.5" />
       New Folder
     </Button>
-  </div>
+  {/if}
+</div>
 
+{#if canWrite}
   <!-- Inline create input -->
   {#if newItemMode !== null}
     <div class="shrink-0 px-2 py-1.5 border-b border-border/60 bg-muted/5">


### PR DESCRIPTION
## One cause, three symptoms

Reported: the file list scrolls the whole page, the markdown viewer scrolls the whole page, and the file list and viewer don't scroll independently.

All three are the same break. `app-shell` used **`min-h-screen`** — a floor, not a cap — and `<main>` had no `min-h-0`, so the flex column grew with its content. Every inner pane already declared `overflow-y-auto` / `overflow-auto` correctly; nothing above them ever bounded the height, so those rules could never engage.

```
app-shell   min-h-screen  ← grows with content
  main      flex-1 flex flex-col   ← no min-h-0, cannot shrink
    page    flex-1 min-h-0         ← already correct
      FileBrowser  h-full          ← already correct
        tree     flex-1 overflow-y-auto   ← never engaged
        preview  flex-1 overflow-hidden   ← never engaged
```

Fixed at the top: the shell is capped and `main` can shrink. **This was suspected to affect other tabs, and it did** — logs, terminal and changeset panels sit in the same chain and are fixed by the same change.

## Refresh

Adds a Refresh control to the file list, **available to read-only viewers too**: the list is a cached view of a machine an agent is actively changing, and re-reading it is not a write. The toolbar previously rendered only when `canWrite`.

Refresh reloads **every folder already loaded**, not just the root — otherwise a file the agent creates inside an expanded folder stays invisible until a full page reload, which is the bug being reported.

## Tests

**715 pass**, `pnpm check` clean. Two new tests: a read-only viewer can refresh, and refresh re-reads expanded folders.

## Not verified

The scroll fix is **not visually verified** — it is a CSS layout change and the test suite runs in jsdom, which does not lay out. It needs a look in a real browser at a small viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW