### PR TITLE
fix(cloudflare): re-derive substrate-owned sandbox env at every start (#253)

### DIFF
--- a/cloudflare/worker-v2/README.md
+++ b/cloudflare/worker-v2/README.md
@@ -69,6 +69,31 @@ archive, and it cannot delete even its own — deletion happens only on the
 admin-authenticated destroy path, so a compromised harness cannot erase the
 user's work.
 
+## The container's environment: caller-owned vs substrate-owned
+
+A container's environment does not survive a stop, so the worker hands it back on
+every start. It used to do that by storing the whole map at creation and
+replaying it verbatim — which froze it. `AGENTPOD_SNAPSHOT_URL` and
+`AGENTPOD_SNAPSHOT_TOKEN`, added on 2026-08-12, therefore reached sandboxes
+created after that deploy and no others; a runtime created 72 minutes earlier
+enrolled, heartbeated and served a terminal while archiving nothing, silently,
+for the life of the sandbox (#253).
+
+`src/env.ts` now splits the environment by ownership, and the split is explicit
+so a new variable has to pick a side:
+
+- **Caller-owned** (`AGENTPOD_HUB_URL`, `AGENTPOD_ENROLL_TOKEN`,
+  `AGENTPOD_RUNTIME_ID`, `AGENTPOD_RUNTIME_CALLBACK_TOKEN`) — minted by the hub
+  and unknowable to the worker afterwards. Stored at creation, replayed verbatim.
+- **Substrate-owned** (`SUBSTRATE_OWNED_KEYS`: the snapshot URL and token) —
+  facts about where this worker is and what it minted. Re-derived on **every**
+  start from the request origin and DO storage, and never persisted.
+
+The consequence worth knowing: a worker-side change to a substrate-owned variable
+reaches **existing** sandboxes on their next start, not just new ones. If you
+cannot recompute a value from the request and DO storage it is caller-owned;
+if you can, making it substrate-owned is what stops this bug recurring.
+
 ## Deploy
 
 ```bash

--- a/cloudflare/worker-v2/src/env.ts
+++ b/cloudflare/worker-v2/src/env.ts
@@ -1,0 +1,166 @@
+/**
+ * The sandbox environment, split by who owns each variable.
+ *
+ * A container's environment does not survive a stop, so this worker has to hand
+ * it back on every start. It used to do that by writing the whole map to Durable
+ * Object storage at creation and replaying it verbatim on each wake — which
+ * froze it. `AGENTPOD_SNAPSHOT_URL` and `AGENTPOD_SNAPSHOT_TOKEN`, added on
+ * 2026-08-12 05:53Z, therefore reached sandboxes created *after* that deploy and
+ * no others; runtime rt_aa47bc04ed34443796bc, created 72 minutes earlier, ran on
+ * looking perfectly healthy while `snapshot-wrapper.sh` skipped both restore and
+ * archive and dropped the workspace on every sleep (#253).
+ *
+ * The fix is the split below, and it is deliberately EXPLICIT: the next person
+ * adding a variable has to put it on one side or the other.
+ *
+ *   caller-owned    — minted by the hub at create time and unknowable to this
+ *                     worker afterwards. Stored, and replayed verbatim forever.
+ *   substrate-owned — facts about where this worker is and what it minted.
+ *                     Re-derived on EVERY start and never persisted, so a
+ *                     worker-side change reaches existing sandboxes on their
+ *                     next start instead of only new ones.
+ *
+ * If you cannot recompute a value from the request and DO storage, it is
+ * caller-owned. If you can, it is substrate-owned — persisting it buys nothing
+ * and costs you this bug again.
+ */
+
+/** DO storage key for the caller-owned environment. */
+export const ENV_KEY = "envVars";
+
+/** DO storage key for the per-sandbox snapshot token. */
+export const SNAPSHOT_TOKEN_KEY = "snapshotToken";
+
+/**
+ * Variables this worker owns and re-derives at every start.
+ *
+ * Adding a key here is a compile-time obligation: `substrateEnv` returns a
+ * record keyed by this list, so the build fails until the key is derived.
+ */
+export const SUBSTRATE_OWNED_KEYS = [
+  // Where the entrypoint archives and restores /workspace. Derived from the
+  // origin of the request that started the container, so the worker never has
+  // to be told its own URL — and so moving it does not strand old sandboxes.
+  "AGENTPOD_SNAPSHOT_URL",
+  // Minted per sandbox by this worker, kept in DO storage, never told to anyone
+  // but the container it belongs to.
+  "AGENTPOD_SNAPSHOT_TOKEN",
+] as const;
+
+export type SubstrateKey = (typeof SUBSTRATE_OWNED_KEYS)[number];
+
+/**
+ * Variables the caller owns. Listed for the reader, not enforced: an unlisted
+ * key from the hub is kept as caller-owned, which is the safe default — the
+ * unsafe default is silently freezing something this worker could recompute.
+ */
+export const CALLER_OWNED_KEYS = [
+  "AGENTPOD_HUB_URL",
+  "AGENTPOD_ENROLL_TOKEN",
+  "AGENTPOD_RUNTIME_ID",
+  "AGENTPOD_RUNTIME_CALLBACK_TOKEN",
+] as const;
+
+/** The slice of Durable Object storage this module needs. */
+export interface EnvStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+}
+
+/**
+ * What the substrate knows at the moment of a start.
+ *
+ * `origin` comes from the request being served — NOT from storage. Storing it
+ * at creation would re-create the very bug this module exists for, one level
+ * down: the sandboxes that need healing are precisely the ones with nothing
+ * stored, and a worker that moves hostname would freeze the old one forever.
+ */
+export interface SubstrateContext {
+  origin: string;
+  sandboxId: string;
+}
+
+/** The per-sandbox snapshot token, minted on first use and kept thereafter. */
+export async function snapshotToken(storage: EnvStorage): Promise<string> {
+  const existing = await storage.get<string>(SNAPSHOT_TOKEN_KEY);
+  if (existing) return existing;
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const token = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  await storage.put(SNAPSHOT_TOKEN_KEY, token);
+  return token;
+}
+
+/** The substrate-owned half of the environment, as of right now. */
+export function substrateEnv(
+  ctx: SubstrateContext,
+  token: string
+): Record<SubstrateKey, string> {
+  return {
+    AGENTPOD_SNAPSHOT_URL: `${ctx.origin}/sandbox/${ctx.sandboxId}/snapshot`,
+    AGENTPOD_SNAPSHOT_TOKEN: token,
+  };
+}
+
+/** Everything the worker cannot recompute — i.e. what is worth persisting. */
+export function callerOwned(env: Record<string, string>): Record<string, string> {
+  const kept: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if ((SUBSTRATE_OWNED_KEYS as readonly string[]).includes(key)) continue;
+    kept[key] = value;
+  }
+  return kept;
+}
+
+/**
+ * Merge stored caller-owned values with freshly derived substrate-owned ones.
+ *
+ * The substrate half goes last on purpose: a stale value in an old stored map
+ * must lose to the current one.
+ */
+async function merge(
+  storage: EnvStorage,
+  ctx: SubstrateContext,
+  stored: Record<string, string>
+): Promise<Record<string, string>> {
+  return {
+    ...callerOwned(stored),
+    ...substrateEnv(ctx, await snapshotToken(storage)),
+  };
+}
+
+/**
+ * The environment for a NEW sandbox: persist the caller-owned half, then start
+ * from the same merge a wake would produce.
+ *
+ * Create and wake share this path deliberately. Two paths would drift, and
+ * drift between them is exactly how a variable ends up reaching new sandboxes
+ * only.
+ */
+export async function createStartEnv(
+  storage: EnvStorage,
+  ctx: SubstrateContext,
+  callerEnv: Record<string, string>
+): Promise<Record<string, string>> {
+  const stored = callerOwned(callerEnv);
+  await storage.put(ENV_KEY, stored);
+  return merge(storage, ctx, stored);
+}
+
+/**
+ * The environment for waking an EXISTING sandbox.
+ *
+ * Throws when nothing was ever stored rather than starting a container that
+ * cannot enrol: a restart loop is far worse than a failed request, because it
+ * is silent and it bills.
+ */
+export async function storedStartEnv(
+  storage: EnvStorage,
+  ctx: SubstrateContext
+): Promise<Record<string, string>> {
+  const stored = await storage.get<Record<string, string>>(ENV_KEY);
+  if (!stored) {
+    throw new Error("no stored environment for this sandbox; create it first");
+  }
+  return merge(storage, ctx, stored);
+}

--- a/cloudflare/worker-v2/src/index.ts
+++ b/cloudflare/worker-v2/src/index.ts
@@ -2,6 +2,12 @@ import { Container, getContainer } from "@cloudflare/containers";
 import { isAuthorised } from "./auth";
 import { handleSnapshot, handleDestroy, type SnapshotDeps } from "./snapshot";
 import {
+  SNAPSHOT_TOKEN_KEY,
+  createStartEnv,
+  storedStartEnv,
+  type SubstrateContext,
+} from "./env";
+import {
   deriveState,
   handleStatus,
   STATE_KEY,
@@ -79,41 +85,36 @@ export class NodeAgentContainer extends Container {
   }
 
   /**
-   * Start with the environment this sandbox was created with, persisting it so
-   * a later wake can reuse it.
+   * Start a NEW sandbox: persist the caller-owned environment, then start with
+   * it plus the substrate-owned variables derived for this request.
    *
-   * The env MUST be stored, not merely passed to start(): a container's
-   * environment does not survive a stop, and a woken container with no
-   * AGENTPOD_HUB_URL or AGENTPOD_ENROLL_TOKEN fails `agentpod-node enroll`,
+   * The caller-owned half MUST be stored, not merely passed to start(): a
+   * container's environment does not survive a stop, and a woken container with
+   * no AGENTPOD_HUB_URL or AGENTPOD_ENROLL_TOKEN fails `agentpod-node enroll`,
    * exits under `set -e`, and is restarted forever. That produced 7 live
    * instances in a silent restart loop the first time this was deployed.
+   *
+   * The substrate-owned half is deliberately NOT stored — see src/env.ts.
    */
-  async createWithEnv(envVars: Record<string, string>): Promise<void> {
-    await this.ctx.storage.put("envVars", envVars);
-    this.envVars = envVars;
+  async createWithEnv(
+    envVars: Record<string, string>,
+    ctx: SubstrateContext
+  ): Promise<void> {
+    this.envVars = await createStartEnv(this.ctx.storage, ctx, envVars);
     await this.start();
   }
 
   /**
-   * The per-sandbox snapshot token, minted on first use and kept for the life
-   * of the sandbox so it survives sleep/wake alongside envVars.
+   * Read the per-sandbox snapshot token without minting one, for authenticating
+   * a container's request.
    *
+   * Minting happens on the start paths only (src/env.ts), so a request naming
+   * an unknown or destroyed sandbox cannot bring a token into existence.
    * Deliberately NOT the worker admin token: a container holding that could
    * create and destroy sandboxes across the whole fleet.
    */
-  async snapshotToken(): Promise<string> {
-    const existing = await this.ctx.storage.get<string>("snapshotToken");
-    if (existing) return existing;
-    const bytes = new Uint8Array(32);
-    crypto.getRandomValues(bytes);
-    const token = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
-    await this.ctx.storage.put("snapshotToken", token);
-    return token;
-  }
-
-  /** Read the stored token without minting one, for authenticating a request. */
   async storedSnapshotToken(): Promise<string | null> {
-    return (await this.ctx.storage.get<string>("snapshotToken")) ?? null;
+    return (await this.ctx.storage.get<string>(SNAPSHOT_TOKEN_KEY)) ?? null;
   }
 
   /**
@@ -126,7 +127,7 @@ export class NodeAgentContainer extends Container {
    * 2026-08-12: a destroy returned 200 and left the archive behind.
    */
   async revokeSnapshotToken(): Promise<void> {
-    await this.ctx.storage.delete("snapshotToken");
+    await this.ctx.storage.delete(SNAPSHOT_TOKEN_KEY);
   }
 
   /**
@@ -141,18 +142,21 @@ export class NodeAgentContainer extends Container {
   }
 
   /**
-   * Wake: start again with the stored environment.
+   * Wake: start again with the stored caller-owned environment, MERGED with
+   * substrate-owned variables derived afresh for this request.
    *
-   * Throws when there is none rather than starting a container that cannot
+   * The merge is the fix for #253. Replaying the stored map verbatim froze the
+   * environment at creation, so a sandbox created before the snapshot feature
+   * shipped could never learn about it and dropped its workspace on every
+   * sleep, silently, forever. Deriving instead of replaying means a
+   * worker-side change reaches EXISTING sandboxes on their next start.
+   *
+   * Throws when nothing was stored rather than starting a container that cannot
    * enrol — a restart loop is far worse than a failed request, because it is
    * silent and it bills.
    */
-  async wake(): Promise<void> {
-    const envVars = await this.ctx.storage.get<Record<string, string>>("envVars");
-    if (!envVars) {
-      throw new Error("no stored environment for this sandbox; create it first");
-    }
-    this.envVars = envVars;
+  async wake(ctx: SubstrateContext): Promise<void> {
+    this.envVars = await storedStartEnv(this.ctx.storage, ctx);
     await this.start();
   }
 
@@ -288,18 +292,20 @@ export default {
       const c = getContainer(env.NODE_AGENT, body.id);
       // The token is passed through but never logged, here or anywhere in this
       // worker. Do not add log statements that reference body.enrollToken.
-      const snapshotToken = await c.snapshotToken();
-      await c.createWithEnv({
-        AGENTPOD_HUB_URL: body.hubUrl,
-        AGENTPOD_ENROLL_TOKEN: body.enrollToken,
-        // Read by the container class's notifyHub, not by agentpod-node.
-        AGENTPOD_RUNTIME_ID: body.id,
-        AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
-        // Where the entrypoint archives and restores /workspace. Derived from
-        // the request so the worker never has to be told its own URL.
-        AGENTPOD_SNAPSHOT_URL: `${url.origin}/sandbox/${body.id}/snapshot`,
-        AGENTPOD_SNAPSHOT_TOKEN: snapshotToken,
-      });
+      //
+      // Only caller-owned variables are listed here. The snapshot URL and token
+      // are substrate-owned and derived on every start, create included — see
+      // src/env.ts. Adding one of those here would freeze it again (#253).
+      await c.createWithEnv(
+        {
+          AGENTPOD_HUB_URL: body.hubUrl,
+          AGENTPOD_ENROLL_TOKEN: body.enrollToken,
+          // Read by the container class's notifyHub, not by agentpod-node.
+          AGENTPOD_RUNTIME_ID: body.id,
+          AGENTPOD_RUNTIME_CALLBACK_TOKEN: body.callbackToken,
+        },
+        { origin: url.origin, sandboxId: body.id }
+      );
       return json({ sandboxId: body.id }, 201);
     }
 
@@ -340,12 +346,15 @@ export default {
       return json({ touched: id });
     }
 
-    // The wake path. Uses the STORED environment — a bare start() would boot a
-    // container with no hub URL or enrolment token, which cannot enrol and gets
-    // restarted forever.
+    // The wake path. Uses the STORED caller-owned environment — a bare start()
+    // would boot a container with no hub URL or enrolment token, which cannot
+    // enrol and gets restarted forever — merged with substrate-owned variables
+    // derived from THIS request. The origin is taken from the request rather
+    // than from storage on purpose: the sandboxes that need healing are exactly
+    // the ones with nothing useful stored (#253).
     if (request.method === "POST" && parts[2] === "start") {
       try {
-        await container.wake();
+        await container.wake({ origin: url.origin, sandboxId: id });
       } catch (e) {
         return json({ error: e instanceof Error ? e.message : String(e) }, 409);
       }

--- a/cloudflare/worker-v2/test/env.test.ts
+++ b/cloudflare/worker-v2/test/env.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests: the sandbox environment, split by ownership.
+ *
+ * The bug these exist for (#253): the environment was written to DO storage once
+ * at creation and replayed verbatim on every wake, so `AGENTPOD_SNAPSHOT_URL`
+ * and `AGENTPOD_SNAPSHOT_TOKEN` — added to the worker on 2026-08-12 05:53Z —
+ * reached new sandboxes only. Runtime rt_aa47bc04ed34443796bc, created 72
+ * minutes earlier, enrolled, heartbeated and served a terminal while
+ * snapshot-wrapper.sh silently skipped both restore and archive, dropping the
+ * user's workspace on every sleep, for the life of the sandbox.
+ *
+ * So the first test here is the healing one: a stored env that predates the
+ * snapshot keys must come back from a start WITH them. Everything else is the
+ * boundary — what the worker may re-derive, and what it must never touch.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ENV_KEY,
+  SNAPSHOT_TOKEN_KEY,
+  SUBSTRATE_OWNED_KEYS,
+  callerOwned,
+  createStartEnv,
+  snapshotToken,
+  storedStartEnv,
+  type EnvStorage,
+} from "../src/env";
+
+/** In-memory stand-in for Durable Object storage. */
+function fakeStorage(seed: Record<string, unknown> = {}) {
+  const map = new Map<string, unknown>(Object.entries(seed));
+  const storage: EnvStorage = {
+    get: async <T>(key: string) => map.get(key) as T | undefined,
+    put: async <T>(key: string, value: T) => {
+      map.set(key, value);
+    },
+  };
+  return { storage, map };
+}
+
+/** Exactly what a sandbox created before 2026-08-12 05:53Z has in storage. */
+const PRE_SNAPSHOT_ENV = {
+  AGENTPOD_HUB_URL: "https://hub.agentpod.dev",
+  AGENTPOD_ENROLL_TOKEN: "enrol-tok",
+  AGENTPOD_RUNTIME_ID: "rt_aa47bc04ed34443796bc",
+  AGENTPOD_RUNTIME_CALLBACK_TOKEN: "callback-tok",
+};
+
+const ctx = {
+  origin: "https://sandbox.agentpod.dev",
+  sandboxId: "rt_aa47bc04ed34443796bc",
+};
+
+describe("storedStartEnv — a sandbox older than the snapshot feature heals", () => {
+  it("gives a pre-snapshot stored env both snapshot keys on its next start", async () => {
+    // THE regression test for #253. Before the fix this returned the stored map
+    // untouched, `configured()` in snapshot-wrapper.sh was false, and the
+    // container archived nothing on SIGTERM — silently, forever.
+    const { storage } = fakeStorage({ [ENV_KEY]: PRE_SNAPSHOT_ENV });
+
+    const env = await storedStartEnv(storage, ctx);
+
+    expect(env.AGENTPOD_SNAPSHOT_URL).toBe(
+      "https://sandbox.agentpod.dev/sandbox/rt_aa47bc04ed34443796bc/snapshot"
+    );
+    expect(env.AGENTPOD_SNAPSHOT_TOKEN).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("mints the snapshot token the sandbox never had, and keeps it", async () => {
+    // The healing sandbox has no stored token either — it was minted at create
+    // time, and this one was created before that code existed. The token must
+    // be minted on this start and be the SAME one the snapshot routes will
+    // authenticate against, or the container uploads and gets a 401.
+    const { storage, map } = fakeStorage({ [ENV_KEY]: PRE_SNAPSHOT_ENV });
+
+    const first = await storedStartEnv(storage, ctx);
+    expect(first.AGENTPOD_SNAPSHOT_TOKEN).toMatch(/^[0-9a-f]{64}$/);
+    expect(map.get(SNAPSHOT_TOKEN_KEY)).toBe(first.AGENTPOD_SNAPSHOT_TOKEN);
+
+    // And a later wake must not rotate it: the archive in R2 is reachable only
+    // with the token the sandbox holds, so a new one each start would be a
+    // slow-motion version of the same data loss.
+    const second = await storedStartEnv(storage, ctx);
+    expect(second.AGENTPOD_SNAPSHOT_TOKEN).toBe(first.AGENTPOD_SNAPSHOT_TOKEN);
+  });
+
+  it("preserves every caller-owned value verbatim", async () => {
+    // The worker cannot re-derive these: the enrolment and callback tokens were
+    // minted by the hub at create time and exist nowhere else. Dropping one
+    // gives a container that cannot enrol and is restarted forever.
+    const { storage } = fakeStorage({ [ENV_KEY]: PRE_SNAPSHOT_ENV });
+
+    const env = await storedStartEnv(storage, ctx);
+
+    expect(env).toMatchObject(PRE_SNAPSHOT_ENV);
+  });
+
+  it("refuses to start a sandbox that was never created", async () => {
+    // A container booted with no hub URL cannot enrol, exits under `set -e`,
+    // and is restarted forever — silently, and it bills. A failed request is
+    // strictly better.
+    const { storage } = fakeStorage();
+    await expect(storedStartEnv(storage, ctx)).rejects.toThrow(
+      /no stored environment/
+    );
+  });
+});
+
+describe("storedStartEnv — substrate-owned values are re-derived, never replayed", () => {
+  it("overrides a stale stored snapshot URL with one derived from this request", async () => {
+    // Belt and braces for the class of bug, not just its one instance: even a
+    // sandbox whose stored map DOES carry a snapshot URL gets the current one,
+    // so moving the worker to another hostname does not strand every existing
+    // sandbox pointing at the old one.
+    const { storage } = fakeStorage({
+      [ENV_KEY]: {
+        ...PRE_SNAPSHOT_ENV,
+        AGENTPOD_SNAPSHOT_URL: "https://old-worker.workers.dev/sandbox/rt_x/snapshot",
+      },
+    });
+
+    const env = await storedStartEnv(storage, ctx);
+
+    expect(env.AGENTPOD_SNAPSHOT_URL).toBe(
+      "https://sandbox.agentpod.dev/sandbox/rt_aa47bc04ed34443796bc/snapshot"
+    );
+  });
+
+  it("never writes a substrate-owned value into storage", async () => {
+    // Storage holds only what the worker cannot recompute. A substrate value
+    // that gets persisted is a frozen value waiting to happen — which is the
+    // whole of #253.
+    const { storage, map } = fakeStorage();
+
+    await createStartEnv(storage, ctx, {
+      ...PRE_SNAPSHOT_ENV,
+      // A caller (or an older worker) handing us one must not make it stick.
+      AGENTPOD_SNAPSHOT_URL: "https://old-worker.workers.dev/sandbox/rt_x/snapshot",
+    });
+
+    const stored = map.get(ENV_KEY) as Record<string, string>;
+    for (const key of SUBSTRATE_OWNED_KEYS) {
+      expect(stored).not.toHaveProperty(key);
+    }
+    expect(stored).toEqual(PRE_SNAPSHOT_ENV);
+  });
+});
+
+describe("createStartEnv", () => {
+  it("starts a new sandbox with the same env a wake would produce", async () => {
+    // One derivation path for create and wake. Two would drift, and drift is
+    // exactly how a key ends up reaching new sandboxes only.
+    const { storage } = fakeStorage();
+
+    const created = await createStartEnv(storage, ctx, PRE_SNAPSHOT_ENV);
+    const woken = await storedStartEnv(storage, ctx);
+
+    expect(woken).toEqual(created);
+  });
+});
+
+describe("callerOwned", () => {
+  it("strips substrate-owned keys and keeps the rest", () => {
+    expect(
+      callerOwned({
+        AGENTPOD_HUB_URL: "https://hub.agentpod.dev",
+        AGENTPOD_SNAPSHOT_TOKEN: "stale",
+        AGENTPOD_SNAPSHOT_URL: "stale",
+      })
+    ).toEqual({ AGENTPOD_HUB_URL: "https://hub.agentpod.dev" });
+  });
+});
+
+describe("snapshotToken", () => {
+  it("mints once and returns the same token afterwards", async () => {
+    const { storage } = fakeStorage();
+    const first = await snapshotToken(storage);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(await snapshotToken(storage)).toBe(first);
+  });
+});


### PR DESCRIPTION
Fixes #253.

## The defect

`createWithEnv()` wrote the sandbox's whole environment into Durable Object storage once, at creation, and `wake()` replayed that frozen map. So `AGENTPOD_SNAPSHOT_URL` / `AGENTPOD_SNAPSHOT_TOKEN` — added to the worker at 05:53Z on 2026-08-12 — reached **new sandboxes only**. Runtime `rt_aa47bc04ed34443796bc`, created 72 minutes earlier, enrolled, heartbeated and served a terminal while `snapshot-wrapper.sh`'s `configured()` gate was false: no restore on boot, no archive on SIGTERM, no complaint. For the life of the sandbox, with no backfill short of destroying the runtime.

The blast radius was bounded; the shape was not. Any substrate-owned value added at creation had this property.

## The fix

`cloudflare/worker-v2/src/env.ts` splits the environment by **ownership**, and the split is explicit — a named, commented `SUBSTRATE_OWNED_KEYS` list — because the implicit rule is what produced the bug:

| | keys | treatment |
|---|---|---|
| **Caller-owned** | `AGENTPOD_HUB_URL`, `AGENTPOD_ENROLL_TOKEN`, `AGENTPOD_RUNTIME_ID`, `AGENTPOD_RUNTIME_CALLBACK_TOKEN` | minted by the hub, unknowable to the worker afterwards → stored, replayed verbatim |
| **Substrate-owned** | `AGENTPOD_SNAPSHOT_URL`, `AGENTPOD_SNAPSHOT_TOKEN` | facts about where this worker is and what it minted → re-derived on **every** start, never persisted |

`substrateEnv()` returns `Record<SubstrateKey, string>` keyed off that list, so adding a key to it is a compile-time obligation to derive it. Anything the hub sends that is not on the list stays caller-owned — the safe default; the unsafe default is silently freezing something the worker could recompute.

Three design decisions worth stating:

1. **The request origin is passed in from the fetch handler, not stored at creation.** Storing it would re-create the same bug one level down: the sandboxes that need healing are precisely the ones with nothing stored, and a stored origin would freeze forever if the worker ever moved hostname. `POST /sandbox/:id/start` already carries a live origin — the hub's `CLOUDFLARE_WORKER_URL`, the same value used at create.
2. **Create and wake share one merge path.** Two paths would drift, and drift between them is exactly how a variable ends up reaching new sandboxes only. `POST /sandbox` no longer lists the snapshot variables at all; they are derived on create just like on wake.
3. **A stale stored value loses to the derived one.** `callerOwned()` strips substrate keys off whatever is in storage before the merge, so a map written by an older worker cannot keep pointing a container at an old hostname.

The DO's `snapshotToken()` RPC is gone — minting now happens only inside the start paths, so a request naming an unknown or destroyed sandbox still cannot bring a token into existence. `storedSnapshotToken()` (read-only, used by the snapshot routes' auth) is unchanged.

## Do existing sandboxes heal?

**Yes** — that was the requirement, and it holds. On the next `POST /sandbox/:id/start`, a sandbox whose stored env has only the four pre-2026-08-12 keys gets both snapshot variables merged in, and the snapshot token it never had is minted on the way through and persisted, so the container's uploads authenticate against the same token the routes check. That is asserted directly by the regression test, from a stored map that is byte-for-byte what such a sandbox has.

Two caveats:

- **The worker must be deployed** for any of this to take effect. Not deployed here.
- Healing happens on a **start**, so an affected sandbox that is currently running keeps its broken environment until it is stopped and started again. Its next sleep still drops the workspace — stop/start it deliberately, before any work worth keeping goes into it.

The remediation note on #253 changes accordingly: once this is deployed, an affected runtime does **not** need destroying and re-provisioning. Note the interaction with #252 — a runtime whose enrolment token has expired still needs that dealt with, but re-minting a token is now safe rather than reviving a sandbox with persistence permanently disabled.

Not taken: the issue's alternative of having the wrapper report an unconfigured snapshot loudly. With this merge in place `configured()` cannot be false on a worker-provisioned sandbox, so the warning would be unreachable — worth revisiting only if the wrapper ever runs somewhere the worker does not set its environment.

## Tests

`cloudflare/worker-v2/test/env.test.ts`, using the fake-DO-storage / injected-deps pattern the other worker tests already use. The first test is the regression one: a stored env containing only `AGENTPOD_HUB_URL`, `AGENTPOD_ENROLL_TOKEN`, `AGENTPOD_RUNTIME_ID` and `AGENTPOD_RUNTIME_CALLBACK_TOKEN` must come back from a start with both snapshot variables present.

**Vacuity check.** With the merge reverted to `return stored` (the pre-fix behaviour), 3 of the 9 fail on exactly the right assertions:

```
× a sandbox older than the snapshot feature heals > gives a pre-snapshot stored env both snapshot keys on its next start
    → expected undefined to be 'https://sandbox.agentpod.dev/sandbox/rt_aa47bc04ed34443796bc/snapshot'
× a sandbox older than the snapshot feature heals > mints the snapshot token the sandbox never had, and keeps it
× substrate-owned values are re-derived, never replayed > overrides a stale stored snapshot URL with one derived from this request
    → expected 'https://old-worker.workers.dev/sandbox/rt_x/snapshot' to be 'https://sandbox.agentpod.dev/…'
```

Restored: `cd cloudflare/worker-v2 && npx vitest run` → **36 passed** (27 before, 9 new). No existing test changed or weakened. `tsc --noEmit` is clean over `src/` (the pre-existing `test/` errors — missing node types — are unchanged from `main`). The hub is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW