### PR TITLE
feat: Pi harness — detection, chat, and container image

### DIFF
--- a/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte
+++ b/apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte
@@ -39,6 +39,7 @@
   const harnessOptions = [
     { value: "none", label: "Generic" },
     { value: "opencode", label: "OpenCode" },
+    { value: "pi", label: "Pi" },
   ];
 
   // provider/name/tier/harness are reset each time the dialog opens via $effect

--- a/apps/console/src/routes/nodes/[id]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/+page.svelte
@@ -174,7 +174,7 @@
     {:else if stations.detected.length === 0}
       <Empty
         title="No agents found on this node"
-        description="AgentPod looks for hermes, openclaw, claude-code, codex, and opencode. Start one and rescan."
+        description="AgentPod looks for hermes, openclaw, claude-code, codex, opencode, and pi. Start one and rescan."
       >
         <Button variant="outline" size="sm" onclick={loadStations}>Rescan</Button>
       </Empty>

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -40,11 +40,15 @@ const prefixedId = (prefix: string) =>
  *
  * Env overrides allow operators to pin specific image tags per harness:
  *   NODE_AGENT_OPENCODE_IMAGE — opencode harness (default: agentpod-node-opencode:local)
+ *   NODE_AGENT_PI_IMAGE       — pi harness      (default: agentpod-node-pi:local)
  *   NODE_AGENT_IMAGE          — generic / no harness (default: agentpod-node:local)
  */
 function imageForHarness(harness: string): string {
   if (harness === "opencode") {
     return process.env.NODE_AGENT_OPENCODE_IMAGE ?? "agentpod-node-opencode:local";
+  }
+  if (harness === "pi") {
+    return process.env.NODE_AGENT_PI_IMAGE ?? "agentpod-node-pi:local";
   }
   return process.env.NODE_AGENT_IMAGE ?? "agentpod-node:local";
 }

--- a/apps/node-agent/cmd/agentpod-node/registry.go
+++ b/apps/node-agent/cmd/agentpod-node/registry.go
@@ -26,6 +26,7 @@ func buildRegistry(cfg config.Config) *descriptor.Registry {
 		NodeBinary:   cfg.NodeBinary,
 	}))
 	reg.Register(descriptor.NewOpenCode(""))
