### PR TITLE
fix(node-agent): give the pi-acp adapter a PATH that can find pi

### DIFF
--- a/apps/node-agent/internal/descriptor/pi.go
+++ b/apps/node-agent/internal/descriptor/pi.go
@@ -52,6 +52,17 @@ import (
 type piDescriptor struct {
 	dataDir    string // absolute path to ~/.pi/agent
 	sessionDir string // absolute path to the sessions directory
+
+	// Host seams, mirroring claudeCodeDescriptor. They are fields so that no
+	// test depends on what the developer happens to have installed: binary
+	// resolution ends in wellKnownBinaryDirs, which probes /opt/homebrew/bin
+	// whatever PATH says, so a machine with a real Pi install made the
+	// "nothing resolves" cases pass for the wrong reason (or fail outright).
+	// Production wiring in NewPi uses the real host.
+	userHome     string                       // OS user home; "" omits home-relative candidates
+	lookPath     func(string) (string, error) // exec.LookPath
+	isExecutable func(string) bool            // isExecutableFile
+	getenv       func(string) string          // os.Getenv
 }
 
 const (
@@ -88,7 +99,17 @@ const (
 // $HOME/.pi/agent, with PI_CODING_AGENT_SESSION_DIR overriding the sessions
 // directory alone.
 func NewPi(dataDir string) Descriptor {
-	p := &piDescriptor{dataDir: dataDir}
+	p := &piDescriptor{
+		dataDir:      dataDir,
+		lookPath:     exec.LookPath,
+		isExecutable: isExecutableFile,
+		getenv:       os.Getenv,
+	}
+	// userHome is "" when it can't be determined, which the binary locator
+	// reads as "skip the home-relative candidates".
+	if home, err := os.UserHomeDir(); err == nil {
+		p.userHome = home
+	}
 	if dataDir == "" {
 		p.dataDir = piDefaultDataDir()
 		p.sessionDir = os.Getenv(piSessionDirEnv)
@@ -148,14 +169,21 @@ func (p *piDescriptor) Detect() ([]Station, error) {
 	// start, so this descriptor does not implement Lifecycle at all.
 	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "cleanup"}
 
-	// "acp" is advertised ONLY when the pi-acp adapter actually resolves. The
-	// console gates the Chat tab on this capability alone, so advertising it
-	// unconditionally (as the harnesses with an npx fallback can afford to)
-	// would buy every Pi station a Chat tab that fails the moment it is
-	// clicked. No adapter, no tab. Resolved once here rather than per station:
-	// it is a property of the node, not of the workspace.
-	if _, ok := piACPAdapter(); ok {
-		caps = append(caps, "acp")
+	// "acp" is advertised ONLY when BOTH halves of the chat path resolve: the
+	// pi-acp adapter, and the `pi` it spawns. The console gates the Chat tab on
+	// this capability alone, so advertising it unconditionally (as the harnesses
+	// with an npx fallback can afford to) would buy every Pi station a Chat tab
+	// that fails the moment it is clicked.
+	//
+	// Requiring `pi` too is the 2026-08-12 lesson: the adapter alone was checked,
+	// the tab appeared, and every session died in ~500ms because pi-acp could not
+	// find Pi. A gate that verifies half the chain advertises a capability the
+	// node does not have. Resolved once here rather than per station: both are
+	// properties of the node, not of the workspace.
+	if _, ok := p.acpAdapter(); ok {
+		if _, ok := p.piBinary(); ok {
+			caps = append(caps, "acp")
+		}
 	}
 
 	seen := make(map[string]bool)
@@ -322,7 +350,32 @@ const (
 	piACPBinaryEnv = "PI_ACP_PATH"
 )
 
-// piACPAdapter resolves the pi-acp adapter: the PI_ACP_PATH override (used
+// locator returns the shared executable resolver, wired to this descriptor's
+// host seams.
+func (p *piDescriptor) locator() binaryLocator {
+	return binaryLocator{
+		userHome:     p.userHome,
+		lookPath:     p.lookPath,
+		isExecutable: p.isExecutable,
+	}
+}
+
+// piBinary resolves the `pi` executable: the PI_PATH override (used verbatim),
+// then PATH, then the well-known install directories. It is the ONE place `pi`
+// is resolved — health's process pattern and the ACP session's PATH must agree
+// about which Pi this node has, or one of them is describing a different
+// machine.
+//
+// The well-known-dirs leg is what the LookPath-only version was missing. On the
+// operator's Mac (2026-08-12) `pi` is at /opt/homebrew/bin/pi while the
+// node-agent LaunchAgent runs with PATH=/usr/bin:/bin:/usr/sbin:/sbin, so
+// LookPath found nothing: health reported "process check unavailable" and the
+// ACP adapter was spawned with no way to find Pi at all.
+func (p *piDescriptor) piBinary() (string, bool) {
+	return p.locator().locate("pi", p.getenv(piBinaryEnv))
+}
+
+// acpAdapter resolves the pi-acp adapter: the PI_ACP_PATH override (used
 // verbatim), then PATH, then the well-known install directories — the shared
 // order in binary.go, which exists precisely because a service PATH is not the
 // operator's interactive PATH. NOTHING is hardcoded.
@@ -345,17 +398,8 @@ const (
 // adapter's shebang picks. Compare codexACPMinNodeMajor, which skips the
 // refusal for a related reason; claude-code enforces a floor because it has a
 // configured runtime to enforce it against.
-func piACPAdapter() (string, bool) {
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		userHome = "" // omits the home-relative candidates
-	}
-	loc := binaryLocator{
-		userHome:     userHome,
-		lookPath:     exec.LookPath,
-		isExecutable: isExecutableFile,
-	}
-	return loc.locate(piACPBinaryName, os.Getenv(piACPBinaryEnv))
+func (p *piDescriptor) acpAdapter() (string, bool) {
+	return p.locator().locate(piACPBinaryName, p.getenv(piACPBinaryEnv))
 }
 
 // ACPCommand implements ACPCommander. argv is the resolved adapter alone: it
@@ -364,16 +408,29 @@ func piACPAdapter() (string, bool) {
 // Health and Cleanup tabs operate on, which is what makes a chat session and
 // the rest of the station agree about which directory they are in.
 //
-// env is nil. Pi's credentials live in ~/.pi/agent/auth.json, which the adapter
-// reaches through Pi itself, so there is nothing to inject — and nothing about
-// a credential belongs in argv (world-readable via ps) or in a child env when
-// the file it already reads will do.
+// env carries ONE variable, PATH, with the directory holding the resolved `pi`
+// prepended to the inherited value. pi-acp spawns `pi --mode rpc` BY NAME, so
+// the adapter's own PATH decides whether a session can start at all — and the
+// node-agent's PATH is not the operator's. Observed live on 2026-08-12: a macOS
+// LaunchAgent with PATH=/usr/bin:/bin:/usr/sbin:/sbin spawned the adapter from
+// /opt/homebrew/bin (found by the well-known-dirs probe, so the capability was
+// advertised) with env=nil; pi-acp could not see /opt/homebrew/bin/pi, exited
+// at once, and the console showed "ACP Connection Closed" while the hub logged
+// a 502 in ~500ms with no acp.* audit row. Prepending rather than replacing is
+// deliberate: the adapter is still a Node program that needs the rest of the
+// host's PATH (this is the same move claude-code makes for its node runtime).
 //
-// Detect gates the "acp" capability on the same resolution, so in practice this
-// error is only reachable if the adapter is removed between a Detect and a
-// session open. It still names the adapter, the install command and the
-// override, because that race lands in the console as a session-open failure
-// and a message with nothing actionable in it wastes the operator's time.
+// No credential is injected. Pi's live in ~/.pi/agent/auth.json, which the
+// adapter reaches through Pi itself, and nothing about a credential belongs in
+// argv (world-readable via ps) or in a child env when the file it already reads
+// will do.
+//
+// Detect gates the "acp" capability on the same two resolutions, so in practice
+// these errors are only reachable if pi or the adapter is removed between a
+// Detect and a session open. They still name the missing binary, the install
+// command and the override, because that race lands in the console as a
+// session-open failure and a message with nothing actionable in it wastes the
+// operator's time.
 func (p *piDescriptor) ACPCommand(key string) ([]string, string, []string, error) {
 	// The station must exist before anything is probed on the host: an unknown
 	// key has no workspace to run in.
@@ -382,13 +439,28 @@ func (p *piDescriptor) ACPCommand(key string) ([]string, string, []string, error
 		return nil, "", nil, err
 	}
 
-	adapter, ok := piACPAdapter()
+	adapter, ok := p.acpAdapter()
 	if !ok {
 		return nil, "", nil, fmt.Errorf(
 			"pi: couldn't find the %s adapter on this node — install it (npm i -g %s) or set %s",
 			piACPBinaryName, piACPPackage, piACPBinaryEnv)
 	}
-	return []string{adapter}, wsPath, nil, nil
+
+	// An adapter that cannot find Pi is not a usable adapter. Failing here, by
+	// name, beats a session that opens and closes with nothing to read.
+	piPath, ok := p.piBinary()
+	if !ok {
+		return nil, "", nil, fmt.Errorf(
+			"pi: found the %s adapter but no `pi` executable for it to drive — install Pi or set %s",
+			piACPBinaryName, piBinaryEnv)
+	}
+	piDir := filepath.Dir(piPath)
+	if abs, err := filepath.Abs(piDir); err == nil {
+		piDir = abs
+	}
+	env := []string{"PATH=" + pathWithDirFirst(piDir, p.getenv("PATH"))}
+
+	return []string{adapter}, wsPath, env, nil
 }
 
 // Health returns a best-effort liveness/resource snapshot for a Pi station.
@@ -409,7 +481,7 @@ func (p *piDescriptor) Health(key string) (Health, error) {
 	// (a node_modules-laden workspace walk can exceed the hub's timeout).
 	health.DiskBytes = diskUsage(wsPath)
 
-	running, note := piProcessRunning()
+	running, note := p.piProcessRunning()
 	health.Running = running
 	if note != "" {
 		health.Note = &note
@@ -435,16 +507,13 @@ func (p *piDescriptor) Health(key string) (Health, error) {
 // differs (npm installs `bin/pi` as a symlink to the package's dist/cli.js, and
 // which one lands in argv depends on how Pi was launched).
 //
-// Resolution order: PI_PATH, then `pi` on PATH. Nothing is hardcoded — the npm
-// prefix is routinely user-local (see piBinaryEnv).
-func piEntryPaths() []string {
-	path := os.Getenv(piBinaryEnv)
-	if path == "" {
-		resolved, err := exec.LookPath("pi")
-		if err != nil {
-			return nil
-		}
-		path = resolved
+// Resolution is piBinary's — PI_PATH, PATH, then the well-known install dirs.
+// Nothing is hardcoded; the npm prefix is routinely user-local (see piBinaryEnv)
+// and a service PATH routinely misses it.
+func (p *piDescriptor) piEntryPaths() []string {
+	path, ok := p.piBinary()
+	if !ok {
+		return nil
 	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
@@ -489,8 +558,8 @@ func piEntryPaths() []string {
 //
 // ok is false when no Pi executable can be resolved at all, which is not a
 // pattern this function may guess at.
-func piProcessPattern() (pattern string, ok bool) {
-	paths := piEntryPaths()
+func (p *piDescriptor) piProcessPattern() (pattern string, ok bool) {
+	paths := p.piEntryPaths()
 	if len(paths) == 0 {
 		return "", false
 	}
@@ -511,8 +580,8 @@ func piProcessPattern() (pattern string, ok bool) {
 // ordinary resting state, so it returns false with NO note. A note is reserved
 // for the cases where the check genuinely could not run — pgrep missing, or no
 // Pi executable to build a safe pattern from.
-func piProcessRunning() (running bool, note string) {
-	pattern, ok := piProcessPattern()
+func (p *piDescriptor) piProcessRunning() (running bool, note string) {
+	pattern, ok := p.piProcessPattern()
 	if !ok {
 		return false, "process check unavailable (no pi executable found; set " + piBinaryEnv + ")"
 	}

--- a/apps/node-agent/internal/descriptor/pi_acp_test.go
+++ b/apps/node-agent/internal/descriptor/pi_acp_test.go
@@ -1,23 +1,61 @@
 package descriptor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// writePiACPStub drops an executable named pi-acp into a fresh directory and
-// makes that directory the whole of PATH. It returns the stub's path.
+// writePiACPStub drops the two executables a Pi chat session needs — the
+// pi-acp adapter and the `pi` it spawns — into a fresh directory and makes that
+// directory the whole of PATH. It returns the adapter's path.
+//
+// Both stubs, because the "acp" capability rides on both binaries resolving:
+// pi-acp is useless without a Pi to drive, which is exactly the live failure of
+// 2026-08-12.
 func writePiACPStub(t *testing.T) string {
 	t.Helper()
 	bin := t.TempDir()
 	stub := filepath.Join(bin, piACPBinaryName)
-	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
+	for _, name := range []string{piACPBinaryName, "pi"} {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 	t.Setenv("PATH", bin)
 	return stub
+}
+
+// stubPiHost replaces a descriptor's host seams so a case can state exactly
+// what this node has installed. installed maps an executable name to the path
+// PATH would report for it; anything absent is not installed anywhere — the
+// well-known dirs included, which is the whole point. /opt/homebrew/bin/pi and
+// /opt/homebrew/bin/pi-acp both exist on the machine this bug was found on, and
+// wellKnownBinaryDirs probes that directory whatever PATH says, so a case about
+// a MISSING binary cannot be written against the real host at all.
+func stubPiHost(t *testing.T, d Descriptor, installed map[string]string) *piDescriptor {
+	t.Helper()
+	p, ok := d.(*piDescriptor)
+	if !ok {
+		t.Fatalf("expected *piDescriptor, got %T", d)
+	}
+	p.userHome = testStubHome
+	p.lookPath = func(name string) (string, error) {
+		if path, ok := installed[name]; ok {
+			return path, nil
+		}
+		return "", fmt.Errorf("%s: not found in $PATH", name)
+	}
+	p.isExecutable = func(string) bool { return false }
+	p.getenv = func(name string) string {
+		if name == "PATH" {
+			return testStubPath
+		}
+		return ""
+	}
+	return p
 }
 
 // The Chat tab is gated on the "acp" capability alone, so advertising it
@@ -25,11 +63,9 @@ func writePiACPStub(t *testing.T) string {
 // No adapter must mean no capability — and an error that names what is missing.
 func TestPiACPCapabilityGatedOnAdapter(t *testing.T) {
 	dataDir, ws := buildPiFixture(t)
-	// No adapter on PATH → no acp capability, and a clear error rather than a
+	// Nothing installed → no acp capability, and a clear error rather than a
 	// Chat tab that fails when clicked.
-	t.Setenv("PATH", t.TempDir())
-	t.Setenv(piACPBinaryEnv, "")
-	stations, err := NewPi(dataDir).Detect()
+	stations, err := stubPiHost(t, NewPi(dataDir), nil).Detect()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +77,7 @@ func TestPiACPCapabilityGatedOnAdapter(t *testing.T) {
 			t.Fatal("acp must not be advertised without the pi-acp adapter")
 		}
 	}
-	_, _, _, err = NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws))
+	_, _, _, err = stubPiHost(t, NewPi(dataDir), nil).ACPCommand(piProjectKey(ws))
 	if err == nil {
 		t.Fatal("ACPCommand should error when the adapter is absent")
 	}
@@ -50,9 +86,38 @@ func TestPiACPCapabilityGatedOnAdapter(t *testing.T) {
 	}
 }
 
+// The other half of the gate, and the one the fleet paid for: the adapter is
+// installed but Pi is not reachable. pi-acp exists only to spawn `pi --mode
+// rpc`, so advertising "acp" here promises a Chat tab that can only close on
+// its first prompt — precisely the failure the gate exists to prevent. Half a
+// chain verified is a capability the node does not have.
+func TestPiACPCapabilityGatedOnPiItself(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+	installed := map[string]string{piACPBinaryName: "/opt/homebrew/bin/pi-acp"}
+
+	stations, err := stubPiHost(t, NewPi(dataDir), installed).Detect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range stations[0].Capabilities {
+		if c == "acp" {
+			t.Fatal("acp must not be advertised when `pi` itself cannot be resolved: pi-acp has nothing to drive")
+		}
+	}
+
+	_, _, _, err = stubPiHost(t, NewPi(dataDir), installed).ACPCommand(piProjectKey(ws))
+	if err == nil {
+		t.Fatal("ACPCommand should error when `pi` cannot be found — a session that closes with no explanation is worse")
+	}
+	if !strings.Contains(err.Error(), piBinaryEnv) {
+		t.Errorf("error %q should name %s, the operator's escape hatch", err, piBinaryEnv)
+	}
+}
+
 // The adapter is spawned directly: argv[0] is the resolved pi-acp, the working
 // directory is the station's workspace (the same one Files, Health and Cleanup
-// use), and nothing is added to the environment.
+// use), and the only thing added to the environment is the PATH that lets the
+// adapter find Pi.
 func TestPiACPCommandUsesAdapterAndWorkspaceDir(t *testing.T) {
 	dataDir, ws := buildPiFixture(t)
 	stub := writePiACPStub(t)
@@ -73,8 +138,12 @@ func TestPiACPCommandUsesAdapterAndWorkspaceDir(t *testing.T) {
 	if dir != ws {
 		t.Errorf("dir = %q, want %q", dir, ws)
 	}
-	if env != nil {
-		t.Errorf("env = %v, want nil", env)
+	if len(env) != 1 {
+		t.Errorf("env = %v, want exactly PATH: no credential belongs in a child env (Pi reads auth.json itself)", env)
+	}
+	// The stubs share a directory, so PATH's head is that directory.
+	if got, ok := envValue(env, "PATH"); !ok || !strings.HasPrefix(got, filepath.Dir(stub)+string(os.PathListSeparator)) {
+		t.Errorf("PATH = %q, want the directory holding pi (%q) first", got, filepath.Dir(stub))
 	}
 	// Never npx: a network fetch on the first prompt of a session is a stall
 	// the operator cannot see the reason for.
@@ -91,6 +160,9 @@ func TestPiACPCommandHonoursEnvOverride(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // nothing resolvable here
 	adapter := filepath.Join(t.TempDir(), "npm-global", "bin", "pi-acp")
 	t.Setenv(piACPBinaryEnv, adapter)
+	// The same host that hides the adapter from PATH hides Pi from it, and the
+	// capability now requires both — so this case names both overrides.
+	t.Setenv(piBinaryEnv, fakePiBinary(t))
 
 	stations, err := NewPi(dataDir).Detect()
 	if err != nil {
@@ -115,6 +187,53 @@ func TestPiACPCommandHonoursEnvOverride(t *testing.T) {
 	}
 	if dir != ws {
 		t.Errorf("dir = %q, want %q", dir, ws)
+	}
+}
+
+// TestPiACPCommandPutsPiOnTheAdapterPath is the regression test for the live
+// failure of 2026-08-12: a Pi station's Chat tab answered "ACP Connection
+// Closed", the hub returned 502 in ~500ms (a spawn failure, not a timeout) and
+// no acp.* row was ever written to station_audit.
+//
+// The node-agent ran as a macOS LaunchAgent with PATH=/usr/bin:/bin:/usr/sbin:
+// /sbin. `pi-acp` lives in /opt/homebrew/bin, which the well-known-dirs probe
+// finds — so the capability was advertised correctly — but `pi` lives there
+// too, and /opt/homebrew/bin is not on that PATH. ACPCommand returned env=nil,
+// so the adapter inherited the service's minimal PATH and could not find the
+// `pi` it exists to spawn (`pi-acp` runs `pi --mode rpc` internally). It exited
+// immediately.
+//
+// The shape reproduced here is exactly that one: pi-acp resolvable through
+// PATH, `pi` reachable ONLY off it. Every earlier test put its stubs on the
+// test process's own PATH, where the adapter would have found `pi` by accident
+// — which is why the whole suite was green while the fleet was broken.
+func TestPiACPCommandPutsPiOnTheAdapterPath(t *testing.T) {
+	dataDir, ws := buildPiFixture(t)
+
+	adapterDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(adapterDir, piACPBinaryName), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", adapterDir) // pi-acp resolves here; `pi` does NOT
+
+	piPath := fakePiBinary(t) // <tmp>/bin/pi — off PATH, like /opt/homebrew/bin
+	t.Setenv(piBinaryEnv, piPath)
+
+	_, _, env, err := NewPi(dataDir).(ACPCommander).ACPCommand(piProjectKey(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	piDir := filepath.Dir(piPath)
+	got, ok := envValue(env, "PATH")
+	if !ok {
+		t.Fatalf("env = %v, want a PATH carrying %q: the adapter spawns `pi` by name", env, piDir)
+	}
+	if !strings.HasPrefix(got, piDir+string(os.PathListSeparator)) {
+		t.Errorf("PATH = %q, want the directory holding pi (%q) FIRST", got, piDir)
+	}
+	if !strings.HasSuffix(got, adapterDir) {
+		t.Errorf("PATH = %q must PREPEND to the inherited PATH %q, not replace it", got, adapterDir)
 	}
 }
 


### PR DESCRIPTION
## The failure

A Pi station's Chat tab showed **ACP Connection Closed**. `POST /api/stations/<id>/acp/sessions` returned **502 in 501ms** — fast, so a spawn failure rather than a timeout — and **no `acp.*` row was ever written to `station_audit`**.

## Root cause (measured live, operator's Mac, 2026-08-12)

- The node-agent runs as a macOS LaunchAgent with `PATH=/usr/bin:/bin:/usr/sbin:/sbin`.
- `pi-acp` is at `/opt/homebrew/bin/pi-acp`. Not on that PATH — but `/opt/homebrew/bin` **is** in `wellKnownBinaryDirs`, so `binaryLocator` found it and the `acp` capability was advertised, correctly.
- `pi` is at `/opt/homebrew/bin/pi`. Also not on that PATH.
- `piDescriptor.ACPCommand` returned `env = nil`, so the spawned `pi-acp` inherited the agent's minimal PATH — and `pi-acp` spawns `pi --mode rpc` **by name**. It could not find Pi and exited immediately.

The capability gate verified the adapter existed. Nothing verified the adapter could find Pi.

## The fix

- `ACPCommand` returns `PATH` with the directory holding the resolved `pi` **prepended** to the inherited value — the same machinery claude-code uses for a configured node runtime (`pathWithDirFirst` in `binary.go`), prepending rather than replacing because the adapter is still a Node program that needs the rest of the host's PATH.
- `pi` is resolved in ONE place, `piBinary()`, through the shared `binaryLocator`: `PI_PATH` override → PATH → well-known dirs. Nothing hardcoded. Health's pgrep pattern now uses the same resolution; it was `exec.LookPath`-only, so on this same host health had been reporting *\"process check unavailable\"* for the identical reason.
- If `pi` cannot be resolved at all, `ACPCommand` fails loudly and names `PI_PATH`. A session that opens and closes with no explanation is the worse outcome.

### The `acp` gate now requires `pi` too

Yes — deliberately. `pi-acp` exists only to spawn `pi --mode rpc`; an adapter with no Pi to drive is not an ACP capability, it is a Chat tab that can only fail on its first prompt. That is precisely the failure this gate was written to prevent, and gating on half the chain is what let it through. The cost is the honest one Pi's gate already accepts elsewhere: on a node with the adapter but no Pi, the tab is simply absent instead of broken.

### Host seams on `piDescriptor`

`piDescriptor` gains the injected `lookPath` / `isExecutable` / `getenv` / `userHome` seams `claudeCodeDescriptor` already has. Without them a *\"this binary is missing\"* case cannot be written honestly: the well-known-dirs probe finds the real `/opt/homebrew/bin/pi` no matter what `PATH` says. `TestPiACPCapabilityGatedOnAdapter` already failed on such a machine before this PR (it passes in CI only because CI has no Pi installed) — it is hermetic now.

## Why unit tests could not catch this

Every existing test placed its stubs on the **test process's own PATH**. In that world the adapter would have found `pi` by accident, so `env = nil` was indistinguishable from a correct env — the assertion literally read `want nil`. The real agent runs with a PATH nobody chose, where the two binaries resolve through a different leg of the locator than the tests ever exercised.

`TestPiACPCommandPutsPiOnTheAdapterPath` reproduces exactly that shape: `pi-acp` resolvable through PATH, `pi` reachable **only** off it, asserting the returned env's PATH leads with Pi's directory and still ends with the inherited PATH.

**Vacuity check:** with the fix reverted to `env = nil`, the new test fails (`env = [], want a PATH carrying .../bin`) and so does the updated `TestPiACPCommandUsesAdapterAndWorkspaceDir`. With the gate reverted to adapter-only, `TestPiACPCapabilityGatedOnPiItself` fails (`acp must not be advertised when pi itself cannot be resolved`). Both restored, all green.

## Verification

`cd apps/node-agent && go test -race ./...` — all packages pass. `TestBuildRegistry_ThreadsClaudeCodeACPKeys` (the known 2s `node --version` timeout flake) failed once under full-suite load and passes isolated; untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW