### PR TITLE
fix(hub): mint durable enrollment tokens from createRuntime

### DIFF
--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -115,13 +115,19 @@ export async function createRuntime(
     updatedAt: now,
   });
 
-  // Mint a short-lived enrollment token linked to this runtime.
-  // The node-agent container will use it to self-enroll and flip the runtime online.
+  // Mint an enrollment token linked to this runtime. The node-agent container
+  // uses it to self-enroll and flip the runtime online.
+  //
+  // No ttlMs override: a runtime-bound token gets the durable
+  // RUNTIME_TOKEN_TTL_MS default on purpose. On an ephemeral-disk substrate the
+  // container's config does not survive a restart, so it re-presents this same
+  // token on EVERY boot — an expiry would mean a runtime that silently loses
+  // the ability to come back after its first sleep. The token is revoked by
+  // destroying the runtime, not by waiting.
   let enrollToken: string;
   try {
     const result = await mintEnrollmentToken(userId, {
       provisionedRuntimeId: id,
-      ttlMs: 30 * 60 * 1000, // 30-minute window for the container to boot and enroll
     });
     enrollToken = result.token;
   } catch (err) {

--- a/apps/hub/tests/integration/runtime-enrollment-token.test.ts
+++ b/apps/hub/tests/integration/runtime-enrollment-token.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration Test: the token createRuntime actually mints.
+ *
+ * A provisioned runtime on an ephemeral-disk substrate (Cloudflare containers)
+ * re-runs `agentpod-node enroll` on EVERY boot, re-presenting the token it was
+ * provisioned with. If that token can expire, the runtime is permanently dead
+ * the first time it sleeps past the expiry: enroll gets 401, the entrypoint's
+ * `set -e` kills the container, and it never dials the hub again.
+ *
+ * The token lifetime therefore has to be asserted on the path that mints
+ * production tokens — createRuntime — not on mintEnrollmentToken directly.
+ * Calling the minter directly gets the runtime-bound default and passes happily
+ * while createRuntime overrides it with a short TTL, which is exactly how a
+ * 30-minute production token shipped under a green suite.
+ */
+
+// ─── Env vars BEFORE any src/ imports ─────────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+process.env.ENABLE_DOCKER_PROVISIONING = "true";
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+
+import { rawSql } from "../../src/db/drizzle";
+import { createTestUser } from "../helpers/database";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import {
+  registerProvisioner,
+  resetProvisioners,
+} from "../../src/services/provisioner/registry";
+import type { RuntimeProvisioner } from "../../src/services/provisioner/types";
+import { createRuntime } from "../../src/services/runtimes";
+
+const TEST_USER = "test-user-runtime-token-001";
+
+const fakeDockerProvisioner: RuntimeProvisioner = {
+  provider: "docker",
+  async provision(spec) {
+    return { externalId: `fake-container-${spec.runtimeId}` };
+  },
+  async destroy() {},
+};
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: "runtime-token-test@example.com",
+    name: "Runtime Token Test User",
+  });
+  registerProvisioner(fakeDockerProvisioner);
+});
+
+afterAll(async () => {
+  resetProvisioners();
+  try {
+    await rawSql`DELETE FROM enrollment_tokens    WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM provisioned_runtimes WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM "user"               WHERE id      = ${TEST_USER}`;
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+test("createRuntime mints an enrollment token that outlives the container", async () => {
+  const runtime = await createRuntime(
+    TEST_USER,
+    { provider: "docker", name: "ttl-box", resourceTier: "small" },
+    "https://hub.example.test"
+  );
+
+  const rows = (await rawSql`
+    SELECT expires_at FROM enrollment_tokens
+    WHERE provisioned_runtime_id = ${runtime.id}
+  `) as Array<{ expires_at: string | Date }>;
+
+  expect(rows).toHaveLength(1);
+
+  // A year is far past any provisioning window and far short of the ten-year
+  // runtime-bound default, so this catches a re-introduced short TTL without
+  // pinning the exact constant.
+  const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+  const expiresAt = new Date(rows[0]!.expires_at);
+  const lifetimeMs = expiresAt.getTime() - Date.now();
+  expect(lifetimeMs).toBeGreaterThan(oneYearMs);
+});


### PR DESCRIPTION
## Root cause

A Cloudflare-backed station can never re-enrol after its first sleep — it is permanently offline while the hub still reports the runtime `online`.

`apps/hub/src/services/enrollment.ts` already has a runtime-bound default (`RUNTIME_TOKEN_TTL_MS`, ten years) for exactly this case:

```ts
const ttlMs = opts?.ttlMs ?? (opts?.provisionedRuntimeId ? RUNTIME_TOKEN_TTL_MS : 60 * 60 * 1000);
```

But the only production caller — `createRuntime` in `apps/hub/src/services/runtimes.ts` — passed an explicit override that defeated it:

```ts
const result = await mintEnrollmentToken(userId, {
  provisionedRuntimeId: id,
  ttlMs: 30 * 60 * 1000, // 30-minute window for the container to boot and enroll
});
```

Cloudflare container disk is ephemeral, so `agentpod-node enroll` runs on **every** boot and re-presents the same token — not just once during provisioning. Past 30 minutes the hub returns 401, the entrypoint's `set -e` kills the container, and the node never dials the gateway.

## Live evidence

- Same token: `200` at 04:44 (first enrolment), then `401` at 07:01, 07:25 and 07:33 on subsequent boots.
- Container `exitCode: 1`, 892 ms after start — `set -e` on the failed enroll.
- Hub kept reporting the runtime `online` throughout, so the failure was invisible from the console.

## Fix

Drop the `ttlMs` override so the runtime-bound default applies:

```ts
const result = await mintEnrollmentToken(userId, { provisionedRuntimeId: id });
```

The surrounding comment now explains *why* a runtime token is durable: it is re-presented on every container restart on ephemeral-disk substrates, and it is revoked by destroying the runtime, not by waiting.

## Why the existing test did not catch this

#245's test called `mintEnrollmentToken` directly with `provisionedRuntimeId`, so it received the ten-year default and passed — while `createRuntime`, the path that actually mints every production runtime token, overrode that default with 30 minutes. The suite was green and production was broken.

The new regression test closes that hole by going through `createRuntime` and asserting on the persisted `enrollment_tokens.expires_at` row for the created runtime (must be more than a year out — well past any provisioning window, without pinning the exact constant).

Before the fix:

```
error: expect(received).toBeGreaterThan(expected)
Expected: > 31536000000
Received: 1799980          # ~30 minutes
```

After: passes. Full hub suite: **488 pass, 0 fail** across 55 files.

## Scope

One-line behaviour change plus its regression test. The separate snapshot-`envVars` issue is tracked elsewhere and deliberately untouched here. No live hub or runtime was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW