### PR TITLE
fix(hub): a runtime is only online when a node has actually arrived

### DIFF
--- a/apps/console/src/routes/runtimes/+page.svelte
+++ b/apps/console/src/routes/runtimes/+page.svelte
@@ -174,7 +174,11 @@
       accessorKey: "status",
       header: "Status",
       enableSorting: false,
-      cell: (ctx) => renderSnippet(statusCell, { value: ctx.getValue<string>() }),
+      cell: (ctx) =>
+        renderSnippet(statusCell, {
+          value: ctx.getValue<string>(),
+          reason: ctx.row.original.statusReason ?? null,
+        }),
     },
     {
       accessorKey: "createdAt",
@@ -217,10 +221,24 @@
   {/if}
 {/snippet}
 
-{#snippet statusCell({ value }: { value: string })}
-  <Badge variant="outline" class={statusBadgeClass(value)} data-testid="status-badge">
-    {value}
-  </Badge>
+{#snippet statusCell({ value, reason }: { value: string; reason: string | null })}
+  <div class="flex flex-col items-start gap-1">
+    <Badge variant="outline" class={statusBadgeClass(value)} data-testid="status-badge">
+      {value}
+    </Badge>
+    <!-- Why, when the status alone doesn't say. An operator who sees only
+         "error" restarts things; one who reads "no node enrolled within 2m of
+         the start request" goes and looks at the container instead. -->
+    {#if reason}
+      <span
+        class="max-w-[22rem] text-xs leading-snug text-muted-foreground"
+        title={reason}
+        data-testid="status-reason"
+      >
+        {reason}
+      </span>
+    {/if}
+  </div>
 {/snippet}
 
 {#snippet createdCell({ value }: { value: string })}

--- a/apps/console/src/routes/runtimes/page.svelte.test.ts
+++ b/apps/console/src/routes/runtimes/page.svelte.test.ts
@@ -342,6 +342,64 @@ test("waking calls startRuntime", async () => {
   await waitFor(() => expect(start).toHaveBeenCalledWith("rt-sleep"));
 });
 
+// ---------------------------------------------------------------------------
+// Starting + why a runtime failed (issue #254)
+// ---------------------------------------------------------------------------
+
+test("a starting runtime reads as starting, not online", async () => {
+  // The substrate accepting a start request is not a node being connected.
+  // Showing green here is what sent an operator restarting a container that
+  // was crash-exiting in under a second.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-starting", name: "booting", status: "starting" as never },
+  ]);
+
+  const { getByTestId } = render(RuntimesPage);
+  await waitFor(() => expect(getByTestId("status-badge").textContent).toContain("starting"));
+  // Styled as in-flight, not as running — an unmapped status would render bare.
+  expect(getByTestId("status-badge").className).toContain("status-starting");
+});
+
+test("a starting runtime offers no Start or Stop, but can still be destroyed", async () => {
+  // Nothing to do but wait — except escape, if it never comes back.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-starting", name: "booting", status: "starting" as never },
+  ]);
+
+  const { queryByTestId, getByTestId } = render(RuntimesPage);
+  await waitFor(() => expect(getByTestId("destroy-btn")).toBeTruthy());
+  expect(queryByTestId("start-btn")).toBeNull();
+  expect(queryByTestId("stop-btn")).toBeNull();
+});
+
+test("a failed runtime shows why it failed", async () => {
+  // "error" alone leaves the operator's actual question unanswered. The whole
+  // point of the timeout is that the console can say the container never came
+  // back, rather than inviting another pointless restart.
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    {
+      ...mockRuntimes[0]!,
+      id: "rt-dead",
+      name: "never-returned",
+      status: "error" as const,
+      statusReason: "no node enrolled within 2m of the start request — the container was asked to run but never came back",
+    },
+  ]);
+
+  const { container } = render(RuntimesPage);
+  await waitFor(() => expect(container.textContent).toMatch(/no node enrolled/));
+});
+
+test("a healthy runtime shows no reason line", async () => {
+  vi.spyOn(api, "listRuntimes").mockResolvedValue([
+    { ...mockRuntimes[0]!, id: "rt-ok", name: "fine", statusReason: null },
+  ]);
+
+  const { queryByTestId, getByText } = render(RuntimesPage);
+  await waitFor(() => expect(getByText("fine")).toBeTruthy());
+  expect(queryByTestId("status-reason")).toBeNull();
+});
+
 test("an online runtime offers no Wake", async () => {
   vi.spyOn(api, "listRuntimes").mockResolvedValue([
     { ...mockRuntimes[0]!, id: "rt-up", name: "awake", status: "online" as const },

--- a/apps/hub/CLAUDE.md
+++ b/apps/hub/CLAUDE.md
@@ -15,7 +15,8 @@ Test DB requirements (pgvector image + env override): see root `CLAUDE.md` / `TE
 ## Architecture facts that bite
 
 - **Node gateway** (`routes/gateway.ts`, WSS `/public/nodes/gateway`, auth `Bearer <nodeId>:<nodeSecret>`): onMessage must await `authReady` (one-shot frames race async auth); teardown is epoch-guarded (`connectionManager.isCurrent`) so a late close from a replaced socket can't kill a fresh connection; a heartbeat on an unregistered socket re-registers it.
-- **Sweeper** (`services/node-sweeper.ts`): every 15s, expires online nodes silent >45s (agent heartbeats every 15s) with the same full teardown as a real close. False positives self-heal via heartbeat re-register.
+- **Sweeper** (`services/node-sweeper.ts`): every 15s, expires online nodes silent >45s (agent heartbeats every 15s) with the same full teardown as a real close. False positives self-heal via heartbeat re-register. The same tick runs `sweepStalledRuntimeStarts` (`services/runtimes.ts`): a runtime left `starting`/`provisioning` for >2min with an externalId becomes `error` + `statusReason`.
+- **Runtime `online` is evidence-only**: only `enrollment.ts` writes it, because a node enrolled. `startRuntime` writes `starting` — the substrate accepting a start request is not a node existing (issue #254). Never widen a lifecycle write back to `online` on a driver call returning.
 - **Broker** (`services/broker.ts`): request/stream correlation by UUID; `request()` never rejects — resolves `{ok:false, error}` on timeout/offline/disconnect.
 - **Auth**: Better Auth, session cookies; secret comes from config (`BETTER_AUTH_SECRET`) passed explicitly to `betterAuth({secret})`. First signup becomes admin, then signup closes (`system_settings`).
 - **Stations**: presence in the `stations` table = adopted; there is no `adopted` column. Observe routes (`/api/stations/:id/...`) proxy to the node via broker and 502 on node-side failure.

--- a/apps/hub/src/db/drizzle-migrations/0032_runtime_starting_status.sql
+++ b/apps/hub/src/db/drizzle-migrations/0032_runtime_starting_status.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."runtime_status" ADD VALUE 'starting' BEFORE 'online';--> statement-breakpoint
+ALTER TABLE "provisioned_runtimes" ADD COLUMN "status_reason" text;

--- a/apps/hub/src/db/drizzle-migrations/meta/0032_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0032_snapshot.json
@@ -1,0 +1,2017 @@
+{
+  "id": "9969909d-d2ed-41ac-9698-d792ba586c0b",
+  "prevId": "f4c11c48-ea51-482f-ac0d-a3f003b1e01a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1786506652047,
       "tag": "0031_clumsy_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1786532106455,
+      "tag": "0032_runtime_starting_status",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/nodes.ts
+++ b/apps/hub/src/db/schema/nodes.ts
@@ -21,7 +21,7 @@ export const nodes = pgTable("nodes", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (t) => [index("nodes_user_id_idx").on(t.userId)]);
 
-export const runtimeStatusEnum = pgEnum("runtime_status", ["provisioning", "online", "stopped", "asleep", "error", "destroyed"]);
+export const runtimeStatusEnum = pgEnum("runtime_status", ["provisioning", "starting", "online", "stopped", "asleep", "error", "destroyed"]);
 
 export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   id: text("id").primaryKey(),
@@ -29,6 +29,10 @@ export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   provider: text("provider").notNull(),
   externalId: text("external_id"),
   status: runtimeStatusEnum("status").notNull().default("provisioning"),
+  // Why the runtime is in its current status, when the status alone doesn't
+  // say — e.g. "no node enrolled within 2m of the start request". Null when
+  // there is nothing to explain.
+  statusReason: text("status_reason"),
   nodeId: text("node_id").references(() => nodes.id, { onDelete: "set null" }),
   name: text("name").notNull(),
   resourceTier: text("resource_tier").notNull().default("small"),

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -36,6 +36,8 @@ import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
 import { registerProvisioner, resetProvisioners } from "../services/provisioner/registry";
 import type { RuntimeProvisioner, ProvisionSpec } from "../services/provisioner/types";
 import { runtimeRoutes } from "./runtimes";
+import { sweepStalledRuntimeStarts, START_TIMEOUT_MS } from "../services/runtimes";
+import { enrollNode } from "../services/enrollment";
 import type { AuthUser } from "../auth/middleware";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -517,3 +519,142 @@ test("a driver that reports no runtime stores null", async () => {
   expect(res.status).toBe(201);
   expect(((await res.json()) as Record<string, unknown>).runtime).toBeNull();
 });
+
+// ─── "started but never came back" (issue #254) ───────────────────────────────
+//
+// `online` is a claim that a node for this runtime is connected. The start path
+// cannot know that: it only knows the substrate accepted a start request. On
+// 2026-08-12 a runtime read `online` while its container was crash-exiting in
+// 892 ms, and the operator restarted it twice on the strength of the lie.
+
+async function startVia(id: string, userId = TEST_USER) {
+  return testApp.request(`/api/runtimes/${id}/start`, {
+    method: "POST",
+    headers: { "X-Test-User-Id": userId },
+  });
+}
+
+async function rowOf(id: string) {
+  const [row] = await db
+    .select()
+    .from(provisionedRuntimes)
+    .where(eq(provisionedRuntimes.id, id));
+  return row!;
+}
+
+test("a started runtime is not online until a node actually arrives", async () => {
+  const createRes = await createRuntime(TEST_USER, "start-no-evidence");
+  const { id } = (await createRes.json()) as { id: string };
+
+  // The fake driver's start() resolves — the substrate accepted the request.
+  const res = await startVia(id);
+  expect(res.status).toBe(204);
+  expect(fakeCalls.start).toHaveLength(1);
+
+  // ...but no node has enrolled, so the hub must not claim it is online.
+  const row = await rowOf(id);
+  expect(row.status).not.toBe("online");
+  expect(row.status).toBe("starting");
+}, 30_000);
+
+test("a start whose node never arrives times out into error with the reason", async () => {
+  // The state the old code could not represent: started, never came back.
+  const createRes = await createRuntime(TEST_USER, "start-never-returns");
+  const { id } = (await createRes.json()) as { id: string };
+  await startVia(id);
+
+  // Before the deadline it is still legitimately "starting".
+  expect(await sweepStalledRuntimeStarts(Date.now())).not.toContain(id);
+  expect((await rowOf(id)).status).toBe("starting");
+
+  const swept = await sweepStalledRuntimeStarts(Date.now() + START_TIMEOUT_MS + 1_000);
+  expect(swept).toContain(id);
+
+  const row = await rowOf(id);
+  expect(row.status).toBe("error");
+  // The console must be able to say *why*, not just show a red light.
+  expect(row.statusReason).toContain("no node enrolled");
+}, 30_000);
+
+test("a node enrolling is what makes a started runtime online", async () => {
+  const createRes = await createRuntime(TEST_USER, "start-then-enrol");
+  const { id } = (await createRes.json()) as { id: string };
+  const enrollToken = fakeCalls.provision[0]!.enrollToken;
+
+  await startVia(id);
+  expect((await rowOf(id)).status).toBe("starting");
+
+  await enrollNode(enrollToken, {
+    hostname: "startbox",
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+
+  const row = await rowOf(id);
+  expect(row.status).toBe("online");
+  expect(row.nodeId).toBeTruthy();
+  // A stale failure reason must not linger next to a green badge.
+  expect(row.statusReason).toBeNull();
+}, 30_000);
+
+test("an error reason from an earlier failure is cleared when the runtime is started again", async () => {
+  const createRes = await createRuntime(TEST_USER, "start-clears-reason");
+  const { id } = (await createRes.json()) as { id: string };
+  await startVia(id);
+  await sweepStalledRuntimeStarts(Date.now() + START_TIMEOUT_MS + 1_000);
+  expect((await rowOf(id)).statusReason).toBeTruthy();
+
+  await startVia(id);
+  const row = await rowOf(id);
+  expect(row.status).toBe("starting");
+  expect(row.statusReason).toBeNull();
+}, 30_000);
+
+test("an asleep runtime is never swept into error", async () => {
+  // A sleeping runtime's node is legitimately offline and it wakes on demand.
+  // Reporting a routine state as a fault is the failure shape this codebase
+  // keeps hitting — the sweeper must not reintroduce it.
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes
+      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${TEST_USER}, 'cloudflare', 'ext-asleep', 'asleep', 'sleeper', 'small', 'none',
+            now() - interval '1 day', now() - interval '1 day')
+  `;
+
+  const swept = await sweepStalledRuntimeStarts(Date.now() + START_TIMEOUT_MS + 1_000);
+  expect(swept).not.toContain(id);
+  expect((await rowOf(id)).status).toBe("asleep");
+}, 30_000);
+
+test("a created runtime whose node never arrives times out too", async () => {
+  // createRuntime has the same shape as startRuntime: it asks a substrate and
+  // then waits. A create that never enrols used to read "provisioning" forever.
+  const createRes = await createRuntime(TEST_USER, "create-never-returns");
+  const { id } = (await createRes.json()) as { id: string };
+  expect((await rowOf(id)).status).toBe("provisioning");
+
+  const swept = await sweepStalledRuntimeStarts(Date.now() + START_TIMEOUT_MS + 1_000);
+  expect(swept).toContain(id);
+
+  const row = await rowOf(id);
+  expect(row.status).toBe("error");
+  expect(row.statusReason).toContain("no node enrolled");
+}, 30_000);
+
+test("a runtime still being provisioned (no external id yet) is not swept", async () => {
+  // Between the row insert and provision() resolving there is no container to
+  // have failed — a slow image pull must not be reported as a failure.
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes
+      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${TEST_USER}, 'docker', NULL, 'provisioning', 'slow-pull', 'small', 'none',
+            now() - interval '1 day', now() - interval '1 day')
+  `;
+
+  const swept = await sweepStalledRuntimeStarts(Date.now() + START_TIMEOUT_MS + 1_000);
+  expect(swept).not.toContain(id);
+  expect((await rowOf(id)).status).toBe("provisioning");
+}, 30_000);

--- a/apps/hub/src/services/enrollment.ts
+++ b/apps/hub/src/services/enrollment.ts
@@ -148,7 +148,10 @@ export async function enrollNode(
       if (updated.length > 0) {
         await db
           .update(provisionedRuntimes)
-          .set({ status: "online", updatedAt: new Date() })
+          // A node is here: this is the evidence "online" is a claim about.
+          // Clearing statusReason retires any earlier "never came back" note —
+          // it just did.
+          .set({ status: "online", statusReason: null, updatedAt: new Date() })
           .where(eq(provisionedRuntimes.id, runtime.id));
 
         return { nodeId: runtime.nodeId, nodeSecret };
@@ -201,7 +204,7 @@ export async function enrollNode(
   if (row.provisionedRuntimeId) {
     await db
       .update(provisionedRuntimes)
-      .set({ nodeId, status: "online", updatedAt: new Date() })
+      .set({ nodeId, status: "online", statusReason: null, updatedAt: new Date() })
       .where(eq(provisionedRuntimes.id, row.provisionedRuntimeId));
   }
 

--- a/apps/hub/src/services/node-sweeper.ts
+++ b/apps/hub/src/services/node-sweeper.ts
@@ -13,6 +13,7 @@ import { connectionManager } from "./connection-manager";
 import { dropNode } from "./broker";
 import { clearNode } from "./health-cache";
 import { setNodeStatus } from "./node-registry";
+import { sweepStalledRuntimeStarts } from "./runtimes";
 
 export const SWEEP_INTERVAL_MS = 15_000;
 export const OFFLINE_THRESHOLD_MS = 45_000;
@@ -40,11 +41,20 @@ export async function sweepStaleNodes(now: number = Date.now()): Promise<string[
   return stale.map((s) => s.id);
 }
 
-/** Start the periodic sweeper. Returns a stop function. */
+/**
+ * Start the periodic sweeper. Returns a stop function.
+ *
+ * Two expiries share the tick because they are the same idea at two levels: a
+ * node that stopped talking, and a runtime that was asked to run and never
+ * produced a node at all (see sweepStalledRuntimeStarts).
+ */
 export function startNodeSweeper(): () => void {
   const timer = setInterval(() => {
     void sweepStaleNodes().catch((err) =>
       console.error("[sweeper] sweep failed:", err)
+    );
+    void sweepStalledRuntimeStarts().catch((err) =>
+      console.error("[sweeper] runtime sweep failed:", err)
     );
   }, SWEEP_INTERVAL_MS);
   return () => clearInterval(timer);

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -6,6 +6,11 @@
  *   destroy → driver.destroy → mark destroyed
  *   start / stop → driver.start/stop (guard on capability)
  *
+ * Status honesty: `online` means "a node for this runtime is connected" and is
+ * written only by enrolment (enrollment.ts). Everything here can say at most
+ * "the substrate accepted my request" — hence `provisioning` / `starting`, and
+ * sweepStalledRuntimeStarts() to expire the ones that never come back.
+ *
  * Error semantics for routes:
  *   - "provider disabled: X"     → 400 (user chose a disabled provider)
  *   - "provider not registered"  → 400 (same surface — misconfigured)
@@ -14,7 +19,7 @@
  *   - driver provision() throw   → status set to "error"; rethrow (→ 502)
  */
 
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, lt, ne } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { provisionedRuntimes, nodes } from "../db/schema/nodes";
 import { mintEnrollmentToken } from "./enrollment";
@@ -67,6 +72,7 @@ function toContract(row: RuntimeRow): ProvisionedRuntime {
     resourceTier: row.resourceTier as ProvisionedRuntime["resourceTier"],
     harness: (row.harness ?? "none") as ProvisionedRuntime["harness"],
     runtime: row.runtime ?? null,
+    statusReason: row.statusReason ?? null,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
@@ -137,7 +143,11 @@ export async function createRuntime(
   } catch (err) {
     await db
       .update(provisionedRuntimes)
-      .set({ status: "error", updatedAt: new Date() })
+      .set({
+        status: "error",
+        statusReason: `could not mint an enrolment token: ${(err as Error).message}`,
+        updatedAt: new Date(),
+      })
       .where(eq(provisionedRuntimes.id, id));
     throw Object.assign(err as Error, { status: 502 });
   }
@@ -149,7 +159,11 @@ export async function createRuntime(
     // Driver not registered (env flag on but no driver wired) → 400
     await db
       .update(provisionedRuntimes)
-      .set({ status: "error", updatedAt: new Date() })
+      .set({
+        status: "error",
+        statusReason: (err as Error).message,
+        updatedAt: new Date(),
+      })
       .where(eq(provisionedRuntimes.id, id));
     throw Object.assign(err as Error, { status: 400 });
   }
@@ -178,7 +192,11 @@ export async function createRuntime(
   } catch (err) {
     await db
       .update(provisionedRuntimes)
-      .set({ status: "error", updatedAt: new Date() })
+      .set({
+        status: "error",
+        statusReason: `the ${provider} driver failed to provision it: ${(err as Error).message}`,
+        updatedAt: new Date(),
+      })
       .where(eq(provisionedRuntimes.id, id));
     // Surface as 502 — the driver (external system) failed
     throw Object.assign(err as Error, { status: 502 });
@@ -269,7 +287,11 @@ export async function destroyRuntime(userId: string, id: string): Promise<void> 
 }
 
 /**
- * Start a stopped runtime. Throws 400 if the driver has no start() support.
+ * Start (or wake) a runtime. Throws 400 if the driver has no start() support.
+ *
+ * Leaves the runtime `starting`, never `online`: see the comment on the write.
+ * A wake takes the same path, so an asleep runtime goes asleep → starting →
+ * online (or → error, if the substrate says yes and nothing comes back).
  */
 export async function startRuntime(userId: string, id: string): Promise<void> {
   const [row] = await db
@@ -303,10 +325,102 @@ export async function startRuntime(userId: string, id: string): Promise<void> {
 
   await provisioner.start(row.externalId);
 
+  // NOT "online". All we know is that the substrate accepted a start request;
+  // whether a node exists is a different question, and only enrolment can
+  // answer it (see enrollment.ts, the evidence-based writer of "online").
+  //
+  // On 2026-08-12 this line claimed online for a container that crash-exited in
+  // 892 ms, and the operator restarted it twice on the strength of that claim.
+  // `starting` is the honest state, and sweepStalledRuntimeStarts() below walks
+  // it back to `error` with a reason when no node ever arrives.
   await db
     .update(provisionedRuntimes)
-    .set({ status: "online", updatedAt: new Date() })
+    .set({ status: "starting", statusReason: null, updatedAt: new Date() })
     .where(eq(provisionedRuntimes.id, id));
+}
+
+/**
+ * How long a runtime may sit in `starting`/`provisioning` before the hub
+ * concludes its node is never coming.
+ *
+ * A node-agent enrols within seconds of its container booting, so two minutes
+ * is many times the honest worst case (cold image pull excluded — see below)
+ * while still answering the operator's question in the time they would spend
+ * staring at the console.
+ */
+export const START_TIMEOUT_MS = 2 * 60_000;
+
+const humanMs = (ms: number) =>
+  ms >= 60_000 ? `${Math.round(ms / 60_000)}m` : `${Math.round(ms / 1000)}s`;
+
+/**
+ * Expire runtimes that were asked to run and never came back.
+ *
+ * "Started but never came back" is the most common way a provisioned runtime
+ * fails and used to be invisible: `starting`/`provisioning` had no exit except
+ * a node arriving, so a runtime whose container died on boot sat there — or,
+ * before #254, sat there lying about being `online`.
+ *
+ * Deliberately narrow:
+ *   - Only `starting` and `provisioning` are considered. `asleep` is a healthy
+ *     state whose node is legitimately offline and must never be reclassified
+ *     as failed; `stopped`/`online`/`error`/`destroyed` are not waiting on
+ *     anything.
+ *   - Only rows with an externalId. Between the insert and provision()
+ *     resolving there is no container yet, so a slow image pull is not a
+ *     failure.
+ *   - The write is a compare-and-set on the status we read. A node that enrols
+ *     mid-sweep wins: evidence always beats a timeout.
+ *
+ * Not terminal — a late enrolment still flips the runtime to `online`.
+ *
+ * @param now injectable clock for tests.
+ * @returns the ids actually flipped to `error`.
+ */
+export async function sweepStalledRuntimeStarts(
+  now: number = Date.now()
+): Promise<string[]> {
+  const cutoff = new Date(now - START_TIMEOUT_MS);
+
+  const stalled = await db
+    .select({ id: provisionedRuntimes.id, status: provisionedRuntimes.status })
+    .from(provisionedRuntimes)
+    .where(
+      and(
+        inArray(provisionedRuntimes.status, ["starting", "provisioning"]),
+        isNotNull(provisionedRuntimes.externalId),
+        lt(provisionedRuntimes.updatedAt, cutoff)
+      )
+    );
+
+  const expired: string[] = [];
+  for (const row of stalled) {
+    const verb = row.status === "starting" ? "the start request" : "provisioning";
+    const flipped = await db
+      .update(provisionedRuntimes)
+      .set({
+        status: "error",
+        statusReason:
+          `no node enrolled within ${humanMs(START_TIMEOUT_MS)} of ${verb} — ` +
+          `the container was asked to run but never came back ` +
+          `(check the substrate's container logs)`,
+        updatedAt: new Date(now),
+      })
+      .where(
+        and(
+          eq(provisionedRuntimes.id, row.id),
+          eq(provisionedRuntimes.status, row.status)
+        )
+      )
+      .returning({ id: provisionedRuntimes.id });
+
+    if (flipped.length > 0) {
+      expired.push(row.id);
+      console.log(`[runtime-sweeper] ${row.id} ${row.status} → error (no node enrolled)`);
+    }
+  }
+
+  return expired;
 }
 
 /**

--- a/packages/contract/src/runtime.test.ts
+++ b/packages/contract/src/runtime.test.ts
@@ -93,6 +93,41 @@ describe("ProvisionedRuntime.runtime", () => {
   });
 });
 
+describe("RuntimeStatus starting", () => {
+  it("accepts starting", () => {
+    // "the substrate accepted a start request" is not "a node is connected".
+    // Without its own value the hub had to claim online on no evidence.
+    expect(RuntimeStatus.parse("starting")).toBe("starting");
+  });
+
+  it("keeps online distinct", () => {
+    // online is now a claim about a node actually being connected.
+    expect(RuntimeStatus.parse("online")).toBe("online");
+  });
+});
+
+describe("ProvisionedRuntime.statusReason", () => {
+  const BASE = {
+    id: "rt_1", ownerId: "u_1", provider: "docker" as const, externalId: "abc",
+    status: "error" as const, nodeId: null, name: "n",
+    resourceTier: "small" as const, harness: "none" as const,
+    createdAt: "2026-08-12T00:00:00Z", updatedAt: "2026-08-12T00:00:00Z",
+  };
+
+  it("carries why a runtime failed", () => {
+    const parsed = ProvisionedRuntime.parse({
+      ...BASE,
+      statusReason: "no node enrolled within 2m of the start request",
+    });
+    expect(parsed.statusReason).toContain("no node enrolled");
+  });
+
+  it("is absent when there is nothing to explain", () => {
+    expect(ProvisionedRuntime.parse(BASE).statusReason).toBeUndefined();
+    expect(ProvisionedRuntime.parse({ ...BASE, statusReason: null }).statusReason).toBeNull();
+  });
+});
+
 describe("RuntimeStatus asleep", () => {
   it("accepts asleep", () => {
     // A slept container is not stopped and not broken. Without its own value the

--- a/packages/contract/src/runtime.ts
+++ b/packages/contract/src/runtime.ts
@@ -4,11 +4,17 @@ export const RuntimeProvider = z.enum(["docker", "cloudflare"]);
 export type RuntimeProvider = z.infer<typeof RuntimeProvider>;
 
 /**
+ * `starting` — the substrate accepted a start request and no node has arrived
+ * yet. It is NOT `online`: `online` means a node for this runtime is connected,
+ * which only enrolment can establish. A start that never produces a node times
+ * out into `error` with a reason, so "started but never came back" — the most
+ * common way a provisioned runtime fails — is a state the console can show.
+ *
  * `asleep` — the substrate idled the runtime out and stopped billing it. Its
  * node is legitimately offline; the runtime is healthy and can be woken.
  * Distinct from `stopped`, which means an operator stopped it deliberately.
  */
