### PR TITLE
test(hub): make the hub suite deterministic — wait for the condition, not the clock (fixes #64)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -47,8 +47,13 @@ DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod"
 ```
 
 Migrations apply automatically via the test helpers (`ensurePgMigrations`).
-Test files set env vars **before** importing anything from `src/` (ESM import
-order — see the header comment in any `tests/integration/*.test.ts`).
+
+Test files open with a `process.env.DATABASE_URL = process.env.DATABASE_URL || ...`
+preamble "before any `src/` imports". Treat that as a comment, not a mechanism:
+ESM hoists the `import`s above it, so `src/db/drizzle.ts` has already read the
+variable by the time the assignment runs (and in a full run it is evaluated once,
+for the whole process). **The `DATABASE_URL` on the command line is what actually
+points the suite at the test database** — the preamble is a no-op fallback.
 
 ## Conventions
 
@@ -58,6 +63,16 @@ order — see the header comment in any `tests/integration/*.test.ts`).
   `tests/unit/`; DB-touching tests in `tests/integration/`, each cleaning up
   its own rows in `afterAll`. Gateway/WS tests build a minimal Hono app rather
   than importing `src/index.ts` (which starts the sweeper and boot hooks).
+- **Hub — never sleep for a barrier.** `bun test` runs every hub test file
+  sequentially inside **one process with one module registry**: the
+  `connectionManager`, the broker and the Postgres pool are shared by all 55
+  files, so a file that passes alone runs under much more load in the full
+  suite. Waiting a fixed number of milliseconds for something to become true is
+  therefore a coin toss — the gateway's `onOpen` verifies an argon2id hash
+  (~105 ms idle, more under load) before it registers the node, which is what
+  turned a 150 ms sleep into issue #64's random reds. Wait on the condition
+  with `waitForNodeOnline` / `pollUntil` from `apps/hub/tests/helpers/wait.ts`.
+  A plain sleep is only correct when proving something does *not* happen.
 - **Node-agent**: standard library only — `httptest` for hub stubs, temp dirs,
   injected command runners (see `selfupdate`'s `RunCommand` seam). Two
   macOS-specific traps: don't leave unreaped child processes named after

--- a/apps/hub/CLAUDE.md
+++ b/apps/hub/CLAUDE.md
@@ -26,3 +26,5 @@ Test DB requirements (pgvector image + env override): see root `CLAUDE.md` / `TE
 ## Tests
 
 Unit next to code or `tests/unit/`; DB-touching in `tests/integration/` (per-file row cleanup in `afterAll`). WS/gateway tests build a minimal Hono app — never import `src/index.ts` (it starts the sweeper and boot hooks).
+
+- **Never sleep for a barrier.** `bun test` runs all 55 files sequentially **in one process with one module registry**, so `connectionManager`, the broker and the Postgres pool are shared by the whole run and everything gets slower as it goes. A fixed `setTimeout` standing in for "the node has registered" is a coin toss: gateway `onOpen` runs an argon2id `verifyNodeCredential` (~105 ms idle, far more under suite load) before `connectionManager.register`. Use `waitForNodeOnline(nodeId)` from `tests/helpers/wait.ts` — the flake this cost is issue #64. Sleeping is only legitimate to prove something does *not* happen.

--- a/apps/hub/src/routes/node-posture.test.ts
+++ b/apps/hub/src/routes/node-posture.test.ts
@@ -29,6 +29,7 @@ import { nodes } from "../db/schema/nodes";
 import { stationAudit } from "../db/schema/audit";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { nodePostureRoutes } from "./node-posture";
@@ -148,7 +149,23 @@ async function connectFakeNode(
     ws.send(JSON.stringify({ type: "res", id: msg.id, ok: true, data: report }));
   };
 
-  await new Promise((r) => setTimeout(r, 250));
+  // Two things must land before a posture request can be judged, and neither
+  // has a duration worth guessing at: the gateway's onOpen (argon2id verify,
+  // then register) and the hello frame's writes, which are what the capability
+  // gate reads. Wait for both — the version write is the last thing onMessage
+  // does before the capability write, so a node that sent capabilities is only
+  // ready once the column is populated too.
+  await waitForNodeOnline(nodeId);
+  await pollUntil(async () => {
+    const [row] = await db
+      .select({ version: nodes.agentVersion, caps: nodes.capabilities })
+      .from(nodes)
+      .where(eq(nodes.id, nodeId));
+    if (row?.version !== "v0.1.22") return false;
+    // A node that sent no capabilities leaves the column null by design; there
+    // is nothing further to wait for.
+    return capabilities === null || row.caps !== null;
+  });
   return ws;
 }
 

--- a/apps/hub/src/routes/station-activity.test.ts
+++ b/apps/hub/src/routes/station-activity.test.ts
@@ -23,6 +23,10 @@ import { db, rawSql } from "../db/drizzle";
 import { stationAudit } from "../db/schema/audit";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import {
+  waitForNodeOnline,
+  waitForNodeUnregistered,
+} from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { stationRoutes } from "./stations";
@@ -103,6 +107,12 @@ afterAll(async () => {
 
 /** Start a minimal Bun server with a fake node gateway, adopt the station. */
 async function setupServer() {
+  // Every test in this file reconnects the SAME node id. The previous test's
+  // socket must be out of the connection manager before this one dials, or the
+  // "is it online yet" barrier below is satisfied by the dying connection and
+  // its teardown can unregister the node out from under this test.
+  await waitForNodeUnregistered(nodeId);
+
   const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
 
   const baseUrl = `http://localhost:${server.port}`;
@@ -144,8 +154,9 @@ async function setupServer() {
     }
   };
 
-  // Allow node WS to register
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
 
   // Adopt the station via the API
   const adoptRes = await fetch(`${baseUrl}/api/nodes/${nodeId}/stations/adopt`, {

--- a/apps/hub/src/routes/station-changeset.test.ts
+++ b/apps/hub/src/routes/station-changeset.test.ts
@@ -28,6 +28,7 @@ import { db, rawSql } from "../db/drizzle";
 import { stationAudit } from "../db/schema/audit";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { stationChangesetRoutes } from "./station-changeset";
@@ -177,7 +178,9 @@ async function connectFakeNode(
     }
   };
 
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 

--- a/apps/hub/src/routes/station-cleanup.test.ts
+++ b/apps/hub/src/routes/station-cleanup.test.ts
@@ -27,6 +27,7 @@ import { db, rawSql } from "../db/drizzle";
 import { stationAudit } from "../db/schema/audit";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { stationCleanupRoutes } from "./station-cleanup";
@@ -165,7 +166,9 @@ async function connectFakeNode(
     }
   };
 
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 

--- a/apps/hub/src/routes/station-lifecycle.test.ts
+++ b/apps/hub/src/routes/station-lifecycle.test.ts
@@ -25,6 +25,7 @@ import { db, rawSql } from "../db/drizzle";
 import { stationAudit } from "../db/schema/audit";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { stationLifecycleRoutes } from "./station-lifecycle";
@@ -155,7 +156,9 @@ async function connectFakeNode(
     }
   };
 
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 

--- a/apps/hub/src/routes/station-terminal.test.ts
+++ b/apps/hub/src/routes/station-terminal.test.ts
@@ -24,6 +24,7 @@ import { Hono } from "hono";
 import { rawSql } from "../db/drizzle";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { stationTerminalRoutes } from "./station-terminal";
@@ -190,8 +191,9 @@ async function connectFakeNode(
     }
   };
 
-  // Allow onOpen → connectionManager.register to settle
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 
@@ -331,7 +333,7 @@ test(
       });
 
       // Wait for the attach handshake to complete on the node side.
-      await new Promise((r) => setTimeout(r, 300));
+      await pollUntil(() => attachIdRef[0] !== null);
       expect(attachIdRef[0]).not.toBeNull(); // term.attach must have been sent
 
       // Send input from the client.

--- a/apps/hub/src/routes/station-writes.test.ts
+++ b/apps/hub/src/routes/station-writes.test.ts
@@ -28,6 +28,7 @@ import { db, rawSql } from "../db/drizzle";
 import { stationAudit } from "../db/schema/audit";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "./gateway";
 import { stationWriteRoutes } from "./station-writes";
@@ -192,8 +193,9 @@ async function connectFakeNode(
     }
   };
 
-  // Allow the connection to register with the connectionManager
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -49,6 +49,7 @@ import { db, rawSql } from "../db/drizzle";
 import { acpSessions, acpEvents } from "../db/schema/acp";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeUnregistered } from "../../tests/helpers/wait";
 import {
   connectFakeAcpNode,
   parsedNodeMsgs,
@@ -1041,8 +1042,11 @@ test(
       });
 
       // Reconnect: no second acp.close for the already-cleared orphan.
+      // The old socket must be OUT of the connection manager first, or the
+      // reconnect's own "is it online yet" barrier is satisfied by the corpse
+      // of this one and fake2 gets asserted against before it has registered.
       fake.close();
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForNodeUnregistered(nodeId);
       const fake2 = await connectFakeAcpNode(server.port!, nodeId, nodeSecret, {
         stationKey: "acp-orphan-station",
       });

--- a/apps/hub/src/services/acp-transport.test.ts
+++ b/apps/hub/src/services/acp-transport.test.ts
@@ -32,6 +32,7 @@ import { Hono } from "hono";
 import { rawSql } from "../db/drizzle";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { gatewayRoutes } from "../routes/gateway";
 import { websocket } from "../ws";
@@ -240,8 +241,9 @@ async function connectFakeNode(
     }
   };
 
-  // Allow onOpen → connectionManager.register to settle
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 

--- a/apps/hub/tests/helpers/acp-fake-node.ts
+++ b/apps/hub/tests/helpers/acp-fake-node.ts
@@ -31,6 +31,12 @@
  * prompts (e.g. to flip the toolCall kind for accept-edits coverage).
  */
 
+import { pollUntil, waitForNodeOnline } from "./wait";
+
+// `pollUntil` used to live here; it now has a home alongside the other
+// deterministic waits. Re-exported so existing importers keep working.
+export { pollUntil };
+
 const encoder = new TextEncoder();
 
 const b64encode = (s: string) => Buffer.from(encoder.encode(s)).toString("base64");
@@ -120,21 +126,6 @@ export function parsedNodeMsgs(raw: string[]): Record<string, unknown>[] {
       }
     })
     .filter((m): m is Record<string, unknown> => m !== null);
-}
-
-/** Poll condition() every pollMs until truthy, or throw after timeoutMs. Supports async conditions. */
-export async function pollUntil<T>(
-  condition: () => T | undefined | null | false | Promise<T | undefined | null | false>,
-  timeoutMs = 5000,
-  pollMs = 30
-): Promise<T> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const result = await condition();
-    if (result) return result as T;
-    await new Promise((r) => setTimeout(r, pollMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs} ms`);
 }
 
 export async function connectFakeAcpNode(
@@ -509,8 +500,10 @@ export async function connectFakeAcpNode(
     }
   };
 
-  // Allow onOpen → connectionManager.register to settle.
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → connectionManager.register is
+  // slower than any fixed sleep is safe against under full-suite load; wait for
+  // the registration itself.
+  await waitForNodeOnline(nodeId);
 
   return {
     ws,

--- a/apps/hub/tests/helpers/wait.ts
+++ b/apps/hub/tests/helpers/wait.ts
@@ -1,0 +1,80 @@
+/**
+ * Deterministic waits for test code.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A test that sleeps a fixed number of milliseconds and then asserts is a
+ * coin toss whose odds depend on machine load. The hub had a fleet of
+ * `await new Promise(r => setTimeout(r, 150))` calls standing in for "the
+ * gateway has finished authenticating this node and registered it", and the
+ * work being waited on is an argon2id password verify (~105 ms idle on an M-series
+ * laptop, considerably more when 500 other tests are competing for the CPU)
+ * plus two Postgres round trips. In a full `bun test` run those sleeps lost
+ * the race often enough that every run failed a different handful of tests
+ * with "Node is offline".
+ *
+ * The fix is to wait for the condition instead of guessing its duration:
+ * poll the observable state, with a timeout that is long enough to never
+ * expire on a healthy machine and an error message that says what never
+ * happened. The assertions the tests make are unchanged — a node that never
+ * comes online still fails, it just fails with a diagnosis.
+ */
+
+import { connectionManager } from "../../src/services/connection-manager";
+
+/**
+ * Poll `condition()` every `pollMs` until it returns something truthy, or
+ * throw after `timeoutMs`. Supports async conditions.
+ */
+export async function pollUntil<T>(
+  condition: () => T | undefined | null | false | Promise<T | undefined | null | false>,
+  timeoutMs = 5000,
+  pollMs = 30
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await condition();
+    if (result) return result as T;
+    if (Date.now() >= deadline) break;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs} ms`);
+}
+
+/**
+ * Block until the gateway has registered `nodeId` in the connection manager —
+ * i.e. onOpen finished `verifyNodeCredential` and `connectionManager.register`.
+ * Everything that routes hub→node traffic (broker requests, station observe,
+ * ACP opens) is gated on this, so tests must await it rather than sleep.
+ */
+export async function waitForNodeOnline(
+  nodeId: string,
+  timeoutMs = 10_000
+): Promise<void> {
+  try {
+    await pollUntil(() => connectionManager.isOnline(nodeId), timeoutMs, 10);
+  } catch {
+    throw new Error(
+      `node ${nodeId} was not registered with the connection manager within ${timeoutMs} ms ` +
+        `(gateway onOpen: verifyNodeCredential → register never completed)`
+    );
+  }
+}
+
+/**
+ * Block until the gateway has torn `nodeId` out of the connection manager,
+ * which onClose does before it writes the offline status to the database.
+ */
+export async function waitForNodeUnregistered(
+  nodeId: string,
+  timeoutMs = 10_000
+): Promise<void> {
+  try {
+    await pollUntil(() => !connectionManager.isOnline(nodeId), timeoutMs, 10);
+  } catch {
+    throw new Error(
+      `node ${nodeId} was still registered with the connection manager after ${timeoutMs} ms ` +
+        `(gateway onClose: unregister never ran)`
+    );
+  }
+}