+	reg.Register(descriptor.NewPi(""))
 	reg.Register(descriptor.NewCodexFrom(descriptor.CodexConfig{
 		AcpBinary:   cfg.CodexAcpBinary,
 		CodexBinary: cfg.CodexBinary,

--- a/apps/node-agent/deploy/Dockerfile
+++ b/apps/node-agent/deploy/Dockerfile
@@ -1,16 +1,12 @@
 # syntax=docker/dockerfile:1
 
-# Stage 1: Build
-FROM golang:1.26 AS builder
-WORKDIR /src
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /agentpod-node ./cmd/agentpod-node
+# Generic node-agent image: no harness preloaded, just enrol and run.
+#
+# Everything it needs (the agentpod-node binary, ca-certificates, curl, git,
+# procps and /node-entrypoint.sh) comes from the shared base image, which must
+# be built first:
+#
+#   docker build -f apps/node-agent/deploy/Dockerfile.base -t agentpod-node:base apps/node-agent
+FROM agentpod-node:base
 
-# Stage 2: Runtime
-# alpine used so the shell entrypoint script can run
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
-COPY --from=builder /agentpod-node /agentpod-node
-COPY deploy/node-entrypoint.sh /node-entrypoint.sh
-RUN chmod +x /node-entrypoint.sh
 ENTRYPOINT ["/node-entrypoint.sh"]

--- a/apps/node-agent/deploy/Dockerfile.base
+++ b/apps/node-agent/deploy/Dockerfile.base
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+# Shared base for every node-agent container image. The per-harness images
+# (Dockerfile, Dockerfile.opencode, ...) are `FROM agentpod-node:base` and add
+# only what their harness needs, so the build stage, the runtime distro and the
+# common tooling are defined exactly once.
+#
+# This image must be built FIRST — the harness Dockerfiles will not resolve
+# without it:
+#
+#   docker build -f apps/node-agent/deploy/Dockerfile.base -t agentpod-node:base apps/node-agent
+#
+# It sets no ENTRYPOINT on purpose: each harness layer chooses its own (the
+# generic enrol-then-run script, or a harness supervision loop).
+
+# Stage 1: Build the static node-agent binary
+FROM golang:1.26 AS builder
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /agentpod-node ./cmd/agentpod-node
+
+# Stage 2: Runtime base
+# Debian rather than alpine because the harness layers install glibc-linked
+# toolchains on top of it (bun for OpenCode, node for Pi). Trixie specifically:
+# it is the distro oven/bun:1-slim is built on, so the OpenCode image keeps the
+# exact userland it already runs on today.
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git procps \
+    && rm -rf /var/lib/apt/lists/*
+# procps provides `pgrep`, used by the descriptors' running-process health
+# checks (and by OpenCode's supervised-serve Stop/Start); without it the
+# station Health panel shows "process check unavailable". ca-certificates is
+# needed to dial the hub over WSS; curl and git are what an agent working
+# inside the container reaches for first.
+
+COPY --from=builder /agentpod-node /agentpod-node
+
+# The generic entrypoint (enrol, then exec the run loop) lives here because
+# more than one harness layer uses it verbatim — a harness only ships its own
+# entrypoint when it needs supervision, as OpenCode does.
+COPY deploy/node-entrypoint.sh /node-entrypoint.sh
+RUN chmod +x /node-entrypoint.sh

--- a/apps/node-agent/deploy/Dockerfile.opencode
+++ b/apps/node-agent/deploy/Dockerfile.opencode
@@ -1,20 +1,19 @@
 # syntax=docker/dockerfile:1
 
-# Stage 1: Build the static node-agent binary
-FROM golang:1.26 AS builder
-WORKDIR /src
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /agentpod-node ./cmd/agentpod-node
-
-# Stage 2: Runtime — bun base (Debian) for opencode
-FROM oven/bun:1-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates git procps \
-    && rm -rf /var/lib/apt/lists/*
-# procps provides `pgrep`, used by the OpenCode descriptor's running-process
-# health check and its supervised-serve Stop/Start; without it the station
-# Health panel shows "process check unavailable".
+# OpenCode harness image.
 #
+# The agentpod-node binary, ca-certificates, curl, git and procps come from the
+# shared base image, which must be built first:
+#
+#   docker build -f apps/node-agent/deploy/Dockerfile.base -t agentpod-node:base apps/node-agent
+FROM agentpod-node:base
+
+# bun, copied out of its own published image rather than fetched by a network
+# install script. BUN_INSTALL_BIN is what oven/bun's image sets, and is what
+# puts `bun add -g` binaries (i.e. `opencode`) on PATH.
+COPY --from=oven/bun:1-slim /usr/local/bin/bun /usr/local/bin/bun
+ENV BUN_INSTALL_BIN=/usr/local/bin
+
 # `sqlite3` is deliberately NOT installed. The entrypoint used to hand-seed
 # opencode.db (the descriptor's PRIMARY project-discovery path) with a schema
 # snapshot that broke across opencode-ai version bumps (see
@@ -28,7 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # the node-agent's ACPCommand uses to spawn `opencode acp` sessions).
 RUN bun add -g opencode-ai@1.18.15
 
-COPY --from=builder /agentpod-node /agentpod-node
+# OpenCode ships its own entrypoint rather than the base image's: `opencode
+# serve` is a daemon, so the container needs a supervision loop.
 COPY deploy/node-opencode-entrypoint.sh /node-opencode-entrypoint.sh
 RUN chmod +x /node-opencode-entrypoint.sh
 

--- a/apps/node-agent/deploy/Dockerfile.pi
+++ b/apps/node-agent/deploy/Dockerfile.pi
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# Pi harness image.
+#
+# The agentpod-node binary, ca-certificates, curl, git, procps (the `pgrep` the
+# descriptor's health check shells out to) and the generic /node-entrypoint.sh
+# all come from the shared base image, which must be built first:
+#
+#   docker build -f apps/node-agent/deploy/Dockerfile.base -t agentpod-node:base apps/node-agent
+#
+# Unlike the OpenCode image this needs NO supervision loop: Pi has no daemon,
+# it is invoked per command, so the base image's generic entrypoint (enrol,
+# then run) is correct — no stop sentinel, no double-fork, no
+# AGENTPOD_*_SUPERVISED env, and so no entrypoint-parity pair to keep in step.
+FROM agentpod-node:base
+
+# Node 24 from NodeSource: Pi requires Node >= 22.19, and Debian trixie's own
+# nodejs package is older than that. The setup script runs its own apt-get
+# update, so only the install and the list cleanup are needed after it.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# ripgrep, because --ignore-scripts (below) skips the postinstall that would
+# otherwise fetch Pi's own ~/.pi/agent/bin/rg; Pi's file search falls back to
+# whatever `rg` is on PATH.
+RUN apt-get update && apt-get install -y --no-install-recommends ripgrep \
+ && rm -rf /var/lib/apt/lists/*
+
+# --ignore-scripts matches Pi's own installer. Both pins are deliberate: a
+# floating tag would make two builds of the same image behave differently, and
+# pi-acp@0.0.33 is the version the descriptor's ACP path is written against
+# (it is what opens the "acp" capability at detect time).
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.84.1 \
+ && npm install -g --ignore-scripts pi-acp@0.0.33
+
+ENTRYPOINT ["/node-entrypoint.sh"]

--- a/apps/node-agent/internal/descriptor/acp_command_test.go
+++ b/apps/node-agent/internal/descriptor/acp_command_test.go
@@ -252,6 +252,16 @@ func TestCapabilitiesIncludeACP(t *testing.T) {
 		home, _, _ := buildCodexFixture(t)
 		assertAllStationsHaveACP(t, NewCodex(home))
 	})
+	// Pi is the one harness whose "acp" capability is CONDITIONAL: it rides on
+	// the external pi-acp adapter resolving, so the stub has to be on PATH
+	// before Detect runs or this subtest fails for a reason that has nothing to
+	// do with the conformance it is here to check. The gating itself is
+	// asserted by TestPiACPCapabilityGatedOnAdapter.
+	t.Run("pi", func(t *testing.T) {
+		dataDir, _ := buildPiFixture(t)
+		writePiACPStub(t)
+		assertAllStationsHaveACP(t, NewPi(dataDir))
+	})
 }
 
 func assertAllStationsHaveACP(t *testing.T, d Descriptor) {

--- a/apps/node-agent/internal/descriptor/pi.go
+++ b/apps/node-agent/internal/descriptor/pi.go
@@ -148,6 +148,16 @@ func (p *piDescriptor) Detect() ([]Station, error) {
 	// start, so this descriptor does not implement Lifecycle at all.
 	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup"}
 
+	// "acp" is advertised ONLY when the pi-acp adapter actually resolves. The
+	// console gates the Chat tab on this capability alone, so advertising it
+	// unconditionally (as the harnesses with an npx fallback can afford to)
+	// would buy every Pi station a Chat tab that fails the moment it is
+	// clicked. No adapter, no tab. Resolved once here rather than per station:
+	// it is a property of the node, not of the workspace.
+	if _, ok := piACPAdapter(); ok {
+		caps = append(caps, "acp")
+	}
+
 	seen := make(map[string]bool)
 	stations := []Station{}
 
@@ -282,6 +292,103 @@ func (p *piDescriptor) resolveKey(key string) (wsPath string, sessionDirs []stri
 func (p *piDescriptor) workspaceForKey(key string) (string, error) {
 	wsPath, _, err := p.resolveKey(key)
 	return wsPath, err
+}
+
+// Pi has no ACP mode of its own — the maintainer declined one
+// (earendil-works/pi#175), and the source carries interactive/, json-event.ts,
+// print-mode.ts and rpc/ with nothing ACP-shaped between them. Sessions
+// therefore run through the community pi-acp adapter, a Node program that
+// speaks ACP on stdio outward and spawns `pi --mode rpc` inward. This is the
+// THIRD external Node adapter in this package (claude-agent-acp, codex-acp),
+// and it is resolved the same way they are.
+const (
+	// piACPBinaryName is the adapter's executable name once installed.
+	piACPBinaryName = "pi-acp"
+
+	// piACPPackage is the npm package, VERSION-PINNED for the same reason
+	// opencode-ai@1.18.15 is: it is a 0.0.x package with a single maintainer
+	// sitting on the Chat path, and an unpinned install would change every
+	// node's adapter the moment a new version is published. It appears here
+	// only in the install hint of an error message and in the container image
+	// layer — it is deliberately NOT an `npx -y` fallback (see ACPCommand).
+	piACPPackage = "pi-acp@0.0.33"
+
+	// piACPBinaryEnv names the adapter executable explicitly, the same escape
+	// hatch PI_PATH provides for Pi itself and for the same reason: pi-acp is
+	// an npm bin, and the npm prefix is routinely user-local (on the fleet host
+	// `superchotu`, observed 2026-08-12, Pi's own npm prefix is
+	// /home/openclaw/.npm-global/bin). A node-agent running as a systemd user
+	// service inherits a minimal PATH that misses such a prefix entirely.
+	piACPBinaryEnv = "PI_ACP_PATH"
+)
+
+// piACPAdapter resolves the pi-acp adapter: the PI_ACP_PATH override (used
+// verbatim), then PATH, then the well-known install directories — the shared
+// order in binary.go, which exists precisely because a service PATH is not the
+// operator's interactive PATH. NOTHING is hardcoded.
+//
+// There is deliberately no `npx -y` fallback, unlike claude-code and codex. npx
+// on the request path resolves the package over the network on first use, so a
+// node without the adapter installed would answer its user's first prompt with
+// a multi-second stall and no visible reason for it. Gating the capability is
+// the honest alternative: the Chat tab is simply absent until an operator
+// installs the adapter.
+//
+// The adapter's own Node floor (>= 20) is NOT probed here, and that is a
+// decision rather than an omission. Pi itself requires Node >= 22.19, so any
+// host with a Pi station to chat with already clears the adapter's floor by a
+// wide margin — a `node --version` fork on every acp.open could only ever
+// confirm what Pi's presence implies, at the cost of a 2s timeout on a host
+// whose node sits on a stalled network mount. It would also be checking the
+// WRONG node: with no configured-runtime key on this descriptor there is
+// nothing to prepend to PATH, so the version measured need not be the one the
+// adapter's shebang picks. Compare codexACPMinNodeMajor, which skips the
+// refusal for a related reason; claude-code enforces a floor because it has a
+// configured runtime to enforce it against.
+func piACPAdapter() (string, bool) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		userHome = "" // omits the home-relative candidates
+	}
+	loc := binaryLocator{
+		userHome:     userHome,
+		lookPath:     exec.LookPath,
+		isExecutable: isExecutableFile,
+	}
+	return loc.locate(piACPBinaryName, os.Getenv(piACPBinaryEnv))
+}
+
+// ACPCommand implements ACPCommander. argv is the resolved adapter alone: it
+// takes no arguments, reads its Pi settings from the Pi install it drives, and
+// the working directory is the station's workspace — the same path the Files,
+// Health and Cleanup tabs operate on, which is what makes a chat session and
+// the rest of the station agree about which directory they are in.
+//
+// env is nil. Pi's credentials live in ~/.pi/agent/auth.json, which the adapter
+// reaches through Pi itself, so there is nothing to inject — and nothing about
+// a credential belongs in argv (world-readable via ps) or in a child env when
+// the file it already reads will do.
+//
+// Detect gates the "acp" capability on the same resolution, so in practice this
+// error is only reachable if the adapter is removed between a Detect and a
+// session open. It still names the adapter, the install command and the
+// override, because that race lands in the console as a session-open failure
+// and a message with nothing actionable in it wastes the operator's time.
+func (p *piDescriptor) ACPCommand(key string) ([]string, string, []string, error) {
+	// The station must exist before anything is probed on the host: an unknown
+	// key has no workspace to run in.
+	wsPath, err := p.workspaceForKey(key)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	adapter, ok := piACPAdapter()
+	if !ok {
+		return nil, "", nil, fmt.Errorf(
+			"pi: couldn't find the %s adapter on this node — install it (npm i -g %s) or set %s",
+			piACPBinaryName, piACPPackage, piACPBinaryEnv)
+	}
+	return []string{adapter}, wsPath, nil, nil
 }
 
 // Health returns a best-effort liveness/resource snapshot for a Pi station.

--- a/apps/node-agent/internal/descriptor/pi.go
+++ b/apps/node-agent/internal/descriptor/pi.go
@@ -6,9 +6,14 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"time"
 )
 
 // piDescriptor implements Descriptor for the Pi leaf harness
@@ -59,6 +64,20 @@ const (
 	// directory through settings.json under-reports. That is accepted and
 	// documented rather than guessed at.
 	piSessionDirEnv = "PI_CODING_AGENT_SESSION_DIR"
+
+	// piBinaryEnv names the Pi executable explicitly, mirroring CODEX_PATH in
+	// codex.go. It exists because Pi is an npm package and the npm prefix is
+	// frequently user-local: on the fleet host `superchotu` (observed
+	// 2026-08-12) `pi` resolves to /home/openclaw/.npm-global/bin/pi, not to
+	// /usr/local or /opt/homebrew. Hardcoding a location would miss it, and a
+	// node-agent running as a service may have a PATH that misses it too.
+	piBinaryEnv = "PI_PATH"
+
+	// piDebugLogName is Pi's ONLY log file, and it lives beside the data dir
+	// rather than under a station: it is global, not per-workspace. It is also
+	// written only when the hidden /debug command is enabled, so on nearly
+	// every real station it does not exist at all.
+	piDebugLogName = "pi-debug.log"
 )
 
 // NewPi returns a Descriptor for the Pi harness.
@@ -222,25 +241,347 @@ func piCwdFromSessionFile(path string) (string, bool) {
 	return header.Cwd, true
 }
 
-// --- Descriptor surface implemented in a later task ---
+// resolveKey maps a station key back to its workspace path and the session
+// directories recorded against it.
 //
-// Health, ListDir, ReadFile and TailLogs land with the rest of the station
-// capabilities; they are stubbed here only so piDescriptor satisfies
-// Descriptor. Detect does not advertise a capability these would serve before
-// they are real.
+// Resolution re-reads the session headers rather than caching Detect's output:
+// the same source of truth, so a key can never resolve to a workspace Detect
+// would not have produced. Session directories are returned as a slice because
+// Pi writes one per workspace *string*, and two of them can name the same
+// workspace (Detect dedupes those through EvalSymlinks); LastActivity should
+// see every transcript belonging to the station.
+//
+// Unlike Detect, a workspace that no longer exists is NOT filtered out here.
+// Detect already keeps such keys from ever reaching the hub, and letting the
+// underlying os call report "no such file" is a clearer failure than a
+// station-not-found for a station the caller can see.
+func (p *piDescriptor) resolveKey(key string) (wsPath string, sessionDirs []string, err error) {
+	entries, err := os.ReadDir(p.sessionDir)
+	if err != nil && !os.IsNotExist(err) {
+		return "", nil, fmt.Errorf("pi: listing %s: %w", p.sessionDir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(p.sessionDir, e.Name())
+		cwd, ok := piWorkspaceFromSessionDir(dir)
+		if !ok || piProjectKey(cwd) != key {
+			continue
+		}
+		wsPath = cwd
+		sessionDirs = append(sessionDirs, dir)
+	}
+	if wsPath == "" {
+		return "", nil, fmt.Errorf("pi: station not found: %q", key)
+	}
+	return wsPath, sessionDirs, nil
+}
 
+// workspaceForKey returns just the workspace path for a station key.
+func (p *piDescriptor) workspaceForKey(key string) (string, error) {
+	wsPath, _, err := p.resolveKey(key)
+	return wsPath, err
+}
+
+// Health returns a best-effort liveness/resource snapshot for a Pi station.
+//
+// Running is normally FALSE and that is correct, not a fault: Pi has no
+// daemon. It is invoked per command, so a station with nobody currently
+// talking to it has no process at all. Health therefore never treats the
+// absence of a process as an error, and never sets a note for it.
 func (p *piDescriptor) Health(key string) (Health, error) {
-	return Health{}, fmt.Errorf("pi: health %q: not implemented", key)
+	wsPath, sessionDirs, err := p.resolveKey(key)
+	if err != nil {
+		return Health{}, err
+	}
+
+	health := Health{}
+
+	// Disk usage from the shared async cache — never walk on the request path
+	// (a node_modules-laden workspace walk can exceed the hub's timeout).
+	health.DiskBytes = diskUsage(wsPath)
+
+	running, note := piProcessRunning()
+	health.Running = running
+	if note != "" {
+		health.Note = &note
+	}
+
+	// LastActivity: newest transcript mtime across the station's session dirs.
+	var newest time.Time
+	for _, dir := range sessionDirs {
+		if t := newestMtime(dir); t.After(newest) {
+			newest = t
+		}
+	}
+	if !newest.IsZero() {
+		s := newest.UTC().Format(time.RFC3339)
+		health.LastActivity = &s
+	}
+
+	return health, nil
 }
 
+// piEntryPaths returns the absolute paths a running Pi would carry in its
+// command line: the resolved `pi` executable, plus the symlink target when it
+// differs (npm installs `bin/pi` as a symlink to the package's dist/cli.js, and
+// which one lands in argv depends on how Pi was launched).
+//
+// Resolution order: PI_PATH, then `pi` on PATH. Nothing is hardcoded — the npm
+// prefix is routinely user-local (see piBinaryEnv).
+func piEntryPaths() []string {
+	path := os.Getenv(piBinaryEnv)
+	if path == "" {
+		resolved, err := exec.LookPath("pi")
+		if err != nil {
+			return nil
+		}
+		path = resolved
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	paths := []string{abs}
+	if real, err := filepath.EvalSymlinks(abs); err == nil && real != abs {
+		paths = append(paths, real)
+	}
+	return paths
+}
+
+// piProcessPattern builds the pgrep -f pattern that matches a live
+// `pi --mode rpc` process, and nothing else.
+//
+// Three properties, each paid for by a bug:
+//
+//  1. It matches on the RESOLVED ABSOLUTE PATH, never the bare word "pi",
+//     which occurs inside countless unrelated command lines.
+//
+//  2. It requires "--mode rpc" as well. `pgrep -x pi` cannot substitute:
+//     measured on macOS and on Linux (superchotu, 2026-08-12), Pi's `comm` is
+//     "node" — process.title = "pi" does not rewrite comm — so -x matches
+//     nothing and only -f can see the arguments.
+//
+//  3. It is ANCHORED, and allows the path only as the first or second token
+//     (the second covers the `node <pi> --mode rpc` form the shebang produces;
+//     comm is node, so that is the usual shape). This is what defeats the
+//     self-match hazard: `pgrep -f "dist/cli.js"` was observed matching the
+//     very shell that ran it, because that shell's own command line contained
+//     the pattern text. Any process that merely MENTIONS the Pi path — a pgrep
+//     caller, a grep, an editor, a debugging shell — carries it several tokens
+//     deep, past the anchor, so it cannot match. The same class of bug twice
+//     broke opencode health, where the broad "opencode" pattern matched
+//     docker-init's own cmdline and health could never report stopped.
+//
+// The cost is a false negative if Pi is ever launched under an interpreter
+// bearing its own flags (`node --flag <pi> --mode rpc`). That is the cheap
+// direction to be wrong for a daemonless harness whose resting state is
+// already "not running" — the expensive direction is reporting a station busy
+// when nothing is there.
+//
+// ok is false when no Pi executable can be resolved at all, which is not a
+// pattern this function may guess at.
+func piProcessPattern() (pattern string, ok bool) {
+	paths := piEntryPaths()
+	if len(paths) == 0 {
+		return "", false
+	}
+	quoted := make([]string, 0, len(paths))
+	for _, path := range paths {
+		// QuoteMeta's escapes (\. \+ \* \? \( \) \| \[ \] \{ \} \^ \$) are all
+		// valid POSIX ERE, which is the dialect pgrep compiles.
+		quoted = append(quoted, regexp.QuoteMeta(path))
+	}
+	// ^[optional interpreter token] <pi path> <anything> --mode rpc
+	return "^([^[:space:]]+[[:space:]]+)?(" + strings.Join(quoted, "|") +
+		")[[:space:]].*--mode[[:space:]=]+rpc", true
+}
+
+// piProcessRunning reports whether a `pi --mode rpc` process is alive.
+//
+// Best-effort by design. pgrep exiting 1 means "no match", which for Pi is the
+// ordinary resting state, so it returns false with NO note. A note is reserved
+// for the cases where the check genuinely could not run — pgrep missing, or no
+// Pi executable to build a safe pattern from.
+func piProcessRunning() (running bool, note string) {
+	pattern, ok := piProcessPattern()
+	if !ok {
+		return false, "process check unavailable (no pi executable found; set " + piBinaryEnv + ")"
+	}
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, "" // no match — normal for a daemonless harness
+		}
+		return false, "process check unavailable (pgrep not found or failed)"
+	}
+	return strings.TrimSpace(string(out)) != "", ""
+}
+
+// ListDir lists the directory at rel within the station's workspace.
+// Paths that escape the workspace via ".." are rejected.
 func (p *piDescriptor) ListDir(key, rel string) ([]FsEntry, error) {
-	return nil, fmt.Errorf("pi: ListDir %q: not implemented", key)
+	wsPath, err := p.workspaceForKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := safeJoin(wsPath, rel)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		return nil, fmt.Errorf("pi: ListDir %q: %w", target, err)
+	}
+
+	result := make([]FsEntry, 0, len(entries))
+	for _, entry := range entries {
+		fsEntry := FsEntry{
+			Name: entry.Name(),
+			Path: filepath.Join(rel, entry.Name()),
+		}
+		switch {
+		case entry.Type()&fs.ModeSymlink != 0:
+			fsEntry.Type = "symlink"
+		case entry.IsDir():
+			fsEntry.Type = "dir"
+		default:
+			fsEntry.Type = "file"
+			if info, err := entry.Info(); err == nil {
+				sz := info.Size()
+				fsEntry.Size = &sz
+				mod := info.ModTime().UTC().Format(time.RFC3339)
+				fsEntry.Modified = &mod
+			}
+		}
+		result = append(result, fsEntry)
+	}
+	return result, nil
 }
 
+// ReadFile reads up to maxBytes from rel within the station's workspace.
+// maxBytes+1 bytes are requested so that a file exactly filling the budget is
+// distinguishable from one that overflows it.
 func (p *piDescriptor) ReadFile(key, rel string, maxBytes int64) ([]byte, string, bool, error) {
-	return nil, "", false, fmt.Errorf("pi: ReadFile %q: not implemented", key)
+	wsPath, err := p.workspaceForKey(key)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	target, err := safeJoin(wsPath, rel)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBytes
+	}
+
+	f, err := os.Open(target)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("pi: ReadFile %q: %w", target, err)
+	}
+	defer f.Close()
+
+	buf := make([]byte, maxBytes+1)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return nil, "", false, fmt.Errorf("pi: ReadFile read %q: %w", target, err)
+	}
+
+	truncated := int64(n) > maxBytes
+	if truncated {
+		n = int(maxBytes)
+	}
+	return buf[:n], "", truncated, nil
 }
 
+// TailLogs emits <dataDir>/pi-debug.log, Pi's single global log file.
+//
+// The file is usually ABSENT (it is written only with the hidden /debug
+// enabled), which makes Pi the worst case for the 2026-08-09 dogfooding bug:
+// follow mode with zero log files returned immediately, the hub closed the
+// SSE, and the console's Logs tab retry-looped into "Disconnected". Follow mode
+// therefore blocks in waitForLogFiles until the file appears or ctx is done.
+// One-shot mode with no file emits nothing and returns nil — not an error.
 func (p *piDescriptor) TailLogs(ctx context.Context, key string, follow bool, emit func([]byte) error) error {
-	return fmt.Errorf("pi: TailLogs %q: not implemented", key)
+	// Validate the key resolves to a known station.
+	if _, err := p.workspaceForKey(key); err != nil {
+		return err
+	}
+
+	logPath := filepath.Join(p.dataDir, piDebugLogName)
+	collect := func() []string {
+		if info, err := os.Stat(logPath); err == nil && !info.IsDir() {
+			return []string{logPath}
+		}
+		return nil
+	}
+
+	if !follow {
+		return emitLastNLines(collect(), tailDefaultN, tailMaxBytes, emit)
+	}
+
+	logFiles := waitForLogFiles(ctx, collect)
+	if err := emitLastNLines(logFiles, tailDefaultN, tailMaxBytes, emit); err != nil {
+		return err
+	}
+
+	var offset int64
+	if info, err := os.Stat(logPath); err == nil {
+		offset = info.Size()
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			n, err := emitLogFileFrom(logPath, offset, emit)
+			if err != nil {
+				continue
+			}
+			offset += n
+		}
+	}
+}
+
+// CleanPlan returns the cleanable items for a Pi station.
+//
+// The candidate-directory list is deliberately EMPTY. Every other descriptor
+// names directories (".cache", "tmp", …) that were observed to be caches on a
+// real machine; no Pi cache directory has been. A guessed entry here is a path
+// the console invites a user to delete, so the list stays empty until an
+// observation justifies widening it — the honest plan is the one that offers
+// nothing rather than the one that offers a plausible-looking source
+// directory. cleanPlanCommon still offers *.log files at the workspace root,
+// which is its generic behaviour for all harnesses and not a Pi-specific
+// claim.
+func (p *piDescriptor) CleanPlan(key string) ([]CleanItem, error) {
+	wsPath, err := p.workspaceForKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return cleanPlanCommon(wsPath, nil)
+}
+
+// CleanApply removes selected cleanable paths from the Pi workspace. Paths are
+// re-jailed to the workspace AND intersected with the current plan, so an
+// off-plan path is silently skipped rather than removed.
+func (p *piDescriptor) CleanApply(key string, paths []string) (int64, error) {
+	wsPath, err := p.workspaceForKey(key)
+	if err != nil {
+		return 0, err
+	}
+	plan, err := p.CleanPlan(key)
+	if err != nil {
+		return 0, err
+	}
+	return cleanApplyCommon(wsPath, paths, plan)
 }

--- a/apps/node-agent/internal/descriptor/pi.go
+++ b/apps/node-agent/internal/descriptor/pi.go
@@ -1,0 +1,246 @@
+package descriptor
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// piDescriptor implements Descriptor for the Pi leaf harness
+// (@earendil-works/pi-coding-agent).
+//
+// Pi is a project-workspace harness with NO daemon: it is invoked per command,
+// so one install yields one station per workspace and "lifecycle" is never
+// advertised. The data-dir layout, read off a real Pi 0.84.1 install on
+// 2026-08-12 (see docs/superpowers/specs/2026-08-12-pi-harness-design.md):
+//
+//	~/.pi/agent/
+//	  auth.json           credentials (0600)
+//	  models-store.json   cached model catalogs (0600)
+//	  settings.json
+//	  bin/rg
+//	  sessions/
+//	    --Users-foo-Projects-research--/   <ts>_<uuid>.jsonl
+//	    --private-tmp--/                   (no .jsonl at all)
+//
+// Key format: "pi:<8-hex-char SHA256 prefix of the workspace path>", the same
+// scheme claude-code, codex and opencode use.
+//
+// Workspace discovery reads the FIRST LINE of a session's *.jsonl file and
+// takes its "cwd" field verbatim:
+//
+//	{"type":"session","version":3,"id":"…","timestamp":"…","cwd":"/Users/foo/Projects/research"}
+//
+// The sanitised directory name is NEVER decoded. Pi encodes a workspace by
+// replacing '/' with '-', so a real project named "idea-bank" becomes
+// "--Users-foo-Projects-idea-bank--" and decoding hyphens back to slashes
+// yields ".../idea/bank", a path that does not exist — the station would
+// disappear silently. That was observed live, not theorised, which is why the
+// decode path from opencode.go is deliberately not implemented here: a session
+// directory with no readable *.jsonl is SKIPPED rather than guessed at
+// (observed: `pi --mode rpc` creates the directory without writing a session).
+type piDescriptor struct {
+	dataDir    string // absolute path to ~/.pi/agent
+	sessionDir string // absolute path to the sessions directory
+}
+
+const (
+	// piDataDirEnv overrides the default Pi data directory.
+	piDataDirEnv = "PI_CODING_AGENT_DIR"
+
+	// piSessionDirEnv overrides the session directory independently of the
+	// data directory. Pi also allows --session-dir and a "sessionDir" key in
+	// settings.json; neither is read here, so a machine that moved its session
+	// directory through settings.json under-reports. That is accepted and
+	// documented rather than guessed at.
+	piSessionDirEnv = "PI_CODING_AGENT_SESSION_DIR"
+)
+
+// NewPi returns a Descriptor for the Pi harness.
+//
+// dataDir is the path to the Pi agent directory. An explicit value wins over
+// everything: it means "all of Pi's state lives here" and neither environment
+// override applies. When it is empty the default is PI_CODING_AGENT_DIR, or
+// $HOME/.pi/agent, with PI_CODING_AGENT_SESSION_DIR overriding the sessions
+// directory alone.
+func NewPi(dataDir string) Descriptor {
+	p := &piDescriptor{dataDir: dataDir}
+	if dataDir == "" {
+		p.dataDir = piDefaultDataDir()
+		p.sessionDir = os.Getenv(piSessionDirEnv)
+	}
+	if p.sessionDir == "" {
+		p.sessionDir = filepath.Join(p.dataDir, "sessions")
+	}
+	return p
+}
+
+// piDefaultDataDir returns PI_CODING_AGENT_DIR when set, else $HOME/.pi/agent.
+func piDefaultDataDir() string {
+	if dir := os.Getenv(piDataDirEnv); dir != "" {
+		return dir
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		userHome = "."
+	}
+	return filepath.Join(userHome, ".pi", "agent")
+}
+
+// Harness returns the harness identifier. It MUST equal the RuntimeHarness
+// enum value, or auto-adoption (which matches on harness string equality)
+// silently fails to match a provisioned runtime to its detected station.
+func (p *piDescriptor) Harness() string { return "pi" }
+
+// piProjectKey derives a stable station key from a workspace path.
+// Uses the first 4 bytes (8 hex chars) of SHA256(path), mirroring
+// openCodeProjectKey. The key is the hub's primary identity for a station and
+// cannot be changed after adoption.
+func piProjectKey(workspacePath string) string {
+	h := sha256.Sum256([]byte(workspacePath))
+	return fmt.Sprintf("pi:%x", h[:4])
+}
+
+// Detect discovers leaf stations for Pi, one per workspace.
+//
+// It enumerates <sessionDir>/*/ and reads each session's workspace path from
+// the first line of a *.jsonl file. Directories with no readable session file
+// are skipped; workspaces that no longer exist are filtered out; and resolved
+// paths are deduplicated through filepath.EvalSymlinks because Pi stores the
+// RESOLVED path (/tmp is recorded as /private/tmp).
+//
+// A missing data/session directory is not an error — it just means Pi has
+// never run here.
+func (p *piDescriptor) Detect() ([]Station, error) {
+	entries, err := os.ReadDir(p.sessionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Station{}, nil
+		}
+		return nil, fmt.Errorf("pi: listing %s: %w", p.sessionDir, err)
+	}
+
+	// "lifecycle" is NEVER advertised: Pi has no persistent process to stop or
+	// start, so this descriptor does not implement Lifecycle at all.
+	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup"}
+
+	seen := make(map[string]bool)
+	stations := []Station{}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		wsPath, ok := piWorkspaceFromSessionDir(filepath.Join(p.sessionDir, e.Name()))
+		if !ok {
+			continue // no readable session header — skip, never guess
+		}
+		if _, err := os.Stat(wsPath); err != nil {
+			continue // workspace deleted (or unreadable)
+		}
+		resolved, err := filepath.EvalSymlinks(wsPath)
+		if err != nil {
+			resolved = wsPath
+		}
+		if seen[resolved] {
+			continue
+		}
+		seen[resolved] = true
+
+		wsCopy := wsPath
+		stations = append(stations, Station{
+			Key:           piProjectKey(wsPath),
+			Harness:       "pi",
+			Kind:          "leaf",
+			DisplayName:   filepath.Base(wsPath),
+			ParentKey:     nil,
+			WorkspacePath: &wsCopy,
+			Capabilities:  AppendChangesetCap(caps, &wsCopy),
+			MatrixId:      nil,
+		})
+	}
+
+	return stations, nil
+}
+
+// piSessionHeader is the first line of a Pi session transcript. Only "cwd"
+// matters here, and it carries the workspace path verbatim.
+type piSessionHeader struct {
+	Type string `json:"type"`
+	Cwd  string `json:"cwd"`
+}
+
+// piHeaderMaxBytes bounds the first-line read. A session header is a short
+// single line; anything larger is not one, and reading it whole would let a
+// malformed transcript pull megabytes into memory during detection.
+const piHeaderMaxBytes = 1 << 20 // 1 MiB
+
+// piWorkspaceFromSessionDir returns the workspace path recorded in the first
+// line of a *.jsonl file inside dir. Files are tried in directory order until
+// one yields a non-empty "cwd"; ok is false when none does.
+func piWorkspaceFromSessionDir(dir string) (string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".jsonl") {
+			continue
+		}
+		if cwd, ok := piCwdFromSessionFile(filepath.Join(dir, e.Name())); ok {
+			return cwd, true
+		}
+	}
+	return "", false
+}
+
+// piCwdFromSessionFile reads the first line of path and returns its "cwd".
+func piCwdFromSessionFile(path string) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), piHeaderMaxBytes)
+	if !scanner.Scan() {
+		return "", false // empty file
+	}
+	var header piSessionHeader
+	if err := json.Unmarshal(scanner.Bytes(), &header); err != nil {
+		return "", false
+	}
+	if header.Cwd == "" {
+		return "", false
+	}
+	return header.Cwd, true
+}
+
+// --- Descriptor surface implemented in a later task ---
+//
+// Health, ListDir, ReadFile and TailLogs land with the rest of the station
+// capabilities; they are stubbed here only so piDescriptor satisfies
+// Descriptor. Detect does not advertise a capability these would serve before
+// they are real.
+
+func (p *piDescriptor) Health(key string) (Health, error) {
+	return Health{}, fmt.Errorf("pi: health %q: not implemented", key)
+}
+
+func (p *piDescriptor) ListDir(key, rel string) ([]FsEntry, error) {
+	return nil, fmt.Errorf("pi: ListDir %q: not implemented", key)
+}
+
+func (p *piDescriptor) ReadFile(key, rel string, maxBytes int64) ([]byte, string, bool, error) {
+	return nil, "", false, fmt.Errorf("pi: ReadFile %q: not implemented", key)
+}
+
+func (p *piDescriptor) TailLogs(ctx context.Context, key string, follow bool, emit func([]byte) error) error {
+	return fmt.Errorf("pi: TailLogs %q: not implemented", key)
+}

