### PR TITLE
fix(hub): cancel the gateway's deferred work when the socket closes

### DIFF
--- a/apps/hub/src/routes/gateway.ts
+++ b/apps/hub/src/routes/gateway.ts
@@ -7,7 +7,7 @@
  * Auth: Authorization: Bearer <nodeId>:<nodeSecret>
  * On open:       register + set online
  * On heartbeat:  refresh online + ack
- * On close:      unregister + set offline
+ * On close:      cancel deferred work + unregister + set offline
  */
 
 import { Hono } from "hono";
@@ -43,6 +43,31 @@ export const gatewayRoutes = new Hono().get(
       resolveAuth = r;
     });
 
+    // Deferred work this connection scheduled, so onClose can cancel it.
+    // onOpen fires auto-adopt retries and a capability refresh on timers
+    // nothing held a handle to, so a node that connected and hung up a
+    // millisecond later still got three adopt attempts and a refresh aimed at
+    // it — DB and broker work charged to a socket that was already gone, worst
+    // for exactly the crash-looping node that reconnects most often.
+    const pending = new Map<ReturnType<typeof setTimeout>, (ok: boolean) => void>();
+    let closed = false;
+
+    /**
+     * Sleep that this connection can cancel. Resolves true if the delay
+     * elapsed with the socket still open, false if onClose cancelled it —
+     * callers must bail on false rather than do node work for a dead socket.
+     */
+    function sleep(ms: number): Promise<boolean> {
+      if (closed) return Promise.resolve(false);
+      return new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => {
+          pending.delete(timer);
+          resolve(!closed);
+        }, ms);
+        pending.set(timer, resolve);
+      });
+    }
+
     return {
       async onOpen(_e, ws) {
         if (
@@ -64,7 +89,9 @@ export const gatewayRoutes = new Hono().get(
         // Fire-and-forget with retries — never blocks or throws into the gateway.
         void (async () => {
           for (const delay of [1500, 4000, 9000]) {
-            await new Promise((res) => setTimeout(res, delay));
+            // Cancelled by onClose: stop retrying rather than keep adopting
+            // for a connection that no longer exists.
+            if (!(await sleep(delay))) return;
             try {
               await autoAdoptProvisionedHarness(nodeId);
             } catch {
@@ -79,7 +106,7 @@ export const gatewayRoutes = new Hono().get(
         // a new capability appears only on stations adopted after the update.
         // Fire-and-forget: it must never block or throw into the gateway.
         void (async () => {
-          await new Promise((res) => setTimeout(res, 2000));
+          if (!(await sleep(2000))) return;
           try {
             await refreshAdoptedCapabilities(nodeId);
           } catch {
@@ -129,6 +156,20 @@ export const gatewayRoutes = new Hono().get(
 
       async onClose() {
         resolveAuth(false); // unblock any onMessage awaiting auth on early close
+
+        // Cancel this connection's deferred work. Deliberately NOT behind the
+        // epoch guard below: `pending` is this closure's own state, and a
+        // replacement socket scheduled its own timers in its own closure, so
+        // cancelling here can never starve the fresh connection. Gating it on
+        // isCurrent would do the opposite — a replaced socket would fail its
+        // own guard and leak its timers, which is precisely the bug.
+        closed = true;
+        for (const [timer, resolve] of pending) {
+          clearTimeout(timer);
+          resolve(false); // unblock the awaiting closure so it can return
+        }
+        pending.clear();
+
         // Epoch guard: only the currently registered socket tears down. A late
         // close from a replaced socket must not mark the fresh connection
         // offline or drop its send entry.

--- a/apps/hub/tests/integration/gateway.test.ts
+++ b/apps/hub/tests/integration/gateway.test.ts
@@ -30,7 +30,11 @@ import { listNodes } from "../../src/services/node-registry";
 import { gatewayRoutes } from "../../src/routes/gateway";
 import { websocket } from "../../src/ws";
 import { connectionManager } from "../../src/services/connection-manager";
-import { pollUntil, waitForNodeOnline } from "../helpers/wait";
+import {
+  pollUntil,
+  waitForNodeOnline,
+  waitForNodeUnregistered,
+} from "../helpers/wait";
 
 /**
  * Barrier for "this socket's onOpen finished registering it".
@@ -74,6 +78,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   try {
+    await rawSql`DELETE FROM provisioned_runtimes WHERE user_id = ${TEST_USER_ID}`;
     await rawSql`DELETE FROM nodes              WHERE user_id = ${TEST_USER_ID}`;
     await rawSql`DELETE FROM enrollment_tokens  WHERE user_id = ${TEST_USER_ID}`;
     await rawSql`DELETE FROM "user"             WHERE id      = ${TEST_USER_ID}`;
@@ -332,3 +337,122 @@ test("hello frame version is persisted to agentVersion on the node row", async (
     server.stop(true);
   }
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deferred work scheduled by onOpen must not outlive the connection (#267)
+//
+// onOpen schedules auto-adopt attempts (first at 1.5 s) and a capability
+// refresh (2 s) on timers. Both reach the node the same way — through
+// `broker.request(nodeId, "detect")` — so a `detect` req handed to whatever
+// send fn the connection manager holds for the node is the observable that
+// the deferred work ran.
+//
+// The two tests are a pair and must stay one. The first proves those timers
+// really do fire and really do reach the node under this harness; without it
+// the second test's "no detect ever arrived" would pass just as well against
+// a gateway that never scheduled anything at all.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Watch window: comfortably past both the 1.5 s and 2 s deadlines. */
+const DEFERRED_WINDOW_MS = 3_000;
+
+/**
+ * Enroll a node that auto-adopt will actually do work for. It returns early
+ * unless the node has a provisioned runtime with a real harness, so without
+ * this row the deferred work would never reach the broker and neither test
+ * below would observe anything.
+ */
+async function enrollProvisionedNode(hostname: string) {
+  const { token } = await mintEnrollmentToken(TEST_USER_ID);
+  const creds = await enrollNode(token, {
+    hostname, os: "linux", arch: "amd64", cpuCount: 1,
+  });
+  await rawSql`
+    INSERT INTO provisioned_runtimes (id, user_id, provider, status, node_id, name, harness)
+    VALUES (${`rt-${creds.nodeId}`}, ${TEST_USER_ID}, 'docker', 'online',
+            ${creds.nodeId}, ${hostname}, 'opencode')
+  `;
+  return creds;
+}
+
+test("onOpen's deferred work reaches a node whose socket stays open", async () => {
+  const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+  try {
+    const { nodeId, nodeSecret } = await enrollProvisionedNode("deferred-live-host");
+    const ws = new WebSocket(`ws://localhost:${server.port}/public/nodes/gateway`, {
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    } as RequestInit & { headers: Record<string, string> });
+    await new Promise<void>((res, rej) => {
+      ws.onopen = () => res();
+      ws.onerror = () => rej(new Error("WebSocket connection error"));
+    });
+
+    const detects: string[] = [];
+    const gotDetect = new Promise<void>((res) => {
+      ws.onmessage = (e) => {
+        const msg = JSON.parse(String(e.data));
+        if (msg.type !== "req" || msg.verb !== "detect") return;
+        detects.push(msg.id);
+        // Answer with a failure: nothing is adopted, and the broker request
+        // does not sit pending for its full 10 s timeout after the test ends.
+        ws.send(JSON.stringify({ type: "res", id: msg.id, ok: false, error: "test" }));
+        res();
+      };
+    });
+
+    await waitForNodeOnline(nodeId);
+    await Promise.race([
+      gotDetect,
+      new Promise((r) => setTimeout(r, DEFERRED_WINDOW_MS)),
+    ]);
+    expect(detects.length).toBeGreaterThan(0);
+
+    ws.close();
+  } finally {
+    server.stop(true);
+  }
+}, 15_000);
+
+test("a socket that closes before its deferred work fires cancels it", async () => {
+  const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+  try {
+    const { nodeId, nodeSecret } = await enrollProvisionedNode("deferred-closed-host");
+    const ws = new WebSocket(`ws://localhost:${server.port}/public/nodes/gateway`, {
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    } as RequestInit & { headers: Record<string, string> });
+    await new Promise<void>((res, rej) => {
+      ws.onopen = () => res();
+      ws.onerror = () => rej(new Error("WebSocket connection error"));
+    });
+    await waitForNodeOnline(nodeId);
+
+    // Close well inside the 1.5 s deadline for the first auto-adopt attempt.
+    ws.close();
+    // unregister happens after the cancellation in onClose, so this is the
+    // barrier for "onClose has run" — no sleeping to guess at it.
+    await waitForNodeUnregistered(nodeId);
+
+    // Stand in for the node having reconnected on a fresh socket, which is
+    // what makes the leak observable: give the connection manager a send fn
+    // that records what the hub pushes at the node. The closed socket's
+    // timers are now the only thing that could put anything here.
+    const pushed: Array<{ type: string; verb?: string }> = [];
+    connectionManager.register(nodeId, (m) => {
+      pushed.push(m as { type: string; verb?: string });
+    });
+
+    try {
+      // Sleeping is legitimate here and only here: proving something does NOT
+      // happen needs a deadline, and this one is double the 1.5 s it waits out.
+      await new Promise((r) => setTimeout(r, DEFERRED_WINDOW_MS));
+      const verbs = pushed
+        .filter((m) => m.type === "req")
+        .map((m) => m.verb);
+      expect(verbs).toEqual([]);
+    } finally {
+      connectionManager.unregister(nodeId);
+    }
+  } finally {
+    server.stop(true);
+  }
+}, 15_000);


### PR DESCRIPTION
Fixes #267.

`onOpen` scheduled auto-adopt retries (1.5 s, then 4 s and 9 s further on) and a
capability refresh (2 s) on timers nothing held a handle to, and `onClose` cancelled
none of them. A node that connected and hung up a millisecond later still got three
adopt attempts and a refresh fired at it — two Postgres round trips and a broker request
each, charged to a connection that was already gone. Worst exactly where connections are
cheapest: a crash-looping node, or a provisioned runtime whose container exits before it
can enrol, reconnects continuously and leaves a 14.5 s tail of work behind every
short-lived socket.

## The fix

Per-connection `Map` of pending timers plus a cancellable `sleep(ms)` that resolves
`false` when the connection is gone, so the retry loop returns instead of pressing on to
the next delay. `onClose` clears them.

**The cancellation is deliberately not behind the epoch guard**, which is where the
issue's own proposal had it and where I'd have put it without checking. `pending` is the
closure's own state, and a replacement socket scheduled its own timers in its own
closure — so cancelling here can never starve the fresh connection. Gating on
`isCurrent` would do the opposite: a replaced socket fails its own guard and leaks its
timers, which is the bug. Noted on the issue too, since the proposal there is wrong on
this point.

An in-flight `autoAdoptProvisionedHarness` that has already started isn't clawed back
and doesn't need to be — the work is short and the waits are long, so cancelling the
pending timers removes essentially all of the tail.

## The regression test is a pair, and must stay one

A test asserting "nothing happened" is usually vacuous, and this one would be: after the
socket closes, the node is unregistered, so the broker fails and no station is adopted
whether or not the timers were cancelled. The only real observable is *whether the
deferred work ran at all*.

So:

1. **`onOpen's deferred work reaches a node whose socket stays open`** — socket stays up,
   fake node-agent asserts a `detect` req arrives. Proves the timers fire and reach the
   node under this exact harness.
2. **`a socket that closes before its deferred work fires cancels it`** — socket closes
   inside the 1.5 s deadline; a recording `send` fn is then registered with the
   connection manager (standing in for the node having reconnected, which is what makes
   the leak observable at all); asserts nothing is pushed at the node afterwards.

Without (1), (2) would pass just as well against a gateway that never scheduled anything.
Both need a `provisioned_runtimes` row, or auto-adopt returns early and never reaches the
broker.

**Proven non-vacuous**: reverting just the cancellation block makes (2) fail, and it
catches *both* leaked paths —

```
+ [ "detect", "detect" ]   // auto-adopt at 1.5 s, capability refresh at 2 s
- []
```

while (1) still passes. The 3 s watch window is double the deadline it waits out;
sleeping is legitimate here for the reason `apps/hub/CLAUDE.md` L30 allows it — proving
something does *not* happen.

## Verification

Full hub suite run three times, since this touches the machinery #264 made deterministic:

| run | result |
| --- | --- |
| 1 | **540 pass, 0 fail** (57 files, 52.65 s) |
| 2 | **540 pass, 0 fail** (57 files, 50.41 s) |
| 3 | **540 pass, 0 fail** (57 files, 50.15 s) |

538 on the base + the 2 added here. `bun run typecheck` adds no new errors — `gateway.ts`
is clean, everything reported is the pre-existing known-red set.

No test weakened; nothing outside the gateway and its tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