--- a/apps/hub/tests/integration/broker-gateway.test.ts
+++ b/apps/hub/tests/integration/broker-gateway.test.ts
@@ -23,6 +23,7 @@ import { Hono } from "hono";
 import { rawSql } from "../../src/db/drizzle";
 import { createTestUser } from "../helpers/database";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { waitForNodeOnline } from "../helpers/wait";
 import {
   mintEnrollmentToken,
   enrollNode,
@@ -114,8 +115,9 @@ test(
         }
       };
 
-      // Allow onOpen → connectionManager.register to complete
-      await new Promise((r) => setTimeout(r, 150));
+      // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+      // sleep under load; wait for the registration itself.
+      await waitForNodeOnline(nodeId);
 
       // Call broker.request — should resolve with the station data
       const result = await broker.request(nodeId, "detect", {}, {

--- a/apps/hub/tests/integration/gateway.test.ts
+++ b/apps/hub/tests/integration/gateway.test.ts
@@ -30,6 +30,26 @@ import { listNodes } from "../../src/services/node-registry";
 import { gatewayRoutes } from "../../src/routes/gateway";
 import { websocket } from "../../src/ws";
 import { connectionManager } from "../../src/services/connection-manager";
+import { pollUntil, waitForNodeOnline } from "../helpers/wait";
+
+/**
+ * Barrier for "this socket's onOpen finished registering it".
+ *
+ * The gateway resolves `authReady` only after `connectionManager.register`,
+ * and onMessage awaits `authReady` — so an ack proves the registration
+ * already happened. Needed where `waitForNodeOnline` cannot tell the sockets
+ * apart because an earlier socket already has the node marked online.
+ */
+async function awaitSocketRegistered(ws: WebSocket): Promise<void> {
+  const ack = new Promise<void>((res) => {
+    ws.onmessage = (e) => {
+      if ((JSON.parse(String(e.data)) as { type: string }).type === "ack") res();
+    };
+  });
+  ws.send(JSON.stringify({ type: "heartbeat", ts: Date.now() }));
+  await ack;
+  ws.onmessage = null;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Minimal test server (avoids importing full index.ts which has many side effects)
@@ -93,20 +113,18 @@ test("a node that connects to the gateway shows online via listNodes", async () 
       ws.onerror = () => rej(new Error("WebSocket connection error"));
     });
 
-    // Give the onOpen handler time to call setNodeStatus
-    await new Promise((r) => setTimeout(r, 200));
-
-    // Node should be online
-    const list = await listNodes(TEST_USER_ID);
-    const node = list.find((n) => n.id === nodeId);
+    // Wait for onOpen's setNodeStatus rather than guessing how long the
+    // argon2id credential verify plus two DB round trips will take.
+    const node = await pollUntil(async () =>
+      (await listNodes(TEST_USER_ID)).find((n) => n.id === nodeId && n.status === "online")
+    );
     expect(node?.status).toBe("online");
 
     // Close the connection — node should go offline
     ws.close();
-    await new Promise((r) => setTimeout(r, 200));
-
-    const listAfterClose = await listNodes(TEST_USER_ID);
-    const nodeAfterClose = listAfterClose.find((n) => n.id === nodeId);
+    const nodeAfterClose = await pollUntil(async () =>
+      (await listNodes(TEST_USER_ID)).find((n) => n.id === nodeId && n.status === "offline")
+    );
     expect(nodeAfterClose?.status).toBe("offline");
   } finally {
     server.stop(true);
@@ -183,7 +201,7 @@ test("heartbeat keeps node online and receives ack", async () => {
       ws.onerror = () => rej(new Error("WebSocket connection error"));
     });
 
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForNodeOnline(nodeId);
 
     // Send a heartbeat and await the ack
     const ackPromise = new Promise<unknown>((res) => {
@@ -211,15 +229,21 @@ test("a late close from a replaced socket does not mark the reconnected node off
 
     const wsOld = new WebSocket(url, { headers } as RequestInit & { headers: Record<string, string> });
     await new Promise<void>((res, rej) => { wsOld.onopen = () => res(); wsOld.onerror = () => rej(new Error("old socket failed")); });
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForNodeOnline(nodeId);
 
     // Node reconnects on a new socket while the old one is still open.
     const wsNew = new WebSocket(url, { headers } as RequestInit & { headers: Record<string, string> });
     await new Promise<void>((res, rej) => { wsNew.onopen = () => res(); wsNew.onerror = () => rej(new Error("new socket failed")); });
-    await new Promise((r) => setTimeout(r, 200));
+    // The node is already online from wsOld, so isOnline cannot tell the two
+    // sockets apart — use the ack barrier to know wsNew's onOpen registered.
+    await awaitSocketRegistered(wsNew);
 
     // The OLD socket closes late.
+    const closed = new Promise<void>((res) => { wsOld.onclose = () => res(); });
     wsOld.close();
+    await closed;
+    // onClose's teardown is async after the close event; give the epoch guard
+    // a chance to run the (wrong) teardown if it is going to.
     await new Promise((r) => setTimeout(r, 200));
 
     // Node must still be online, and the NEW socket must still be routable.
@@ -246,7 +270,7 @@ test("a heartbeat from a socket with no registry entry re-registers it", async (
       headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
     } as RequestInit & { headers: Record<string, string> });
     await new Promise<void>((res, rej) => { ws.onopen = () => res(); ws.onerror = () => rej(new Error("connect failed")); });
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForNodeOnline(nodeId);
 
     // Simulate a sweep: the registry entry is gone but the socket is alive.
     connectionManager.unregister(nodeId);
@@ -294,11 +318,13 @@ test("hello frame version is persisted to agentVersion on the node row", async (
     // dropped-hello race that left agent_version null in production.
     ws.send(JSON.stringify({ type: "hello", hostInfo: { hostname: "version-host", os: "linux", arch: "amd64", cpuCount: 2 }, version: "v0.1.1" }));
 
-    await new Promise((r) => setTimeout(r, 300));
-
-    // Verify agentVersion was persisted
-    const list = await listNodes(TEST_USER_ID);
-    const node = list.find((n) => n.id === nodeId);
+    // Verify agentVersion was persisted — poll rather than guess how long the
+    // auth-then-hello path takes; a hello that is never ingested still fails.
+    const node = await pollUntil(async () =>
+      (await listNodes(TEST_USER_ID)).find(
+        (n) => n.id === nodeId && n.agentVersion === "v0.1.1"
+      )
+    );
     expect(node?.agentVersion).toBe("v0.1.1");
 
     ws.close();

--- a/apps/hub/tests/integration/station-observe.test.ts
+++ b/apps/hub/tests/integration/station-observe.test.ts
@@ -26,6 +26,7 @@ import { Hono } from "hono";
 import { rawSql } from "../../src/db/drizzle";
 import { createTestUser } from "../helpers/database";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { waitForNodeOnline } from "../helpers/wait";
 import {
   mintEnrollmentToken,
   enrollNode,
@@ -196,8 +197,9 @@ async function connectFakeNode(
     }
   };
 
-  // Allow onOpen → connectionManager.register to complete
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 

--- a/apps/hub/tests/integration/stations.test.ts
+++ b/apps/hub/tests/integration/stations.test.ts
@@ -30,6 +30,7 @@ import { Hono } from "hono";
 import { rawSql } from "../../src/db/drizzle";
 import { createTestUser } from "../helpers/database";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { waitForNodeOnline } from "../helpers/wait";
 import {
   mintEnrollmentToken,
   enrollNode,
@@ -164,8 +165,9 @@ async function connectFakeNode(
     }
   };
 
-  // Allow onOpen → connectionManager.register to complete
-  await new Promise((r) => setTimeout(r, 150));
+  // onOpen → verifyNodeCredential (argon2id) → register outlasts any fixed
+  // sleep under load; wait for the registration itself.
+  await waitForNodeOnline(nodeId);
   return ws;
 }
 


### PR DESCRIPTION
Fixes #64.

## What was actually wrong

The issue proposed per-file database isolation, on the theory that suites collide on shared fixtures. I measured before building that, and the theory does not hold — **no failure in any baseline run came from a fixture collision**, and per-file DB isolation would have fixed none of them.

Three measurements:

1. **`bun test` (1.2.8) does not run test files in parallel.** A probe with two test files importing one shared module: the module is evaluated **once**, its mutable state accumulates across files, and file B finishes entirely before file A starts. All 55 hub files share one process, one module registry, and therefore one `connectionManager`, one broker, one Postgres pool. There is no interleaving to isolate — but the run gets progressively busier, so a file behaves differently in the suite than it does alone.
2. **Every baseline failure was `connectionManager.isOnline(nodeId) === false`** — surfacing as `Error: Node is offline`, HTTP 502, or an adopt call returning no rows. Not one was a row collision, a duplicate id, or a truncation race.
3. **The gateway's `onOpen` calls `verifyNodeCredential`, which is an argon2id `Bun.password.verify`.** Measured on this machine: **~105 ms** per verify when idle, **702 ms** for 10 concurrent. Registration in `connectionManager` happens *after* that, plus two Postgres round trips.

The test helpers waited for all of that with `await new Promise(r => setTimeout(r, 150))`.

A 150 ms sleep in front of a deliberately-slow >100 ms hash, in a process carrying 500 other tests, is a coin toss. Alone it lands; in the full suite it sometimes doesn't — and which tests lose the toss changes every run. That is the whole flake.

## The fix

Wait for the condition, not the clock.

New `apps/hub/tests/helpers/wait.ts`:

- `pollUntil` (moved here from `acp-fake-node.ts`, which is where it already existed)
- `waitForNodeOnline(nodeId)` — polls `connectionManager.isOnline`
- `waitForNodeUnregistered(nodeId)` — the teardown direction

Each has a real timeout and an error message naming what never happened, so the next person gets a diagnosis rather than a mystery.

All **12** test files that dial the node gateway now await registration instead of sleeping at it. Note that only 8 of these were findable by grepping the "allow register to settle" comments — 5 more were bare, uncommented `setTimeout(r, 150)` lines, and one of them (`station-cleanup`) is what turned an early 10-run attempt into 9/10. The sweep is now by construction: every file that opens `ws://…/public/nodes/gateway` has a barrier.

Four places needed more than a poll on `isOnline`:

- **`gateway.test.ts`'s replaced-socket test** has two sockets on one node, so `isOnline` can't tell them apart. It sends a heartbeat and awaits the ack — the gateway resolves `authReady` only after `register`, and `onMessage` awaits `authReady`, so an ack proves *this* socket registered.
- **`station-activity.test.ts`** and one **`acp-sessions.test.ts`** case reconnect the *same* node id, where a stale registration would satisfy the barrier vacuously. They wait for the previous socket to be unregistered first.
- **`node-posture.test.ts`** gates on capabilities carried by the *hello* frame, not on registration, so its sleep was covering a longer chain; it now waits for the hello's writes to land.

**Nothing was weakened, skipped or deleted.** A node that never comes online still fails the test. Sleeps that prove something does *not* happen (e.g. "no `posture.scan` was sent to the node") are left as sleeps — that is the one case where a sleep is the correct instrument.

## Baseline: 5 runs on unmodified main

| Run | Result | Failures | Wall clock |
|-----|--------|----------|------------|
| 1 | ❌ FAIL | 9 | 59.1 s |
| 2 | ❌ FAIL | 2 | 57.2 s |
| 3 | ❌ FAIL | 2 | 57.0 s |
| 4 | ❌ FAIL | 5 | 58.0 s |
| 5 | ❌ FAIL | 1 | 54.7 s |

**5/5 red, a different failure set every time.** Files hit across the five runs: `src/services/acp-sessions.test.ts`, `src/routes/station-acp.test.ts`, `src/routes/station-activity.test.ts`, `src/routes/station-terminal.test.ts`, `src/services/acp-transport.test.ts`, `tests/integration/station-observe.test.ts`. Every failure traced to `Node is offline` / 502 / empty adopt.

## After: 10 runs

| Run | Result | Tests | Wall clock |
|-----|--------|-------|------------|
| 1 | ✅ PASS | 516 pass / 0 fail | 45.2 s |
| 2 | ✅ PASS | 516 pass / 0 fail | 45.5 s |
| 3 | ✅ PASS | 516 pass / 0 fail | 45.0 s |
| 4 | ✅ PASS | 516 pass / 0 fail | 44.4 s |
| 5 | ✅ PASS | 516 pass / 0 fail | 43.9 s |
| 6 | ✅ PASS | 516 pass / 0 fail | 45.5 s |
| 7 | ✅ PASS | 516 pass / 0 fail | 45.8 s |
| 8 | ✅ PASS | 516 pass / 0 fail | 44.4 s |
| 9 | ✅ PASS | 516 pass / 0 fail | 46.6 s |
| 10 | ✅ PASS | 516 pass / 0 fail | 47.6 s |

**10/10 clean.** Same 516 tests as baseline — none removed.

An earlier attempt hit 9/10 (`station-cleanup` failed run 5). Rather than call that good, I chased the tenth: it was a sixth uncommented `setTimeout(r, 150)` I had missed. Fixing it is what produced the run above.

## Timing

| | Before | After |
|---|---|---|
| Wall clock | 54.7 – 59.1 s (mean 57.2 s) | 43.9 – 47.6 s (mean 45.4 s) |

**~21% faster.** CI gets cheaper, not more expensive: polling returns the moment registration lands instead of always burning a fixed 150 ms, roughly 100 times per run. This should help more on CI than locally — GitHub runners have fewer cores, so the argon2 verify the old sleep was racing is *slower* there.

## What I did NOT do, and why

- **No per-file schema or database.** With one process, one module registry and one `src/db/drizzle.ts` evaluated once for the whole run, a per-file `DATABASE_URL` is not reachable without a process per file, and a per-file `search_path` is fragile across a shared 10-connection pool. It would have cost setup time and CI minutes to fix zero of the observed failures. If cross-file DB collisions ever do appear, the evidence for them should come first.
- **No `--concurrency 1` / serialisation.** Files are already serial; there is nothing to serialise.
- **No test weakened to get to green.**

## Two findings left open

1. **The gateway leaks per-connection background work.** `onOpen` schedules auto-adopt retries at 1.5 s / 4 s / 9 s and a capability refresh at 2 s, fire-and-forget, with nothing cancelling them when the socket closes. In tests that means DB and broker work firing seconds after the file that created it has finished; in production it means a node that hangs up immediately still gets three auto-adopt attempts. I have a working patch (cancel the timers in `onClose`) but could not find an honest way to regression-test the cancellation, and this repo's rule is a regression test per fix — so it is not in this PR. It did not need to be: 10/10 is clean without it. Worth its own issue.
2. **`TESTING.md`'s "set env vars before any `src/` imports" is not a mechanism.** ESM hoists the `import`s above the assignment, so `src/db/drizzle.ts` has already read `DATABASE_URL` by the time the preamble runs — verified with a probe. The command-line `DATABASE_URL` is what actually points the suite at the test database. Corrected in `TESTING.md` so nobody relies on the preamble.

Both `apps/hub/CLAUDE.md` and `TESTING.md` now carry the rule this cost us: **never sleep for a barrier** — the suite is single-process and sequential, load accumulates, and a fixed sleep in front of an argon2 verify is a coin toss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