--- a/apps/node-agent/internal/descriptor/pi_acp_test.go
+++ b/apps/node-agent/internal/descriptor/pi_acp_test.go
@@ -1,0 +1,128 @@
+package descriptor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writePiACPStub drops an executable named pi-acp into a fresh directory and
+// makes that directory the whole of PATH. It returns the stub's path.
+func writePiACPStub(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir()
+	stub := filepath.Join(bin, piACPBinaryName)
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	return stub
+}
+
+// The Chat tab is gated on the "acp" capability alone, so advertising it
+// without the adapter installed buys a tab that fails the moment it is clicked.
+// No adapter must mean no capability — and an error that names what is missing.
+func TestPiACPCapabilityGatedOnAdapter(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	// No adapter on PATH → no acp capability, and a clear error rather than a
+	// Chat tab that fails when clicked.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv(piACPBinaryEnv, "")
+	stations, err := NewPi(dataDir).Detect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stations) == 0 {
+		t.Fatal("fixture produced no stations")
+	}
+	for _, c := range stations[0].Capabilities {
+		if c == "acp" {
+			t.Fatal("acp must not be advertised without the pi-acp adapter")
+		}
+	}
+	_, _, _, err = NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws))
+	if err == nil {
+		t.Fatal("ACPCommand should error when the adapter is absent")
+	}
+	if !strings.Contains(err.Error(), piACPBinaryName) {
+		t.Errorf("error %q should name %q so the console message is actionable", err, piACPBinaryName)
+	}
+}
+
+// The adapter is spawned directly: argv[0] is the resolved pi-acp, the working
+// directory is the station's workspace (the same one Files, Health and Cleanup
+// use), and nothing is added to the environment.
+func TestPiACPCommandUsesAdapterAndWorkspaceDir(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	stub := writePiACPStub(t)
+
+	argv, dir, env, err := NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(argv) == 0 || filepath.Base(argv[0]) != piACPBinaryName {
+		t.Errorf("argv = %v, want pi-acp first", argv)
+	}
+	if len(argv) != 1 {
+		t.Errorf("argv = %v, want exactly the adapter (it needs no arguments)", argv)
+	}
+	if argv[0] != stub {
+		t.Errorf("argv[0] = %q, want the resolved stub %q", argv[0], stub)
+	}
+	if dir != ws {
+		t.Errorf("dir = %q, want %q", dir, ws)
+	}
+	if env != nil {
+		t.Errorf("env = %v, want nil", env)
+	}
+	// Never npx: a network fetch on the first prompt of a session is a stall
+	// the operator cannot see the reason for.
+	if strings.Contains(filepath.Base(argv[0]), "npx") {
+		t.Errorf("argv %v must not shell out to npx on the request path", argv)
+	}
+}
+
+// The npm prefix is routinely user-local (/home/openclaw/.npm-global/bin on the
+// fleet host superchotu), which a service PATH commonly misses. PI_ACP_PATH is
+// the escape hatch, and it is used verbatim — the operator knows their layout.
+func TestPiACPCommandHonoursEnvOverride(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	t.Setenv("PATH", t.TempDir()) // nothing resolvable here
+	adapter := filepath.Join(t.TempDir(), "npm-global", "bin", "pi-acp")
+	t.Setenv(piACPBinaryEnv, adapter)
+
+	stations, err := NewPi(dataDir).Detect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var advertised bool
+	for _, c := range stations[0].Capabilities {
+		if c == "acp" {
+			advertised = true
+		}
+	}
+	if !advertised {
+		t.Errorf("acp must be advertised when %s names an adapter: %v", piACPBinaryEnv, stations[0].Capabilities)
+	}
+
+	argv, dir, _, err := NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(argv) == 0 || argv[0] != adapter {
+		t.Errorf("argv = %v, want the configured %q", argv, adapter)
+	}
+	if dir != ws {
+		t.Errorf("dir = %q, want %q", dir, ws)
+	}
+}
+
+func TestPiACPCommandUnknownKey(t *testing.T) {
+	dataDir, _ := buildPiFixture(t)
+	writePiACPStub(t)
+
+	if _, _, _, err := NewPi(dataDir).(ACPCommander).ACPCommand("pi:deadbeef"); err == nil {
+		t.Fatal("expected error for unknown station key")
+	}
+}