-export const RuntimeStatus = z.enum(["provisioning", "online", "stopped", "asleep", "error", "destroyed"]);
+export const RuntimeStatus = z.enum(["provisioning", "starting", "online", "stopped", "asleep", "error", "destroyed"]);
 export type RuntimeStatus = z.infer<typeof RuntimeStatus>;
 
 export const ResourceTier = z.enum(["small", "medium", "large"]);
@@ -46,6 +52,14 @@ export const ProvisionedRuntime = z.object({
    * created before it was recorded — never inferred.
    */
   runtime: z.string().min(1).nullable().optional(),
+  /**
+   * Why the runtime is in its current status, when the status alone does not
+   * say. Set on failures — an `error` that reads "no node enrolled within 2m of
+   * the start request" answers the operator's actual question ("why is it not
+   * coming back") instead of leaving them to restart something that cannot
+   * work. Null/absent whenever there is nothing to explain.
+   */
+  statusReason: z.string().min(1).nullable().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
Fixes #254.

## The incident

On 2026-08-12 runtime `rt_aa47bc04ed34443796bc` read **online** in the console while its container was crash-exiting in 892 ms (`exitCode: 1`, expired enrolment token — fixed separately in #252). Its node's `last_seen_at` was hours old and it never reconnected.

The operator restarted it twice. That was the reasonable move given what the console said, and it could never have worked: each restart re-ran a container that died in under a second.

The hub said `online` because `startRuntime` wrote that status the moment `provisioner.start()` resolved:

```ts
await provisioner.start(row.externalId);
await db.update(provisionedRuntimes).set({ status: "online", ... })
```

That is a claim about the substrate accepting a request, not about a node existing. `row.nodeId` was right there and never consulted. Meanwhile `enrollment.ts` writes the *same* status on real evidence — a node enrolled. Two writers of one status, with different epistemic standards, and one of them guessing.

## The shape

`online` now means **a node for this runtime is connected**, and only enrolment writes it.

- `startRuntime` writes **`starting`** — asked, not yet arrived.
- `sweepStalledRuntimeStarts()` expires runtimes stuck in `starting`/`provisioning` past `START_TIMEOUT_MS` (2 min) into `error` with a `statusReason`: *"no node enrolled within 2m of the start request — the container was asked to run but never came back (check the substrate's container logs)"*. It runs on the node-sweeper's existing 15 s tick, next to the node-level expiry it mirrors.
- `createRuntime` gets the same treatment. It already wrote `provisioning` honestly, but had no exit either: a create whose node never enrolled sat in `provisioning` forever. Its driver-failure paths now record a reason too, so `error` is never unexplained.

So "started but never came back" — the most common way a provisioned runtime fails, and the one state the old code could not represent — is now a state the console can show *and explain*.

### Why `starting` rather than reusing `provisioning`

`provisioning` carries the same epistemics ("asked, not arrived") and reusing it would have avoided a contract change. But it would make the console tell an operator that a runtime they restarted is being *provisioned*, which is a different event and raises "am I losing my workspace?"; and the runtimes page deliberately hides Destroy during `provisioning`, so a stuck start would have been unactionable. `starting` is one enum value and one `ALTER TYPE ... ADD VALUE` (precedent: `asleep`, 0031), and the console's `tokenFor()` already maps `starting` to the in-flight badge — pinned by a new test.

### What it does not do

- **`asleep` is never swept.** A sleeping runtime's node is legitimately offline and it wakes on demand; reporting a routine state as a fault is the shape `runtime-callback.ts` exists to avoid. Existing callback tests pass unweakened, and there is a new test asserting a day-old `asleep` row survives a sweep untouched.
- **Rows with no `externalId` are never swept.** Between the row insert and `provision()` resolving there is no container to have failed — a slow image pull is not a failure.
- **The timeout never beats evidence.** The flip is a compare-and-set on the status the sweep read, so a node enrolling mid-sweep wins, and `error` is not terminal: a late enrolment still flips the runtime `online` and clears the reason.
- **Wake still works.** A Cloudflare wake reuses the start path, so it goes `asleep → starting → online` — or `→ error` if the substrate says yes and nothing comes back, which is precisely the case that used to show green.

## Console

`ProvisionedRuntime` gains a nullable `statusReason`, rendered under the status badge. The operator's question in the incident was "why is it not coming back"; they now read the answer instead of restarting something that cannot work.

## Tests

TDD, and the regression tests go through the real route → `startRuntime` path — a helper-level test is exactly what let #245's defect ship green. With the one-line fix reverted, 4 of the new tests fail, the headline one on `Expected: not "online"`.

- contract 89 pass
- hub 495 pass (7 new)
- console 737 pass, `pnpm check` 0 errors, production build with `PUBLIC_HUB_URL` OK

Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
