### PR TITLE
Render pre-prompt agent output as session metadata, not a chat turn

### DIFF
--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte
@@ -37,11 +37,22 @@
    * Ending a session is destructive (the agent process stops) — gated behind
    * ConfirmDialog. "New session" sits beside it and is offered whatever the
    * status; only "End session" disappears once there is nothing left to end.
+   *
+   * The PREAMBLE row is session metadata, not conversation: harnesses that
+   * announce themselves before anyone has spoken (pi prints its version and
+   * loaded skills on stdout before the protocol stream starts) used to have
+   * that banner rendered as the first agent message. It belongs here, collapsed
+   * to its first line and expandable — and when there is none, nothing is
+   * rendered at all rather than an empty affordance. It is deliberately outside
+   * the status region: metadata is not an announcement.
    */
   import type { AcpSessionMode, AcpSessionStatus } from "@agentpod/contract";
   import type { AcpSessionRow } from "$lib/api/acp";
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import type { ChatConnection } from "./acp-chat.svelte";
+  import type { SessionPreamble } from "./transcript";
   import { Button } from "$lib/components/ui/button";
+  import * as Collapsible from "$lib/components/ui/collapsible";
   import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
   import * as Select from "$lib/components/ui/select";
   import { Status } from "$lib/components/ui/status";
@@ -58,6 +69,11 @@
     status: AcpSessionStatus;
     connection: ChatConnection;
     mode: AcpSessionMode;
+    /**
+     * Whatever the agent said before the user's first prompt (the harness
+     * banner), or null when it said nothing — then no row is rendered.
+     */
+    preamble?: SessionPreamble | null;
     /** True while a create POST is in flight (disables "New session"). */
     creating?: boolean;
     onModeChange: (mode: AcpSessionMode) => void;
@@ -75,6 +91,7 @@
     status,
     connection,
     mode,
+    preamble = null,
     creating = false,
     onModeChange,
     onEnd,
@@ -188,87 +205,134 @@
   }
 
   let confirmEndOpen = $state(false);
+
+  /**
+   * The preamble disclosure. Collapsed by default — it is reference material,
+   * and the whole point of moving it out of the transcript was that it stopped
+   * being the first thing you read.
+   */
+  let preambleOpen = $state(false);
 </script>
 
-<div class="flex flex-wrap items-center gap-3">
-  <div role="status" aria-live="polite" class="flex min-w-0 items-center gap-2">
-    <!-- aria-hidden: the visible label is the ONE accessible text; the dot's
-         built-in sr-only label would read as a duplicate. -->
-    <span aria-hidden="true" class="flex">
-      <Status form="dot" status={dotStatus} animate={dotAnimate} {label} />
-    </span>
-    <span class="t-label truncate">{label}</span>
-  </div>
-
-  {#if sessions.length > 1}
-    <Select.Root type="single" bind:value={selectValue} onValueChange={handleValueChange}>
-      <Select.Trigger
-        size="sm"
-        class="min-w-0 max-w-56"
-        aria-label={selectedRow
-          ? `Switch session — currently ${sessionLabel(selectedRow)}`
-          : "Switch session"}
-      >
-        <!-- aria-hidden: the label carries the status word, so the dot's own
-             sr-only text would read as a duplicate. -->
-        {#if selectedRow}
-          <span aria-hidden="true" class="flex">
-            <Status form="dot" status={STATUS_DOT[selectedRow.status]} />
-          </span>
-          <span class="truncate">{sessionLabel(selectedRow)}</span>
-        {:else}
-          <span class="truncate">Sessions</span>
-        {/if}
-      </Select.Trigger>
-      <Select.Content class="max-w-[calc(100vw-2rem)]">
-        {#each visibleSessions as s (s.id)}
-          <!-- aria-label: the row is two spans (a truncating name + its meta), so
-               the accessible name is stated once, verbatim, instead of being
-               reassembled from them. -->
-          <Select.Item value={s.id} aria-label={sessionLabel(s)}>
-            <span aria-hidden="true" class="flex">
-              <Status form="dot" status={STATUS_DOT[s.status]} />
-            </span>
-            <!-- min-w-0 + truncate: a title is up to 80 chars of the user's own
-                 prose and must not stretch the dropdown across the viewport. -->
-            <span class="min-w-0 max-w-64 truncate">{nameOf(s)}</span>
-            <span class="shrink-0 text-muted-foreground">{metaOf(s)}</span>
-          </Select.Item>
-        {/each}
-        {#if hasMoreSessions}
-          <!-- Not a session: picking it opens history (handleValueChange reverts
-               the value straight away). It lives INSIDE the listbox so it is
-               reachable by keyboard like every other row. -->
-          <Select.Item value={ALL_SESSIONS} aria-label="All sessions…">
-            <span class="truncate">All sessions…</span>
-          </Select.Item>
-        {/if}
-      </Select.Content>
-    </Select.Root>
-  {/if}
-
-  <div role="group" aria-label="Permission mode" class="flex items-center gap-1 text-xs">
-    {#each MODES as m (m.value)}
-      <button
-        type="button"
-        class={chipClass(mode === m.value)}
-        aria-pressed={mode === m.value}
-        onclick={() => onModeChange(m.value)}
-      >
-        {m.label}
-      </button>
-    {/each}
-  </div>
-
-  {#if session}
-    <div class="ml-auto flex items-center gap-1">
-      {#if status !== "ended"}
-        <Button variant="ghost" size="sm" onclick={() => (confirmEndOpen = true)}>
-          End session
-        </Button>
-      {/if}
-      <Button variant="outline" size="sm" disabled={creating} onclick={onNew}>New session</Button>
+<div class="flex flex-col gap-1.5">
+  <div class="flex flex-wrap items-center gap-3">
+    <div role="status" aria-live="polite" class="flex min-w-0 items-center gap-2">
+      <!-- aria-hidden: the visible label is the ONE accessible text; the dot's
+           built-in sr-only label would read as a duplicate. -->
+      <span aria-hidden="true" class="flex">
+        <Status form="dot" status={dotStatus} animate={dotAnimate} {label} />
+      </span>
+      <span class="t-label truncate">{label}</span>
     </div>
+
+    {#if sessions.length > 1}
+      <Select.Root type="single" bind:value={selectValue} onValueChange={handleValueChange}>
+        <Select.Trigger
+          size="sm"
+          class="min-w-0 max-w-56"
+          aria-label={selectedRow
+            ? `Switch session — currently ${sessionLabel(selectedRow)}`
+            : "Switch session"}
+        >
+          <!-- aria-hidden: the label carries the status word, so the dot's own
+               sr-only text would read as a duplicate. -->
+          {#if selectedRow}
+            <span aria-hidden="true" class="flex">
+              <Status form="dot" status={STATUS_DOT[selectedRow.status]} />
+            </span>
+            <span class="truncate">{sessionLabel(selectedRow)}</span>
+          {:else}
+            <span class="truncate">Sessions</span>
+          {/if}
+        </Select.Trigger>
+        <Select.Content class="max-w-[calc(100vw-2rem)]">
+          {#each visibleSessions as s (s.id)}
+            <!-- aria-label: the row is two spans (a truncating name + its meta), so
+                 the accessible name is stated once, verbatim, instead of being
+                 reassembled from them. -->
+            <Select.Item value={s.id} aria-label={sessionLabel(s)}>
+              <span aria-hidden="true" class="flex">
+                <Status form="dot" status={STATUS_DOT[s.status]} />
+              </span>
+              <!-- min-w-0 + truncate: a title is up to 80 chars of the user's own
+                   prose and must not stretch the dropdown across the viewport. -->
+              <span class="min-w-0 max-w-64 truncate">{nameOf(s)}</span>
+              <span class="shrink-0 text-muted-foreground">{metaOf(s)}</span>
+            </Select.Item>
+          {/each}
+          {#if hasMoreSessions}
+            <!-- Not a session: picking it opens history (handleValueChange reverts
+                 the value straight away). It lives INSIDE the listbox so it is
+                 reachable by keyboard like every other row. -->
+            <Select.Item value={ALL_SESSIONS} aria-label="All sessions…">
+              <span class="truncate">All sessions…</span>
+            </Select.Item>
+          {/if}
+        </Select.Content>
+      </Select.Root>
+    {/if}
+
+    <div role="group" aria-label="Permission mode" class="flex items-center gap-1 text-xs">
+      {#each MODES as m (m.value)}
+        <button
+          type="button"
+          class={chipClass(mode === m.value)}
+          aria-pressed={mode === m.value}
+          onclick={() => onModeChange(m.value)}
+        >
+          {m.label}
+        </button>
+      {/each}
+    </div>
+
+    {#if session}
+      <div class="ml-auto flex items-center gap-1">
+        {#if status !== "ended"}
+          <Button variant="ghost" size="sm" onclick={() => (confirmEndOpen = true)}>
+            End session
+          </Button>
+        {/if}
+        <Button variant="outline" size="sm" disabled={creating} onclick={onNew}>New session</Button>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Session metadata, not conversation. Rendered ONLY when the agent actually
+       said something before the first prompt — an empty disclosure would be a
+       permanent affordance for nothing. The purpose lives in the trigger's
+       aria-label because the visible text is the banner's own first line, which
+       says nothing about what it is. -->
+  {#if preamble}
+    <Collapsible.Root bind:open={preambleOpen}>
+      <div data-testid="session-preamble" class="min-w-0">
+        <Collapsible.Trigger
+          class="group flex min-w-0 max-w-full items-center gap-1.5 rounded-sm py-0.5 text-left text-muted-foreground hover:text-foreground"
+          aria-label={preamble.more > 0
+            ? `Agent startup output — ${preamble.summary}, ${preamble.more} more ${preamble.more === 1 ? "line" : "lines"}`
+            : `Agent startup output — ${preamble.summary}`}
+        >
+          <ChevronDownIcon
+            class="size-3 shrink-0 transition-transform motion-reduce:transition-none group-data-[state=closed]:-rotate-90"
+            aria-hidden="true"
+          />
+          <span class="t-label truncate font-mono">{preamble.summary}</span>
+          {#if preamble.more > 0}
+            <span class="t-label shrink-0 opacity-70">
+              +{preamble.more}
+              {preamble.more === 1 ? "line" : "lines"}
+            </span>
+          {/if}
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <!-- Verbatim, so a path or a version string is copyable as printed;
+               capped and scrollable so a chatty harness can't push the
+               transcript off the panel. -->
+          <pre
+            data-testid="session-preamble-text"
+            class="t-label mt-1 max-h-40 overflow-auto border-l-2 border-border pl-3 font-mono break-words whitespace-pre-wrap text-muted-foreground">{preamble.text}</pre>
+        </Collapsible.Content>
+      </div>
+    </Collapsible.Root>
   {/if}
 </div>
 

--- a/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatHeader.svelte.test.ts
@@ -420,3 +420,60 @@ test("the capped switcher still adds no second live region", async () => {
 
   expect(u.getAllByRole("status")).toHaveLength(1);
 });
+
+// ─── Session preamble (pre-prompt agent output) ──────────────────────────────
+
+/** The disclosure's body — `hidden` while collapsed (bits-ui keeps it mounted). */
+function preambleBody(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>(
+    "[data-testid='session-preamble'] [data-slot='collapsible-content']",
+  );
+  if (!el) throw new Error("preamble content not rendered");
+  return el;
+}
+
+test("the preamble collapses to its first line and expands to the full text", async () => {
+  const u = setup({
+    preamble: {
+      text: "pi v0.84.1\n\nSkills\n\n/s/basecamp/SKILL.md",
+      summary: "pi v0.84.1",
+      more: 2,
+    },
+  });
+
+  const trigger = u.getByRole("button", { name: /pi v0\.84\.1/ });
+  expect(trigger.textContent).toContain("pi v0.84.1");
+  expect(trigger.textContent).toContain("2");
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  // Collapsed: the rest of the banner is off screen. (bits-ui keeps its content
+  // mounted and marks it `hidden` — the same collapsed state Reasoning asserts
+  // through aria-expanded.)
+  expect(preambleBody(u.container).hasAttribute("hidden")).toBe(true);
+
+  await fireEvent.click(trigger);
+
+  await waitFor(() => expect(preambleBody(u.container).hasAttribute("hidden")).toBe(false));
+  expect(u.getByTestId("session-preamble-text").textContent).toContain("/s/basecamp/SKILL.md");
+  expect(trigger.getAttribute("aria-expanded")).toBe("true");
+});
+
+test("a one-line preamble shows no 'more' count", () => {
+  const u = setup({ preamble: { text: "pi v0.84.1", summary: "pi v0.84.1", more: 0 } });
+
+  expect(u.getByRole("button", { name: /pi v0\.84\.1/ }).textContent).not.toContain("more");
+});
+
+test("no preamble renders no affordance at all", () => {
+  const u = setup();
+
+  expect(u.queryByTestId("session-preamble")).toBeNull();
+  expect(u.queryByTestId("session-preamble-text")).toBeNull();
+});
+
+test("the preamble adds no second live region", () => {
+  // The status line is the header's ONE announcement; session metadata is not
+  // news to read out.
+  const u = setup({ preamble: { text: "pi v0.84.1", summary: "pi v0.84.1", more: 0 } });
+
+  expect(u.getAllByRole("status")).toHaveLength(1);
+});

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte
@@ -24,6 +24,12 @@
    * Retry when the transport is dead) plus a toast for a failed session create,
    * which is the one failure that leaves nothing on screen to explain itself.
    *
+   * What the agent says BEFORE the first prompt is not conversation: harnesses
+   * announce themselves (version, loaded skills) on stdout before their protocol
+   * stream begins, and that banner arrives as an agent message. It is split off
+   * by position in the controller and rendered as session metadata in the
+   * header — see AcpChat.preamble / splitPreamble.
+   *
    * A station can host several sessions at once, so this panel is a view onto
    * ONE of them: the header's switcher picks, `chat.attach` swaps the socket and
    * the transcript. The panel is deliberately not remounted per session — the
@@ -241,6 +247,7 @@
       status={chat.status}
       connection={chat.connection}
       mode={chat.mode}
+      preamble={chat.preamble}
       creating={chat.creating}
       onModeChange={(mode) => chat.setMode(mode)}
       onEnd={() => {
@@ -256,8 +263,11 @@
   </div>
 
   <div class="min-h-0 flex-1">
+    <!-- `chat.conversation`, not the raw transcript: whatever the agent said
+         before the first prompt is session metadata and belongs to the header
+         (see AcpChat.preamble), not to a conversation nobody had started. -->
     <Conversation
-      items={chat.transcript.items}
+      items={chat.conversation}
       onAnswer={(requestSeq, optionId) => chat.answer(requestSeq, optionId)}
     />
   </div>

--- a/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/ChatPanel.svelte.test.ts
@@ -902,6 +902,78 @@ test("an exhausted reconnect budget shows the offline strip with a working Retry
   expect(u.queryByText("Couldn't reach the hub — check your connection.")).toBeNull();
 });
 
+// ─── Session preamble (agent output before the first prompt) ────────────────
+//
+// Live defect: a Pi station's Chat tab opened with the harness banner ("pi
+// v0.84.1 / Skills / …SKILL.md") sitting there as the first agent message,
+// before the user had said anything — the adapter forwards the human-readable
+// stdout lines that precede the NDJSON stream. The information is worth having;
+// impersonating a conversational turn is not. Identification is POSITIONAL —
+// anything the agent says before the first user prompt — so no banner format
+// from another project is baked in here.
+
+const BANNER = "pi v0.84.1\n\nSkills\n\n/s/basecamp/SKILL.md";
+
+const bannerChunk = (seq: number, text: string) =>
+  ev(seq, "agent-update", { sessionUpdate: "agent_message_chunk", content: { type: "text", text } });
+
+test("pre-prompt agent output goes to the header, never into the conversation", async () => {
+  const u = await renderConnected();
+
+  u.ws.fireMessage({ t: "event", event: bannerChunk(1, BANNER) });
+  await tick();
+
+  // Header: collapsed to one line, expandable to the whole banner.
+  const trigger = u.getByRole("button", { name: /pi v0\.84\.1/ });
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  await fireEvent.click(trigger);
+  await waitFor(() => expect(trigger.getAttribute("aria-expanded")).toBe("true"));
+  expect(u.getByTestId("session-preamble-text").textContent).toContain("/s/basecamp/SKILL.md");
+
+  // Conversation: still nothing has been said.
+  expect(u.queryAllByTestId("response-stub")).toHaveLength(0);
+  expect(u.getByText("No conversation yet.")).toBeTruthy();
+});
+
+test("an agent reply AFTER a prompt stays in the conversation and is no preamble", async () => {
+  const u = await renderConnected();
+
+  u.ws.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "run the tests" }) });
+  u.ws.fireMessage({ t: "event", event: bannerChunk(2, "on it") });
+  await tick();
+
+  expect(u.getByTestId("response-stub").textContent).toContain("on it");
+  expect(u.queryByTestId("session-preamble")).toBeNull();
+});
+
+test("no pre-prompt output → no header affordance at all", async () => {
+  const u = await renderConnected();
+
+  expect(u.queryByTestId("session-preamble")).toBeNull();
+});
+
+test("a reloaded session history renders its preamble in the header, not the transcript", async () => {
+  // Reattaching replays the persisted stream from seq 0 — the banner is again
+  // simply what precedes the first user-prompt event.
+  const u = await renderConnected();
+
+  for (const event of [
+    bannerChunk(1, BANNER),
+    ev(2, "user-prompt", { text: "run the tests" }),
+    bannerChunk(3, "on it"),
+  ]) {
+    u.ws.fireMessage({ t: "event", event });
+  }
+  u.ws.fireMessage({ t: "replay-done", lastSeq: 3 });
+  await tick();
+
+  expect(u.getByRole("button", { name: /pi v0\.84\.1/ })).toBeTruthy();
+  const responses = u.queryAllByTestId("response-stub");
+  expect(responses).toHaveLength(1);
+  expect(responses[0].textContent).toContain("on it");
+  expect(u.getByText("run the tests")).toBeTruthy();
+});
+
 test("unmount closes the socket but never ends the session", async () => {
   const u = await renderConnected();
   const end = vi.spyOn(api, "endAcpSession");

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.test.ts
@@ -745,6 +745,68 @@ test("pendingPermissions counts unanswered permission items", async () => {
   expect(chat.pendingPermissions).toBe(0);
 });
 
+// ─── Session preamble: agent output that precedes the first prompt ───────────
+
+test("pre-prompt agent output is exposed as preamble and kept out of the conversation", async () => {
+  const { chat, ws } = await connectedChat();
+
+  // The harness banner arrives as an agent message before anyone has spoken.
+  ws.fireMessage({ t: "event", event: chunk(1, "pi v0.84.1\n\nSkills\n\n/s/basecamp/SKILL.md") });
+
+  expect(chat.preamble?.summary).toBe("pi v0.84.1");
+  expect(chat.preamble?.text).toContain("/s/basecamp/SKILL.md");
+  expect(chat.conversation).toEqual([]);
+
+  // A real turn: the reply is conversation, and the preamble stays put.
+  ws.fireMessage({ t: "event", event: ev(2, "user-prompt", { text: "hi" }) });
+  ws.fireMessage({ t: "event", event: chunk(3, "hello") });
+
+  expect(chat.preamble?.summary).toBe("pi v0.84.1");
+  expect(chat.conversation.map((it) => it.kind)).toEqual(["user", "assistant"]);
+});
+
+test("a replayed history splits the same way — preamble is positional, not remembered", async () => {
+  // Reattaching replays the persisted stream from seq 0, so the banner is just
+  // whatever precedes the first user-prompt event. Same rule, no extra state.
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row(), row({ id: "s2" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  for (const event of [
+    chunk(1, "pi v0.84.1\nSkills"),
+    ev(2, "user-prompt", { text: "hi" }),
+    chunk(3, "hello"),
+  ]) {
+    ws.fireMessage({ t: "event", event });
+  }
+  ws.fireMessage({ t: "replay-done", lastSeq: 3 });
+
+  expect(chat.preamble).toEqual({ text: "pi v0.84.1\nSkills", summary: "pi v0.84.1", more: 1 });
+  expect(chat.conversation.map((it) => it.kind)).toEqual(["user", "assistant"]);
+});
+
+test("no pre-prompt output → no preamble, and switching sessions drops the old one", async () => {
+  vi.spyOn(api, "listAcpSessions").mockResolvedValue([row(), row({ id: "s2" })]);
+  const chat = new AcpChat("st1");
+  await chat.init();
+  const ws = MockWebSocket.latest()!;
+  ws.open();
+  ws.fireMessage({ t: "event", event: chunk(1, "pi v0.84.1") });
+  expect(chat.preamble?.summary).toBe("pi v0.84.1");
+
+  await chat.attach("s2");
+  // A fresh transcript means a fresh preamble — never the previous session's.
+  expect(chat.preamble).toBeNull();
+
+  const ws2 = MockWebSocket.latest()!;
+  ws2.open();
+  ws2.fireMessage({ t: "event", event: ev(1, "user-prompt", { text: "hi" }) });
+  ws2.fireMessage({ t: "event", event: chunk(2, "hello") });
+  expect(chat.preamble).toBeNull();
+  expect(chat.conversation).toHaveLength(2);
+});
+
 // ─── The dead socket: a send into a connection nothing has noticed is gone ───
 //
 // Live-dogfooding defect: after a laptop sleep the browser still held a socket

--- a/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
+++ b/apps/console/src/lib/components/stations/chat/acp-chat.svelte.ts
@@ -75,6 +75,9 @@ import {
   dropPendingPrompt,
   emptyTranscript,
   foldEvent,
+  splitPreamble,
+  type ChatItem,
+  type SessionPreamble,
   type Transcript,
 } from "./transcript";
 
@@ -219,6 +222,31 @@ export class AcpChat {
 
   get transcript(): Transcript {
     return this.#transcript;
+  }
+
+  /**
+   * The transcript split into session metadata and the conversation proper.
+   *
+   * Derived HERE rather than in the view so the live stream and a replayed
+   * history share one rule: both land in `#transcript`, and the rule is purely
+   * positional (see `splitPreamble`) — nothing has to be remembered across a
+   * reattach. It also means a session swap can't leak the previous session's
+   * banner: `attachRow` replaces the transcript, and this follows it.
+   */
+  #view = $derived(splitPreamble(this.#transcript.items));
+
+  /**
+   * What the agent said before the user's first prompt — the harness banner.
+   * Session metadata for the header, NOT a conversational turn. Null when the
+   * agent hasn't spoken first (which is most harnesses, most of the time).
+   */
+  get preamble(): SessionPreamble | null {
+    return this.#view.preamble;
+  }
+
+  /** The transcript as the conversation should render it — preamble removed. */
+  get conversation(): ChatItem[] {
+    return this.#view.items;
   }
 
   get connection(): ChatConnection {

--- a/apps/console/src/lib/components/stations/chat/transcript.test.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.test.ts
@@ -5,6 +5,7 @@ import {
   foldEvent,
   addPendingPrompt,
   dropPendingPrompt,
+  splitPreamble,
   type Transcript,
 } from "./transcript";
 
@@ -383,6 +384,89 @@ test("user-prompt without a pending item pushes normally and closes streaming it
     { kind: "assistant", seq: 1, text: "old answer", streaming: false },
     { kind: "user", seq: 2, text: "next question" },
   ]);
+});
+
+// ─── (h) session preamble (agent output before the first prompt) ─────────────
+
+test("agent output before the first user prompt is preamble, not conversation", () => {
+  // The live shape: pi prints a human-readable banner on stdout before its
+  // NDJSON protocol stream begins, and the adapter forwards it as an agent
+  // message. Nobody has spoken yet, so it is not a conversational turn.
+  const banner = "pi v0.84.1\n\nSkills\n\n/home/u/.agents/skills/basecamp/SKILL.md";
+  const t = fold([
+    ev(1, "state", { status: "idle" }),
+    chunk(2, banner),
+    ev(3, "user-prompt", { text: "run the tests" }),
+    chunk(4, "on it"),
+  ]);
+
+  const split = splitPreamble(t.items);
+  expect(split.preamble).toEqual({
+    text: banner,
+    summary: "pi v0.84.1",
+    more: 2, // "Skills" and the skill path; blank spacer lines don't count
+  });
+  // The banner is gone from the conversation; the real turn is untouched.
+  expect(split.items).toEqual([
+    { kind: "user", seq: 3, text: "run the tests" },
+    { kind: "assistant", seq: 4, text: "on it", streaming: true },
+  ]);
+});
+
+test("an agent reply AFTER a user prompt is never preamble", () => {
+  const t = fold([ev(1, "user-prompt", { text: "hi" }), chunk(2, "hello there")]);
+
+  const split = splitPreamble(t.items);
+  expect(split.preamble).toBeNull();
+  // No preamble → the same array reference back, so views don't re-key.
+  expect(split.items).toBe(t.items);
+});
+
+test("agent output with no user prompt yet is still preamble", () => {
+  const t = fold([ev(1, "state", { status: "idle" }), chunk(2, "pi v0.84.1")]);
+
+  const split = splitPreamble(t.items);
+  expect(split.preamble?.summary).toBe("pi v0.84.1");
+  expect(split.preamble?.more).toBe(0);
+  expect(split.items).toEqual([]);
+});
+
+test("a pending optimistic prompt already closes the preamble window", () => {
+  // The echo hasn't landed, but the user HAS spoken — anything after it is a
+  // reply, not a banner.
+  const t = addPendingPrompt(fold([chunk(1, "pi v0.84.1")]), "hi");
+  const after = foldEvent(t, chunk(2, "hello"));
+
+  const split = splitPreamble(after.items);
+  expect(split.preamble?.summary).toBe("pi v0.84.1");
+  expect(split.items).toEqual([
+    { kind: "user", seq: -1, text: "hi", pending: true },
+    { kind: "assistant", seq: 2, text: "hello", streaming: true },
+  ]);
+});
+
+test("only agent MESSAGES are lifted out — notices and tool calls stay in the conversation", () => {
+  const t = fold([
+    ev(1, "error", { message: "harness restarted" }),
+    ev(2, "agent-update", { sessionUpdate: "tool_call", toolCallId: "t1", title: "Read file" }),
+    chunk(3, "pi v0.84.1"),
+  ]);
+
+  const split = splitPreamble(t.items);
+  expect(split.preamble?.summary).toBe("pi v0.84.1");
+  expect(split.items.map((it) => it.kind)).toEqual(["notice", "tool"]);
+});
+
+test("whitespace-only agent output before the first prompt is no preamble at all", () => {
+  const t = fold([chunk(1, "  \n\n "), ev(2, "user-prompt", { text: "hi" })]);
+
+  const split = splitPreamble(t.items);
+  expect(split.preamble).toBeNull();
+  expect(split.items).toEqual([{ kind: "user", seq: 2, text: "hi" }]);
+});
+
+test("an empty transcript has no preamble", () => {
+  expect(splitPreamble(emptyTranscript().items).preamble).toBeNull();
 });
 
 // ─── forward compat / malformed payloads ─────────────────────────────────────

--- a/apps/console/src/lib/components/stations/chat/transcript.ts
+++ b/apps/console/src/lib/components/stations/chat/transcript.ts
@@ -60,6 +60,16 @@ export interface Transcript {
   usage?: { used: number; size: number };
 }
 
+/** Session metadata lifted out of the transcript — see `splitPreamble`. */
+export interface SessionPreamble {
+  /** The whole preamble, verbatim (ends trimmed), for the expanded view. */
+  text: string;
+  /** First non-empty line — the collapsed one-liner ("pi v0.84.1"). */
+  summary: string;
+  /** How many further non-empty lines `text` holds beyond the summary. */
+  more: number;
+}
+
 export function emptyTranscript(): Transcript {
   return { items: [], lastSeq: 0, status: "starting", usage: undefined };
 }
@@ -83,6 +93,59 @@ export function dropPendingPrompt(t: Transcript): { transcript: Transcript; text
   const last = t.items.at(-1);
   if (last?.kind !== "user" || last.pending !== true) return { transcript: t, text: null };
   return { transcript: { ...t, items: t.items.slice(0, -1) }, text: last.text };
+}
+
+/**
+ * Split a session's items into its PREAMBLE — agent output that arrived before
+ * the user's first prompt — and the conversation proper.
+ *
+ * Harnesses announce themselves before anyone has spoken: pi prints a
+ * human-readable banner on stdout ("pi v0.84.1", loaded skills) before its
+ * NDJSON protocol stream begins, and the adapter forwards those pre-protocol
+ * lines as an agent message. It is genuinely useful — it names the exact
+ * harness version answering you — but it is session METADATA, and rendering it
+ * as the first turn of a conversation nobody has started is a lie about who
+ * said what.
+ *
+ * Identification is POSITIONAL, never by content. Matching on "pi v" or
+ * "Skills" would bake another project's banner format into this console and
+ * would rot silently the moment they reworded it; "the agent spoke before the
+ * user did" holds for every harness that does the same thing, and needs no
+ * remembering — a replayed history splits exactly like a live stream, because
+ * position is a property of the items, not of how they arrived.
+ *
+ * Only agent MESSAGES are lifted. Notices (errors, "session ended") and tool
+ * calls that precede the first prompt are events in their own right and stay
+ * in the transcript, where the user can see them next to what followed.
+ *
+ * Returns the SAME items reference when there is nothing to lift, so views
+ * don't re-key an untouched list. A preamble of pure whitespace yields `null`
+ * (no header affordance) while still being lifted out — an empty bubble is no
+ * better in the transcript than in the header.
+ */
+export function splitPreamble(items: ChatItem[]): {
+  preamble: SessionPreamble | null;
+  items: ChatItem[];
+} {
+  const firstPrompt = items.findIndex((it) => it.kind === "user");
+  const end = firstPrompt === -1 ? items.length : firstPrompt;
+
+  const texts: string[] = [];
+  for (let i = 0; i < end; i += 1) {
+    const it = items[i];
+    if (it.kind === "assistant") texts.push(it.text);
+  }
+  if (texts.length === 0) return { preamble: null, items };
+
+  const rest = items.filter((it, i) => !(i < end && it.kind === "assistant"));
+  const text = texts.join("\n").replace(/^\s+|\s+$/g, "");
+  const lines = text.split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length === 0) return { preamble: null, items: rest };
+
+  return {
+    preamble: { text, summary: lines[0].trim(), more: lines.length - 1 },
+    items: rest,
+  };
 }
 
 // ─── Defensive narrowing helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## The problem, observed live

A Pi station's Chat tab opened with this as the first "agent message", before the user had said anything:

```
pi v0.84.1

Skills

/Users/rakeshgangwar/.agents/skills/basecamp/SKILL.md
/Users/rakeshgangwar/.agents/skills/ai-elements/SKILL.md
```

## Root cause

Pi prints a human-readable banner on stdout **before** its NDJSON protocol stream begins. The `pi-acp` adapter forwards those pre-protocol lines as an agent message — its own source notes that they are "Human-readable stdout lines emitted before RPC NDJSON begins (e.g. Context/Skills/Extensions info)" and that "callers can filter as needed". We are the caller.

The information is genuinely useful: it names the exact harness version answering you and which skills are loaded. It just isn't a conversational turn, and rendering it as one is a lie about who said what in a conversation nobody had started.

## What changed

Pre-prompt agent output is now **session metadata in the chat header**:

- collapsed to its first non-empty line (`pi v0.84.1`) with a `+N lines` count,
- expandable (chevron disclosure) to the verbatim text, capped and scrollable,
- rendered **not at all** when there is no preamble — no empty affordance,
- outside the header's `role="status"` region: metadata is not an announcement.

## Why identification is positional, not content-based

The rule is "an agent message that arrives before the user's first prompt in the session". No string matching on `pi v` or `Skills`:

- content matching would hard-code another project's banner format into this console, and would rot **silently** the moment they reword it;
- position is harness-agnostic — it works for any harness that announces itself the same way;
- position needs nothing remembered, which is what makes history reload correct for free: a replay folds into the same transcript, so a reattached session splits exactly like a live stream.

Only agent *messages* are lifted. Notices (errors, "session ended") and tool calls that precede the first prompt are events in their own right and stay in the transcript.

## Where it lives

`splitPreamble()` in `transcript.ts` (pure, unit-tested) is consumed by the controller as `AcpChat.preamble` / `AcpChat.conversation`, so live streaming and reloaded history share one rule and a session swap cannot leak the previous session's banner (the transcript is replaced, and the derived split follows it).

## Tests (TDD, and proven non-vacuous)

14 new tests written first, failing (`splitPreamble is not a function`, missing header affordance), then implemented to green.

Vacuity checks — the behaviour was reverted three ways and the suites watched to fail, then restored:

| reverted behaviour | result |
| --- | --- |
| `splitPreamble` returns everything as conversation (the old behaviour) | 10 failures, incl. header/conversation placement in all three layers |
| the split ignores position (lifts *every* agent message) | 9 failures, incl. "an agent reply AFTER a user prompt is never preamble" and the pre-existing "renders replayed transcript items" |
| the header's `preamble` prop defaults to a non-null value | 1 failure: "no preamble renders no affordance at all" |

Console-only; no node-agent, hub, or contract changes. No existing test weakened.

Verified separately on Node 22: `pnpm check` 0 errors / 0 warnings across 6208 files, `pnpm test` 733 passed (70 files), `PUBLIC_HUB_URL=https://hub.agentpod.dev pnpm build` built in 42s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