--- a/apps/node-agent/internal/descriptor/pi_test.go
+++ b/apps/node-agent/internal/descriptor/pi_test.go
@@ -1,0 +1,79 @@
+package descriptor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildPiFixture creates <tmp>/sessions/<encoded>/<ts>_<uuid>.jsonl files whose
+// first line carries the workspace path verbatim, plus a session dir with no
+// jsonl at all (observed live: `pi --mode rpc` creates the dir without a session).
+func buildPiFixture(t *testing.T) (dataDir string, wsHyphen string) {
+	t.Helper()
+	root := t.TempDir()
+	dataDir = filepath.Join(root, "agent")
+
+	// A real workspace whose name CONTAINS A HYPHEN. Decoding the directory
+	// name would yield ".../idea/bank", which does not exist — the station
+	// would vanish silently. This is the case that forces header parsing.
+	wsHyphen = filepath.Join(root, "Projects", "idea-bank")
+	if err := os.MkdirAll(wsHyphen, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePiSession(t, dataDir, "--"+strings.ReplaceAll(strings.TrimPrefix(wsHyphen, "/"), "/", "-")+"--", wsHyphen)
+
+	// A session dir with NO jsonl — must be skipped, never guessed at.
+	if err := os.MkdirAll(filepath.Join(dataDir, "sessions", "--private-tmp--"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A session whose workspace no longer exists — must be filtered out.
+	writePiSession(t, dataDir, "--gone--", filepath.Join(root, "deleted"))
+	return dataDir, wsHyphen
+}
+
+func writePiSession(t *testing.T, dataDir, encoded, cwd string) {
+	t.Helper()
+	dir := filepath.Join(dataDir, "sessions", encoded)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	header := fmt.Sprintf(`{"type":"session","version":3,"id":"x","timestamp":"2026-08-12T08:10:23.796Z","cwd":%q}`, cwd)
+	if err := os.WriteFile(filepath.Join(dir, "2026-08-12T08-10-23-796Z_uuid.jsonl"), []byte(header+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPiDetectReadsWorkspaceFromSessionHeader(t *testing.T) {
+	dataDir, wsHyphen := buildPiFixture(t)
+	stations, err := NewPi(dataDir).Detect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("want 1 station, got %d: %+v", len(stations), stations)
+	}
+	s := stations[0]
+	if s.WorkspacePath == nil || *s.WorkspacePath != wsHyphen {
+		t.Errorf("workspace = %v, want %s (a hyphenated path must survive)", s.WorkspacePath, wsHyphen)
+	}
+	if s.Harness != "pi" {
+		t.Errorf("harness = %q, want pi", s.Harness)
+	}
+	if s.Key != piProjectKey(wsHyphen) {
+		t.Errorf("key = %q", s.Key)
+	}
+}
+
+func TestPiDetectMissingDataDirReturnsEmpty(t *testing.T) {
+	stations, err := NewPi(filepath.Join(t.TempDir(), "nope")).Detect()
+	if err != nil {
+		t.Fatalf("missing data dir must not error: %v", err)
+	}
+	if len(stations) != 0 {
+		t.Errorf("want empty, got %+v", stations)
+	}
+}

--- a/apps/node-agent/internal/descriptor/pi_test.go
+++ b/apps/node-agent/internal/descriptor/pi_test.go
@@ -1,11 +1,15 @@
 package descriptor
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // buildPiFixture creates <tmp>/sessions/<encoded>/<ts>_<uuid>.jsonl files whose
@@ -75,5 +79,350 @@ func TestPiDetectMissingDataDirReturnsEmpty(t *testing.T) {
 	}
 	if len(stations) != 0 {
 		t.Errorf("want empty, got %+v", stations)
+	}
+}
+
+// piDescriptor must satisfy Cleaner, or Detect's "cleanup" capability is a lie
+// (the gateway advertises cleanup only for descriptors implementing Cleaner).
+var _ Cleaner = (*piDescriptor)(nil)
+
+// fakePiBinary writes an executable file that looks like a Pi entrypoint and
+// returns its path. Nothing is spawned from it, so a health check pointed at
+// it must report Running=false — which makes every health test hermetic on a
+// developer machine that happens to have a real Pi session open.
+func fakePiBinary(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "pi")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// spawnPiStub copies THIS test binary to path and runs it with args, giving
+// pgrep a real process with a real command line to match. The copy re-execs
+// into the sleep branch of TestMain (claudecode_test.go — a package may only
+// have one, so Pi's stubs reuse it rather than declaring another).
+//
+// Copying /bin/sleep is not an option: macOS SIGKILLs relocated platform
+// binaries. The child is killed AND reaped on cleanup — an unreaped zombie
+// would leak into the other pgrep-based tests in this package.
+func spawnPiStub(t *testing.T, path string, args ...string) {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := os.ReadFile(self)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(path, args...)
+	cmd.Env = append(os.Environ(), "CLAUDE_STUB_SLEEP=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	// Give the stub a moment to exec before pgrep looks for it.
+	time.Sleep(300 * time.Millisecond)
+}
+
+func TestPiHealthNoProcessIsNotAnError(t *testing.T) {
+	t.Setenv(piBinaryEnv, fakePiBinary(t))
+	dataDir, ws := buildPiFixture(t)
+	h, err := NewPi(dataDir).Health(piProjectKey(ws))
+	if err != nil {
+		t.Fatalf("health must not error when Pi is not running: %v", err)
+	}
+	if h.Running {
+		t.Error("Running should be false with no pi process")
+	}
+	// pgrep exit 1 means "no match", which is the NORMAL state for a daemonless
+	// harness — it must not surface as a health note.
+	if h.Note != nil {
+		t.Errorf("Note = %q, want none: no matching process is not a fault", *h.Note)
+	}
+}
+
+func TestPiHealthReportsLastActivityFromSessionDir(t *testing.T) {
+	t.Setenv(piBinaryEnv, fakePiBinary(t))
+	dataDir, ws := buildPiFixture(t)
+	h, err := NewPi(dataDir).Health(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.LastActivity == nil {
+		t.Fatal("LastActivity is nil: the station's session dir has a transcript in it")
+	}
+	if _, err := time.Parse(time.RFC3339, *h.LastActivity); err != nil {
+		t.Errorf("LastActivity = %q, want RFC3339: %v", *h.LastActivity, err)
+	}
+}
+
+// TestPiHealthDetectsRpcProcess is the positive half of the pgrep pattern
+// contract: a real process whose command line is "<pi path> --mode rpc" must
+// be seen. Without it, the negative test below could be satisfied by a pattern
+// that matches nothing at all.
+func TestPiHealthDetectsRpcProcess(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	piPath := filepath.Join(t.TempDir(), "bin", "pi")
+	spawnPiStub(t, piPath, "--mode", "rpc")
+	t.Setenv(piBinaryEnv, piPath)
+
+	h, err := NewPi(dataDir).Health(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !h.Running {
+		note := ""
+		if h.Note != nil {
+			note = *h.Note
+		}
+		t.Fatalf("Running = false with `%s --mode rpc` alive (note=%q)", piPath, note)
+	}
+}
+
+// TestPiHealthIgnoresProcessMerelyMentioningPi is the self-match regression.
+//
+// Observed live on 2026-08-12: `pgrep -f "dist/cli.js"` matched the shell
+// running it, because that shell's own command line contained the pattern
+// text. This test reproduces exactly that shape — a process that is NOT Pi but
+// whose command line carries the Pi entry path AND "--mode rpc" as arguments,
+// as any pgrep caller, ps grep or debugging shell would. It is the same class
+// of bug that twice broke opencode health (the broad "opencode" pattern
+// matching docker-init's cmdline).
+func TestPiHealthIgnoresProcessMerelyMentioningPi(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	piPath := fakePiBinary(t)
+	// argv: <stub> -f <piPath> --mode rpc  — i.e. what our own process check
+	// looks like from the outside. Nothing here is a Pi process.
+	spawnPiStub(t, filepath.Join(t.TempDir(), "pgrep-caller"), "-f", piPath, "--mode", "rpc")
+	t.Setenv(piBinaryEnv, piPath)
+
+	h, err := NewPi(dataDir).Health(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Running {
+		t.Fatal("Running = true for a process that merely mentions the Pi path in its arguments")
+	}
+}
+
+func TestPiHealthUnknownKeyErrors(t *testing.T) {
+	dataDir, _ := buildPiFixture(t)
+	if _, err := NewPi(dataDir).Health("pi:deadbeef"); err == nil {
+		t.Error("expected an error for an unknown station key")
+	}
+}
+
+func TestPiListDirRejectsEscape(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	if _, err := NewPi(dataDir).ListDir(piProjectKey(ws), "../.."); err == nil {
+		t.Error("expected .. escape to be rejected")
+	}
+}
+
+func TestPiListDirListsWorkspace(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	if err := os.WriteFile(filepath.Join(ws, "notes.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(ws, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := NewPi(dataDir).ListDir(piProjectKey(ws), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kinds := map[string]string{}
+	for _, e := range entries {
+		kinds[e.Name] = e.Type
+	}
+	if kinds["notes.md"] != "file" {
+		t.Errorf("notes.md type = %q, want file", kinds["notes.md"])
+	}
+	if kinds["src"] != "dir" {
+		t.Errorf("src type = %q, want dir", kinds["src"])
+	}
+}
+
+func TestPiReadFileTruncatesAtMaxBytes(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	content := bytes.Repeat([]byte("x"), 100)
+	if err := os.WriteFile(filepath.Join(ws, "big.txt"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := NewPi(dataDir)
+
+	got, _, truncated, err := p.ReadFile(piProjectKey(ws), "big.txt", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Error("truncated = false for a 100-byte file read with maxBytes=10")
+	}
+	if len(got) != 10 {
+		t.Errorf("read %d bytes, want 10", len(got))
+	}
+
+	got, _, truncated, err = p.ReadFile(piProjectKey(ws), "big.txt", 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated || len(got) != 100 {
+		t.Errorf("full read: got %d bytes truncated=%v, want 100 false", len(got), truncated)
+	}
+}
+
+func TestPiReadFileRejectsEscape(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	if _, _, _, err := NewPi(dataDir).ReadFile(piProjectKey(ws), "../../etc/passwd", 100); err == nil {
+		t.Error("expected .. escape to be rejected")
+	}
+}
+
+func TestPiTailLogsWithNoLogFileDoesNotError(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	err := NewPi(dataDir).TailLogs(context.Background(), piProjectKey(ws), false, func([]byte) error { return nil })
+	if err != nil {
+		t.Fatalf("absent pi-debug.log must not error: %v", err)
+	}
+}
+
+func TestPiTailLogsEmitsDebugLog(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "pi-debug.log"), []byte("line one\nline two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var got bytes.Buffer
+	err := NewPi(dataDir).TailLogs(context.Background(), piProjectKey(ws), false, func(b []byte) error {
+		got.Write(b)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.String(), "line two") {
+		t.Errorf("emitted %q, want the contents of pi-debug.log", got.String())
+	}
+}
+
+// TestPiTailLogsFollowWaitsForLogFile guards the 2026-08-09 dogfooding bug:
+// follow mode with zero log files used to return immediately, the hub closed
+// the SSE, and the console's Logs tab retry-looped into "Disconnected". Pi is
+// the worst case for this — pi-debug.log only exists once the hidden /debug is
+// enabled, so it is absent on nearly every station.
+func TestPiTailLogsFollowWaitsForLogFile(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- NewPi(dataDir).TailLogs(ctx, piProjectKey(ws), true, func([]byte) error { return nil })
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("follow mode returned immediately with no log file (err=%v)", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("follow mode returned %v after cancel, want nil", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("follow mode did not return after ctx cancel")
+	}
+}
+
+func TestPiTailLogsUnknownKeyErrors(t *testing.T) {
+	dataDir, _ := buildPiFixture(t)
+	err := NewPi(dataDir).TailLogs(context.Background(), "pi:deadbeef", false, func([]byte) error { return nil })
+	if err == nil {
+		t.Error("expected an error for an unknown station key")
+	}
+}
+
+// TestPiCleanPlanClaimsOnlyVerifiedPaths pins the deliberate decision that no
+// Pi cache directory has been verified on a real machine, so none is offered.
+// A guessed entry here is a path the console would invite a user to DELETE.
+// Widening the list is fine — but only with an observation to back it up, and
+// this test is where that evidence gets recorded.
+func TestPiCleanPlanClaimsOnlyVerifiedPaths(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	// A plausible-looking but UNVERIFIED directory, plus a root *.log file
+	// (which cleanPlanCommon offers for every harness).
+	if err := os.MkdirAll(filepath.Join(ws, ".pi", "cache"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "build.log"), []byte("noise\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner, ok := NewPi(dataDir).(Cleaner)
+	if !ok {
+		t.Fatal("piDescriptor does not implement Cleaner")
+	}
+	plan, err := cleaner.CleanPlan(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range plan {
+		if !strings.HasSuffix(strings.ToLower(item.Path), ".log") {
+			t.Errorf("CleanPlan offers %q, which is not a verified-cleanable path", item.Path)
+		}
+	}
+	found := false
+	for _, item := range plan {
+		if item.Path == "build.log" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("CleanPlan = %+v, want the root build.log", plan)
+	}
+}
+
+// TestPiCleanApplyRefusesOffPlanPaths checks the second safety of
+// cleanApplyCommon: a path the plan never offered is never removed, even when
+// it exists and is inside the workspace.
+func TestPiCleanApplyRefusesOffPlanPaths(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	src := filepath.Join(ws, "main.go")
+	if err := os.WriteFile(src, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(ws, "build.log")
+	if err := os.WriteFile(logFile, []byte("noise\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner := NewPi(dataDir).(Cleaner)
+	if _, err := cleaner.CleanApply(piProjectKey(ws), []string{"main.go", "../escape", "build.log"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Errorf("CleanApply removed an off-plan source file: %v", err)
+	}
+	if _, err := os.Stat(logFile); !os.IsNotExist(err) {
+		t.Errorf("build.log survived CleanApply (err=%v)", err)
 	}
 }

--- a/apps/node-agent/internal/posture/creds.go
+++ b/apps/node-agent/internal/posture/creds.go
@@ -55,6 +55,21 @@ var CredentialPaths = map[string][]string{
 
 	// This Mac 2026-08-11: present, 600.
 	"opencode": {".local/share/opencode/auth.json"},
+
+	// This Mac 2026-08-12, Pi 0.84.1: ~/.pi/agent held auth.json (mode 600, API
+	// keys and OAuth tokens) and models-store.json (mode 600, cached model
+	// catalogs), alongside settings.json (mode 644), bin/ and sessions/.
+	// settings.json is not a credential file and is deliberately not listed.
+	// models.json was ABSENT — Pi writes it on demand — but it is listed because
+	// a custom provider definition puts literal API keys in it; an absent path is
+	// silent, so listing it costs nothing and catches the machine that has one.
+	// trust.json, which Pi's docs also mention, holds trust decisions rather than
+	// secrets and is not listed.
+	"pi": {
+		".pi/agent/auth.json",
+		".pi/agent/models-store.json",
+		".pi/agent/models.json",
+	},
 }
 
 // KnownHarnesses returns every harness this package can check credentials for.

--- a/apps/node-agent/internal/posture/posture_test.go
+++ b/apps/node-agent/internal/posture/posture_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -257,6 +258,31 @@ func TestCredentialPathsDropTheFilesThatNeverExisted(t *testing.T) {
 			if slices.Contains(CredentialPaths[harness], p) {
 				t.Errorf("%s: %q does not exist on any real machine and must be removed", harness, p)
 			}
+		}
+	}
+}
+
+// Verified against a live Pi 0.84.1 install on 2026-08-12: ~/.pi/agent held
+// auth.json (0600), models-store.json (0600) and settings.json (0644), plus
+// bin/ and sessions/. settings.json is not a credential file and is not listed;
+// models.json was absent but is listed because it holds literal API keys once a
+// custom provider is defined.
+func TestPiCredentialPathsMatchRealLayout(t *testing.T) {
+	got := CredentialPaths["pi"]
+	want := []string{".pi/agent/auth.json", ".pi/agent/models-store.json", ".pi/agent/models.json"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPiCredentialPathsDropFilesThatNeverExisted(t *testing.T) {
+	// trust.json is documented by Pi but is created on demand and was absent on
+	// the machine observed 2026-08-12. It records trust decisions, not secrets.
+	// Naming files that do not exist is how the scanner once graded a machine
+	// "A" without opening anything.
+	for _, p := range CredentialPaths["pi"] {
+		if strings.Contains(p, "trust.json") {
+			t.Errorf("trust.json must not be listed: %s", p)
 		}
 	}
 }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -80,6 +80,12 @@ docker build \
   -t agentpod-node-opencode:local \
   -f apps/node-agent/deploy/Dockerfile.opencode \
   apps/node-agent
+
+# Pi harness image (Node 24 + @earendil-works/pi-coding-agent@0.84.1 + pi-acp@0.0.33)
+docker build \
+  -t agentpod-node-pi:local \
+  -f apps/node-agent/deploy/Dockerfile.pi \
+  apps/node-agent
 ```
 
 Verify: `docker images | grep agentpod-node`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,18 +56,26 @@ Tune for a shared box (optional): set `shared_buffers = 256MB` in `/etc/postgres
 
 ## 3. Build the node-agent Docker images
 
-Build both images on the Docker host from the repo root. The context path is `apps/node-agent`; the Dockerfiles live in `apps/node-agent/deploy/`.
+Build the images on the Docker host from the repo root. The context path is `apps/node-agent`; the Dockerfiles live in `apps/node-agent/deploy/`.
+
+`Dockerfile.base` carries everything shared — the Go build stage, the runtime distro, `ca-certificates curl git procps`, and the `agentpod-node` binary — and every harness image is `FROM agentpod-node:base`. **Build the base first**, or the harness builds fail to resolve their `FROM`. Rebuild it (and then the harness images) whenever the node-agent source changes.
 
 ```bash
 cd /opt/agentpod
 
-# Base node-agent image (no harness preloaded)
+# Shared base image — build this first
+docker build \
+  -t agentpod-node:base \
+  -f apps/node-agent/deploy/Dockerfile.base \
+  apps/node-agent
+
+# Generic node-agent image (no harness preloaded)
 docker build \
   -t agentpod-node:local \
   -f apps/node-agent/deploy/Dockerfile \
   apps/node-agent
 
-# OpenCode harness image (bun + opencode-ai@0.5.5 preloaded)
+# OpenCode harness image (bun + opencode-ai@1.18.15 preloaded)
 docker build \
   -t agentpod-node-opencode:local \
   -f apps/node-agent/deploy/Dockerfile.opencode \

--- a/docs/superpowers/plans/2026-08-12-pi-harness.md
+++ b/docs/superpowers/plans/2026-08-12-pi-harness.md
@@ -1,0 +1,449 @@
+# Pi Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Pi as the sixth harness — detected on enrolled machines, conversable via the Chat tab, and provisionable as a container image.
+
+**Architecture:** A new Go descriptor (`pi.go`) discovers stations by enumerating `~/.pi/agent/sessions/*/` and reading each session file's header for the workspace path *verbatim*. Chat goes through the pinned `pi-acp` adapter, with the `acp` capability gated on that adapter resolving. Container images are refactored to a shared base plus thin per-harness layers, and Pi's layer needs no supervision loop because Pi has no daemon.
+
+**Tech Stack:** Go 1.26 (node-agent), Bun + Hono + Drizzle (hub), Svelte 5 (console), Docker, zod 4 (contract).
+
+**Spec:** `docs/superpowers/specs/2026-08-12-pi-harness-design.md` — read it first. Every design decision and its evidence lives there.
+
+## Global Constraints
+
+- Pi version pinned: `@earendil-works/pi-coding-agent@0.84.1`. Adapter pinned: `pi-acp@0.0.33`.
+- Pi requires **Node ≥ 22.19**; the image uses `node:24-bookworm-slim`.
+- `Harness()` returns exactly `"pi"` and **must** equal the `RuntimeHarness` enum value, or auto-adoption silently fails to match.
+- Station key format: `pi:<first 8 hex chars of SHA256(workspacePath)>`.
+- `lifecycle` is **never** advertised and `Lifecycle` is **not** implemented — Pi has no daemon.
+- Every external path added to `creds.go` carries a dated observation comment. Paths are verified on a real machine, never taken from documentation.
+- TDD: failing test first, every time. Never weaken a test to get green.
+- Run the FULL command set after the LAST edit, not before it: node-agent `go test -race ./...`; hub `DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test`; console `pnpm check && pnpm test && pnpm build`.
+
+---
+
+### Task 1: Container base image refactor
+
+Do this FIRST and alone. It touches the working OpenCode image, and Pi must not be what discovers a regression in it.
+
+**Files:**
+- Create: `apps/node-agent/deploy/Dockerfile.base`
+- Modify: `apps/node-agent/deploy/Dockerfile`, `apps/node-agent/deploy/Dockerfile.opencode`
+- Modify: `docs/DEPLOYMENT.md` (build commands, section 3)
+
+**Interfaces:**
+- Produces: an image tagged `agentpod-node:base` carrying the built `agentpod-node` binary at `/agentpod-node` and `ca-certificates`, `curl`, `git`, `procps`.
+
+- [ ] **Step 1: Read the two existing Dockerfiles completely** before changing anything, and note which lines are harness-specific versus shared.
+
+- [ ] **Step 2: Create `Dockerfile.base`** with everything shared: the Go build stage, the runtime base, `ca-certificates curl git procps`, and the binary at `/agentpod-node`. Do **not** set an `ENTRYPOINT` — layers set their own.
+
+- [ ] **Step 3: Rewrite `Dockerfile` and `Dockerfile.opencode` as `FROM agentpod-node:base`**, keeping only their harness-specific lines. `Dockerfile.opencode` keeps bun, `opencode-ai@1.18.15`, the deliberate omission of `sqlite3`, and its existing entrypoint unchanged.
+
+- [ ] **Step 4: Build all three images**
+
+```bash
+cd /Users/rakeshgangwar/Projects/agentpod
+docker build -f apps/node-agent/deploy/Dockerfile.base     -t agentpod-node:base           apps/node-agent
+docker build -f apps/node-agent/deploy/Dockerfile          -t agentpod-node:local          apps/node-agent
+docker build -f apps/node-agent/deploy/Dockerfile.opencode -t agentpod-node-opencode:local apps/node-agent
+```
+Expected: all three succeed.
+
+- [ ] **Step 5: Verify the OpenCode entrypoint is byte-identical** (the Cloudflare parity test depends on this file being untouched)
+
+```bash
+cd cloudflare/worker-v2 && npx vitest run test/entrypoint-parity.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 6: Verify the rebuilt OpenCode image still enrols.** Provision an OpenCode runtime against the local hub, confirm the station is adopted, then destroy it. **This is the gate for the whole task** — if it fails, stop and fix before Task 2.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/node-agent/deploy docs/DEPLOYMENT.md
+git commit -m "refactor(images): shared base image with per-harness layers"
+```
+
+---
+
+### Task 2: Pi descriptor — Detect
+
+**Files:**
+- Create: `apps/node-agent/internal/descriptor/pi.go`, `apps/node-agent/internal/descriptor/pi_test.go`
+
+**Interfaces:**
+- Produces: `func NewPi(dataDir string) Descriptor` (empty `dataDir` → `$HOME/.pi/agent`, honouring `PI_CODING_AGENT_DIR`); `piProjectKey(path string) string`; type `piDescriptor` with `Harness() string` returning `"pi"`.
+
+- [ ] **Step 1: Write the failing test.** Build a fixture mirroring the real layout observed on 2026-08-12, including the two cases that matter:
+
+```go
+// buildPiFixture creates <tmp>/sessions/<encoded>/<ts>_<uuid>.jsonl files whose
+// first line carries the workspace path verbatim, plus a session dir with no
+// jsonl at all (observed live: `pi --mode rpc` creates the dir without a session).
+func buildPiFixture(t *testing.T) (dataDir string, wsHyphen string) {
+	t.Helper()
+	root := t.TempDir()
+	dataDir = filepath.Join(root, "agent")
+
+	// A real workspace whose name CONTAINS A HYPHEN. Decoding the directory
+	// name would yield ".../idea/bank", which does not exist — the station
+	// would vanish silently. This is the case that forces header parsing.
+	wsHyphen = filepath.Join(root, "Projects", "idea-bank")
+	if err := os.MkdirAll(wsHyphen, 0o755); err != nil { t.Fatal(err) }
+	writePiSession(t, dataDir, "--"+strings.ReplaceAll(strings.TrimPrefix(wsHyphen, "/"), "/", "-")+"--", wsHyphen)
+
+	// A session dir with NO jsonl — must be skipped, never guessed at.
+	if err := os.MkdirAll(filepath.Join(dataDir, "sessions", "--private-tmp--"), 0o755); err != nil { t.Fatal(err) }
+
+	// A session whose workspace no longer exists — must be filtered out.
+	writePiSession(t, dataDir, "--gone--", filepath.Join(root, "deleted"))
+	return dataDir, wsHyphen
+}
+
+func writePiSession(t *testing.T, dataDir, encoded, cwd string) {
+	t.Helper()
+	dir := filepath.Join(dataDir, "sessions", encoded)
+	if err := os.MkdirAll(dir, 0o755); err != nil { t.Fatal(err) }
+	header := fmt.Sprintf(`{"type":"session","version":3,"id":"x","timestamp":"2026-08-12T08:10:23.796Z","cwd":%q}`, cwd)
+	if err := os.WriteFile(filepath.Join(dir, "2026-08-12T08-10-23-796Z_uuid.jsonl"), []byte(header+"\n"), 0o644); err != nil { t.Fatal(err) }
+}
+
+func TestPiDetectReadsWorkspaceFromSessionHeader(t *testing.T) {
+	dataDir, wsHyphen := buildPiFixture(t)
+	stations, err := NewPi(dataDir).Detect()
+	if err != nil { t.Fatal(err) }
+	if len(stations) != 1 {
+		t.Fatalf("want 1 station, got %d: %+v", len(stations), stations)
+	}
+	s := stations[0]
+	if s.WorkspacePath == nil || *s.WorkspacePath != wsHyphen {
+		t.Errorf("workspace = %v, want %s (a hyphenated path must survive)", s.WorkspacePath, wsHyphen)
+	}
+	if s.Harness != "pi" { t.Errorf("harness = %q, want pi", s.Harness) }
+	if s.Key != piProjectKey(wsHyphen) { t.Errorf("key = %q", s.Key) }
+}
+
+func TestPiDetectMissingDataDirReturnsEmpty(t *testing.T) {
+	stations, err := NewPi(filepath.Join(t.TempDir(), "nope")).Detect()
+	if err != nil { t.Fatalf("missing data dir must not error: %v", err) }
+	if len(stations) != 0 { t.Errorf("want empty, got %+v", stations) }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd apps/node-agent && go test ./internal/descriptor/ -run TestPiDetect -v`
+Expected: FAIL — `undefined: NewPi`.
+
+- [ ] **Step 3: Implement `pi.go`** — `NewPi`, `piProjectKey` (SHA256 prefix, mirroring `openCodeProjectKey`), and `Detect`: stat `<dataDir>/sessions`, return `[]Station{}` when absent; for each subdirectory read the first line of the first `*.jsonl`, `json.Unmarshal` it, take `cwd`; skip dirs with no readable jsonl; skip paths that no longer exist; dedupe via `filepath.EvalSymlinks`. Capabilities: `[]string{"health","logs","fs.read","fs.write","terminal","cleanup"}` wrapped in `AppendChangesetCap(caps, &wsCopy)`. **Do not** add `acp` yet (Task 4) and **never** add `lifecycle`.
+
+- [ ] **Step 4: Run the test again**
+
+Run: `cd apps/node-agent && go test ./internal/descriptor/ -run TestPiDetect -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/node-agent/internal/descriptor/pi.go apps/node-agent/internal/descriptor/pi_test.go
+git commit -m "feat(node-agent): Pi descriptor detection via session headers"
+```
+
+---
+
+### Task 3: Pi descriptor — Health, fs, logs, cleanup
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/pi.go`, `apps/node-agent/internal/descriptor/pi_test.go`
+
+**Interfaces:**
+- Consumes: `NewPi`, `piProjectKey` from Task 2.
+- Produces: `Health`, `ListDir`, `ReadFile`, `TailLogs`, `CleanPlan`, `CleanApply` on `piDescriptor` — satisfying the full `Descriptor` interface plus `Cleaner`.
+
+- [ ] **Step 1: Write the failing tests** — health returns without error and `Running=false` when no Pi process exists (that is correct, not a fault); `ListDir` rejects `..` escape; `ReadFile` truncates at `maxBytes`; `TailLogs` with no log file returns without error in one-shot mode.
+
+```go
+func TestPiHealthNoProcessIsNotAnError(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	h, err := NewPi(dataDir).Health(piProjectKey(ws))
+	if err != nil { t.Fatalf("health must not error when Pi is not running: %v", err) }
+	if h.Running { t.Error("Running should be false with no pi process") }
+}
+
+func TestPiListDirRejectsEscape(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	if _, err := NewPi(dataDir).ListDir(piProjectKey(ws), "../.."); err == nil {
+		t.Error("expected .. escape to be rejected")
+	}
+}
+
+func TestPiTailLogsWithNoLogFileDoesNotError(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	err := NewPi(dataDir).TailLogs(context.Background(), piProjectKey(ws), false, func([]byte) error { return nil })
+	if err != nil { t.Fatalf("absent pi-debug.log must not error: %v", err) }
+}
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd apps/node-agent && go test ./internal/descriptor/ -run TestPi -v`
+Expected: FAIL — methods undefined.
+
+- [ ] **Step 3: Implement.** `ListDir`/`ReadFile` via `safeJoin`, copied in shape from `opencode.go:484-559`. `CleanPlan`/`CleanApply` via `cleanPlanCommon(projPath, []string{".pi/cache"})` — verify that directory is genuinely cache on a real machine before widening the list. `TailLogs` reads `<dataDir>/pi-debug.log` using the shared `emitLastNLines` / `waitForLogFiles` helpers from `tail.go`. `Health`: `DiskBytes` from `diskUsage(projPath)`, `LastActivity` from `newestMtime` over the station's session dir, `Running` from `pgrep -f` matching the **resolved Pi entry path plus `--mode rpc`** — never the bare string `pi`. On `exec.ExitError` code 1 return `false` with no note (no match is not an error).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/node-agent && go test -race ./internal/descriptor/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/node-agent/internal/descriptor/
+git commit -m "feat(node-agent): Pi health, fs, logs and cleanup"
+```
+
+---
+
+### Task 4: ACP via the pinned pi-acp adapter
+
+**Files:**
+- Modify: `apps/node-agent/internal/descriptor/pi.go`
+- Create: `apps/node-agent/internal/descriptor/pi_acp_test.go`
+- Modify: `apps/node-agent/internal/descriptor/acp_command_test.go` (add the sixth subtest)
+
+**Interfaces:**
+- Consumes: `NewPi` from Task 2.
+- Produces: `ACPCommand(key string) (argv []string, dir string, env []string, err error)` on `piDescriptor`.
+
+- [ ] **Step 1: Read `claudecode.go` and `codex.go` ACPCommand plus `binary.go` completely.** They already solve adapter resolution with a version floor; follow their pattern rather than inventing one.
+
+- [ ] **Step 2: Write the failing test** — `acp` is advertised only when the adapter resolves, and `ACPCommand` returns the adapter argv with the workspace as cwd:
+
+```go
+func TestPiACPCapabilityGatedOnAdapter(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	// No adapter on PATH → no acp capability, and a clear error rather than a
+	// Chat tab that fails when clicked.
+	t.Setenv("PATH", t.TempDir())
+	stations, err := NewPi(dataDir).Detect()
+	if err != nil { t.Fatal(err) }
+	for _, c := range stations[0].Capabilities {
+		if c == "acp" { t.Fatal("acp must not be advertised without the pi-acp adapter") }
+	}
+	if _, _, _, err := NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws)); err == nil {
+		t.Error("ACPCommand should error when the adapter is absent")
+	}
+}
+
+func TestPiACPCommandUsesAdapterAndWorkspaceDir(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	bin := t.TempDir()
+	stub := filepath.Join(bin, "pi-acp")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { t.Fatal(err) }
+	t.Setenv("PATH", bin)
+
+	argv, dir, _, err := NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws))
+	if err != nil { t.Fatal(err) }
+	if len(argv) == 0 || filepath.Base(argv[0]) != "pi-acp" { t.Errorf("argv = %v, want pi-acp first", argv) }
+	if dir != ws { t.Errorf("dir = %q, want %q", dir, ws) }
+}
+```
+
+- [ ] **Step 3: Run and confirm failure**
+
+Run: `cd apps/node-agent && go test ./internal/descriptor/ -run TestPiACP -v`
+Expected: FAIL — `ACPCommand` undefined.
+
+- [ ] **Step 4: Implement.** Resolve `pi-acp` on `PATH` (honouring a `PI_ACP_PATH` override, mirroring `CODEX_PATH`). Add `"acp"` to the capability slice in `Detect` **only** when resolution succeeds. `ACPCommand` returns `[]string{resolvedPath}`, `dir` = workspace, `env` = nil, and a descriptive error when unresolved.
+
+- [ ] **Step 5: Add the sixth conformance subtest** in `acp_command_test.go` — but note it asserts every fixture station carries `acp`, so the Pi subtest must place a `pi-acp` stub on `PATH` first.
+
+- [ ] **Step 6: Run the full descriptor suite**
+
+Run: `cd apps/node-agent && go test -race ./internal/descriptor/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/node-agent/internal/descriptor/
+git commit -m "feat(node-agent): Pi ACP via the pinned pi-acp adapter, capability-gated"
+```
+
+---
+
+### Task 5: Registry wiring and posture
+
+**Files:**
+- Modify: `apps/node-agent/cmd/agentpod-node/registry.go:28` (after the OpenCode registration)
+- Modify: `apps/node-agent/internal/posture/creds.go:29`
+- Modify: `apps/node-agent/internal/posture/posture_test.go`
+
+**Interfaces:**
+- Consumes: `descriptor.NewPi` from Task 2.
+
+- [ ] **Step 1: Register the descriptor** — add `reg.Register(descriptor.NewPi(""))` to `buildRegistry`.
+
+- [ ] **Step 2: Write the failing posture test** asserting the Pi entry lists exactly the files observed on a real machine, and that the two files Pi's docs mention but that do not exist are absent:
+
+```go
+func TestPiCredentialPathsMatchRealLayout(t *testing.T) {
+	got := CredentialPaths["pi"]
+	want := []string{".pi/agent/auth.json", ".pi/agent/models-store.json", ".pi/agent/models.json"}
+	if !reflect.DeepEqual(got, want) { t.Errorf("got %v, want %v", got, want) }
+}
+
+func TestPiCredentialPathsDropFilesThatNeverExisted(t *testing.T) {
+	// trust.json is documented by Pi but is created on demand and was absent on
+	// the machine observed 2026-08-12. Naming files that do not exist is how the
+	// scanner once graded a machine "A" without opening anything.
+	for _, p := range CredentialPaths["pi"] {
+		if strings.Contains(p, "trust.json") { t.Errorf("trust.json must not be listed: %s", p) }
+	}
+}
+```
+
+- [ ] **Step 3: Run and confirm failure**
+
+Run: `cd apps/node-agent && go test ./internal/posture/ -run TestPi -v`
+Expected: FAIL — no `"pi"` key.
+
+- [ ] **Step 4: Add the `creds.go` entry** with a dated comment recording that the layout was verified on 2026-08-12, that `auth.json` and `models-store.json` were observed `0600`, and that `models.json` is conditional (it can hold literal API keys but does not exist until a custom provider is defined). Add nothing to `StationCredentialLayouts` — Pi is not composite. Add nothing to `HarnessProcessNames` — Pi is stdio-only.
+
+- [ ] **Step 5: Run the whole node-agent suite**
+
+Run: `cd apps/node-agent && go test -race ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/node-agent
+git commit -m "feat(node-agent): register Pi and add its dated posture entry"
+```
+
+---
+
+### Task 6: Pi container image
+
+**Files:**
+- Create: `apps/node-agent/deploy/Dockerfile.pi`
+- Modify: `docs/DEPLOYMENT.md`
+
+**Interfaces:**
+- Consumes: `agentpod-node:base` from Task 1.
+
+- [ ] **Step 1: Create `Dockerfile.pi`**
+
+```dockerfile
+# Pi harness image. Unlike the OpenCode image this needs NO supervision loop:
+# Pi has no daemon, it is invoked per command, so the generic entrypoint
+# (enrol, then run) is correct and no entrypoint-parity pair arises.
+FROM agentpod-node:base
+
+# Pi requires Node >= 22.19.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# --ignore-scripts matches Pi's own installer. Both pins are deliberate:
+# a floating tag would make two builds of the same image behave differently.
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.84.1 \
+ && npm install -g --ignore-scripts pi-acp@0.0.33
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+- [ ] **Step 2: Build it**
+
+```bash
+docker build -f apps/node-agent/deploy/Dockerfile.pi -t agentpod-node-pi:local apps/node-agent
+```
+Expected: success.
+
+- [ ] **Step 3: Verify the harness and adapter are present and the versions are the pinned ones**
+
+```bash
+docker run --rm --entrypoint sh agentpod-node-pi:local -c 'pi --version; pi-acp --version || true; node -v'
+```
+Expected: `0.84.1`, and Node ≥ 22.19.
+
+- [ ] **Step 4: Verify detection inside the image.** Create a Pi session directory with a header, then run `agentpod-node detect` and confirm a `pi:` station appears. **This is the gate** — the descriptor must work in the image, not only against the Go fixture.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/node-agent/deploy/Dockerfile.pi docs/DEPLOYMENT.md
+git commit -m "feat(images): Pi harness image"
+```
+
+---
+
+### Task 7: Provisioning — contract, hub, console
+
+**Files:**
+- Modify: `packages/contract/src/runtime.ts:17`, `packages/contract/src/runtime.test.ts`
+- Modify: `apps/hub/src/services/runtimes.ts:44-50`
+- Modify: `apps/console/src/lib/components/fleet/NewRuntimeDialog.svelte:39-42`
+- Modify: `apps/console/src/routes/nodes/[id]/+page.svelte:177`
+
+- [ ] **Step 1: Write the failing contract test**
+
+```ts
+it("accepts pi as a provisionable harness", () => {
+  expect(ProvisionRequest.parse({ provider: "docker", name: "x", resourceTier: "small", harness: "pi" }).harness).toBe("pi");
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd packages/contract && bun test`
+Expected: FAIL — `"pi"` not in the enum.
+
+- [ ] **Step 3: Add `"pi"`** to `RuntimeHarness`, add the `imageForHarness` branch returning `process.env.NODE_AGENT_PI_IMAGE ?? "agentpod-node-pi:local"`, add `{ value: "pi", label: "Pi" }` to the dialog, and add Pi to the empty-state copy at `+page.svelte:177` (it enumerates the harnesses by name).
+
+- [ ] **Step 4: Run all three suites**
+
+```bash
+cd packages/contract && bun test
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+cd apps/console && pnpm check && pnpm test && pnpm build
+```
+Expected: all pass. Run these **after** the last edit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/contract apps/hub apps/console
+git commit -m "feat: Pi as a provisionable harness"
+```
+
+---
+
+### Task 8: Live verification
+
+Not optional. Everything above is scaffolding for this.
+
+- [ ] **Step 1: Detection on a real machine.** On a host with Pi installed and at least two projects, run `apn detect` and confirm one `pi:` station per project — including any workspace whose directory name contains a hyphen.
+
+- [ ] **Step 2: Verify Linux process naming.** The spec records `comm` as `node` on macOS and flags Linux as unverified. Run Pi on a Linux node, check what `pgrep -f` matches, and correct the health pattern if it differs. **Do not skip this** — the health pattern is the single most bug-prone line in any descriptor here.
+
+- [ ] **Step 3: Chat end to end.** Open the Chat tab on a Pi station and send a prompt. Confirm a reply, and confirm `station_audit` records `acp.prompt` with result `ok`.
+
+- [ ] **Step 4: Provision a Pi runtime**, confirm the station is auto-adopted (this proves `Harness()` matches the enum value), then destroy it.
+
+- [ ] **Step 5: Record what was verified, on which machines, with dates** in the PR body. Anything not verified is stated as not verified.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** base image (T1), Detect (T2), health/fs/logs/cleanup (T3), ACP (T4), registry + posture (T5), image (T6), provisioning (T7), live verification (T8). The spec's "out of scope" items — a Pi Cloudflare worker, a multi-harness image, `pi-server` — have no tasks by design.
+- **Deliberately deferred within this plan:** a Pi Cloudflare deployment. Task 6 produces the image; wiring a second worker is separate work.
+- **Known risk:** Task 1 touches the working OpenCode image. Its Step 6 gate exists precisely so a regression there is caught before any Pi code is written.

--- a/packages/contract/src/runtime.test.ts
+++ b/packages/contract/src/runtime.test.ts
@@ -28,6 +28,13 @@ describe("ProvisionRequest harness", () => {
     expect(result.harness).toBe("opencode");
   });
 
+  it("accepts pi as a provisionable harness", () => {
+    // The value must be exactly "pi": the Go descriptor's Harness() returns
+    // "pi" and auto-adoption matches it against a runtime's harness by string
+    // equality, so any other spelling silently breaks adoption.
+    expect(ProvisionRequest.parse({ provider: "docker", name: "x", resourceTier: "small", harness: "pi" }).harness).toBe("pi");
+  });
+
   it("throws for an invalid harness value", () => {
     expect(() => ProvisionRequest.parse({ provider: "docker", name: "x", harness: "bogus" })).toThrow();
   });

--- a/packages/contract/src/runtime.ts
+++ b/packages/contract/src/runtime.ts
@@ -14,7 +14,12 @@ export type RuntimeStatus = z.infer<typeof RuntimeStatus>;
 export const ResourceTier = z.enum(["small", "medium", "large"]);
 export type ResourceTier = z.infer<typeof ResourceTier>;
 
-export const RuntimeHarness = z.enum(["none", "opencode"]);
+/**
+ * Values must match the node-agent descriptor's `Harness()` string exactly:
+ * auto-adoption pairs a provisioned runtime with its detected station by
+ * string equality on this field.
+ */
+export const RuntimeHarness = z.enum(["none", "opencode", "pi"]);
 export type RuntimeHarness = z.infer<typeof RuntimeHarness>;
 
 export const ProvisionRequest = z.object({


### PR DESCRIPTION
Adds **Pi** (https://pi.dev, MIT, `@earendil-works/pi-coding-agent@0.84.1`) as the sixth harness. Requested ad hoc.

Spec: `docs/superpowers/specs/2026-08-12-pi-harness-design.md` · Plan: `docs/superpowers/plans/2026-08-12-pi-harness.md`

## Written from observation, not documentation

Every external path here was read off real Pi installs — a Mac and a Linux node — and that discipline changed the design three times:

- **`models.json` and `trust.json` do not exist** on a real machine, though Pi's docs list both. `trust.json` is excluded entirely; `models.json` is listed as conditional because it *can* hold literal keys once a custom provider is defined.
- **A workspace named `idea-bank`** encodes to `--Users-…-Projects-idea-bank--`. Decoding hyphens back to slashes yields a path that does not exist, so a decode strategy would have **silently lost a real station**. Detection reads `cwd` verbatim from the session header instead — no decode path exists.
- **`comm` is `node` on both macOS and Linux** (measured; `pgrep -x pi` matches nothing on either). Pi's `process.title = "pi"` does not rewrite `comm`, so health uses `pgrep -f` against the resolved entry path.

## Design

- **No `lifecycle`, ever** — Pi has no daemon, so the descriptor does not implement the interface. `Running=false` is normal, not a fault.
- **Chat via pinned `pi-acp@0.0.33`**, with `acp` advertised only when the adapter resolves — no adapter means no Chat tab, rather than one that fails on click. Third instance of the external-adapter pattern claude-code and codex already use.
- **Container images refactored to base + per-harness layers.** Deferring would have made it touch three images instead of two. Pi's layer needs no supervision loop, so **no second entrypoint-parity pair arises**.

## Verification

Two tests were explicitly proven non-vacuous by breaking the code and watching them fail:

- The **self-match guard** on the health pattern — a real process whose argv merely *mentions* the Pi path must not count as running. (I reproduced that exact false positive by accident while measuring on a live node.)
- The **ACP capability gate** — forcing `acp` on unconditionally makes the gating test fail on precisely the gating property.

The strongest single signal is the descriptor running **inside the built image**:

```json
{ "key": "pi:111b1182", "harness": "pi", "workspacePath": "/work/demo",
  "capabilities": ["health","logs","fs.read","fs.write","terminal","cleanup","acp"] }
```

`acp` present means the gate opened against a genuinely installed adapter; `lifecycle` correctly absent.

Suites: contract 85, hub 488, node-agent full `-race` green, console 715 (on Node 22 — see below).

## Not yet verified

- **No live fleet verification.** Nothing provisioned against the real hub, no Chat session opened, Pi never actually ran a session inside the container.
- **Linux station detection** — Pi is installed on superchotu but has never run there, so it has no session file and correctly reports no stations.
- The clean plan offers **no Pi-specific directories**, deliberately: none was observed. A test asserts a plausible-looking `.pi/cache` is *not* offered, so widening it requires deleting that assertion.

## Note for local dev

Console tests fail on **Node 26** (125 failures — jsdom 25 leaves `window.localStorage` undefined); they pass on Node 22, and CI pins Node 20. Pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW