### PR TITLE
feat(provisioner): Modal driver (Tasks 1–14, live verification pending)

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -44,6 +44,7 @@
     "gray-matter": "^4.0.3",
     "hono": "^4.13.1",
     "isomorphic-git": "^1.40.4",
+    "modal": "0.9.0",
     "nanoid": "^5.1.16",
     "postgres": "^3.4.9",
     "superjson": "^2.2.6",

--- a/apps/hub/src/config.ts
+++ b/apps/hub/src/config.ts
@@ -153,6 +153,23 @@ export const config = {
     autoSelect: getEnvBool('AUTO_SELECT_PROVIDER', false),
   },
 
+  modal: {
+    enabled: getEnvBool('ENABLE_MODAL_PROVISIONING', false),
+    // Workspace-wide on Modal's Starter plan: per-resource scoping needs the
+    // $250/mo Team plan. Use a Modal workspace dedicated to AgentPod.
+    tokenId: getEnv('MODAL_TOKEN_ID', ''),
+    tokenSecret: getEnv('MODAL_TOKEN_SECRET', ''),
+    // Modal pulls from a registry and runs linux/amd64 only, so the local tags
+    // a Docker-first hub uses are meaningless to it.
+    image: getEnv('NODE_AGENT_MODAL_IMAGE', ''),
+    appName: getEnv('MODAL_APP_NAME', 'agentpod'),
+  },
+
+  // Hub URL a provisioned container dials to enrol. Request-scoped for a
+  // console-initiated create, but a rotating substrate re-creates instances on
+  // a timer with no request in sight — so it must be configured.
+  provisioningHubUrl: getEnv('PROVISIONING_HUB_URL', ''),
+
   metamcp: {
     // Internal URL for MetaMCP (used for tRPC/auth calls from API container)
     // Port 12008 is the Next.js frontend which proxies auth + tRPC

--- a/apps/hub/src/db/drizzle-migrations/0034_runtime_external_started_at.sql
+++ b/apps/hub/src/db/drizzle-migrations/0034_runtime_external_started_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provisioned_runtimes" ADD COLUMN "external_started_at" timestamp;

--- a/apps/hub/src/db/drizzle-migrations/meta/0034_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0034_snapshot.json
@@ -1,0 +1,2024 @@
+{
+  "id": "291aa73b-8d31-4b07-83b1-75e5b667f1ae",
+  "prevId": "ea4ec754-bc4c-4216-b9a2-10b2d27e55d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1786534120547,
       "tag": "0033_runtime_stopping_status",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1786578432361,
+      "tag": "0034_runtime_external_started_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/nodes.ts
+++ b/apps/hub/src/db/schema/nodes.ts
@@ -40,6 +40,18 @@ export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   // Container runtime the provider reported, e.g. "runsc". Null when the
   // provider has no such concept, or the row predates the field.
   runtime: text("runtime"),
+  // When the CURRENT external instance started — which is not created_at on a
+  // substrate that replaces the instance while the runtime lives on. Written
+  // wherever externalId is written, because the two describe the same instance:
+  // one names it, this one dates it.
+  //
+  // Nullable and never defaulted, on purpose. Null means "there is no instance
+  // to date" — a row that predates this column, a provision that failed, or a
+  // runtime that has not been created yet — and a sweeper deciding whether the
+  // substrate is about to destroy an instance must be able to tell that from a
+  // real age. A DEFAULT now() would make every such row look like a brand-new
+  // instance and cost a real one.
+  externalStartedAt: timestamp("external_started_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 }, (t) => [index("provisioned_runtimes_user_id_idx").on(t.userId)]);

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -1263,6 +1263,43 @@ test("re-creating mints a fresh enrolment token, because the old one is not in t
   expect(tokenRows.length).toBe(2);
 }, 30_000);
 
+test("every path resolves the image for the runtime's OWN provider", async () => {
+  // Provider-scoped image resolution is only worth anything if both call sites
+  // use it. The re-create path is the one that matters most and is the easiest
+  // to get wrong: a rotation runs every 24 hours with no request and nobody
+  // watching, and a re-create that resolved Docker's local tag would hand Modal
+  // an image it cannot pull — the sandbox never boots, the runtime sits in
+  // `starting`, and the sweeper names nothing useful two minutes later.
+  //
+  // The docker assertion is the other half: one variable set for one provider
+  // must not move the live hub, which runs docker + cloudflare.
+  const MODAL_IMAGE = "ghcr.io/example/agentpod-node-modal:v1";
+  const previous = process.env.NODE_AGENT_MODAL_IMAGE;
+  process.env.NODE_AGENT_MODAL_IMAGE = MODAL_IMAGE;
+  try {
+    const { id } = await createModalRuntime("scoped-image");
+    // Call site 1: createRuntime.
+    expect(terminalCalls.provision.at(-1)!.image).toBe(MODAL_IMAGE);
+
+    // Call site 2: reprovisionRuntime, reached through start-as-create.
+    await startVia(id);
+    expect(terminalCalls.provision).toHaveLength(2);
+    expect(terminalCalls.provision.at(-1)!.image).toBe(MODAL_IMAGE);
+
+    // ...and the Docker runtime on the same hub is untouched by Modal's variable.
+    const dockerRes = await createRuntime(TEST_USER, "docker-image-unmoved");
+    expect(dockerRes.status).toBe(201);
+    expect(fakeCalls.provision.at(-1)!.image).toBe(
+      process.env.NODE_AGENT_IMAGE ?? "agentpod-node:local"
+    );
+  } finally {
+    // `bun test` shares one process: a stray NODE_AGENT_MODAL_IMAGE would
+    // follow this file into every later one.
+    if (previous === undefined) delete process.env.NODE_AGENT_MODAL_IMAGE;
+    else process.env.NODE_AGENT_MODAL_IMAGE = previous;
+  }
+}, 30_000);
+
 test("a re-create the substrate refuses leaves the runtime in error, saying so", async () => {
   // A create can fail, and this one is a create. Leaving the row `starting`
   // after the substrate said no would hand the operator a spinner for something

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -23,6 +23,11 @@ process.env.DATABASE_URL =
   "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
 process.env.NODE_ENV = "test";
 process.env.ENABLE_DOCKER_PROVISIONING = "true";
+process.env.ENABLE_MODAL_PROVISIONING = "true";
+// reprovisionRuntime runs without a request in hand — a rotation sweep has no
+// origin to take a hub URL from — so it reads one from configuration. Unset,
+// every re-create throws rather than handing a container a hub it cannot dial.
+process.env.PROVISIONING_HUB_URL = "https://hub.test";
 
 import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { Hono } from "hono";
@@ -87,6 +92,59 @@ const fakeDockerProvisioner: RuntimeProvisioner = {
   // Note: no `stop` — deliberately omitted to test the 400 unsupported path.
 };
 
+// ─── A terminal-stop fake: the shape Modal forces ─────────────────────────────
+//
+// No start(), because there is nothing to start — terminate is irreversible and
+// every restart is a new sandbox. What survives is the driver's ANCHOR, and a
+// driver anchors by spec.runtimeId, so provisioning again with the same
+// runtimeId re-attaches the same workspace. The external id below is shaped
+// like the real Modal driver's (`<volume>#<sandbox>`) so a test can see which
+// half changed.
+
+const terminalCalls: {
+  provision: ProvisionSpec[];
+  stop: string[];
+  /** Interleaved log, so "terminate BEFORE create" is checkable, not assumed. */
+  order: string[];
+} = { provision: [], stop: [], order: [] };
+
+let terminalCounter = 0;
+/** Makes the substrate refuse to terminate the instance being replaced. */
+let terminalStopFails = false;
+/** Makes the substrate refuse to create the replacement. */
+let terminalProvisionFails = false;
+
+const fakeTerminalProvisioner: RuntimeProvisioner = {
+  provider: "modal",
+  manifest: {
+    provider: "modal",
+    workspaceStorage: "volume",
+    stopSemantics: "terminal",
+    maxLifetimeMs: 86_400_000,
+    imageBinding: "per-instance",
+    supportedTiers: ["small", "medium", "large"],
+    idleBehaviour: "never",
+    lifecycle: ["stop", "status"],
+  },
+  async provision(spec) {
+    terminalCalls.provision.push(spec);
+    terminalCalls.order.push(`provision:${spec.runtimeId}`);
+    if (terminalProvisionFails) throw new Error("modal: no capacity");
+    return { externalId: `vol-${spec.runtimeId}#sb-${++terminalCounter}` };
+  },
+  async destroy() {},
+  async stop(externalId) {
+    terminalCalls.stop.push(externalId);
+    terminalCalls.order.push(`stop:${externalId}`);
+    if (terminalStopFails) throw new Error("modal: sandbox already terminated");
+  },
+  async status() {
+    return "running";
+  },
+  // Deliberately NO start(): conformance rule 3 forbids one on a terminal
+  // driver, and this is the case startRuntime has to handle without it.
+};
+
 // ─── Minimal test app ─────────────────────────────────────────────────────────
 //
 // The auth middleware in production reads Better Auth sessions / API keys.
@@ -117,19 +175,41 @@ beforeAll(async () => {
     email: "runtimes-other@example.com",
     name: "Runtimes Other User",
   });
-  // Register the fake provisioner (ENABLE_DOCKER_PROVISIONING=true set above).
-  registerProvisioner(fakeDockerProvisioner);
+  registerFakeProvisioners();
 });
+
+/**
+ * Register both fakes.
+ *
+ * A helper rather than two calls, because two tests below clear the registry on
+ * purpose and have to put it back exactly as it was — restoring only docker
+ * left every later modal test failing with "provider not registered", which
+ * reads as a broken feature rather than a broken fixture.
+ */
+function registerFakeProvisioners() {
+  registerProvisioner(fakeDockerProvisioner);
+  registerProvisioner(fakeTerminalProvisioner);
+}
 
 afterEach(() => {
   // Clear call history between tests (but keep the registration).
   fakeCalls.provision.length = 0;
   fakeCalls.destroy.length = 0;
   fakeCalls.start.length = 0;
+  terminalCalls.provision.length = 0;
+  terminalCalls.stop.length = 0;
+  terminalCalls.order.length = 0;
+  terminalStopFails = false;
+  terminalProvisionFails = false;
 });
 
 afterAll(async () => {
   resetProvisioners();
+  // These two are set on `process.env` above and `bun test` runs every file in
+  // ONE process, so leaving them set would silently enable a modal provider —
+  // and pin a hub URL — for every file that runs after this one.
+  delete process.env.ENABLE_MODAL_PROVISIONING;
+  delete process.env.PROVISIONING_HUB_URL;
   try {
     await rawSql`DELETE FROM enrollment_tokens    WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
     await rawSql`DELETE FROM provisioned_runtimes WHERE user_id IN (${TEST_USER}, ${OTHER_USER})`;
@@ -528,8 +608,8 @@ test("DELETE /api/runtimes/:id with unregistered provisioner → row still marke
       .where(eq(provisionedRuntimes.id, id));
     expect(row!.status).toBe("destroyed");
   } finally {
-    // Re-register the fake so later tests continue to work
-    registerProvisioner(fakeDockerProvisioner);
+    // Re-register the fakes so later tests continue to work
+    registerFakeProvisioners();
   }
 }, 30_000);
 
@@ -752,7 +832,7 @@ async function withProvisioner(
   try {
     await body();
   } finally {
-    registerProvisioner(fakeDockerProvisioner);
+    registerFakeProvisioners();
   }
 }
 
@@ -1019,4 +1099,211 @@ test("a row written without an instance start time keeps NULL — the column is 
   `;
 
   expect((await rowOf(id)).externalStartedAt).toBeNull();
+}, 30_000);
+
+// ─── Start means CREATE, on a substrate whose stop is terminal ────────────────
+//
+// Modal has no start verb: terminate cannot be undone, and every restart is a
+// new sandbox with a new id and a fresh rootfs. The honest answer is not a 400
+// forever — it is that a restart on such a substrate IS a create, against the
+// anchor that carries the workspace. The tests below pin the three things that
+// make that safe rather than merely convenient: the SAME runtime id (so the
+// Volume is re-attached instead of orphaned), a FRESH enrolment token (the hub
+// stores only a hash and cannot re-present the old one), and a NEW instance
+// clock (the 24h ceiling restarts with the sandbox).
+
+async function createModalRuntime(name: string) {
+  const res = await testApp.request("/api/runtimes", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Test-User-Id": TEST_USER,
+      "Host": "localhost:3001",
+    },
+    body: JSON.stringify({ provider: "modal", name, resourceTier: "small" }),
+  });
+  expect(res.status).toBe(201);
+  return (await res.json()) as { id: string; externalId: string };
+}
+
+/**
+ * Age the current instance by two hours.
+ *
+ * Not cosmetic: without it, "did the re-create rewrite external_started_at?"
+ * would be asked of two timestamps milliseconds apart, and a `>=` assertion
+ * passes just as happily when nothing was rewritten at all. Backdating makes
+ * the question answerable with a strict comparison.
+ */
+async function ageInstanceByTwoHours(id: string) {
+  await rawSql`
+    UPDATE provisioned_runtimes
+       SET external_started_at = now() - interval '2 hours'
+     WHERE id = ${id}
+  `;
+}
+
+test("starting a terminal-stop runtime creates a NEW instance against the SAME anchor", async () => {
+  const { id } = await createModalRuntime("rolling");
+  await ageInstanceByTwoHours(id);
+  const before = await rowOf(id);
+
+  const res = await startVia(id);
+  expect(res.status).toBe(204);
+
+  const after = await rowOf(id);
+  // A new sandbox...
+  expect(after.externalId).not.toBe(before.externalId);
+  // ...on the SAME runtime id, which is what the driver anchors its Volume by.
+  // A fresh id here would silently orphan the old Volume — still billed, and
+  // holding the only copy of the station's work — and hand the new sandbox an
+  // empty workspace, with nothing anywhere saying so.
+  expect(terminalCalls.provision.at(-1)!.runtimeId).toBe(id);
+  expect(after.externalId!.startsWith(`vol-${id}#`)).toBe(true);
+  // The rest of the spec is the runtime's, not a default: a re-create that
+  // quietly resized or renamed the station is a different station.
+  expect(terminalCalls.provision.at(-1)!.name).toBe("rolling");
+  expect(terminalCalls.provision.at(-1)!.resourceTier).toBe("small");
+  // No request to take an origin from, so the hub URL comes from config.
+  expect(terminalCalls.provision.at(-1)!.hubUrl).toBe("https://hub.test");
+
+  // `starting`, never `online`: the substrate accepting a create is not a node
+  // existing. Only enrolment writes online (issue #254).
+  expect(after.status).toBe("starting");
+
+  // The new sandbox has a new 24h ceiling, so it needs a new clock. Left at the
+  // old value, the rotation sweep would find a freshly created sandbox already
+  // "expired" and re-create it again on the very next tick, for ever.
+  expect(after.externalStartedAt!.getTime()).toBeGreaterThan(
+    before.externalStartedAt!.getTime() + 60 * 60_000
+  );
+  expect(after.externalStartedAt!.getTime()).toBeLessThanOrEqual(Date.now());
+}, 30_000);
+
+test("re-creating terminates the instance it replaces, BEFORE creating its successor", async () => {
+  // Leaving the old sandbox behind is one nobody is watching and everybody is
+  // paying for. Ordering matters too: two live sandboxes writing to one Volume
+  // is the corruption case, so the terminate is not merely eventual.
+  const { id, externalId } = await createModalRuntime("no-leak");
+
+  await startVia(id);
+
+  expect(terminalCalls.stop).toEqual([externalId]);
+  expect(terminalCalls.order).toEqual([
+    `provision:${id}`, // the original create
+    `stop:${externalId}`, // the sandbox being replaced, terminated first
+    `provision:${id}`, // its successor, on the same anchor
+  ]);
+}, 30_000);
+
+test("a terminate that fails does not block the re-create, and is not swallowed either", async () => {
+  // Best effort by design: the old instance is very often already gone (that is
+  // the 24h ceiling doing its thing), and refusing to create a replacement
+  // because the corpse would not die again helps nobody. But "best effort" must
+  // not mean "unrecorded" — the one case where it matters is a sandbox that is
+  // still up, still billing, and now unreferenced by any row.
+  const { id, externalId } = await createModalRuntime("stubborn");
+  terminalStopFails = true;
+
+  const res = await startVia(id);
+  expect(res.status).toBe(204);
+
+  const after = await rowOf(id);
+  expect(after.status).toBe("starting");
+  expect(after.externalId).not.toBe(externalId);
+  // The operator has to be able to see which sandbox was left behind, in the
+  // place the console already shows (statusReason renders under the badge).
+  expect(after.statusReason).toContain(externalId);
+  expect(after.statusReason).toContain("already terminated");
+}, 30_000);
+
+test("re-creating mints a fresh enrolment token, because the old one is not in the hub", async () => {
+  // The hub stores only a hash, so it cannot re-inject the token it minted. It
+  // mints another bound to the same runtime; enrollNode resumes the same node
+  // with a rotated secret (PR #252). Nothing is kept in the Volume — the
+  // node-agent's config lives on the disposable rootfs on purpose.
+  const { id } = await createModalRuntime("tokens");
+  const firstToken = terminalCalls.provision.at(-1)!.enrollToken;
+
+  await startVia(id);
+
+  const secondToken = terminalCalls.provision.at(-1)!.enrollToken;
+  expect(secondToken).not.toBe(firstToken);
+  expect(secondToken.startsWith("enr_")).toBe(true);
+
+  const tokenRows = await db
+    .select()
+    .from(enrollmentTokens)
+    .where(eq(enrollmentTokens.provisionedRuntimeId, id));
+  expect(tokenRows.length).toBe(2);
+}, 30_000);
+
+test("a re-create the substrate refuses leaves the runtime in error, saying so", async () => {
+  // A create can fail, and this one is a create. Leaving the row `starting`
+  // after the substrate said no would hand the operator a spinner for something
+  // that already failed, and the stalled-start sweeper would eventually report
+  // the wrong reason ("no node enrolled") for it.
+  const { id } = await createModalRuntime("no-capacity");
+  terminalProvisionFails = true;
+
+  const res = await startVia(id);
+  expect(res.status).toBe(502);
+
+  const after = await rowOf(id);
+  expect(after.status).toBe("error");
+  expect(after.statusReason).toContain("no capacity");
+}, 30_000);
+
+test("a resumable driver's start is unchanged — it starts the instance it already has", async () => {
+  // The terminal branch is additive. Docker and Cloudflare keep the instance
+  // across a stop, so their start is still start(): no new instance, no new
+  // token, and no new instance clock.
+  const createRes = await createRuntime(TEST_USER, "resumable-start");
+  const { id } = (await createRes.json()) as { id: string };
+  const before = await rowOf(id);
+
+  const res = await startVia(id);
+  expect(res.status).toBe(204);
+
+  expect(fakeCalls.start).toEqual([before.externalId!]);
+  // Exactly one provision: the create. A second would mean the terminal branch
+  // fired for a substrate that never needed it.
+  expect(fakeCalls.provision).toHaveLength(1);
+
+  const after = await rowOf(id);
+  expect(after.externalId).toBe(before.externalId);
+  expect(after.status).toBe("starting");
+  expect(after.statusReason).toBeNull();
+  // Same instance, so the same instance clock. Rewriting it here would make
+  // every start reset the age of a sandbox that never restarted.
+  expect(after.externalStartedAt!.getTime()).toBe(
+    before.externalStartedAt!.getTime()
+  );
+}, 30_000);
+
+test("a resumable driver with no start() still refuses — re-creating is not a substitute", async () => {
+  // The branch is gated on the MANIFEST, not on the missing method. A resumable
+  // substrate keeps the instance, and its disk, across a stop; destroying it and
+  // building a new one to satisfy a button would throw the workspace away —
+  // exactly the loss stopSemantics exists to prevent. The honest answer for a
+  // driver that declares resumable and cannot start is the 400 (and conformance
+  // now refuses to let such a driver ship at all).
+  const noStart: RuntimeProvisioner = { ...fakeDockerProvisioner };
+  delete (noStart as { start?: unknown }).start;
+
+  await withProvisioner(noStart, async () => {
+    const createRes = await createRuntime(TEST_USER, "resumable-no-start");
+    const { id } = (await createRes.json()) as { id: string };
+    const before = await rowOf(id);
+
+    const res = await startVia(id);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { message: string }).message).toContain(
+      "does not support start"
+    );
+
+    // Nothing was re-created behind the refusal.
+    expect(fakeCalls.provision).toHaveLength(1);
+    const after = await rowOf(id);
+    expect(after.externalId).toBe(before.externalId);
+  });
 }, 30_000);

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -945,3 +945,78 @@ test("a runtime still being provisioned (no external id yet) is not swept", asyn
   expect(swept).not.toContain(id);
   expect((await rowOf(id)).status).toBe("provisioning");
 }, 30_000);
+
+// ─── external_started_at: the age of the CURRENT instance ─────────────────────
+//
+// A substrate with a lifetime ceiling — Modal destroys a sandbox at 24h, with no
+// warning callback and no way back — forces the hub to know how old the
+// *instance* is. `created_at` cannot answer that: once a runtime has been
+// re-created against its durable anchor, the row is older than the thing
+// running. These tests pin the only three answers the column may give: "when
+// the substrate accepted this instance", "null, because provisioning failed and
+// there is no instance", and "null, because nobody wrote one".
+
+test("provisioning records when the instance started, not only when the row was made", async () => {
+  const before = Date.now();
+  const { id } = (await (await createRuntime(TEST_USER, "instance-clock")).json()) as {
+    id: string;
+  };
+
+  const row = await rowOf(id);
+  expect(row.externalStartedAt).toBeInstanceOf(Date);
+  // Bounded on both sides. The rotation sweeper subtracts this from now(), so a
+  // constant, a far-off default or a zero is worse than useless: it would date
+  // an instance that is not the one running.
+  expect(row.externalStartedAt!.getTime()).toBeGreaterThanOrEqual(before);
+  expect(row.externalStartedAt!.getTime()).toBeLessThanOrEqual(Date.now());
+  // It is written with the externalId because the two describe the same
+  // instance: one names it, the other dates it, and they must not disagree.
+  expect(row.externalId).toBe(`fake-container-${id}`);
+}, 30_000);
+
+test("a runtime whose provision failed has NO instance start time", async () => {
+  // The guard that keeps this column from decaying into a second created_at.
+  // Nothing was started here, so there is no age to report — and a DEFAULT
+  // now(), or a write at insert time, would hand sweepExpiringRuntimes the age
+  // of an instance that does not exist. Its answer to an old instance is to
+  // terminate and re-create, so a fabricated timestamp buys a billed sandbox
+  // for a runtime that failed.
+  const refusing: RuntimeProvisioner = {
+    ...fakeDockerProvisioner,
+    async provision(spec) {
+      fakeCalls.provision.push(spec);
+      throw new Error("substrate refused");
+    },
+  };
+
+  await withProvisioner(refusing, async () => {
+    const res = await createRuntime(TEST_USER, "never-started");
+    expect(res.status).toBe(502);
+
+    const [row] = await db
+      .select()
+      .from(provisionedRuntimes)
+      .where(eq(provisionedRuntimes.name, "never-started"));
+    expect(row!.status).toBe("error");
+    expect(row!.externalId).toBeNull();
+    expect(row!.externalStartedAt).toBeNull();
+  });
+}, 30_000);
+
+test("a row written without an instance start time keeps NULL — the column is additive", async () => {
+  // Every provisioned_runtimes row on the live hub predates this column, and a
+  // driver with no ceiling (docker, cloudflare) never writes it. So the
+  // migration has to be additive in the strict sense: an INSERT naming only the
+  // pre-existing columns must still succeed (no NOT NULL), and must leave the
+  // new column NULL rather than dating an instance the hub never started (no
+  // DEFAULT). Both halves are what makes this deployable against live rows.
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes
+      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${TEST_USER}, 'docker', 'ext-legacy-row', 'online', 'legacy', 'small', 'none',
+            now() - interval '30 days', now() - interval '30 days')
+  `;
+
+  expect((await rowOf(id)).externalStartedAt).toBeNull();
+}, 30_000);

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -39,13 +39,19 @@ import { stations } from "../db/schema/stations";
 import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
 import { registerProvisioner, resetProvisioners } from "../services/provisioner/registry";
-import type { RuntimeProvisioner, ProvisionSpec } from "../services/provisioner/types";
+import type {
+  RuntimeProvisioner,
+  ProvisionSpec,
+  RuntimeState,
+} from "../services/provisioner/types";
 import { runtimeRoutes } from "./runtimes";
 import {
   sweepStalledRuntimeStarts,
   START_TIMEOUT_MS,
   sweepStalledRuntimeStops,
   STOP_TIMEOUT_MS,
+  sweepExpiringRuntimes,
+  ROTATION_MARGIN_MS,
 } from "../services/runtimes";
 import { enrollNode } from "../services/enrollment";
 import type { AuthUser } from "../auth/middleware";
@@ -104,15 +110,26 @@ const fakeDockerProvisioner: RuntimeProvisioner = {
 const terminalCalls: {
   provision: ProvisionSpec[];
   stop: string[];
+  /** Every id the hub asked the substrate about. Rotation must ask about none. */
+  status: string[];
   /** Interleaved log, so "terminate BEFORE create" is checkable, not assumed. */
   order: string[];
-} = { provision: [], stop: [], order: [] };
+} = { provision: [], stop: [], status: [], order: [] };
 
 let terminalCounter = 0;
 /** Makes the substrate refuse to terminate the instance being replaced. */
 let terminalStopFails = false;
 /** Makes the substrate refuse to create the replacement. */
 let terminalProvisionFails = false;
+/** What the substrate reports about a sandbox, when it is asked at all. */
+let terminalState: RuntimeState = "running";
+/**
+ * Runs once, inside the next provision() call, then clears itself.
+ *
+ * The seam a test needs to act WHILE the hub is mid-flight — an operator
+ * stopping one runtime while a sweep is busy re-creating another.
+ */
+let terminalDuringProvision: ((spec: ProvisionSpec) => Promise<void>) | null = null;
 
 const fakeTerminalProvisioner: RuntimeProvisioner = {
   provider: "modal",
@@ -129,6 +146,11 @@ const fakeTerminalProvisioner: RuntimeProvisioner = {
   async provision(spec) {
     terminalCalls.provision.push(spec);
     terminalCalls.order.push(`provision:${spec.runtimeId}`);
+    if (terminalDuringProvision) {
+      const hook = terminalDuringProvision;
+      terminalDuringProvision = null;
+      await hook(spec);
+    }
     if (terminalProvisionFails) throw new Error("modal: no capacity");
     return { externalId: `vol-${spec.runtimeId}#sb-${++terminalCounter}` };
   },
@@ -138,8 +160,9 @@ const fakeTerminalProvisioner: RuntimeProvisioner = {
     terminalCalls.order.push(`stop:${externalId}`);
     if (terminalStopFails) throw new Error("modal: sandbox already terminated");
   },
-  async status() {
-    return "running";
+  async status(externalId) {
+    terminalCalls.status.push(externalId);
+    return terminalState;
   },
   // Deliberately NO start(): conformance rule 3 forbids one on a terminal
   // driver, and this is the case startRuntime has to handle without it.
@@ -198,9 +221,12 @@ afterEach(() => {
   fakeCalls.start.length = 0;
   terminalCalls.provision.length = 0;
   terminalCalls.stop.length = 0;
+  terminalCalls.status.length = 0;
   terminalCalls.order.length = 0;
   terminalStopFails = false;
   terminalProvisionFails = false;
+  terminalState = "running";
+  terminalDuringProvision = null;
 });
 
 afterAll(async () => {
@@ -1306,4 +1332,386 @@ test("a resumable driver with no start() still refuses — re-creating is not a 
     const after = await rowOf(id);
     expect(after.externalId).toBe(before.externalId);
   });
+}, 30_000);
+
+// ─── Rotation: the substrate is about to kill a healthy runtime ───────────────
+//
+// Modal destroys a sandbox at 24 hours however well it is working, with no
+// warning callback, no way to extend it and no way back afterwards. Nothing in
+// the API rotates for you, so the hub replaces the instance ahead of the
+// deadline — early enough that the replacement has enrolled before the platform
+// takes the original, and against the same anchor, so the workspace carries
+// over.
+//
+// The tests below are as much about what must NOT be rotated as what must. On a
+// substrate that bills wall-clock for as long as an instance exists, a sweeper
+// that re-creates the wrong runtime is not a bug that shows up in a dashboard,
+// it is a bill that arrives at the end of the month.
+
+/** The ceiling the terminal fake declares — read from it, never re-typed. */
+const CEILING_MS = fakeTerminalProvisioner.manifest.maxLifetimeMs!;
+
+/** Backdate the CURRENT instance's clock, leaving the row's own dates alone. */
+async function ageInstanceBy(id: string, ms: number) {
+  await db
+    .update(provisionedRuntimes)
+    .set({ externalStartedAt: new Date(Date.now() - ms) })
+    .where(eq(provisionedRuntimes.id, id));
+}
+
+async function setRuntimeStatus(
+  id: string,
+  status: (typeof provisionedRuntimes.$inferSelect)["status"]
+) {
+  await db
+    .update(provisionedRuntimes)
+    .set({ status })
+    .where(eq(provisionedRuntimes.id, id));
+}
+
+/** An instance one second past the point where rotation is due. */
+const PAST_DUE_MS = CEILING_MS - ROTATION_MARGIN_MS + 1_000;
+
+/**
+ * Forget the calls a test's own setup made.
+ *
+ * Every createModalRuntime is itself a provision, so counting from zero after
+ * setup is what makes "the sweep touched the substrate N times" readable — and
+ * for the tests that must see NO substrate call, it is the assertion.
+ */
+function forgetSubstrateCalls() {
+  terminalCalls.provision.length = 0;
+  terminalCalls.stop.length = 0;
+  terminalCalls.status.length = 0;
+  terminalCalls.order.length = 0;
+}
+
+/**
+ * The instances this sweep created FOR ONE RUNTIME.
+ *
+ * The sweep is global — it has to be, it runs on a timer with no request — so
+ * rows other tests left behind are swept too, and a bare count would make these
+ * assertions depend on what ran before them.
+ */
+const provisionsFor = (id: string) =>
+  terminalCalls.provision.filter((p) => p.runtimeId === id);
+
+test("rotates a runtime before the substrate's ceiling destroys it", async () => {
+  const { id, externalId } = await createModalRuntime("ages");
+  await setRuntimeStatus(id, "online");
+  await ageInstanceBy(id, PAST_DUE_MS);
+  const before = await rowOf(id);
+
+  const rotated = await sweepExpiringRuntimes();
+  expect(rotated).toContain(id);
+
+  const after = await rowOf(id);
+  // A different sandbox...
+  expect(after.externalId).not.toBe(externalId);
+  // ...on the SAME anchor: the volume half of the external id is derived from
+  // the runtime id, so the workspace follows. A rotation that produced a new
+  // anchor would hand the station an empty disk and orphan a paid volume
+  // holding the only copy of its work.
+  expect(after.externalId!.startsWith(`vol-${id}#`)).toBe(true);
+  expect(terminalCalls.provision.at(-1)!.runtimeId).toBe(id);
+
+  // `starting`, never `online`: a substrate accepting a create is not a node
+  // existing. Only enrolment writes online.
+  expect(after.status).toBe("starting");
+  // The operator has to be able to tell this apart from a failure they caused —
+  // the console renders statusReason under the badge.
+  expect(after.statusReason).toMatch(/24|ceiling|lifetime/i);
+
+  // The replacement gets its own clock. Left at the old value it would be found
+  // "expired" on the very next tick and re-created again, for ever.
+  expect(after.externalStartedAt!.getTime()).toBeGreaterThan(
+    before.externalStartedAt!.getTime()
+  );
+  expect(Date.now() - after.externalStartedAt!.getTime()).toBeLessThan(60_000);
+
+  // The old sandbox is terminated rather than left running beside its
+  // replacement — two live sandboxes on one volume is the corruption case, and
+  // the abandoned one bills until somebody notices.
+  expect(terminalCalls.stop).toEqual([externalId]);
+
+  // A fresh enrolment token, because the hub stores only a hash of the first.
+  const tokenRows = await db
+    .select()
+    .from(enrollmentTokens)
+    .where(eq(enrollmentTokens.provisionedRuntimeId, id));
+  expect(tokenRows.length).toBe(2);
+}, 30_000);
+
+test("does not rotate one minute before rotation is due", async () => {
+  // The margin is not decoration: it is the time the replacement needs to be
+  // created and enrolled before the platform takes the original. But firing
+  // early is its own cost — every rotation is a re-enrolment and a fresh
+  // rootfs — so the boundary is pinned from both sides (with the test above).
+  const { id, externalId } = await createModalRuntime("nearly-due");
+  await setRuntimeStatus(id, "online");
+  await ageInstanceBy(id, CEILING_MS - ROTATION_MARGIN_MS - 60_000);
+  forgetSubstrateCalls();
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+  expect((await rowOf(id)).externalId).toBe(externalId);
+  expect(provisionsFor(id)).toHaveLength(0);
+}, 30_000);
+
+test("does not rotate a young sandbox", async () => {
+  const { id, externalId } = await createModalRuntime("young");
+  await setRuntimeStatus(id, "online");
+  forgetSubstrateCalls();
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+  const after = await rowOf(id);
+  expect(after.externalId).toBe(externalId);
+  expect(after.status).toBe("online");
+  expect(provisionsFor(id)).toHaveLength(0);
+}, 30_000);
+
+test("NEVER rotates a runtime that was deliberately stopped", async () => {
+  // The most expensive mistake available on this substrate. A stopped runtime
+  // costs nothing; re-creating one starts a sandbox nobody asked for that bills
+  // wall-clock until a human notices — and age alone would say it is due,
+  // because a stopped runtime only gets older.
+  const { id, externalId } = await createModalRuntime("stopped-for-a-reason");
+  await setRuntimeStatus(id, "stopped");
+  await ageInstanceBy(id, CEILING_MS + 60 * 60_000);
+  forgetSubstrateCalls();
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+
+  const after = await rowOf(id);
+  expect(after.status).toBe("stopped");
+  expect(after.externalId).toBe(externalId);
+  // Not "no new row" — no substrate call at all. A provision here is the bill.
+  expect(provisionsFor(id)).toHaveLength(0);
+  expect(terminalCalls.stop).not.toContain(externalId);
+}, 30_000);
+
+test("NEVER rotates asleep, error, destroyed or stopping runtimes either", async () => {
+  // Same reasoning as `stopped`, one step wider. `asleep` is a healthy un-billed
+  // state; `stopping` is an operator mid-stop, and re-creating under them is the
+  // stop silently undone; `error` and `destroyed` both need a human, and neither
+  // is made better by a sandbox appearing on the meter.
+  const states = ["asleep", "error", "destroyed", "stopping"] as const;
+  const ids: string[] = [];
+  for (const state of states) {
+    const { id } = await createModalRuntime(`state-${state}`);
+    await setRuntimeStatus(id, state);
+    await ageInstanceBy(id, CEILING_MS + 60 * 60_000);
+    ids.push(id);
+  }
+  forgetSubstrateCalls();
+
+  const rotated = await sweepExpiringRuntimes();
+  for (const id of ids) {
+    expect(rotated).not.toContain(id);
+    expect(provisionsFor(id)).toHaveLength(0);
+  }
+
+  for (let i = 0; i < ids.length; i++) {
+    expect((await rowOf(ids[i]!)).status).toBe(states[i]!);
+  }
+}, 30_000);
+
+test("rotates a runtime still in `starting`, not only an online one", async () => {
+  // A runtime whose node has not enrolled yet still has a sandbox on the
+  // substrate's kill clock, and that sandbox is just as billed and just as
+  // doomed. Excluding `starting` would leave a runtime that is briefly slow to
+  // enrol to be destroyed by the platform with nothing replacing it.
+  const { id, externalId } = await createModalRuntime("still-starting");
+  await ageInstanceBy(id, PAST_DUE_MS);
+  expect((await rowOf(id)).status).toBe("provisioning");
+  await setRuntimeStatus(id, "starting");
+
+  expect(await sweepExpiringRuntimes()).toContain(id);
+  expect((await rowOf(id)).externalId).not.toBe(externalId);
+}, 30_000);
+
+test("ignores a substrate that declares no ceiling, however old the instance", async () => {
+  // Docker and Cloudflare declare maxLifetimeMs: null — nothing destroys their
+  // container for age. Rotating one would throw away a live workspace to solve
+  // a problem that substrate does not have. The rule is the MANIFEST, so a
+  // driver added tomorrow is covered without touching this sweeper.
+  const createRes = await createRuntime(TEST_USER, "eternal");
+  const { id } = (await createRes.json()) as { id: string };
+  await setRuntimeStatus(id, "online");
+  await ageInstanceBy(id, 10 * 86_400_000);
+  const before = await rowOf(id);
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+
+  const after = await rowOf(id);
+  expect(after.status).toBe("online");
+  expect(after.externalId).toBe(before.externalId);
+  // Exactly the create — no re-create hiding behind it.
+  expect(fakeCalls.provision).toHaveLength(1);
+}, 30_000);
+
+test("judges the age of the INSTANCE, not the age of the row", async () => {
+  // After the first rotation these are different numbers, and created_at is the
+  // wrong one: it only grows, so a runtime that has been rotated once would be
+  // found expired on every tick from then on — a fresh sandbox destroyed and
+  // rebuilt every fifteen seconds, each one billed, for ever. updated_at is no
+  // better: any status write refreshes it.
+  const { id, externalId } = await createModalRuntime("old-row-new-sandbox");
+  await setRuntimeStatus(id, "online");
+  await rawSql`
+    UPDATE provisioned_runtimes
+       SET created_at = now() - interval '10 days',
+           updated_at = now() - interval '10 days'
+     WHERE id = ${id}
+  `;
+  forgetSubstrateCalls();
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+  expect((await rowOf(id)).externalId).toBe(externalId);
+  expect(provisionsFor(id)).toHaveLength(0);
+  // ...and the converse is the headline test above: a row created seconds ago
+  // whose INSTANCE clock is old does rotate.
+}, 30_000);
+
+test("skips a row with no instance clock instead of guessing its age", async () => {
+  // Every provisioned_runtimes row on the live hub predates external_started_at.
+  // There is no age to judge here, and the two ways of "handling" that are both
+  // wrong: falling back to created_at rotates a 30-day-old row immediately, and
+  // treating null as zero rotates it immediately too. It is skipped — the next
+  // provision writes a clock, and until then nothing is claimed.
+  const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes
+      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES (${id}, ${TEST_USER}, 'modal', 'vol-legacy#sb-legacy', 'online', 'legacy-modal', 'small', 'none',
+            now() - interval '30 days', now() - interval '30 days')
+  `;
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+  const after = await rowOf(id);
+  expect(after.status).toBe("online");
+  expect(after.externalId).toBe("vol-legacy#sb-legacy");
+  expect(provisionsFor(id)).toHaveLength(0);
+}, 30_000);
+
+test("rotates on AGE alone — never because the substrate says the sandbox is dead", async () => {
+  // The rule that keeps a crash from becoming a paid crash-loop. A sandbox that
+  // died in its first minute will die again the same way, and a sweeper that
+  // re-created it would rebuild it every fifteen seconds with nobody watching,
+  // billing for each attempt. The node going offline already surfaces this, and
+  // Start is one click for the human who looks.
+  const { id, externalId } = await createModalRuntime("died-early");
+  await setRuntimeStatus(id, "online");
+  terminalState = "stopped";
+  forgetSubstrateCalls();
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+  expect((await rowOf(id)).externalId).toBe(externalId);
+  expect(provisionsFor(id)).toHaveLength(0);
+  // Not even asked. Rotation is a clock, not a health check — the moment it
+  // consults substrate state it acquires the power to resurrect things.
+  expect(terminalCalls.status).toHaveLength(0);
+}, 30_000);
+
+test("an operator's stop landing mid-sweep wins — the claim is compare-and-set", async () => {
+  // The window this closes: the sweep reads a batch of due runtimes, and while
+  // it is busy re-creating the first one an operator stops the second. The row
+  // in hand still says `online`, because it was read before the stop. Claiming
+  // on the id alone would then resurrect a runtime somebody just switched off —
+  // a sandbox nobody asked for, billing wall-clock until a human notices, which
+  // is the single most expensive mistake available on this substrate.
+  //
+  // Two due runtimes make the window wide and deterministic: the loop's second
+  // claim happens after the first has been fully re-created, and the stop lands
+  // inside that first re-create.
+  const first = await createModalRuntime("swept-a");
+  const second = await createModalRuntime("swept-b");
+  for (const { id } of [first, second]) {
+    await setRuntimeStatus(id, "online");
+    await ageInstanceBy(id, PAST_DUE_MS);
+  }
+  forgetSubstrateCalls();
+
+  // Whichever the sweep reaches first, the operator stops the other one.
+  terminalDuringProvision = async (spec) => {
+    const other = spec.runtimeId === first.id ? second.id : first.id;
+    await setRuntimeStatus(other, "stopped");
+  };
+
+  const rotated = await sweepExpiringRuntimes();
+
+  const stopped = rotated.includes(first.id) ? second : first;
+  expect(rotated).toEqual([rotated.includes(first.id) ? first.id : second.id]);
+  const after = await rowOf(stopped.id);
+  expect(after.status).toBe("stopped");
+  expect(after.externalId).toBe(stopped.externalId);
+  expect(provisionsFor(stopped.id)).toHaveLength(0);
+}, 30_000);
+
+test("two ticks over the same due runtime rotate it once, not twice", async () => {
+  // The sweeps run on a 15s interval that does not wait for the previous pass.
+  // Whether two passes truly interleave is up to the scheduler — the test above
+  // is the one that pins the claim — but overlapping them must never produce two
+  // instances on one anchor, which is both the corruption case and a sandbox
+  // referenced by no row, billing quietly until the month ends.
+  const { id } = await createModalRuntime("raced");
+  await setRuntimeStatus(id, "online");
+  await ageInstanceBy(id, PAST_DUE_MS);
+  forgetSubstrateCalls();
+
+  const [a, b] = await Promise.all([
+    sweepExpiringRuntimes(),
+    sweepExpiringRuntimes(),
+  ]);
+
+  expect([...a, ...b].filter((x) => x === id)).toEqual([id]);
+  expect(provisionsFor(id)).toHaveLength(1);
+  expect((await rowOf(id)).status).toBe("starting");
+}, 30_000);
+
+test("a ceiling shorter than the margin rotates at its midpoint, not on every tick", async () => {
+  // The Modal driver takes a lifetime override whose stated purpose is verifying
+  // rotation in ten minutes instead of a day. Subtract a flat 30-minute margin
+  // from a 10-minute ceiling and the threshold is NEGATIVE: every instance is
+  // born past due, and the sweeper re-creates it on every 15s tick, billing each
+  // one, for as long as the runtime exists. The margin is capped at half the
+  // ceiling so a short-lived substrate keeps the same promise at a smaller
+  // scale: replaced with time to spare, not replaced constantly.
+  const shortCeiling: RuntimeProvisioner = {
+    ...fakeTerminalProvisioner,
+    manifest: { ...fakeTerminalProvisioner.manifest, maxLifetimeMs: 10 * 60_000 },
+  };
+
+  await withProvisioner(shortCeiling, async () => {
+    const { id, externalId } = await createModalRuntime("short-ceiling");
+    await setRuntimeStatus(id, "online");
+    forgetSubstrateCalls();
+
+    // Brand new, and therefore nowhere near due.
+    expect(await sweepExpiringRuntimes()).not.toContain(id);
+    expect((await rowOf(id)).externalId).toBe(externalId);
+    expect(provisionsFor(id)).toHaveLength(0);
+
+    // ...but still rotated before the substrate takes it.
+    await ageInstanceBy(id, 6 * 60_000);
+    expect(await sweepExpiringRuntimes()).toContain(id);
+    expect((await rowOf(id)).externalId).not.toBe(externalId);
+  });
+}, 30_000);
+
+test("a rotation the substrate refuses leaves the runtime in error, naming the ceiling", async () => {
+  // The runtime is going to be destroyed by the platform within the margin and
+  // the hub could not replace it. Leaving it `online` would be the console
+  // asserting health right up to the moment it vanishes; leaving it `starting`
+  // would blame the wrong thing two minutes later ("no node enrolled").
+  const { id } = await createModalRuntime("rotation-refused");
+  await setRuntimeStatus(id, "online");
+  await ageInstanceBy(id, PAST_DUE_MS);
+  terminalProvisionFails = true;
+
+  expect(await sweepExpiringRuntimes()).not.toContain(id);
+
+  const after = await rowOf(id);
+  expect(after.status).toBe("error");
+  expect(after.statusReason).toContain("no capacity");
+  expect(after.statusReason).toMatch(/24|ceiling|lifetime/i);
 }, 30_000);

--- a/apps/hub/src/routes/runtimes.ts
+++ b/apps/hub/src/routes/runtimes.ts
@@ -120,6 +120,16 @@ export const runtimeRoutes = new Hono()
       if (e.status === 400) {
         return c.json({ error: "Bad Request", message: e.message }, 400);
       }
+      // On a terminal-stop substrate a start is a create, so it can be refused
+      // by the substrate the way a create can. That is a 502, not a 500: the
+      // hub did its part and the external system said no. The runtime row
+      // already carries the reason (see reprovisionRuntime).
+      if (e.status === 502) {
+        return c.json(
+          { error: "Bad Gateway", message: "The start driver call failed" },
+          502
+        );
+      }
       throw err;
     }
   })

--- a/apps/hub/src/services/node-sweeper.ts
+++ b/apps/hub/src/services/node-sweeper.ts
@@ -13,7 +13,11 @@ import { connectionManager } from "./connection-manager";
 import { dropNode } from "./broker";
 import { clearNode } from "./health-cache";
 import { setNodeStatus } from "./node-registry";
-import { sweepStalledRuntimeStarts, sweepStalledRuntimeStops } from "./runtimes";
+import {
+  sweepStalledRuntimeStarts,
+  sweepStalledRuntimeStops,
+  sweepExpiringRuntimes,
+} from "./runtimes";
 
 export const SWEEP_INTERVAL_MS = 15_000;
 export const OFFLINE_THRESHOLD_MS = 45_000;
@@ -44,10 +48,12 @@ export async function sweepStaleNodes(now: number = Date.now()): Promise<string[
 /**
  * Start the periodic sweeper. Returns a stop function.
  *
- * Three expiries share the tick because they are the same idea at three levels:
- * a node that stopped talking, a runtime that was asked to run and never
- * produced a node at all (sweepStalledRuntimeStarts), and a runtime that was
- * asked to stop and has not been seen to (sweepStalledRuntimeStops).
+ * Four expiries share the tick because they are the same idea at four levels: a
+ * node that stopped talking, a runtime that was asked to run and never produced
+ * a node at all (sweepStalledRuntimeStarts), a runtime that was asked to stop
+ * and has not been seen to (sweepStalledRuntimeStops), and the one nobody asked
+ * for — a runtime the SUBSTRATE is about to destroy for age while it is working
+ * perfectly (sweepExpiringRuntimes).
  */
 export function startNodeSweeper(): () => void {
   const timer = setInterval(() => {
@@ -61,6 +67,15 @@ export function startNodeSweeper(): () => void {
     // `stopping` runtime into `stopped` once the substrate says it is down.
     void sweepStalledRuntimeStops().catch((err) =>
       console.error("[sweeper] runtime stop sweep failed:", err)
+    );
+    // And the one nobody asked for: a runtime the substrate is about to destroy
+    // for age. A capped substrate (Modal's sandboxes die at 24 hours however
+    // healthy they are, with no warning and no way back) would otherwise take a
+    // station down once a day, so the hub replaces the instance before that
+    // lands. Driven by the driver's declared ceiling, so uncapped substrates
+    // cost nothing here.
+    void sweepExpiringRuntimes().catch((err) =>
+      console.error("[sweeper] runtime rotation sweep failed:", err)
     );
   }, SWEEP_INTERVAL_MS);
   return () => clearInterval(timer);

--- a/apps/hub/src/services/provisioner/bootstrap.test.ts
+++ b/apps/hub/src/services/provisioner/bootstrap.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The wiring test.
+ *
+ * Registration is the step that has no other test: a driver can be perfect and
+ * still be absent from the registry, in which case createRuntime answers
+ * "provider not registered" and an operator reads it as a missing feature.
+ *
+ * Nothing here constructs the real `ModalClient`. The SDK is 0.x, it falls back
+ * to reading an operator's ~/.modal.toml, and a unit test that can reach Modal
+ * is a test that fails in CI for reasons that have nothing to do with this repo
+ * — so the branch is exercised with a stub client injected at the one seam
+ * `createModalApi` already exposes for exactly this.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "bun:test";
+import { registerEnabledProvisioners } from "./bootstrap";
+import {
+  getProvisioner,
+  getProvisionerUnguarded,
+  resetProvisioners,
+} from "./registry";
+import type { ModalClientLike } from "./modal-api";
+
+/**
+ * Every env var this file touches, saved once and restored at the end.
+ *
+ * `bun test` runs all 59 files sequentially in ONE process with one module
+ * registry, so an env var left set here is set for every later file. The
+ * Docker and Cloudflare flags are cleared for a second reason: registering the
+ * Cloudflare driver also installs a PROCESS-WIDE broker activity hook, which a
+ * test about Modal has no business leaving behind.
+ */
+const MANAGED_ENV = [
+  "ENABLE_MODAL_PROVISIONING",
+  "MODAL_TOKEN_ID",
+  "MODAL_TOKEN_SECRET",
+  "ENABLE_DOCKER_PROVISIONING",
+  "ENABLE_CLOUDFLARE_SANDBOXES",
+] as const;
+
+const savedEnv = new Map<string, string | undefined>();
+
+beforeAll(() => {
+  for (const key of MANAGED_ENV) savedEnv.set(key, process.env[key]);
+});
+
+beforeEach(() => {
+  resetProvisioners();
+  for (const key of MANAGED_ENV) delete process.env[key];
+});
+
+afterEach(() => {
+  resetProvisioners();
+});
+
+afterAll(() => {
+  resetProvisioners();
+  for (const key of MANAGED_ENV) {
+    const value = savedEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+/** Credentials the injected client factory was actually handed, if any. */
+let seenCredentials: { tokenId: string; tokenSecret: string } | null = null;
+
+/**
+ * Stand-in for `new ModalClient(...)`.
+ *
+ * Every call throws: a wiring test that reached the substrate would be testing
+ * something else, and a silent stub would let such a call pass unnoticed.
+ */
+const stubClientFactory = (creds: { tokenId: string; tokenSecret: string }) => {
+  seenCredentials = creds;
+  const refuse = () => {
+    throw new Error("stub Modal client: no substrate call belongs in a wiring test");
+  };
+  return {
+    apps: { fromName: refuse },
+    volumes: { fromName: refuse, delete: refuse },
+    images: { fromRegistry: refuse },
+    sandboxes: { create: refuse, fromId: refuse },
+  } as unknown as ModalClientLike;
+};
+
+beforeEach(() => {
+  seenCredentials = null;
+});
+
+describe("registerEnabledProvisioners — modal", () => {
+  it("registers nothing for modal when the flag is off", () => {
+    registerEnabledProvisioners({ modalClientFactory: stubClientFactory });
+    expect(getProvisionerUnguarded("modal")).toBeUndefined();
+  });
+
+  it("registers nothing for modal on credentials alone — the flag is the switch", () => {
+    // Credentials present in the environment must not turn a substrate on. An
+    // operator who pastes tokens into a hub env while evaluating Modal has not
+    // asked for their fleet to start provisioning on it.
+    process.env.MODAL_TOKEN_ID = "tok-id";
+    process.env.MODAL_TOKEN_SECRET = "tok-secret";
+    registerEnabledProvisioners({ modalClientFactory: stubClientFactory });
+    expect(getProvisionerUnguarded("modal")).toBeUndefined();
+  });
+
+  it("registers the driver when the flag is on and credentials exist", () => {
+    process.env.ENABLE_MODAL_PROVISIONING = "true";
+    process.env.MODAL_TOKEN_ID = "tok-id";
+    process.env.MODAL_TOKEN_SECRET = "tok-secret";
+    registerEnabledProvisioners({ modalClientFactory: stubClientFactory });
+
+    const driver = getProvisionerUnguarded("modal");
+    expect(driver?.provider).toBe("modal");
+    expect(driver?.manifest.stopSemantics).toBe("terminal");
+    expect(driver?.manifest.maxLifetimeMs).toBe(86_400_000);
+
+    // The gated lookup, which is the one createRuntime actually uses. A driver
+    // present in the map but invisible through this call is a driver an
+    // operator cannot provision on.
+    expect(getProvisioner("modal")).toBe(driver!);
+  });
+
+  it("hands the driver the credentials from the environment", () => {
+    // Not decoration: an adapter built with a resolver that reads the wrong
+    // place, or with blanks, registers perfectly and then fails every real
+    // call with what reads like an auth problem.
+    process.env.ENABLE_MODAL_PROVISIONING = "true";
+    process.env.MODAL_TOKEN_ID = "tok-id";
+    process.env.MODAL_TOKEN_SECRET = "tok-secret";
+    registerEnabledProvisioners({ modalClientFactory: stubClientFactory });
+
+    expect(seenCredentials).toEqual({
+      tokenId: "tok-id",
+      tokenSecret: "tok-secret",
+    });
+  });
+
+  it("refuses to boot when the flag is on and the credentials are missing", () => {
+    // Startup refusal, not a runtime failure on somebody's first provision —
+    // and it names both keys so a misconfigured deploy is one fix, not two.
+    process.env.ENABLE_MODAL_PROVISIONING = "true";
+    expect(() => registerEnabledProvisioners()).toThrow(
+      /MODAL_TOKEN_ID.*MODAL_TOKEN_SECRET/
+    );
+  });
+
+  it("registers no half-built driver when it refuses", () => {
+    // A driver in the registry whose substrate has no credentials would answer
+    // `enabledProviders()` and be offered in the console, then fail every call.
+    process.env.ENABLE_MODAL_PROVISIONING = "true";
+    expect(() => registerEnabledProvisioners()).toThrow();
+    expect(getProvisionerUnguarded("modal")).toBeUndefined();
+  });
+
+  it("names only the missing half of a half-configured pair", () => {
+    // Modal's credential is a PAIR, and one-set-one-missing is the case an
+    // operator actually hits. Naming both would send them to re-check a
+    // variable that was already right.
+    process.env.ENABLE_MODAL_PROVISIONING = "true";
+    process.env.MODAL_TOKEN_ID = "tok-id";
+    let message = "";
+    try {
+      registerEnabledProvisioners({ modalClientFactory: stubClientFactory });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/MODAL_TOKEN_SECRET/);
+    expect(message).not.toMatch(/MODAL_TOKEN_ID/);
+  });
+
+  it("treats a blank token as missing, not as configured", () => {
+    // Deploy platforms surface an unset secret as "". Accepting it moves the
+    // failure to the first provision, where it reads as an auth problem.
+    process.env.ENABLE_MODAL_PROVISIONING = "true";
+    process.env.MODAL_TOKEN_ID = "tok-id";
+    process.env.MODAL_TOKEN_SECRET = "";
+    expect(() =>
+      registerEnabledProvisioners({ modalClientFactory: stubClientFactory })
+    ).toThrow(/MODAL_TOKEN_SECRET/);
+  });
+});

--- a/apps/hub/src/services/provisioner/bootstrap.ts
+++ b/apps/hub/src/services/provisioner/bootstrap.ts
@@ -13,10 +13,28 @@ import { provisionedRuntimes } from "../../db/schema/nodes";
 import { registerProvisioner, isProviderEnabled } from "./registry";
 import { DockerRuntimeProvisioner } from "./docker";
 import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
+import { ModalRuntimeProvisioner } from "./modal";
+import { createModalApi } from "./modal-api";
+import type { CreateModalApiOptions } from "./modal-api";
 import { createActivityToucher } from "../runtime-activity";
 import { setActivityHook } from "../broker";
 
-export function registerEnabledProvisioners(): void {
+export interface BootstrapOptions {
+  /**
+   * Stand-in for `new ModalClient(...)`, forwarded to `createModalApi`.
+   *
+   * Exists so the wiring test can prove the Modal branch registers without
+   * constructing the real SDK client — which is 0.x, falls back to reading an
+   * operator's ~/.modal.toml, and has no business being built by a unit test.
+   * The production path passes nothing and is unchanged: credential resolution,
+   * and its refusal, happen either way.
+   */
+  modalClientFactory?: CreateModalApiOptions["clientFactory"];
+}
+
+export function registerEnabledProvisioners({
+  modalClientFactory,
+}: BootstrapOptions = {}): void {
   if (isProviderEnabled("docker")) {
     registerProvisioner(new DockerRuntimeProvisioner());
   }
@@ -53,5 +71,26 @@ export function registerEnabledProvisioners(): void {
     // Fire-and-forget: touch() never throws, and a renewal must never delay or
     // fail the user's actual verb.
     setActivityHook((nodeId) => void toucher.touch(nodeId));
+  }
+
+  if (isProviderEnabled("modal")) {
+    // The flag alone gates this: nothing is derived from the presence of
+    // credentials, so pasting tokens into a hub's environment while evaluating
+    // Modal cannot quietly start provisioning on it.
+    //
+    // createModalApi resolves MODAL_TOKEN_ID/MODAL_TOKEN_SECRET and throws
+    // naming every one that is missing, so a half-configured deploy fails at
+    // boot rather than on a user's first provisioning attempt. validateConfig()
+    // runs earlier in src/index.ts and turns the same misconfiguration into a
+    // message naming the variables; this throw is the backstop for anything
+    // that reaches registration without it.
+    //
+    // No touch hook: Modal reaps nothing for idleness (idleTimeoutMs is opt-in
+    // and we never opt in), so there is no deadline to push out.
+    registerProvisioner(
+      new ModalRuntimeProvisioner({
+        api: createModalApi({ clientFactory: modalClientFactory }),
+      })
+    );
   }
 }

--- a/apps/hub/src/services/provisioner/conformance.test.ts
+++ b/apps/hub/src/services/provisioner/conformance.test.ts
@@ -451,6 +451,38 @@ describe("assertConforms — stopSemantics", () => {
     (driver as { start?: unknown }).start = async () => {};
     await expect(assertConforms(driver)).rejects.toThrow(/stopSemantics/i);
   });
+
+  it("rejects a resumable driver that implements no start()", async () => {
+    // The other direction, and the one that had no rule until startRuntime
+    // started BRANCHING on this field. "terminal" now routes a start into a
+    // re-provision; "resumable" routes it into driver.start(). A driver that
+    // declares resumable and implements no start() is therefore a runtime that
+    // can be stopped and never started again — the manifest promising the
+    // opposite of what the substrate can do, in the one place the hub now
+    // trusts it. Until this rule existed the field was inert and the lie was
+    // free.
+    const driver = fakeDriver({
+      ...base,
+      workspaceStorage: "volume",
+      stopSemantics: "resumable",
+      lifecycle: ["stop", "status"],
+    });
+    await expect(assertConforms(driver)).rejects.toThrow(
+      /stopSemantics:.*implements no start\(\)/s
+    );
+  });
+
+  it("accepts a resumable driver that implements start() — the rule is not vacuous", async () => {
+    // Same manifest but for the one field under test, so a rule that rejected
+    // everything (or that fired on the wrong field) cannot pass unnoticed.
+    const driver = fakeDriver({
+      ...base,
+      workspaceStorage: "volume",
+      stopSemantics: "resumable",
+      lifecycle: ["start", "stop", "status"],
+    });
+    await expect(assertConforms(driver)).resolves.toBeUndefined();
+  });
 });
 
 // ─── Rule 4: workspaceStorage ─────────────────────────────────────────────────

--- a/apps/hub/src/services/provisioner/conformance.test.ts
+++ b/apps/hub/src/services/provisioner/conformance.test.ts
@@ -8,20 +8,24 @@
  *     incident replayed: the suite exists so those become checkable rather than
  *     remembered.
  *
- *  2. The two real drivers, against fake substrates. Their declarations are
+ *  2. The real drivers, against fake substrates. Their declarations are
  *     known-true, so this is what validates the suite against reality before it
  *     gates anything new. If a real driver fails, suspect the suite first.
  *
  * NOTHING here touches a real substrate: the Docker driver is handed a fake
- * orchestrator and the Cloudflare driver a fake fetch, exactly as their own unit
- * tests do. A conformance check that needed a daemon or an API token would run
- * nowhere, which is how the Cloudflare worker went a year without CI.
+ * orchestrator, the Cloudflare driver a fake fetch and the Modal driver a fake
+ * ModalApi, exactly as their own unit tests do. A conformance check that needed
+ * a daemon or an API token would run nowhere, which is how the Cloudflare worker
+ * went a year without CI.
  */
 
 import { describe, it, expect } from "bun:test";
 import { assertConforms } from "./conformance";
 import { DockerRuntimeProvisioner } from "./docker";
 import { CloudflareSandboxProvisioner } from "./cloudflare-sandbox";
+import { ModalRuntimeProvisioner } from "./modal";
+import { ModalNotFoundError } from "./modal-api";
+import type { ModalApi } from "./modal-api";
 import type {
   DockerOrchestrator,
   Sandbox,
@@ -292,6 +296,63 @@ const cloudflareDriver = (overrides: Record<string, unknown> = {}) =>
     ...overrides,
   });
 
+// ─── A fake Modal substrate ───────────────────────────────────────────────────
+
+/**
+ * Faithful stand-in for Modal, and a self-contained copy rather than an import
+ * from `modal.test.ts` — a shared helper would let one file's convenience
+ * quietly weaken another file's rule, and this file has to stay runnable on its
+ * own.
+ *
+ * The unfriendly parts are the load-bearing ones, mirroring exactly what the
+ * adapter maps `NotFoundError` to:
+ *
+ *   - an unknown sandbox id throws from terminate and poll;
+ *   - deleting a volume that is already gone throws.
+ *
+ * Both of those are what make rule 6 mean something here: destroy() takes the
+ * sandbox AND the volume, so a fake that shrugged at a repeat delete would hand
+ * Modal destroy idempotency for free. A terminated sandbox is RETAINED and
+ * reports its exit code, which is what Modal does — the sandbox record outlives
+ * the sandbox, and only the volume is really removable twice.
+ */
+function fakeModalApi(): ModalApi {
+  /** sandboxId → exit code; null means still running. */
+  const sandboxes = new Map<string, number | null>();
+  const volumes = new Set<string>();
+  let counter = 0;
+
+  return {
+    async createSandbox(params) {
+      // createIfMissing: the same runtime always reaches the same volume.
+      volumes.add(params.volumeName);
+      const sandboxId = `sb-${++counter}`;
+      sandboxes.set(sandboxId, null);
+      return { sandboxId };
+    },
+    async terminateSandbox(sandboxId) {
+      if (!sandboxes.has(sandboxId)) {
+        throw new ModalNotFoundError(`Sandbox '${sandboxId}' not found`);
+      }
+      sandboxes.set(sandboxId, 137);
+    },
+    async pollSandbox(sandboxId) {
+      if (!sandboxes.has(sandboxId)) {
+        throw new ModalNotFoundError(`Sandbox '${sandboxId}' not found`);
+      }
+      return sandboxes.get(sandboxId)!;
+    },
+    async deleteVolume(name) {
+      if (!volumes.has(name)) {
+        throw new ModalNotFoundError(`Volume '${name}' not found`);
+      }
+      volumes.delete(name);
+    },
+  };
+}
+
+const modalDriver = () => new ModalRuntimeProvisioner({ api: fakeModalApi() });
+
 // ─── Rule 1: imageBinding ─────────────────────────────────────────────────────
 
 describe("assertConforms — imageBinding", () => {
@@ -529,5 +590,46 @@ describe("assertConforms — the real drivers", () => {
     await expect(
       assertConforms(cloudflareDriver({ deployedImage: "" }))
     ).rejects.toThrow(/imageBinding/i);
+  });
+
+  /**
+   * The point of the whole manifest exercise: Modal is the first substrate whose
+   * constraints the interface was NOT accidentally designed around. Terminal
+   * stop, a 24-hour ceiling, no start verb, a workspace that lives in a Volume
+   * rather than on the rootfs — if the manifest generalises at all, it
+   * generalises here.
+   *
+   * assertConforms is fail-fast and destroy idempotency is the LAST thing it
+   * probes, so reaching the end is itself the proof that imageBinding,
+   * supportedTiers, stopSemantics (no start verb, and none implemented),
+   * workspaceStorage and status all held too.
+   *
+   * NO `{ image }` IS PASSED, deliberately. That argument exists for a `fixed`
+   * driver, whose deployed image is a fact only its deployment knows; Modal
+   * declares `imageBinding: "per-instance"` and honours any registry reference,
+   * so the suite's own PROBE_IMAGE is exactly what a real caller would hand it.
+   * Handing a per-instance driver a pre-vetted image would also be the one way
+   * to hide a real defect: Modal refuses an image with no registry host, and if
+   * the suite's probe image ever lost its host, this test passing an image of
+   * its own would keep going green while the driver rejected what the suite
+   * actually builds. Let it break there instead.
+   */
+  it("holds the real Modal driver to every declaration", async () => {
+    await expect(assertConforms(modalDriver())).resolves.toBeUndefined();
+  });
+
+  it("REFUSES a Modal driver that grew a start() method", async () => {
+    // stopSemantics "terminal" means terminate cannot be undone: every restart
+    // is a NEW sandbox with a new id and a fresh rootfs. The hub reaches for
+    // start() by method presence, so a well-meaning start() added later — not
+    // declared in the manifest, so invisible to review — would have the hub
+    // reporting success for something that can never happen, and a station
+    // "starting" for ever. The refusal must name the field AND the method, or
+    // it proves nothing about which rule fired.
+    const grown = modalDriver() as RuntimeProvisioner;
+    grown.start = async () => {};
+    await expect(assertConforms(grown)).rejects.toThrow(
+      /stopSemantics:.*implements start\(\)/s
+    );
   });
 });

--- a/apps/hub/src/services/provisioner/conformance.ts
+++ b/apps/hub/src/services/provisioner/conformance.ts
@@ -12,7 +12,9 @@
  *                       console offered three sizes and gave you one.
  *   3. stopSemantics  — Modal's terminate is irreversible. A hub that believes
  *                       there is a start to call leaves a station starting for
- *                       ever.
+ *                       ever. Checked both ways since startRuntime began
+ *                       dispatching on the field: "resumable" without a start()
+ *                       is a runtime that can be stopped exactly once.
  *   4. workspaceStorage — the Cloudflare data loss: a container whose disk was
  *                       wiped on sleep looked exactly like Docker's, whose disk
  *                       is not, because the interface had no way to say so.
@@ -129,9 +131,14 @@ export async function assertConforms(
     harness(provider, `probe.image must not be the probe's own sentinel image`);
   }
 
+  // workspaceStorage first, and deliberately: a `rootfs` + `resumable` driver
+  // with no start is a violation of BOTH this rule and stopSemantics, and of the
+  // two, the workspaceStorage message is the one that names what is actually at
+  // stake for that driver — an unverifiable claim about a user's files. The
+  // narrower rule gets to speak first.
+  assertWorkspaceStorageIsCoherent(provider, manifest);
   assertStopSemantics(provider, manifest, driver);
   assertLifecycleIsImplemented(provider, manifest, driver);
-  assertWorkspaceStorageIsCoherent(provider, manifest);
 
   const tier = probe.tier ?? manifest.supportedTiers[0] ?? "small";
   if (!manifest.supportedTiers.includes(tier) && manifest.supportedTiers.length > 0) {
@@ -158,18 +165,44 @@ export async function assertConforms(
 // ─── Rule 3: stopSemantics ────────────────────────────────────────────────────
 
 /**
+ * Both directions, because `startRuntime` now DISPATCHES on this field.
+ *
  * `terminal` means stop is the end of the instance — Modal's terminate cannot
  * be undone, and every restart is a new sandbox with a new id and a fresh
  * filesystem. A start verb on such a driver is not a small inaccuracy: the hub
  * calls start on a stopped runtime, and a driver that accepts the call reports
  * success for something that can never happen.
+ *
+ * `resumable` is the claim that the instance survives a stop and can be brought
+ * back, and it is now the field that routes a start request to `driver.start()`
+ * rather than to a re-provision. Until that branch existed this direction was
+ * inert — nothing in production read `stopSemantics`, so a driver could declare
+ * `resumable` with no start() at no cost. It costs something now: the hub
+ * believes the instance can come back, refuses to re-create it (re-creating a
+ * resumable instance would throw away the disk the declaration promises), and
+ * the runtime can be stopped exactly once. The rule below is what stops that
+ * driver shipping.
  */
 function assertStopSemantics(
   provider: string,
   manifest: DriverManifest,
   driver: RuntimeProvisioner
 ): void {
-  if (manifest.stopSemantics !== "terminal") return;
+  if (manifest.stopSemantics === "resumable") {
+    if (typeof driver.start !== "function") {
+      violation(
+        provider,
+        "stopSemantics",
+        `declared "resumable", so a stopped instance is supposed to come back — ` +
+          `but the driver implements no start(). startRuntime reads this field ` +
+          `to decide between calling start() and provisioning a replacement, ` +
+          `and it will not re-create a resumable instance: doing so would ` +
+          `destroy the very disk this declaration promises survives. Implement ` +
+          `start(), or declare "terminal" and mean it.`
+      );
+    }
+    return;
+  }
 
   if (manifest.lifecycle.includes("start")) {
     violation(

--- a/apps/hub/src/services/provisioner/modal-api.test.ts
+++ b/apps/hub/src/services/provisioner/modal-api.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests: the Modal SDK adapter.
+ *
+ * The real `modal` package is never constructed here — `clientFactory` injects a
+ * structural stand-in, and the one test that omits a factory is the one that
+ * must throw before a client is ever built. What is under test is exactly the
+ * part that breaks when the SDK churns: which parameter names we pass, which
+ * handles we thread into `sandboxes.create`, and how a Modal `NotFoundError`
+ * becomes something the driver above can act on.
+ *
+ * The fake is deliberately unforgiving: it throws for an unknown sandbox id and
+ * for deleting a volume that was never created. A fake that answers everything
+ * makes every behavioural rule pass for free, which is the same as not having
+ * the rule.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createModalApi, ModalNotFoundError } from "./modal-api";
+import type { ModalClientLike, ModalSandboxLike } from "./modal-api";
+
+const CREDS = { MODAL_TOKEN_ID: "tok-id", MODAL_TOKEN_SECRET: "tok-secret" };
+const resolverOf = (env: Record<string, string>) => ({ get: (k: string) => env[k] });
+
+/**
+ * A NotFoundError shaped like the SDK's: `name` set to "NotFoundError", a plain
+ * Error otherwise. Verified against modal@0.9.0's dist, where the class
+ * constructor assigns `this.name = "NotFoundError"` — so matching on the name
+ * rather than the class is a real match, not a hopeful one.
+ */
+class FakeNotFound extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+interface CreateCall {
+  app: unknown;
+  image: unknown;
+  params: Record<string, unknown>;
+}
+
+/**
+ * @param seed.volumes volumes that already exist in the fake workspace; anything
+ *   else is "already gone" to `volumes.delete`.
+ */
+function fakeClient(seed: { volumes?: string[] } = {}) {
+  const calls = {
+    apps: [] as Array<[string, unknown]>,
+    volumes: [] as Array<[string, unknown]>,
+    deleted: [] as string[],
+    images: [] as string[],
+    created: [] as CreateCall[],
+    terminated: [] as string[],
+  };
+
+  const existingVolumes = new Set<string>(seed.volumes ?? []);
+  // Handles are memoised per name so a test can assert that the object threaded
+  // into sandboxes.create is the one fromName/fromRegistry actually returned —
+  // an adapter that swapped the app and image arguments would slip past an
+  // assertion that only looked at the params bag.
+  const appHandles = new Map<string, { appId: string }>();
+  const volumeHandles = new Map<string, { volumeId: string }>();
+
+  const sandboxes = new Map<string, ModalSandboxLike>();
+  const makeSandbox = (id: string, exitCode: number | null = null): ModalSandboxLike => ({
+    sandboxId: id,
+    async terminate() {
+      calls.terminated.push(id);
+    },
+    async poll() {
+      return exitCode;
+    },
+  });
+
+  const client: ModalClientLike = {
+    apps: {
+      async fromName(name, params) {
+        calls.apps.push([name, params]);
+        let handle = appHandles.get(name);
+        if (!handle) {
+          handle = { appId: `ap-${name}` };
+          appHandles.set(name, handle);
+        }
+        return handle;
+      },
+    },
+    volumes: {
+      async fromName(name, params) {
+        calls.volumes.push([name, params]);
+        if (params.createIfMissing) existingVolumes.add(name);
+        if (!existingVolumes.has(name)) {
+          throw new FakeNotFound(`Volume '${name}' not found`);
+        }
+        let handle = volumeHandles.get(name);
+        if (!handle) {
+          handle = { volumeId: `vo-${name}` };
+          volumeHandles.set(name, handle);
+        }
+        return handle;
+      },
+      async delete(name) {
+        if (!existingVolumes.delete(name)) {
+          throw new FakeNotFound(`Volume '${name}' not found`);
+        }
+        calls.deleted.push(name);
+      },
+    },
+    images: {
+      fromRegistry(tag) {
+        calls.images.push(tag);
+        return { imageId: `im-${tag}` };
+      },
+    },
+    sandboxes: {
+      async create(app, image, params) {
+        calls.created.push({ app, image, params });
+        const sandbox = makeSandbox("sb-created");
+        sandboxes.set(sandbox.sandboxId, sandbox);
+        return sandbox;
+      },
+      async fromId(id) {
+        const sandbox = sandboxes.get(id);
+        if (!sandbox) throw new FakeNotFound(`Sandbox '${id}' not found`);
+        return sandbox;
+      },
+    },
+  };
+
+  return { client, calls, sandboxes, makeSandbox };
+}
+
+const apiWith = (client: ModalClientLike) =>
+  createModalApi({ resolver: resolverOf(CREDS), clientFactory: () => client });
+
+/**
+ * A client factory that must never run.
+ *
+ * Every credential-refusal test passes one. Without it a regression in the
+ * guard would fall through to `require("modal")` and construct a real
+ * ModalClient against whatever ~/.modal.toml the machine happens to have — the
+ * test might even still pass, for entirely the wrong reason. Measured: with
+ * requireCredentials removed, that path really is taken.
+ */
+const neverBuilt = (): never => {
+  throw new Error("clientFactory must not run without credentials");
+};
+
+const SANDBOX_SPEC = {
+  appName: "agentpod",
+  image: "ghcr.io/example/agentpod-node-modal:v1",
+  volumeName: "agentpod-rt-abc",
+  mountPath: "/workspace",
+  workdir: "/workspace",
+  command: ["/modal-entrypoint.sh"],
+  env: { AGENTPOD_HUB_URL: "https://hub.example", AGENTPOD_ENROLL_TOKEN: "tok" },
+  cpu: 1,
+  memoryMiB: 2048,
+  timeoutMs: 86_400_000,
+};
+
+describe("createModalApi — credentials", () => {
+  it("refuses to build without credentials, naming every missing key at once", () => {
+    // A startup refusal, not a runtime failure on a user's first provision —
+    // and one that costs an operator one redeploy rather than one per key.
+    expect(() =>
+      createModalApi({ resolver: resolverOf({}), clientFactory: neverBuilt })
+    ).toThrow(/MODAL_TOKEN_ID.*MODAL_TOKEN_SECRET/);
+  });
+
+  it("refuses a half-configured hub, naming only the key that is missing", () => {
+    // The failure mode this guards: a deploy that set the id and forgot the
+    // secret gets an error it can act on, not "credentials are wrong".
+    const half = () =>
+      createModalApi({
+        resolver: resolverOf({ MODAL_TOKEN_ID: "tok-id" }),
+        clientFactory: neverBuilt,
+      });
+    expect(half).toThrow(/MODAL_TOKEN_SECRET/);
+    const err = (() => {
+      try {
+        half();
+        return null;
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    expect(err).not.toBeNull();
+    expect(err!.message).not.toContain("MODAL_TOKEN_ID");
+    expect(err!.message).toContain("modal");
+  });
+
+  it("treats an empty token as missing rather than handing the SDK a blank", () => {
+    // Deploy platforms surface an unset secret as "", and a blank token only
+    // moves the failure to the first API call, where it reads as an auth
+    // problem rather than a configuration one.
+    expect(() =>
+      createModalApi({
+        resolver: resolverOf({ MODAL_TOKEN_ID: "tok-id", MODAL_TOKEN_SECRET: "" }),
+        clientFactory: neverBuilt,
+      })
+    ).toThrow(/MODAL_TOKEN_SECRET/);
+  });
+
+  it("passes the resolved tokens to the client", () => {
+    const seen: Array<{ tokenId: string; tokenSecret: string }> = [];
+    const { client } = fakeClient();
+    createModalApi({
+      resolver: resolverOf(CREDS),
+      clientFactory: (c) => {
+        seen.push(c);
+        return client;
+      },
+    });
+    expect(seen).toEqual([{ tokenId: "tok-id", tokenSecret: "tok-secret" }]);
+  });
+});
+
+describe("createModalApi — createSandbox", () => {
+  it("creates the app and the volume if missing, and mounts that volume", async () => {
+    const { client, calls } = fakeClient();
+    const res = await apiWith(client).createSandbox(SANDBOX_SPEC);
+
+    expect(res.sandboxId).toBe("sb-created");
+    expect(calls.apps).toEqual([["agentpod", { createIfMissing: true }]]);
+    // createIfMissing on the volume is what makes provisioning idempotent on the
+    // anchor: the first sandbox creates it, every later one re-attaches it.
+    expect(calls.volumes).toEqual([["agentpod-rt-abc", { createIfMissing: true }]]);
+    expect(calls.images).toEqual(["ghcr.io/example/agentpod-node-modal:v1"]);
+
+    const call = calls.created[0]!;
+    // The handles, not just the names: sandboxes.create(app, image, params) is
+    // positional, and swapping two opaque objects is a mistake no name-level
+    // assertion would notice.
+    expect(call.app).toEqual({ appId: "ap-agentpod" });
+    expect(call.image).toEqual({ imageId: "im-ghcr.io/example/agentpod-node-modal:v1" });
+
+    const params = call.params;
+    // Mounted at mountPath, and it is THE volume named for this runtime.
+    expect(params.volumes).toEqual({ "/workspace": { volumeId: "vo-agentpod-rt-abc" } });
+    expect(params.workdir).toBe("/workspace");
+    expect(params.command).toEqual(["/modal-entrypoint.sh"]);
+    expect(params.env).toEqual({
+      AGENTPOD_HUB_URL: "https://hub.example",
+      AGENTPOD_ENROLL_TOKEN: "tok",
+    });
+    expect(params.cpu).toBe(1);
+    expect(params.memoryMiB).toBe(2048);
+    // 0.9.0 renamed `timeout` to `timeoutMs` and REJECTS the old key at runtime.
+    expect(params.timeoutMs).toBe(86_400_000);
+    expect(params).not.toHaveProperty("timeout");
+    // Never opt into idle reaping: a node-agent dials out and receives nothing,
+    // so an idle timer would reap a busy station. Off by default; keep it off.
+    expect(params).not.toHaveProperty("idleTimeoutMs");
+  });
+});
+
+describe("createModalApi — terminateSandbox", () => {
+  it("terminates the sandbox it was asked about", async () => {
+    const { client, calls } = fakeClient();
+    const api = apiWith(client);
+    await api.createSandbox(SANDBOX_SPEC);
+    await api.terminateSandbox("sb-created");
+    expect(calls.terminated).toEqual(["sb-created"]);
+  });
+
+  it("reports a sandbox Modal has never heard of as ModalNotFoundError", async () => {
+    const { client } = fakeClient();
+    await expect(apiWith(client).terminateSandbox("sb-gone")).rejects.toBeInstanceOf(
+      ModalNotFoundError
+    );
+  });
+});
+
+describe("createModalApi — not-found mapping", () => {
+  it("turns a Modal NotFoundError into ModalNotFoundError on poll", async () => {
+    const { client } = fakeClient();
+    await expect(apiWith(client).pollSandbox("sb-gone")).rejects.toBeInstanceOf(
+      ModalNotFoundError
+    );
+  });
+
+  it("turns a Modal NotFoundError into ModalNotFoundError on volume delete", async () => {
+    // destroy() has to tell "already gone, which is what I wanted" from "the
+    // substrate is unreachable", and conformance rule 6 fails the driver if it
+    // gets that wrong.
+    const { client } = fakeClient();
+    await expect(apiWith(client).deleteVolume("gone")).rejects.toBeInstanceOf(
+      ModalNotFoundError
+    );
+  });
+
+  it("keeps the substrate's message so an operator can see what was missing", async () => {
+    const { client } = fakeClient();
+    // then(resolve, reject) rather than catch(): it types the value without an
+    // `any`, and it fails loudly if the call resolves instead of rejecting,
+    // which .catch() would have quietly reported as "no message to check".
+    const err = await apiWith(client)
+      .deleteVolume("gone")
+      .then(
+        () => null,
+        (e: unknown) => e as Error
+      );
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain("Volume 'gone' not found");
+  });
+
+  it("does NOT swallow an unrelated failure", async () => {
+    // The other direction of the same guard: if everything became
+    // ModalNotFoundError, destroy() would call an unreachable substrate a
+    // successful deletion and leak a paid volume while reporting success.
+    const { client } = fakeClient();
+    const boom = new Error("connection reset");
+    client.volumes.delete = async () => {
+      throw boom;
+    };
+    const err = await apiWith(client)
+      .deleteVolume("agentpod-rt-abc")
+      .then(
+        () => null,
+        (e: unknown) => e
+      );
+    expect(err).not.toBeNull();
+    expect(err).not.toBeInstanceOf(ModalNotFoundError);
+    expect(err).toBe(boom);
+  });
+
+  it("deletes a volume that does exist, and says nothing", async () => {
+    const { client, calls } = fakeClient({ volumes: ["agentpod-rt-abc"] });
+    await apiWith(client).deleteVolume("agentpod-rt-abc");
+    expect(calls.deleted).toEqual(["agentpod-rt-abc"]);
+  });
+});
+
+describe("createModalApi — poll", () => {
+  it("passes the exit code through untouched", async () => {
+    const { client, sandboxes, makeSandbox } = fakeClient();
+    const api = apiWith(client);
+    await api.createSandbox(SANDBOX_SPEC);
+    // null is "still running" and must never be flattened into a falsy 0 — the
+    // driver's status() reads exactly this distinction.
+    expect(await api.pollSandbox("sb-created")).toBeNull();
+    sandboxes.set("sb-created", makeSandbox("sb-created", 137));
+    expect(await api.pollSandbox("sb-created")).toBe(137);
+    sandboxes.set("sb-created", makeSandbox("sb-created", 0));
+    expect(await api.pollSandbox("sb-created")).toBe(0);
+  });
+});

--- a/apps/hub/src/services/provisioner/modal-api.ts
+++ b/apps/hub/src/services/provisioner/modal-api.ts
@@ -1,12 +1,18 @@
 /**
  * The narrow slice of Modal this driver needs, and the one place the SDK is
- * allowed to be imported (the adapter lands in Task 2).
+ * allowed to be imported.
  *
  * The SDK is 0.x and renames parameters between minor versions — `timeout`
  * became `timeoutMs`, and an unknown key is rejected at runtime by the SDK's own
  * guard rather than ignored. Confining it to one file means a rename costs one
- * edit and one test, not an audit of the driver.
+ * edit and one test, not an audit of the driver. It is pinned exactly
+ * (`"modal": "0.9.0"`, no caret) for the same reason: a caret on an SDK that
+ * renames parameters is how a working hub stops provisioning after an unrelated
+ * install.
  */
+
+import { requireCredentials, envCredentialResolver } from "./credentials";
+import type { CredentialResolver } from "./credentials";
 
 /** Everything Modal needs to start one sandbox for one AgentPod runtime. */
 export interface ModalCreateSandboxParams {
@@ -57,7 +63,7 @@ export class ModalNotFoundError extends Error {}
  */
 export const MODAL_CREDENTIAL_KEYS = ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"];
 
-/** The substrate, as this driver needs it. Implemented for real in Task 2. */
+/** The substrate, as this driver needs it. `createModalApi()` is the real one. */
 export interface ModalApi {
   createSandbox(params: ModalCreateSandboxParams): Promise<{ sandboxId: string }>;
   /** Irreversible. Modal has no start verb; this ends the sandbox for good. */
@@ -66,4 +72,177 @@ export interface ModalApi {
   pollSandbox(sandboxId: string): Promise<number | null>;
   /** Deletes the durable anchor. Throws ModalNotFoundError if already gone. */
   deleteVolume(name: string): Promise<void>;
+}
+
+/**
+ * The slice of the SDK client this adapter uses, described structurally.
+ *
+ * Structural rather than `typeof ModalClient` on purpose: it documents exactly
+ * what we depend on (five calls out of a very large surface), and it lets the
+ * tests inject a stand-in without constructing a real client or reaching the
+ * network. Verified against `node_modules/modal/dist/index.d.ts` at 0.9.0 —
+ * where the signatures really are `apps.fromName(name, params?)`,
+ * `volumes.fromName(name, params?)`, `volumes.delete(name, params?)`,
+ * `images.fromRegistry(tag, secret?)` (synchronous), and
+ * `sandboxes.create(app, image, params?)`.
+ */
+export interface ModalClientLike {
+  apps: {
+    fromName(name: string, params: { createIfMissing: boolean }): Promise<unknown>;
+  };
+  volumes: {
+    fromName(name: string, params: { createIfMissing: boolean }): Promise<unknown>;
+    delete(name: string): Promise<void>;
+  };
+  images: {
+    /** Synchronous in 0.9.0 — it returns an Image, not a Promise. */
+    fromRegistry(tag: string): unknown;
+  };
+  sandboxes: {
+    create(
+      app: unknown,
+      image: unknown,
+      params: Record<string, unknown>
+    ): Promise<ModalSandboxLike>;
+    fromId(sandboxId: string): Promise<ModalSandboxLike>;
+  };
+}
+
+export interface ModalSandboxLike {
+  readonly sandboxId: string;
+  terminate(): Promise<void>;
+  /** `null` while running, else the exit code. */
+  poll(): Promise<number | null>;
+}
+
+export interface CreateModalApiOptions {
+  resolver?: CredentialResolver;
+  /**
+   * Substitute for `new ModalClient(...)`. Injected by tests so no unit test
+   * ever constructs the real client, reads an operator's ~/.modal.toml, or
+   * reaches the network.
+   */
+  clientFactory?: (creds: { tokenId: string; tokenSecret: string }) => ModalClientLike;
+}
+
+/**
+ * Modal reports a missing resource with an exported `NotFoundError`, whose
+ * constructor sets `this.name = "NotFoundError"` (checked in 0.9.0's dist).
+ *
+ * Matching on that NAME rather than importing the class keeps this adapter's
+ * tests free of the SDK and survives the dual CJS/ESM builds shipping two
+ * distinct class objects for the same error — `instanceof` across those two is
+ * false, and a destroy path that reads "already gone" as "substrate unreachable"
+ * leaks a paid volume.
+ */
+function isNotFound(err: unknown): boolean {
+  return (err as { name?: string } | null)?.name === "NotFoundError";
+}
+
+/**
+ * Run `fn`, converting Modal's not-found into the port's own error and letting
+ * everything else through untouched. Both halves matter: mapping too little
+ * breaks destroy idempotency, and mapping too much turns an unreachable
+ * substrate into a reported success.
+ */
+async function mappingNotFound<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isNotFound(err)) {
+      throw new ModalNotFoundError((err as Error).message);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Build the real Modal-backed `ModalApi`.
+ *
+ * Credentials are resolved HERE, at construction, so a hub configured with
+ * ENABLE_MODAL_PROVISIONING=true and no tokens refuses at startup listing every
+ * missing key at once — rather than accepting a provisioning request and failing
+ * it with something that reads like an auth problem.
+ *
+ * Note what these tokens are and are not: they create NEW infrastructure in a
+ * Modal workspace. They cannot reach an enrolled node — enrolment is
+ * outbound-dialled and SSH runs from the operator's machine. See credentials.ts.
+ *
+ * SECURITY: the resolved tokens and `params.env` (which carries the enrolment
+ * token) are never logged by this module. Do not add a log line that touches
+ * either.
+ */
+export function createModalApi({
+  resolver = envCredentialResolver(),
+  clientFactory,
+}: CreateModalApiOptions = {}): ModalApi {
+  // Throws, naming every missing key, before anything below can load or
+  // construct the SDK.
+  const creds = requireCredentials("modal", MODAL_CREDENTIAL_KEYS, resolver);
+
+  const build =
+    clientFactory ??
+    ((c: { tokenId: string; tokenSecret: string }) => {
+      // The only reference to the SDK in the codebase. Required rather than
+      // imported so a hub with Modal disabled never loads it — and `require`
+      // works in Bun's ESM, which is what this app runs on.
+      const { ModalClient } = require("modal") as {
+        ModalClient: new (params: { tokenId: string; tokenSecret: string }) => unknown;
+      };
+      return new ModalClient(c) as ModalClientLike;
+    });
+
+  const client = build({
+    // Non-null because requireCredentials threw above if either was absent or
+    // empty; noUncheckedIndexedAccess cannot see that.
+    tokenId: creds.MODAL_TOKEN_ID!,
+    tokenSecret: creds.MODAL_TOKEN_SECRET!,
+  });
+
+  return {
+    async createSandbox(params: ModalCreateSandboxParams) {
+      const app = await client.apps.fromName(params.appName, { createIfMissing: true });
+      // createIfMissing is the anchor mechanism: the first sandbox for a runtime
+      // creates the volume, every later one re-attaches the same data by name.
+      const volume = await client.volumes.fromName(params.volumeName, {
+        createIfMissing: true,
+      });
+      const image = client.images.fromRegistry(params.image);
+
+      const sandbox = await mappingNotFound(() =>
+        client.sandboxes.create(app, image, {
+          command: params.command,
+          env: params.env,
+          volumes: { [params.mountPath]: volume },
+          workdir: params.workdir,
+          cpu: params.cpu,
+          memoryMiB: params.memoryMiB,
+          // Modal's default is 5 minutes, so this key is load-bearing rather
+          // than tidy. Deliberately no idleTimeoutMs: idle reaping is opt-in
+          // and opting in would reap a busy station whose agent only ever
+          // dials out.
+          timeoutMs: params.timeoutMs,
+        })
+      );
+      return { sandboxId: sandbox.sandboxId };
+    },
+
+    async terminateSandbox(sandboxId: string) {
+      await mappingNotFound(async () => {
+        const sandbox = await client.sandboxes.fromId(sandboxId);
+        await sandbox.terminate();
+      });
+    },
+
+    async pollSandbox(sandboxId: string) {
+      return mappingNotFound(async () => {
+        const sandbox = await client.sandboxes.fromId(sandboxId);
+        return sandbox.poll();
+      });
+    },
+
+    async deleteVolume(name: string) {
+      await mappingNotFound(() => client.volumes.delete(name));
+    },
+  };
 }

--- a/apps/hub/src/services/provisioner/modal-api.ts
+++ b/apps/hub/src/services/provisioner/modal-api.ts
@@ -1,0 +1,69 @@
+/**
+ * The narrow slice of Modal this driver needs, and the one place the SDK is
+ * allowed to be imported (the adapter lands in Task 2).
+ *
+ * The SDK is 0.x and renames parameters between minor versions — `timeout`
+ * became `timeoutMs`, and an unknown key is rejected at runtime by the SDK's own
+ * guard rather than ignored. Confining it to one file means a rename costs one
+ * edit and one test, not an audit of the driver.
+ */
+
+/** Everything Modal needs to start one sandbox for one AgentPod runtime. */
+export interface ModalCreateSandboxParams {
+  /** Modal App the sandbox is grouped under. Grouping only; carries no state. */
+  appName: string;
+  /** Registry reference Modal pulls. Must be linux/amd64 and carry python+pip. */
+  image: string;
+  /** The durable anchor: created if missing, reused by every later sandbox. */
+  volumeName: string;
+  /** Where the volume is mounted. The workspace, and nothing else, lives here. */
+  mountPath: string;
+  /** Working directory of the entrypoint command. */
+  workdir: string;
+  /** Entrypoint argv. The image sets no ENTRYPOINT — see Dockerfile.modal. */
+  command: string[];
+  /** Environment. Carries the enrolment token: NEVER log this object. */
+  env: Record<string, string>;
+  cpu: number;
+  memoryMiB: number;
+  /**
+   * Maximum lifetime. Modal's default is FIVE MINUTES, so omitting it does not
+   * mean "no limit", it means a station that dies before its operator returns
+   * from coffee.
+   */
+  timeoutMs: number;
+}
+
+/**
+ * A resource Modal says does not exist.
+ *
+ * Typed rather than message-matched: the driver has to tell "already gone,
+ * which is what I wanted" from "the substrate is unreachable", and destroy
+ * idempotency (conformance rule 6) hangs on getting that distinction right.
+ */
+export class ModalNotFoundError extends Error {}
+
+/**
+ * Credentials this substrate needs.
+ *
+ * Declared here rather than in modal.ts because the adapter is what consumes
+ * them — `requireCredentials("modal", MODAL_CREDENTIAL_KEYS, resolver)` in
+ * createModalApi() — and because the driver imports this file: a constant
+ * pointing the other way would make the two modules import each other.
+ *
+ * Both keys, not one. Modal's tokens are a pair and requireCredentials() names
+ * every missing key at once, so a hub deployed with half the pair is refused at
+ * startup with one message rather than one redeploy per key.
+ */
+export const MODAL_CREDENTIAL_KEYS = ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"];
+
+/** The substrate, as this driver needs it. Implemented for real in Task 2. */
+export interface ModalApi {
+  createSandbox(params: ModalCreateSandboxParams): Promise<{ sandboxId: string }>;
+  /** Irreversible. Modal has no start verb; this ends the sandbox for good. */
+  terminateSandbox(sandboxId: string): Promise<void>;
+  /** `null` while running, else the exit code. Throws ModalNotFoundError if forgotten. */
+  pollSandbox(sandboxId: string): Promise<number | null>;
+  /** Deletes the durable anchor. Throws ModalNotFoundError if already gone. */
+  deleteVolume(name: string): Promise<void>;
+}

--- a/apps/hub/src/services/provisioner/modal.test.ts
+++ b/apps/hub/src/services/provisioner/modal.test.ts
@@ -358,3 +358,168 @@ describe("ModalRuntimeProvisioner — provision", () => {
     expect(modal.volumes.size).toBe(0);
   });
 });
+
+describe("ModalRuntimeProvisioner — stop", () => {
+  it("terminates the sandbox in the composite id", async () => {
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    await driver.stop(externalId);
+    expect(modal.terminated).toEqual(["sb-1"]);
+  });
+
+  it("terminates the sandbox half, never the volume half", async () => {
+    // The composite id carries two names and terminateSandbox takes one string.
+    // Handing it the volume half would terminate nothing, tolerate the
+    // resulting not-found as success, and report a stop that never happened —
+    // with the sandbox still running and still billing.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+    await driver.stop("agentpod-rt-abc123#sb-1");
+    expect(modal.terminated).toEqual(["sb-1"]);
+    expect(modal.sandboxes.get("sb-1")).not.toBeNull();
+  });
+
+  it("does NOT delete the volume — stopping must not destroy the workspace", async () => {
+    // The Volume is the runtime's identity. A stop that took it would make
+    // every stop a destroy, which is the Cloudflare data loss in a new costume.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    await driver.stop(externalId);
+    expect(modal.deletedVolumes).toEqual([]);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+  });
+
+  it("treats an already-gone sandbox as stopped rather than an error", async () => {
+    // Modal has no start verb, so the sandbox behind an externalId can already
+    // be gone by the time an operator presses Stop — the 24-hour ceiling takes
+    // one every day. "Already in the state you asked for" is a success.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(driver.stop("agentpod-rt-abc123#sb-never")).resolves.toBeUndefined();
+  });
+
+  it("does NOT swallow a substrate failure — only not-found is tolerable", async () => {
+    // Tolerating "already gone" must not slide into tolerating everything.
+    // stopRuntime() writes `stopping` after stop() resolves and then trusts
+    // status() for the rest; a stop() that resolved on a connection reset would
+    // hand a runtime that is still running to a path built to confirm one that
+    // is not.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.api.terminateSandbox = async () => {
+      throw new Error("connection reset");
+    };
+    await expect(driver.stop(externalId)).rejects.toThrow(/connection reset/);
+  });
+
+  it("refuses a malformed external id instead of terminating something else", async () => {
+    // A stop that quietly resolved on an unparseable id would report a stop
+    // that could not have happened, for a runtime nothing had addressed.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+    await expect(driver.stop("sb-1")).rejects.toThrow(/external id/i);
+    expect(modal.terminated).toEqual([]);
+  });
+});
+
+describe("ModalRuntimeProvisioner — status", () => {
+  it("reports running while poll() has no exit code", async () => {
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    expect(await driver.status(externalId)).toBe("running");
+  });
+
+  it("reports stopped once the sandbox has an exit code", async () => {
+    // Including the 24-hour-ceiling case: at the driver level `stopped` means
+    // exactly "this sandbox is not running", which is true however it ended.
+    // Nothing here turns that into the hub's word `stopped` — only
+    // sweepStalledRuntimeStops does, and only for a runtime someone asked to
+    // stop.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    await driver.stop(externalId);
+    expect(await driver.status(externalId)).toBe("stopped");
+  });
+
+  it("reports stopped for exit code 0 — a clean exit is still an exit", async () => {
+    // poll() answers `null` while running and the EXIT CODE once finished, and
+    // 0 is both a valid exit code and falsy. A truthiness test here inverts the
+    // answer for the one exit that means "the work finished cleanly": the hub
+    // would read a finished sandbox as running, leave a stop unconfirmed, and
+    // flip the runtime to `error` five minutes later.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.sandboxes.set("sb-1", 0);
+    expect(await driver.status(externalId)).toBe("stopped");
+  });
+
+  it("reports stopped for a sandbox Modal says does not exist", async () => {
+    // A ModalNotFoundError is an ANSWER, not a silence: an authenticated call
+    // reached Modal and Modal asserted there is no such sandbox in this
+    // workspace. Nothing that does not exist is running, and nothing that does
+    // not exist is billing, so `stopped` is the true statement. `unknown` here
+    // would put every stop of an already-reaped sandbox — and Modal reaps one
+    // per runtime per day — through sweepStalledRuntimeStops' 5-minute timeout
+    // and out the other side as `error: check the substrate before assuming
+    // this runtime has stopped costing money`, an alarm about a bill nobody is
+    // paying.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    expect(await driver.status("agentpod-rt-abc123#sb-never")).toBe("stopped");
+  });
+
+  it("propagates a transport failure instead of inventing an answer", async () => {
+    // probeState() in runtimes.ts logs it and degrades to `unknown`, which the
+    // stop sweeper escalates to `error` after five minutes. Answering `stopped`
+    // here would launder an unreachable substrate into the one word an operator
+    // reads as "it has stopped costing me money".
+    const modal = fakeModal();
+    modal.api.pollSandbox = async () => {
+      throw new Error("connection reset");
+    };
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(driver.status("agentpod-rt-abc123#sb-1")).rejects.toThrow(/connection reset/);
+  });
+
+  it("propagates an auth failure rather than reporting the whole fleet stopped", async () => {
+    // The failure this rule exists for: an expired MODAL_TOKEN_SECRET makes
+    // EVERY call fail at once, so a driver that mapped any error to `stopped`
+    // would report every Modal runtime in the fleet as stopped simultaneously
+    // while all of them keep running and billing. Only ModalNotFoundError —
+    // Modal's positive statement about one sandbox — is an answer.
+    const modal = fakeModal();
+    modal.api.pollSandbox = async () => {
+      throw new Error("401 Unauthorized: invalid token");
+    };
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(driver.status("agentpod-rt-abc123#sb-1")).rejects.toThrow(/401/);
+  });
+
+  it("refuses a malformed external id instead of guessing at one half", async () => {
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+    await expect(driver.status("sb-1")).rejects.toThrow(/external id/i);
+  });
+
+  it("asks and nothing more — status never terminates or deletes", async () => {
+    // status() runs on the sweeper's 15-second tick against every stopping
+    // runtime. A verb that mutated anything would be doing it repeatedly, in
+    // the background, to runtimes nobody touched.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    expect(await driver.status(externalId)).toBe("running");
+    expect(modal.terminated).toEqual([]);
+    expect(modal.deletedVolumes).toEqual([]);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+  });
+});

--- a/apps/hub/src/services/provisioner/modal.test.ts
+++ b/apps/hub/src/services/provisioner/modal.test.ts
@@ -16,9 +16,9 @@ import {
   MODAL_MAX_LIFETIME_MS,
   MODAL_WORKSPACE_PATH,
 } from "./modal";
-import type { ModalApi } from "./modal-api";
-import { MODAL_CREDENTIAL_KEYS } from "./modal-api";
-import type { RuntimeProvisioner } from "./types";
+import type { ModalApi, ModalCreateSandboxParams } from "./modal-api";
+import { MODAL_CREDENTIAL_KEYS, ModalNotFoundError } from "./modal-api";
+import type { ProvisionSpec, ResourceTier, RuntimeProvisioner } from "./types";
 
 /** A port that answers nothing — enough for declaration-only tests. */
 const inertApi: ModalApi = {
@@ -30,6 +30,66 @@ const inertApi: ModalApi = {
     return null;
   },
   async deleteVolume() {},
+};
+
+/**
+ * A faithful fake Modal.
+ *
+ * Faithful means unfriendly where Modal is unfriendly: an unknown sandbox id
+ * and a second delete of the same volume both raise ModalNotFoundError. A
+ * lenient fake would make destroy idempotency (conformance rule 6) pass for
+ * free, which is the same as not checking it.
+ */
+function fakeModal() {
+  const created: ModalCreateSandboxParams[] = [];
+  const terminated: string[] = [];
+  const deletedVolumes: string[] = [];
+  /** sandboxId → exit code; null means still running. */
+  const sandboxes = new Map<string, number | null>();
+  const volumes = new Set<string>();
+  let counter = 0;
+
+  const api: ModalApi = {
+    async createSandbox(params) {
+      created.push(params);
+      volumes.add(params.volumeName);
+      const sandboxId = `sb-${++counter}`;
+      sandboxes.set(sandboxId, null);
+      return { sandboxId };
+    },
+    async terminateSandbox(sandboxId) {
+      if (!sandboxes.has(sandboxId)) {
+        throw new ModalNotFoundError(`Sandbox '${sandboxId}' not found`);
+      }
+      terminated.push(sandboxId);
+      // Modal retains a terminated sandbox and reports its exit code.
+      sandboxes.set(sandboxId, 137);
+    },
+    async pollSandbox(sandboxId) {
+      if (!sandboxes.has(sandboxId)) {
+        throw new ModalNotFoundError(`Sandbox '${sandboxId}' not found`);
+      }
+      return sandboxes.get(sandboxId)!;
+    },
+    async deleteVolume(name) {
+      if (!volumes.has(name)) {
+        throw new ModalNotFoundError(`Volume '${name}' not found`);
+      }
+      volumes.delete(name);
+      deletedVolumes.push(name);
+    },
+  };
+
+  return { api, created, terminated, deletedVolumes, sandboxes, volumes };
+}
+
+const SPEC: ProvisionSpec = {
+  runtimeId: "rt_abc123",
+  name: "modal-box",
+  resourceTier: "medium",
+  hubUrl: "https://hub.example",
+  enrollToken: "enr_secret",
+  image: "ghcr.io/example/agentpod-node-modal:v1",
 };
 
 /**
@@ -169,5 +229,132 @@ describe("modal credential keys", () => {
     // requireCredentials() reports every missing key at once; declaring only
     // one here would cost an operator a redeploy per key.
     expect(MODAL_CREDENTIAL_KEYS).toEqual(["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"]);
+  });
+});
+
+describe("ModalRuntimeProvisioner — provision", () => {
+  it("anchors the workspace in a volume named after the RUNTIME, not the sandbox", async () => {
+    const modal = fakeModal();
+    const res = await new ModalRuntimeProvisioner({ api: modal.api }).provision(SPEC);
+
+    expect(modal.created[0]!.volumeName).toBe("agentpod-rt-abc123");
+    expect(modal.created[0]!.mountPath).toBe("/workspace");
+    // The composite id: the hub stores one string, and this driver needs both
+    // the volume that survives and the sandbox that does not. The volume half
+    // must be the volume that was actually mounted — destroy() deletes what
+    // this string names, and a mismatch would delete a live runtime's anchor.
+    expect(res.externalId).toBe("agentpod-rt-abc123#sb-1");
+    expect(res.runtime).toBe("modal-sandbox");
+  });
+
+  it("re-attaches the SAME volume when the same runtime is provisioned again", async () => {
+    // This is the whole design: a Modal runtime is a rolling series of
+    // sandboxes anchored by one Volume, and "start" is a create.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const first = await driver.provision(SPEC);
+    const second = await driver.provision(SPEC);
+
+    expect(modal.created[1]!.volumeName).toBe(modal.created[0]!.volumeName);
+    expect(second.externalId).not.toBe(first.externalId);
+  });
+
+  it("gives two DIFFERENT runtimes two different volumes", async () => {
+    // The anchor's other direction. Reusing a volume across runtimes is the
+    // same class of silent failure as failing to reuse it within one: two
+    // stations writing over each other's workspace, visible only as corrupted
+    // user files and never as an error.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+    await driver.provision({ ...SPEC, runtimeId: "rt_other" });
+
+    expect(modal.created[1]!.volumeName).not.toBe(modal.created[0]!.volumeName);
+    expect(modal.volumes.size).toBe(2);
+  });
+
+  it("injects the hub url and the enrolment token, and sets no idle timer", async () => {
+    const modal = fakeModal();
+    await new ModalRuntimeProvisioner({ api: modal.api }).provision(SPEC);
+    const params = modal.created[0]!;
+    expect(params.env.AGENTPOD_HUB_URL).toBe("https://hub.example");
+    expect(params.env.AGENTPOD_ENROLL_TOKEN).toBe("enr_secret");
+    expect(params.command).toEqual(["/modal-entrypoint.sh"]);
+    expect(params.workdir).toBe("/workspace");
+    // Asserted HERE and not only in the adapter's test, because the adapter
+    // forwards what it is handed: idle reaping is opt-in on Modal, and opting
+    // in would reap a busy station whose agent only ever dials out — the exact
+    // trap that tore down live Cloudflare sandboxes on 2026-08-12.
+    expect(params).not.toHaveProperty("idleTimeoutMs");
+  });
+
+  it("sets the sandbox timeout to the declared ceiling", async () => {
+    // Modal's default is five minutes. A station that dies in five minutes is
+    // not a station, and nothing in the API warns you.
+    const modal = fakeModal();
+    await new ModalRuntimeProvisioner({ api: modal.api }).provision(SPEC);
+    expect(modal.created[0]!.timeoutMs).toBe(86_400_000);
+  });
+
+  it("uses the CONFIGURED lifetime, so timeoutMs and the manifest never disagree", async () => {
+    // sweepExpiringRuntimes rotates on manifest.maxLifetimeMs; the sandbox dies
+    // on timeoutMs. A hardcoded day here would pass the test above and still
+    // let a hub configured for a shorter ceiling — the ten-minute setting that
+    // exists so rotation can be verified at all — rotate against a sandbox
+    // Modal is keeping alive for twenty-four hours.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api, maxLifetimeMs: 600_000 });
+    await driver.provision(SPEC);
+    // Both against the same number on purpose: what the sandbox is given and
+    // what the manifest promises are the two halves that must not drift.
+    expect(modal.created[0]!.timeoutMs).toBe(600_000);
+    expect(driver.manifest.maxLifetimeMs).toBe(600_000);
+  });
+
+  it("honours the resource tier instead of quietly rounding it", async () => {
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision({ ...SPEC, resourceTier: "small" });
+    await driver.provision({ ...SPEC, runtimeId: "rt_two", resourceTier: "large" });
+    expect(modal.created[0]).toMatchObject({ cpu: 0.5, memoryMiB: 1024 });
+    expect(modal.created[1]).toMatchObject({ cpu: 2, memoryMiB: 4096 });
+  });
+
+  it("refuses a tier it has no sizing for, naming it", async () => {
+    // Not reachable through the typed API, but reachable from a DB row written
+    // before a tier was renamed. Without the guard the lookup yields undefined
+    // and the sandbox is created with cpu: undefined — a sizing decision made
+    // by Modal's defaults, silently, for a tier the operator chose.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(
+      driver.provision({ ...SPEC, resourceTier: "gigantic" as ResourceTier })
+    ).rejects.toThrow(/gigantic/);
+    expect(modal.created).toEqual([]);
+  });
+
+  it("refuses an image Modal could never pull, naming it", async () => {
+    // agentpod-node:local is the DEFAULT for a Docker-first hub and is
+    // meaningless to Modal, which pulls from a registry. Failing here with the
+    // image named beats a sandbox that never boots and a runtime that sits in
+    // `provisioning` until the sweeper gives up.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(
+      driver.provision({ ...SPEC, image: "agentpod-node:local" })
+    ).rejects.toThrow(/agentpod-node:local/);
+  });
+
+  it("creates NOTHING when it refuses, leaving no volume behind to bill for", async () => {
+    // A refusal raised after the volume exists leaves a paid, empty anchor with
+    // no runtime row pointing at it — invisible in the console and billed
+    // monthly. Refuse first, touch the substrate second.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(
+      driver.provision({ ...SPEC, image: "agentpod-node:local" })
+    ).rejects.toThrow();
+    expect(modal.created).toEqual([]);
+    expect(modal.volumes.size).toBe(0);
   });
 });

--- a/apps/hub/src/services/provisioner/modal.test.ts
+++ b/apps/hub/src/services/provisioner/modal.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests: ModalRuntimeProvisioner.
+ *
+ * No real Modal. The driver takes its substrate as a `ModalApi` port and every
+ * test here injects a fake one — which is also what makes the conformance suite
+ * runnable against this driver, since assertConforms really does provision and
+ * destroy.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  ModalRuntimeProvisioner,
+  volumeNameFor,
+  encodeExternalId,
+  decodeExternalId,
+  MODAL_MAX_LIFETIME_MS,
+  MODAL_WORKSPACE_PATH,
+} from "./modal";
+import type { ModalApi } from "./modal-api";
+import { MODAL_CREDENTIAL_KEYS } from "./modal-api";
+import type { RuntimeProvisioner } from "./types";
+
+/** A port that answers nothing — enough for declaration-only tests. */
+const inertApi: ModalApi = {
+  async createSandbox() {
+    throw new Error("inert");
+  },
+  async terminateSandbox() {},
+  async pollSandbox() {
+    return null;
+  },
+  async deleteVolume() {},
+};
+
+/**
+ * Deliberately typed as the INTERFACE, not the class.
+ *
+ * `start` is optional on RuntimeProvisioner and absent from the class, so a
+ * concrete-typed view makes `driver().start` a compile error rather than the
+ * runtime absence check conformance rule 3 is about — and it is the interface
+ * view the hub holds when it reaches for start() by method presence.
+ */
+const driver = (): RuntimeProvisioner => new ModalRuntimeProvisioner({ api: inertApi });
+
+describe("ModalRuntimeProvisioner — manifest", () => {
+  it("declares what Modal actually is, not what would be convenient", () => {
+    const m = driver().manifest;
+    expect(m.provider).toBe("modal");
+    // The workspace lives in a named Volume; the sandbox's rootfs is thrown
+    // away on every recreation, and there are a lot of recreations.
+    expect(m.workspaceStorage).toBe("volume");
+    // terminate() cannot be undone. This is the field the spec calls THE field.
+    expect(m.stopSemantics).toBe("terminal");
+    // The measured platform ceiling: 24h, after which Modal destroys a healthy
+    // sandbox with no warning and no way back.
+    expect(m.maxLifetimeMs).toBe(86_400_000);
+    expect(m.imageBinding).toBe("per-instance");
+    expect(m.supportedTiers).toEqual(["small", "medium", "large"]);
+    // idleTimeoutMs is opt-in and we never opt in, so nothing reaps a busy
+    // station for looking idle — the Cloudflare trap does not exist here.
+    expect(m.idleBehaviour).toBe("never");
+  });
+
+  it("declares NO start verb, because Modal has none", () => {
+    const m = driver().manifest;
+    expect(m.lifecycle).toEqual(["stop", "status"]);
+    // Conformance rule 3 checks the method too: the hub reaches for start() by
+    // presence, so an undeclared-but-present one would still be called.
+    expect(driver().start).toBeUndefined();
+  });
+
+  it("clamps a configured lifetime to Modal's hard ceiling", () => {
+    // The override exists so rotation can be verified in ten minutes instead of
+    // a day, and so a future ceiling change is one env var. It must never claim
+    // more than the platform allows: Modal rejects a longer timeoutMs outright,
+    // which would break provisioning entirely rather than degrade it.
+    const over = new ModalRuntimeProvisioner({ api: inertApi, maxLifetimeMs: 999_999_999 });
+    expect(over.manifest.maxLifetimeMs).toBe(MODAL_MAX_LIFETIME_MS);
+    const under = new ModalRuntimeProvisioner({ api: inertApi, maxLifetimeMs: 600_000 });
+    expect(under.manifest.maxLifetimeMs).toBe(600_000);
+  });
+
+  it("mounts the workspace somewhere HOME is not", () => {
+    // The Volume carries the workspace and nothing else. HOME stays on the
+    // disposable rootfs so the node-agent's config.json — node id and node
+    // secret — dies with each sandbox and no credential is ever left at rest in
+    // shared storage. A mount at "/" or "/root" would quietly undo that.
+    expect(MODAL_WORKSPACE_PATH).toBe("/workspace");
+  });
+});
+
+describe("volumeNameFor", () => {
+  it("derives a stable Modal-legal name from the runtime id", () => {
+    // Stability is the whole mechanism: this is what lets a brand-new sandbox
+    // find the workspace of the sandbox it replaces.
+    expect(volumeNameFor("rt_9f3cAB")).toBe("agentpod-rt-9f3cab");
+    expect(volumeNameFor("rt_9f3cAB")).toBe(volumeNameFor("rt_9f3cAB"));
+  });
+
+  it("refuses a runtime id with nothing usable in it", () => {
+    expect(() => volumeNameFor("___")).toThrow(/volume name/i);
+  });
+
+  it("keeps distinct runtime ids on distinct volumes", () => {
+    // Two runtimes sharing one Volume would have them writing over each other's
+    // workspace, and the collision would only ever be visible as corrupted user
+    // files — never as an error.
+    expect(volumeNameFor("rt_abc")).not.toBe(volumeNameFor("rt_abd"));
+  });
+
+  it("never emits a name that ends in the truncation's leftovers", () => {
+    // Truncation runs after the character scrub, so a runtime id long enough to
+    // be cut at a separator would otherwise yield a trailing dash — a name
+    // shape Modal has no reason to accept, produced only by ids long enough
+    // that no unit test would normally reach them.
+    const long = `rt_${"a".repeat(46)}_tail`;
+    const name = volumeNameFor(long);
+    expect(name.endsWith("-")).toBe(false);
+    expect(name.startsWith("agentpod-")).toBe(true);
+  });
+});
+
+describe("external id codec", () => {
+  it("round-trips the volume and the sandbox", () => {
+    const id = encodeExternalId("agentpod-rt-abc", "sb-123");
+    expect(decodeExternalId(id)).toEqual({
+      volumeName: "agentpod-rt-abc",
+      sandboxId: "sb-123",
+    });
+  });
+
+  it("refuses a bare sandbox id", () => {
+    // A driver that guessed here would delete the wrong volume, or none.
+    expect(() => decodeExternalId("sb-123")).toThrow(/external id/i);
+  });
+
+  // The half-empty cases, each separately, because this is the exact hole the
+  // Fly driver shipped: a codec that let an empty half through built a URL
+  // addressing nothing, whose 404 the destroy path then read as "already gone"
+  // — leaking a machine and its volume with a 200 on the way out. A guard that
+  // rejects only the no-separator form would pass the test above and still
+  // leave both of these open.
+  it("refuses an external id with no volume half", () => {
+    expect(() => decodeExternalId("#sb-123")).toThrow(/external id/i);
+  });
+
+  it("refuses an external id with no sandbox half", () => {
+    expect(() => decodeExternalId("agentpod-rt-abc#")).toThrow(/external id/i);
+  });
+
+  it("refuses an empty external id", () => {
+    expect(() => decodeExternalId("")).toThrow(/external id/i);
+  });
+
+  it("refuses an id carrying a third field rather than guessing which two count", () => {
+    expect(() => decodeExternalId("a#b#c")).toThrow(/external id/i);
+  });
+
+  it("names the id it rejected", () => {
+    // An unattributed refusal is indistinguishable from an unreachable
+    // substrate — the same reasoning conformance.ts applies to image and tier
+    // refusals.
+    expect(() => decodeExternalId("sb-123")).toThrow(/sb-123/);
+  });
+});
+
+describe("modal credential keys", () => {
+  it("declares both tokens, so a half-configured hub is refused naming each", () => {
+    // requireCredentials() reports every missing key at once; declaring only
+    // one here would cost an operator a redeploy per key.
+    expect(MODAL_CREDENTIAL_KEYS).toEqual(["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"]);
+  });
+});

--- a/apps/hub/src/services/provisioner/modal.test.ts
+++ b/apps/hub/src/services/provisioner/modal.test.ts
@@ -523,3 +523,238 @@ describe("ModalRuntimeProvisioner — status", () => {
     expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
   });
 });
+
+describe("ModalRuntimeProvisioner — destroy", () => {
+  it("takes the sandbox AND the volume", async () => {
+    // The one verb where forgetting the Volume costs money forever. A Modal
+    // Volume outlives every sandbox that mounted it and bills for as long as it
+    // exists, so a destroy that only terminated would leave a permanent charge
+    // with no console row left to explain it.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+
+    await driver.destroy(externalId);
+
+    expect(modal.terminated).toEqual(["sb-1"]);
+    expect(modal.deletedVolumes).toEqual(["agentpod-rt-abc123"]);
+    // Not just "delete was called": the anchor is actually gone from the
+    // substrate. This is the assertion a silently-skipped delete cannot pass.
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(false);
+  });
+
+  it("terminates the sandbox BEFORE deleting the volume it has mounted", async () => {
+    // Order is not cosmetic here. Deleting a Volume still mounted by a live
+    // sandbox is a race Modal is under no obligation to make pleasant, and if
+    // the process dies between the two steps the surviving state must be the
+    // cheap, retryable one: sandbox down, volume present, externalId still on
+    // the row. Reversed, the same crash leaves compute running against a
+    // workspace that no longer exists — the larger bill and the unrecoverable
+    // half.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+
+    const order: string[] = [];
+    const terminate = modal.api.terminateSandbox;
+    const remove = modal.api.deleteVolume;
+    modal.api.terminateSandbox = async (id) => {
+      order.push("terminate");
+      return terminate(id);
+    };
+    modal.api.deleteVolume = async (name) => {
+      order.push("deleteVolume");
+      return remove(name);
+    };
+
+    await driver.destroy(externalId);
+
+    expect(order).toEqual(["terminate", "deleteVolume"]);
+  });
+
+  it("is idempotent — a second destroy resolves", async () => {
+    // Conformance rule 6, and not a theoretical one: destroyRuntime() turns a
+    // driver throw into a 502 and leaves the row un-destroyed, so a retry that
+    // threw on "already gone" could never finish a half-done destroy — the
+    // runtime would be wedged permanently, which is exactly the bug found in
+    // the Docker driver.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+
+    await driver.destroy(externalId);
+    await expect(driver.destroy(externalId)).resolves.toBeUndefined();
+    // And the second pass invents no new work.
+    expect(modal.deletedVolumes).toEqual(["agentpod-rt-abc123"]);
+  });
+
+  it("resolves for a runtime this substrate has never heard of", async () => {
+    // The hub can hold an externalId whose sandbox and volume are both long
+    // gone — a workspace deleted from Modal's dashboard, a row restored from a
+    // backup. Destroying that must reach the state the caller asked for, not a
+    // 502 that leaves the row alive for ever.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await expect(
+      driver.destroy("agentpod-rt-gone#sb-gone")
+    ).resolves.toBeUndefined();
+  });
+
+  it("still deletes the volume when the sandbox is already gone", async () => {
+    // The likeliest half-done destroy on this substrate: the 24-hour ceiling
+    // already took the sandbox and the Volume is all that is left — which is
+    // also the only half still billing. A destroy that gave up at the
+    // not-found terminate would leak precisely the expensive part.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.sandboxes.delete("sb-1");
+
+    await driver.destroy(externalId);
+
+    expect(modal.deletedVolumes).toEqual(["agentpod-rt-abc123"]);
+  });
+
+  it("still terminates the sandbox when the volume is already gone", async () => {
+    // The mirror case, and the more expensive one: a Volume removed by hand
+    // leaves a sandbox running and billing compute. Tolerating the volume's
+    // absence must not come at the price of leaving that sandbox alive.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.volumes.delete("agentpod-rt-abc123");
+
+    await expect(driver.destroy(externalId)).resolves.toBeUndefined();
+    expect(modal.terminated).toEqual(["sb-1"]);
+  });
+
+  it("does NOT swallow a substrate failure on the volume delete", async () => {
+    // Tolerating "already gone" must not become tolerating everything. A
+    // destroy that resolved on a connection reset would have destroyRuntime()
+    // write `destroyed` and forget the externalId — and the Volume it named
+    // would bill for ever with nothing left anywhere that could address it.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.api.deleteVolume = async () => {
+      throw new Error("connection reset");
+    };
+
+    await expect(driver.destroy(externalId)).rejects.toThrow(/connection reset/);
+  });
+
+  it("does NOT swallow an auth failure on the volume delete", async () => {
+    // An expired MODAL_TOKEN_SECRET fails every call at once. A bare catch here
+    // would report a successful destroy for every Modal runtime in the fleet
+    // while none of them were deleted and all of them kept billing.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.api.deleteVolume = async () => {
+      throw new Error("401 Unauthorized: invalid token");
+    };
+
+    await expect(driver.destroy(externalId)).rejects.toThrow(/401/);
+  });
+
+  it("does NOT swallow a substrate failure on the terminate, and leaves the volume alone", async () => {
+    // Two rules in one. The throw must surface — a destroy that resolved here
+    // would forget a still-running sandbox. And the Volume must survive: with
+    // the terminate unconfirmed the sandbox may well still be mounting it, and
+    // the retry needs the anchor intact to finish the job properly.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+    modal.api.terminateSandbox = async () => {
+      throw new Error("connection reset");
+    };
+
+    await expect(driver.destroy(externalId)).rejects.toThrow(/connection reset/);
+    expect(modal.deletedVolumes).toEqual([]);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+  });
+
+  it("converges on retry after a partial destroy — the volume is really taken", async () => {
+    // The money case end to end. First attempt: sandbox terminated, volume
+    // delete fails on transport, driver throws, destroyRuntime() 502s and the
+    // row keeps its externalId. Second attempt, once the substrate is back: the
+    // already-terminated sandbox is tolerated and the Volume — the half that is
+    // still billing — is finally gone. If this did not converge, the only way
+    // to stop paying would be Modal's dashboard.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    const { externalId } = await driver.provision(SPEC);
+
+    const remove = modal.api.deleteVolume;
+    modal.api.deleteVolume = async () => {
+      throw new Error("connection reset");
+    };
+    await expect(driver.destroy(externalId)).rejects.toThrow(/connection reset/);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+
+    modal.api.deleteVolume = remove;
+    await expect(driver.destroy(externalId)).resolves.toBeUndefined();
+    expect(modal.deletedVolumes).toEqual(["agentpod-rt-abc123"]);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(false);
+  });
+
+  it("refuses a malformed external id instead of destroying something else", async () => {
+    // A bare sandbox id names no volume. Guessing one — or handing the whole
+    // string to either call — would either delete another runtime's anchor or
+    // resolve on a not-found while the real sandbox kept running.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+
+    await expect(driver.destroy("sb-1")).rejects.toThrow(/external id/i);
+    expect(modal.terminated).toEqual([]);
+    expect(modal.deletedVolumes).toEqual([]);
+  });
+
+  it("refuses an id with an empty volume half rather than reporting a false success", async () => {
+    // This is the Fly driver's shipped bug, transplanted: a codec that let an
+    // empty half through addressed nothing, and the not-found that came back
+    // was read by destroy as "already gone" — a 200 on the way out while a
+    // machine and its volume kept billing. Tolerating not-found makes the codec
+    // the ONLY thing standing between a bypass and a silent leak.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+
+    await expect(driver.destroy("#sb-1")).rejects.toThrow(/external id/i);
+    expect(modal.terminated).toEqual([]);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+  });
+
+  it("refuses an id with an empty sandbox half rather than taking the volume anyway", async () => {
+    // The other direction, and worse: proceeding would delete a live runtime's
+    // workspace while its sandbox kept running, having tolerated the empty
+    // sandbox id's not-found as success.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC);
+
+    await expect(driver.destroy("agentpod-rt-abc123#")).rejects.toThrow(/external id/i);
+    expect(modal.deletedVolumes).toEqual([]);
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+  });
+
+  it("deletes the volume half and terminates the sandbox half, never swapped", async () => {
+    // Both calls take a bare string, so swapping them is a one-character typo
+    // that not-found tolerance would hide completely: every call would raise
+    // ModalNotFoundError, both would be swallowed, and destroy would resolve
+    // having deleted nothing at all. Two live runtimes make the swap visible.
+    const modal = fakeModal();
+    const driver = new ModalRuntimeProvisioner({ api: modal.api });
+    await driver.provision(SPEC); // agentpod-rt-abc123 # sb-1
+    await driver.provision({ ...SPEC, runtimeId: "rt_other" }); // agentpod-rt-other # sb-2
+
+    await driver.destroy(encodeExternalId("agentpod-rt-other", "sb-1"));
+
+    expect(modal.terminated).toEqual(["sb-1"]);
+    expect(modal.deletedVolumes).toEqual(["agentpod-rt-other"]);
+    // The untouched runtime is untouched.
+    expect(modal.volumes.has("agentpod-rt-abc123")).toBe(true);
+    expect(modal.sandboxes.get("sb-2")).toBeNull();
+  });
+});

--- a/apps/hub/src/services/provisioner/modal.ts
+++ b/apps/hub/src/services/provisioner/modal.ts
@@ -27,6 +27,7 @@ import type {
   RuntimeState,
 } from "./types";
 import type { ModalApi } from "./modal-api";
+import { ModalNotFoundError } from "./modal-api";
 
 /**
  * Modal's hard ceiling on a sandbox's life. Not configurable by us.
@@ -291,11 +292,78 @@ export class ModalRuntimeProvisioner implements RuntimeProvisioner {
     throw new Error("modal: destroy is implemented in Task 5");
   }
 
-  async stop(_externalId: string): Promise<void> {
-    throw new Error("modal: stop is implemented in Task 4");
+  /**
+   * Terminate the sandbox. IRREVERSIBLE — Modal has no start verb.
+   *
+   * The Volume is deliberately untouched: it is the runtime's identity, and the
+   * hub restarts a terminal runtime by provisioning a NEW sandbox against the
+   * same volume (see reprovisionRuntime in ../runtimes.ts). A stop that also
+   * deleted the volume would make every stop a destroy — the Cloudflare
+   * workspace loss in a new costume, with the button labelled Stop.
+   *
+   * Only "already gone" is tolerated. stopRuntime() writes `stopping` once this
+   * resolves and then trusts status() for the rest, so a stop() that resolved
+   * on a connection reset would hand a still-running sandbox to a path built to
+   * confirm one that is not.
+   */
+  async stop(externalId: string): Promise<void> {
+    const { sandboxId } = decodeExternalId(externalId);
+    try {
+      await this.api.terminateSandbox(sandboxId);
+    } catch (err) {
+      // Already gone is the state the caller asked for — and on this substrate
+      // it is routine, since the 24-hour ceiling reaps a sandbox a day whether
+      // or not anyone pressed Stop. Anything else is real and must surface.
+      if (err instanceof ModalNotFoundError) return;
+      throw err;
+    }
   }
 
-  async status(_externalId: string): Promise<RuntimeState> {
-    throw new Error("modal: status is implemented in Task 4");
+  /**
+   * Ask Modal whether this sandbox is still running.
+   *
+   * This is the hub's ONLY evidence for writing the runtime status `stopped`,
+   * which an operator reads as "it has stopped costing me money" (PR #260/#261
+   * exists because `stopped` was once written merely because a driver call
+   * returned). The mapping is therefore deliberate in all four directions:
+   *
+   *   poll() === null        → "running".  Modal's own live/finished signal.
+   *   poll() === <exit code> → "stopped".  ANY exit code, INCLUDING 0. `0` is a
+   *                            valid exit code and is falsy, so this compares
+   *                            against null explicitly; a truthiness test would
+   *                            report the one cleanly-finished sandbox as
+   *                            running, leave its stop unconfirmed, and flip the
+   *                            runtime to `error` five minutes later. This is
+   *                            also the 24-hour-ceiling case: at the driver
+   *                            level "stopped" means exactly "this sandbox is
+   *                            not running", which is true however it ended.
+   *   ModalNotFoundError     → "stopped".  An ANSWER, not a silence: an
+   *                            authenticated call reached Modal and Modal
+   *                            asserted no such sandbox exists in this
+   *                            workspace. Nothing that does not exist is
+   *                            running or billing. `unknown` would send every
+   *                            stop of an already-reaped sandbox — one per
+   *                            runtime per day here — through
+   *                            sweepStalledRuntimeStops' five-minute timeout
+   *                            and out as `error`, an alarm about a bill nobody
+   *                            is paying.
+   *   anything else          → rethrow.  NEVER "stopped". An expired
+   *                            MODAL_TOKEN_SECRET fails every call at once, so
+   *                            laundering errors into "stopped" would report
+   *                            every Modal runtime in the fleet as stopped
+   *                            simultaneously while all of them keep running
+   *                            and billing. probeState() in ../runtimes.ts logs
+   *                            the throw and degrades it to `unknown`, which the
+   *                            sweeper escalates to `error` — loud, and correct.
+   */
+  async status(externalId: string): Promise<RuntimeState> {
+    const { sandboxId } = decodeExternalId(externalId);
+    try {
+      const exitCode = await this.api.pollSandbox(sandboxId);
+      return exitCode === null ? "running" : "stopped";
+    } catch (err) {
+      if (err instanceof ModalNotFoundError) return "stopped";
+      throw err;
+    }
   }
 }

--- a/apps/hub/src/services/provisioner/modal.ts
+++ b/apps/hub/src/services/provisioner/modal.ts
@@ -288,8 +288,62 @@ export class ModalRuntimeProvisioner implements RuntimeProvisioner {
     };
   }
 
-  async destroy(_externalId: string): Promise<void> {
-    throw new Error("modal: destroy is implemented in Task 5");
+  /**
+   * Permanently remove the runtime: the sandbox, and then the Volume that
+   * outlives sandboxes.
+   *
+   * BOTH, always. Unlike stop(), which must never touch the Volume because the
+   * Volume is the runtime's identity, destroy() must take it: a Modal Volume
+   * exists independently of any sandbox and bills for as long as it exists, so
+   * one left behind is a permanent charge for a runtime the operator has been
+   * told is gone, with no console row left that could even name it.
+   *
+   * ORDER: terminate first, delete second. Deleting a Volume still mounted by a
+   * live sandbox is a race Modal is under no obligation to make pleasant, and
+   * the ordering also decides what a partial failure leaves behind. Terminate
+   * first and the worst interruption leaves sandbox down / volume present /
+   * externalId still on the row — the cheap half surviving, addressable, and
+   * retryable. Reversed, the same interruption leaves compute running against a
+   * workspace that has been deleted underneath it: the larger bill, plus a
+   * runtime that can no longer be made whole.
+   *
+   * Only ModalNotFoundError is tolerated, and it is tolerated on BOTH steps
+   * rather than one:
+   *
+   *   - on the terminate, because the 24-hour ceiling reaps a sandbox per
+   *     runtime per day, so "the sandbox is already gone and only the billing
+   *     Volume is left" is the ordinary case, not an edge one;
+   *   - on the delete, because that is what makes the retry converge.
+   *
+   * Nothing else is tolerated. destroyRuntime() turns a throw into a 502 and
+   * leaves the row un-destroyed with its externalId intact, which is exactly
+   * what a retry needs; whereas a destroy that resolved on an expired token or
+   * a connection reset would have the hub write `destroyed`, forget the
+   * externalId, and strand a Volume that bills for ever with nothing anywhere
+   * that can address it. The retry therefore converges: a re-terminate of an
+   * already-terminated sandbox is a no-op (or a tolerated not-found), and the
+   * delete is attempted again until the substrate accepts it.
+   *
+   * decodeExternalId() throwing is load-bearing here for the same reason. With
+   * not-found tolerated on both calls, the codec is the ONLY thing preventing a
+   * malformed or half-empty id from addressing nothing, having both not-founds
+   * swallowed, and reporting a successful destroy that deleted nothing — which
+   * is the leak the Fly driver shipped.
+   */
+  async destroy(externalId: string): Promise<void> {
+    const { volumeName, sandboxId } = decodeExternalId(externalId);
+
+    try {
+      await this.api.terminateSandbox(sandboxId);
+    } catch (err) {
+      if (!(err instanceof ModalNotFoundError)) throw err;
+    }
+
+    try {
+      await this.api.deleteVolume(volumeName);
+    } catch (err) {
+      if (!(err instanceof ModalNotFoundError)) throw err;
+    }
   }
 
   /**

--- a/apps/hub/src/services/provisioner/modal.ts
+++ b/apps/hub/src/services/provisioner/modal.ts
@@ -85,6 +85,16 @@ export const MODAL_RESOURCE_TIERS: Record<ResourceTier, { cpu: number; memoryMiB
   large: { cpu: 2, memoryMiB: 4096 },
 };
 
+/**
+ * The sandbox's main process.
+ *
+ * Passed as a COMMAND, not baked as an ENTRYPOINT: Modal requires any image
+ * ENTRYPOINT to `exec "$@"`, and our node-agent entrypoint does not — it enrols
+ * and then execs its own run loop. Dockerfile.modal clears ENTRYPOINT and this
+ * supplies the command instead. See Task 13.
+ */
+export const MODAL_ENTRYPOINT = ["/modal-entrypoint.sh"];
+
 /** Separator for the composite external id. Legal in neither half. */
 const EXTERNAL_ID_SEPARATOR = "#";
 
@@ -212,10 +222,69 @@ export class ModalRuntimeProvisioner implements RuntimeProvisioner {
     };
   }
 
-  async provision(
-    _spec: ProvisionSpec
-  ): Promise<{ externalId: string; runtime?: string }> {
-    throw new Error("modal: provision is implemented in Task 3");
+  /**
+   * Create one sandbox for a runtime, mounting that runtime's durable Volume.
+   *
+   * Called for a first provision and for every recreation alike — there is no
+   * separate "start". Both refusals below happen BEFORE the substrate is
+   * touched, so a rejected spec cannot leave a paid, empty Volume behind with
+   * no runtime row pointing at it.
+   */
+  async provision(spec: ProvisionSpec): Promise<{ externalId: string; runtime?: string }> {
+    // Modal pulls from a registry. A bare local tag — which is the default a
+    // Docker-first hub hands out — produces a sandbox that never boots and a
+    // runtime that sits in `provisioning` until the sweeper expires it, with
+    // nothing anywhere naming the cause.
+    if (!spec.image.includes("/")) {
+      throw new Error(
+        `modal: image "${spec.image}" is not a registry reference Modal can pull ` +
+          `(no registry host). Push a linux/amd64 image and set ` +
+          `NODE_AGENT_MODAL_IMAGE — see docs/DEPLOYMENT.md.`
+      );
+    }
+
+    // Unreachable through the typed API, reachable from a DB row written before
+    // a tier was renamed. Without this the lookup yields undefined and the
+    // sandbox is sized by Modal's defaults instead of by the operator's choice.
+    const tier = MODAL_RESOURCE_TIERS[spec.resourceTier];
+    if (!tier) {
+      throw new Error(`modal: unsupported resource tier "${spec.resourceTier}"`);
+    }
+
+    const volumeName = volumeNameFor(spec.runtimeId);
+    const { sandboxId } = await this.api.createSandbox({
+      appName: this.appName,
+      image: spec.image,
+      // Created if missing, re-attached if not: the same runtime id always
+      // reaches the same workspace, which is what makes a rolling series of
+      // sandboxes look like one durable runtime. Derived from the RUNTIME id,
+      // never from the sandbox or the name — a volume keyed to anything that
+      // changes across recreation loses the workspace on every restart, and
+      // loses it silently.
+      volumeName,
+      mountPath: MODAL_WORKSPACE_PATH,
+      workdir: MODAL_WORKSPACE_PATH,
+      command: MODAL_ENTRYPOINT,
+      // The token lives here and only here — never in the Volume, never in a
+      // log. Each sandbox enrols with a freshly minted one.
+      env: {
+        AGENTPOD_HUB_URL: spec.hubUrl,
+        AGENTPOD_ENROLL_TOKEN: spec.enrollToken,
+      },
+      cpu: tier.cpu,
+      memoryMiB: tier.memoryMiB,
+      // Load-bearing, not tidy: Modal's default is FIVE MINUTES. This is the
+      // same number the manifest declares, so the rotation sweeper and the
+      // platform's own kill clock cannot disagree. And deliberately no
+      // idleTimeoutMs — idle reaping is opt-in, and opting in would reap a busy
+      // station whose agent only ever dials out.
+      timeoutMs: this.maxLifetimeMs,
+    });
+
+    return {
+      externalId: encodeExternalId(volumeName, sandboxId),
+      runtime: "modal-sandbox",
+    };
   }
 
   async destroy(_externalId: string): Promise<void> {

--- a/apps/hub/src/services/provisioner/modal.ts
+++ b/apps/hub/src/services/provisioner/modal.ts
@@ -1,0 +1,232 @@
+/**
+ * Modal sandbox provisioner driver.
+ *
+ * A Modal runtime is A ROLLING SERIES OF SANDBOXES ANCHORED BY A NAMED VOLUME.
+ * That sentence is the design. Modal has no stop/start — `terminate` is
+ * irreversible — and every sandbox is destroyed by the platform at 24 hours
+ * whatever it is doing, so the sandbox cannot be the thing that persists. The
+ * Volume is: it is named after the AgentPod runtime id, so a brand-new sandbox
+ * finds the previous one's workspace by name (measured 2026-08-13; without this
+ * fact Modal would not be usable at all).
+ *
+ * What is NOT in the Volume, on purpose: credentials. HOME stays on the
+ * disposable rootfs, so the node-agent's config.json — node id and node secret
+ * — dies with each sandbox, and every new sandbox enrols with a freshly minted
+ * runtime-bound token. Nothing has to protect a secret at rest in shared storage
+ * because nothing puts one there.
+ *
+ * SECURITY: spec.enrollToken is passed in the sandbox env and is never logged by
+ * this module. Do not add a log statement that references it.
+ */
+
+import type {
+  DriverManifest,
+  ProvisionSpec,
+  ResourceTier,
+  RuntimeProvisioner,
+  RuntimeState,
+} from "./types";
+import type { ModalApi } from "./modal-api";
+
+/**
+ * Modal's hard ceiling on a sandbox's life. Not configurable by us.
+ *
+ * Measured 2026-08-13 against a real Modal account — every number and verb in
+ * the manifest below came from that probe rather than from Modal's docs, and
+ * the date is here because this repo has repeatedly been bitten by declarations
+ * written from documentation. What the probe established:
+ *
+ *   - The first-party JS SDK runs on Bun: client constructed, credentials
+ *     resolved from ~/.modal.toml, sandbox created, volume mounted, `exec` run,
+ *     sandbox terminated. No Python shim is needed; this driver is ordinary
+ *     TypeScript.
+ *   - A named Volume DOES anchor identity across sandbox recreation. Sandbox 1
+ *     wrote a sentinel into a volume-mounted path and terminated; sandbox 2 —
+ *     a DIFFERENT sandboxId — mounted the same Volume by name and read the
+ *     sentinel back. This single fact is what makes Modal viable at all, and it
+ *     is why the durable half of the external id is the volume name.
+ *   - `terminate` is irreversible and there is no start verb. Every restart is
+ *     a new sandbox with a new id and a fresh rootfs → stopSemantics
+ *     "terminal", and conformance rule 3 forbids a start() on this class.
+ *   - Hard 24-hour maximum sandbox lifetime. The platform destroys a HEALTHY
+ *     sandbox on that deadline, never brings it back, and gives no warning
+ *     callback. Nothing in the API rotates for you → maxLifetimeMs below.
+ *   - `idleTimeoutMs` is opt-in and defaults to OFF. Never set it. That
+ *     sidesteps the Cloudflare-style inbound-activity trap entirely: a
+ *     node-agent dials out and receives nothing, so an inbound-keyed idle timer
+ *     reaps a busy station → idleBehaviour "never".
+ *   - `timeoutMs` defaults to FIVE MINUTES. Not setting it is not "no limit",
+ *     it is "your station dies in five minutes" → provision() always sets it.
+ *   - Image and CPU/memory are both per-sandbox → imageBinding "per-instance"
+ *     and all three tiers.
+ *   - The SDK is 0.x and churns: `timeout` was renamed `timeoutMs` and an
+ *     unknown key is REJECTED at runtime by the SDK's own checkForRenamedParams
+ *     guard. Pin the version exactly; keep the SDK behind ./modal-api.
+ */
+export const MODAL_MAX_LIFETIME_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Where the anchoring Volume is mounted. The workspace, and only that.
+ *
+ * Deliberately not HOME: the node-agent writes its node id and node secret to
+ * $HOME/.config/agentpod-node/, and those must die with each sandbox so no
+ * credential is ever left at rest in shared storage. The 24-hour ceiling then
+ * degrades from data loss to daily re-enrolment churn.
+ */
+export const MODAL_WORKSPACE_PATH = "/workspace";
+
+/**
+ * Tier → sandbox sizing, matching the Docker driver's limits so "medium" means
+ * the same thing to a user whichever substrate they picked.
+ */
+export const MODAL_RESOURCE_TIERS: Record<ResourceTier, { cpu: number; memoryMiB: number }> = {
+  small: { cpu: 0.5, memoryMiB: 1024 },
+  medium: { cpu: 1, memoryMiB: 2048 },
+  large: { cpu: 2, memoryMiB: 4096 },
+};
+
+/** Separator for the composite external id. Legal in neither half. */
+const EXTERNAL_ID_SEPARATOR = "#";
+
+/** Longest slug we take from a runtime id, before the "agentpod-" prefix. */
+const VOLUME_SLUG_MAX_LENGTH = 50;
+
+/**
+ * The durable name for a runtime's Volume.
+ *
+ * Derived from the runtime id rather than stored anywhere, so provisioning again
+ * for the same runtime re-attaches the same workspace with no extra bookkeeping
+ * — that is what makes "start" implementable on a substrate with no start verb.
+ */
+export function volumeNameFor(runtimeId: string): string {
+  const slug = runtimeId
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, VOLUME_SLUG_MAX_LENGTH)
+    // Trimmed a second time because the truncation above can land mid-separator
+    // and leave a trailing dash. Only ids longer than the limit reach this, so
+    // it is exactly the case no ordinary test would produce.
+    .replace(/-+$/g, "");
+  if (!slug) {
+    throw new Error(
+      `modal: cannot derive a volume name from runtime id "${runtimeId}"`
+    );
+  }
+  return `agentpod-${slug}`;
+}
+
+/**
+ * The hub stores ONE string per runtime, and this driver needs two identifiers:
+ * the Volume that persists and the sandbox that does not. Encoding both is what
+ * lets a stateless driver, on a fresh hub process, destroy the right volume for
+ * a sandbox it has never seen.
+ */
+export function encodeExternalId(volumeName: string, sandboxId: string): string {
+  return `${volumeName}${EXTERNAL_ID_SEPARATOR}${sandboxId}`;
+}
+
+/**
+ * Split a composite external id, or throw.
+ *
+ * THROWING IS THE POINT. A half — an empty volume name, an empty sandbox id, a
+ * bare id with no separator — must never be handed onward as if it addressed
+ * something. The Fly driver shipped a codec that let an empty half through: it
+ * built a URL addressing nothing, and the 404 that came back was read by the
+ * destroy path as "already gone", which silently leaked a machine and its
+ * volume while reporting success. Every rejection names the id, because an
+ * unattributed refusal is indistinguishable from a substrate that is down.
+ */
+export function decodeExternalId(externalId: string): {
+  volumeName: string;
+  sandboxId: string;
+} {
+  const [volumeName, sandboxId, ...rest] = String(externalId).split(
+    EXTERNAL_ID_SEPARATOR
+  );
+  if (!volumeName || !sandboxId || rest.length > 0) {
+    throw new Error(
+      `modal: malformed external id "${externalId}" — expected ` +
+        `"<volume>${EXTERNAL_ID_SEPARATOR}<sandbox>"`
+    );
+  }
+  return { volumeName, sandboxId };
+}
+
+export interface ModalProvisionerOptions {
+  /** The substrate. Injected so tests and the conformance suite never call Modal. */
+  api: ModalApi;
+  /** Modal App the sandboxes are grouped under. Grouping only. */
+  appName?: string;
+  /**
+   * Override for the platform ceiling, clamped to MODAL_MAX_LIFETIME_MS.
+   *
+   * Two honest uses: verifying rotation in ten minutes rather than a day, and
+   * absorbing a future change to Modal's ceiling without a release. It can only
+   * ever shorten — a longer timeoutMs is rejected by Modal outright.
+   */
+  maxLifetimeMs?: number;
+}
+
+export class ModalRuntimeProvisioner implements RuntimeProvisioner {
+  readonly provider = "modal" as const;
+  readonly supportedTiers: ResourceTier[] = ["small", "medium", "large"];
+  readonly manifest: DriverManifest;
+
+  private readonly api: ModalApi;
+  private readonly appName: string;
+  private readonly maxLifetimeMs: number;
+
+  constructor({ api, appName, maxLifetimeMs }: ModalProvisionerOptions) {
+    this.api = api;
+    this.appName = appName ?? process.env.MODAL_APP_NAME ?? "agentpod";
+    // Parenthesised because `??` may not be mixed with `||` unparenthesised —
+    // it is a SyntaxError, not a precedence surprise. Number(undefined) is NaN
+    // and NaN is falsy, so an unset or unparseable env var falls through to the
+    // platform ceiling rather than clamping to NaN.
+    const requested =
+      maxLifetimeMs ??
+      (Number(process.env.MODAL_MAX_LIFETIME_MS) || MODAL_MAX_LIFETIME_MS);
+    this.maxLifetimeMs = Math.min(requested, MODAL_MAX_LIFETIME_MS);
+
+    this.manifest = {
+      provider: "modal",
+      // The rootfs is thrown away on every recreation and there are a lot of
+      // recreations; the named Volume is the only thing that persists.
+      workspaceStorage: "volume",
+      // terminate() is irreversible and there is no start verb. Conformance
+      // rule 3 turns this into a check that no start() exists on this class.
+      stopSemantics: "terminal",
+      // Measured: the platform destroys a healthy sandbox at this age, silently
+      // and permanently. sweepExpiringRuntimes() rotates before it happens.
+      maxLifetimeMs: this.maxLifetimeMs,
+      // Modal pulls the registry reference per sandbox, so spec.image is real.
+      imageBinding: "per-instance",
+      supportedTiers: this.supportedTiers,
+      // idleTimeoutMs is opt-in and we never set it, so nothing here mistakes an
+      // outbound-only node-agent for an idle one.
+      idleBehaviour: "never",
+      // No "start": there is nothing to start. The hub restarts a terminal
+      // runtime by provisioning again against the same Volume.
+      lifecycle: ["stop", "status"],
+    };
+  }
+
+  async provision(
+    _spec: ProvisionSpec
+  ): Promise<{ externalId: string; runtime?: string }> {
+    throw new Error("modal: provision is implemented in Task 3");
+  }
+
+  async destroy(_externalId: string): Promise<void> {
+    throw new Error("modal: destroy is implemented in Task 5");
+  }
+
+  async stop(_externalId: string): Promise<void> {
+    throw new Error("modal: stop is implemented in Task 4");
+  }
+
+  async status(_externalId: string): Promise<RuntimeState> {
+    throw new Error("modal: status is implemented in Task 4");
+  }
+}

--- a/apps/hub/src/services/runtimes-image.test.ts
+++ b/apps/hub/src/services/runtimes-image.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests: provider-scoped image resolution.
+ *
+ * Image resolution is service-layer work: drivers are image-agnostic and always
+ * use ProvisionSpec.image. It becomes provider-aware here because two enabled
+ * substrates need different references for the SAME harness — Docker a local
+ * tag from the host daemon, Modal a registry reference it can pull. One
+ * variable cannot serve both, and the failure mode when it tries is silent: the
+ * sandbox never boots, the runtime sits in `provisioning`, and the sweeper
+ * names nothing useful two minutes later.
+ *
+ * The live hub runs `docker, cloudflare` and must be completely unaffected.
+ * That claim is checked twice, deliberately:
+ *   - in-process, against `process.env`, which is what imageForHarness reads;
+ *   - in a CHILD PROCESS carrying the exact variables docs/DEPLOYMENT.md tells
+ *     an operator to set, which is the only way to cover the variable NAMES.
+ *     A hand-driven test cannot see a resolver that reads the wrong env key,
+ *     because it sets whatever key the implementation happens to read.
+ */
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "node:path";
+import { imageForHarness } from "./runtimes";
+
+const KEYS = [
+  "NODE_AGENT_IMAGE",
+  "NODE_AGENT_OPENCODE_IMAGE",
+  "NODE_AGENT_PI_IMAGE",
+  "NODE_AGENT_MODAL_IMAGE",
+  "NODE_AGENT_MODAL_OPENCODE_IMAGE",
+  "NODE_AGENT_MODAL_PI_IMAGE",
+  "NODE_AGENT_DOCKER_IMAGE",
+];
+
+/**
+ * `bun test` runs every file in ONE process, so an env var this file sets is an
+ * env var the next file inherits. Restore rather than delete: a deployment (or
+ * a developer's apps/hub/.env) may legitimately have set these before the run.
+ */
+const ORIGINAL = new Map(KEYS.map((key) => [key, process.env[key]] as const));
+
+afterEach(() => {
+  for (const [key, value] of ORIGINAL) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("imageForHarness", () => {
+  it("keeps today's behaviour for a provider with no override", () => {
+    // The regression guard: Docker and Cloudflare must resolve exactly what
+    // they resolved before this change.
+    expect(imageForHarness("none", "docker")).toBe("agentpod-node:local");
+    expect(imageForHarness("opencode", "docker")).toBe("agentpod-node-opencode:local");
+    expect(imageForHarness("pi", "docker")).toBe("agentpod-node-pi:local");
+    expect(imageForHarness("none", "cloudflare")).toBe("agentpod-node:local");
+    expect(imageForHarness("opencode", "cloudflare")).toBe("agentpod-node-opencode:local");
+
+    process.env.NODE_AGENT_IMAGE = "custom:tag";
+    process.env.NODE_AGENT_OPENCODE_IMAGE = "custom-oc:tag";
+    expect(imageForHarness("none", "docker")).toBe("custom:tag");
+    expect(imageForHarness("opencode", "docker")).toBe("custom-oc:tag");
+    expect(imageForHarness("none", "cloudflare")).toBe("custom:tag");
+  });
+
+  it("prefers a provider-scoped override", () => {
+    process.env.NODE_AGENT_IMAGE = "agentpod-node:local";
+    process.env.NODE_AGENT_MODAL_IMAGE = "ghcr.io/example/agentpod-node-modal:v1";
+    expect(imageForHarness("none", "modal")).toBe("ghcr.io/example/agentpod-node-modal:v1");
+    expect(imageForHarness("none", "docker")).toBe("agentpod-node:local");
+  });
+
+  it("gives one provider's override to that provider ONLY", () => {
+    // The point of the whole change. A scope that leaked would hand Docker a
+    // registry reference it has no local tag for — or, the other way round,
+    // hand Modal the local tag that made this task necessary.
+    process.env.NODE_AGENT_MODAL_IMAGE = "ghcr.io/example/agentpod-node-modal:v1";
+    process.env.NODE_AGENT_MODAL_OPENCODE_IMAGE = "ghcr.io/example/modal-oc:v1";
+    expect(imageForHarness("none", "docker")).toBe("agentpod-node:local");
+    expect(imageForHarness("opencode", "docker")).toBe("agentpod-node-opencode:local");
+    expect(imageForHarness("none", "cloudflare")).toBe("agentpod-node:local");
+    expect(imageForHarness("opencode", "cloudflare")).toBe("agentpod-node-opencode:local");
+    // ...and a provider nobody has written a variable for is untouched too.
+    expect(imageForHarness("none", "fly")).toBe("agentpod-node:local");
+  });
+
+  it("scopes per harness as well as per provider", () => {
+    process.env.NODE_AGENT_MODAL_IMAGE = "ghcr.io/example/agentpod-node-modal:v1";
+    process.env.NODE_AGENT_MODAL_OPENCODE_IMAGE = "ghcr.io/example/agentpod-node-modal-oc:v1";
+    process.env.NODE_AGENT_MODAL_PI_IMAGE = "ghcr.io/example/agentpod-node-modal-pi:v1";
+    expect(imageForHarness("opencode", "modal")).toBe(
+      "ghcr.io/example/agentpod-node-modal-oc:v1"
+    );
+    expect(imageForHarness("pi", "modal")).toBe("ghcr.io/example/agentpod-node-modal-pi:v1");
+    // The harness-less scope must not answer for a harness that has its own.
+    expect(imageForHarness("none", "modal")).toBe("ghcr.io/example/agentpod-node-modal:v1");
+  });
+
+  it("falls back to the harness-wide value when the provider has no override", () => {
+    process.env.NODE_AGENT_OPENCODE_IMAGE = "agentpod-node-opencode:local";
+    expect(imageForHarness("opencode", "modal")).toBe("agentpod-node-opencode:local");
+  });
+
+  it("ignores an empty provider-scoped variable rather than provisioning nothing", () => {
+    // An operator who unsets a variable by emptying it means "I have not set
+    // this". Treating "" as a hit would pass an empty image to a driver.
+    process.env.NODE_AGENT_MODAL_IMAGE = "";
+    process.env.NODE_AGENT_IMAGE = "agentpod-node:local";
+    expect(imageForHarness("none", "modal")).toBe("agentpod-node:local");
+  });
+});
+
+// ─── Variable names, through real env parsing ────────────────────────────────
+
+/**
+ * Everything above drives `process.env` in this process, which covers the
+ * resolution ORDER but not the variable NAMES: the test sets whatever key the
+ * implementation reads, so a resolver reading `NODE_AGENT_IMAGE` where
+ * DEPLOYMENT.md says `NODE_AGENT_MODAL_IMAGE` would pass every one of them
+ * while refusing an operator who followed the docs. These load the real modules
+ * in a CHILD PROCESS under a controlled environment — the only way to observe
+ * module-scope env parsing from a suite that shares one module registry — and
+ * they name the variables the way the docs do, not the way the code does.
+ */
+const resolveInChild = (
+  overrides: Record<string, string | null>,
+  queries: Array<[harness: string, provider: string]>
+) => {
+  const hubRoot = join(import.meta.dir, "..", "..");
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  // Every image and Modal variable starts UNSET, so a test that wants one says
+  // so — including any inherited from the developer's own apps/hub/.env.
+  for (const key of [
+    ...KEYS,
+    "ENABLE_MODAL_PROVISIONING",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "MODAL_APP_NAME",
+    "PROVISIONING_HUB_URL",
+  ]) {
+    delete env[key];
+  }
+  env.NODE_ENV = "development";
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) delete env[key];
+    else env[key] = value;
+  }
+
+  const script = `
+    const { imageForHarness } = await import(${JSON.stringify(
+      join(hubRoot, "src", "services", "runtimes.ts")
+    )});
+    const { config } = await import(${JSON.stringify(join(hubRoot, "src", "config.ts"))});
+    const queries = ${JSON.stringify(queries)};
+    console.log(JSON.stringify({
+      images: Object.fromEntries(
+        queries.map(([harness, provider]) => [
+          harness + "@" + provider,
+          imageForHarness(harness, provider),
+        ])
+      ),
+      configModalImage: config.modal.image,
+    }));
+    process.exit(0);
+  `;
+  const proc = Bun.spawnSync(["bun", "-e", script], {
+    cwd: hubRoot,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // A child that died took the assertion with it — say so rather than
+  // reporting a confusing parse failure.
+  expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+  return JSON.parse(proc.stdout.toString().trim().split("\n").at(-1)!) as {
+    images: Record<string, string>;
+    configModalImage: string;
+  };
+};
+
+describe("imageForHarness — the documented variable names", () => {
+  it("resolves the LIVE hub exactly as it resolves today", () => {
+    // docs/DEPLOYMENT.md, verbatim: this is the deployment that must not move.
+    // It has never heard of ENABLE_MODAL_PROVISIONING — a distinction invisible
+    // to a test that passes `{ enabled: false }` by hand.
+    const { images } = resolveInChild(
+      {
+        ENABLE_DOCKER_PROVISIONING: "true",
+        ENABLE_CLOUDFLARE_SANDBOXES: "true",
+        CLOUDFLARE_SANDBOX_IMAGE: "agentpod-node-opencode:local",
+        NODE_AGENT_IMAGE: "agentpod-node:local",
+        NODE_AGENT_OPENCODE_IMAGE: "agentpod-node-opencode:local",
+        ENABLE_MODAL_PROVISIONING: null,
+      },
+      [
+        ["none", "docker"],
+        ["opencode", "docker"],
+        ["pi", "docker"],
+        ["none", "cloudflare"],
+        ["opencode", "cloudflare"],
+      ]
+    );
+    expect(images).toEqual({
+      "none@docker": "agentpod-node:local",
+      "opencode@docker": "agentpod-node-opencode:local",
+      "pi@docker": "agentpod-node-pi:local",
+      "none@cloudflare": "agentpod-node:local",
+      "opencode@cloudflare": "agentpod-node-opencode:local",
+    });
+  });
+
+  it("gives Modal the registry reference the operator set, and Docker its local tag", () => {
+    // The hub this task exists for: both substrates enabled, one harness, two
+    // references. NODE_AGENT_MODAL_IMAGE is the name config.ts validates at
+    // boot, so it is the name the resolver has to read — a resolver reading
+    // anything else boots clean and then hands Modal `agentpod-node:local`.
+    const { images, configModalImage } = resolveInChild(
+      {
+        ENABLE_DOCKER_PROVISIONING: "true",
+        ENABLE_MODAL_PROVISIONING: "true",
+        MODAL_TOKEN_ID: "ak-live-id",
+        MODAL_TOKEN_SECRET: "as-live-secret",
+        PROVISIONING_HUB_URL: "https://hub.example",
+        NODE_AGENT_IMAGE: "agentpod-node:local",
+        NODE_AGENT_OPENCODE_IMAGE: "agentpod-node-opencode:local",
+        NODE_AGENT_MODAL_IMAGE: "ghcr.io/example/agentpod-node-modal:v1",
+      },
+      [
+        ["none", "modal"],
+        ["opencode", "modal"],
+        ["none", "docker"],
+        ["opencode", "docker"],
+      ]
+    );
+    expect(images["none@modal"]).toBe("ghcr.io/example/agentpod-node-modal:v1");
+    expect(images["none@docker"]).toBe("agentpod-node:local");
+    expect(images["opencode@docker"]).toBe("agentpod-node-opencode:local");
+    // One variable, two readers: config.ts refuses to boot without it and the
+    // resolver hands it to the driver. If those two ever name different
+    // variables, the operator satisfies the boot check and Modal still gets a
+    // tag it cannot pull.
+    expect(configModalImage).toBe("ghcr.io/example/agentpod-node-modal:v1");
+    expect(images["none@modal"]).toBe(configModalImage);
+  });
+});

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -6,6 +6,11 @@
  *   destroy → driver.destroy → mark destroyed
  *   start / stop → driver.start/stop (guard on capability)
  *
+ * "start" is not one verb, though. On a substrate whose stop is terminal there
+ * is no start to call, and the honest restart is a create against the anchor
+ * that carries the workspace — so startRuntime branches on the driver's
+ * declared `stopSemantics` and reprovisionRuntime handles that half.
+ *
  * Status honesty: `online` means "a node for this runtime is connected" and is
  * written only by enrolment (enrollment.ts). Everything here can say at most
  * "the substrate accepted my request" — hence `provisioning` / `starting`, and
@@ -63,7 +68,7 @@ function imageForHarness(harness: string): string {
   return process.env.NODE_AGENT_IMAGE ?? "agentpod-node:local";
 }
 
-type RuntimeRow = typeof provisionedRuntimes.$inferSelect;
+export type RuntimeRow = typeof provisionedRuntimes.$inferSelect;
 
 function toContract(row: RuntimeRow): ProvisionedRuntime {
   return {
@@ -314,7 +319,141 @@ export async function destroyRuntime(userId: string, id: string): Promise<void> 
 }
 
 /**
- * Start (or wake) a runtime. Throws 400 if the driver has no start() support.
+ * The hub URL a provisioned container should dial.
+ *
+ * Request-scoped for createRuntime, which can take the origin of the call that
+ * asked for the runtime. A re-create cannot: it runs on a rotation timer with no
+ * request in sight, so there it has to come from configuration. Throwing here is
+ * the point — the alternative is a container handed a hub URL of "" or
+ * "localhost", which boots, fails to enrol, and reports nothing but a runtime
+ * that never came back.
+ */
+function provisioningHubUrl(): string {
+  const url = process.env.PROVISIONING_HUB_URL;
+  if (!url) {
+    throw Object.assign(
+      new Error(
+        "PROVISIONING_HUB_URL is not set, so a runtime cannot be re-created — " +
+          "the new container would have no hub to enrol against"
+      ),
+      { status: 502 }
+    );
+  }
+  return url;
+}
+
+/**
+ * Re-create a runtime's instance on a substrate whose stop is terminal.
+ *
+ * This is what "start" means when there is no start verb. Modal's terminate
+ * cannot be undone and every restart is a new sandbox with a new id and a fresh
+ * rootfs — so the thing that persists is the driver's anchor, and a driver
+ * anchors by `spec.runtimeId`. Provisioning again with the SAME runtimeId
+ * therefore re-attaches the same workspace. A fresh id would look like it
+ * worked: a new sandbox, a new Volume, an empty workspace, and the old Volume
+ * orphaned — still billed, still holding the only copy of the station's work.
+ *
+ * Three things happen alongside the create, and each is easy to forget:
+ *
+ *  - The old instance is terminated FIRST, best effort. Leaving it behind is a
+ *    sandbox nobody is watching and everybody is paying for, and two live
+ *    sandboxes on one Volume is the corruption case. Best effort, because the
+ *    old one is very often already gone (that is the 24h ceiling doing its job)
+ *    and refusing to create a replacement because the corpse would not die again
+ *    helps nobody — but a failure is recorded in statusReason, where the console
+ *    shows it, rather than left to a log nobody reads.
+ *  - A FRESH enrolment token is minted. The hub stores only a hash, so it cannot
+ *    re-present the original; a new runtime-bound token is durable by default
+ *    (RUNTIME_TOKEN_TTL_MS) and enrollNode resumes the existing node with a
+ *    rotated secret rather than orphaning it.
+ *  - `externalStartedAt` is rewritten. The new sandbox has its own ceiling, and
+ *    an instance clock left at the old value would have the rotation sweep find
+ *    a freshly created sandbox already expired and replace it again on the very
+ *    next tick, for ever.
+ *
+ * Leaves the runtime `starting` — never `online`. The substrate accepting a
+ * create is not a node existing, and sweepStalledRuntimeStarts walks it back to
+ * `error` if none arrives.
+ */
+export async function reprovisionRuntime(
+  row: RuntimeRow,
+  reason: string
+): Promise<void> {
+  const provisioner = getProvisionerUnguarded(row.provider);
+  if (!provisioner) {
+    throw Object.assign(new Error(`provider not available: ${row.provider}`), {
+      status: 502,
+    });
+  }
+
+  const hubUrl = provisioningHubUrl();
+
+  let terminateWarning: string | null = null;
+  if (row.externalId && provisioner.stop) {
+    try {
+      await provisioner.stop(row.externalId);
+    } catch (err) {
+      terminateWarning =
+        `the previous instance (${row.externalId}) could not be terminated: ` +
+        `${(err as Error).message} — check the substrate, it may still be billing`;
+      console.warn(`[runtimes] ${row.id}: ${terminateWarning}`);
+    }
+  }
+
+  const { token } = await mintEnrollmentToken(row.userId, {
+    provisionedRuntimeId: row.id,
+  });
+
+  try {
+    const { externalId, runtime } = await provisioner.provision({
+      runtimeId: row.id,
+      name: row.name,
+      resourceTier: row.resourceTier as "small" | "medium" | "large",
+      hubUrl,
+      enrollToken: token,
+      // One argument today; Task 12 makes image resolution provider-aware and
+      // updates this call and createRuntime's together.
+      image: imageForHarness(row.harness ?? "none"),
+    });
+
+    await db
+      .update(provisionedRuntimes)
+      .set({
+        externalId,
+        runtime: runtime ?? row.runtime ?? null,
+        externalStartedAt: new Date(),
+        status: "starting",
+        statusReason: terminateWarning ? `${reason}. ${terminateWarning}` : reason,
+        updatedAt: new Date(),
+      })
+      .where(eq(provisionedRuntimes.id, row.id));
+  } catch (err) {
+    // A re-create is a create, and a create can be refused. Leaving the row
+    // `starting` would hand the operator a spinner for something that has
+    // already failed, and the stalled-start sweeper would eventually blame the
+    // wrong thing ("no node enrolled") two minutes later.
+    await db
+      .update(provisionedRuntimes)
+      .set({
+        status: "error",
+        statusReason:
+          `the ${row.provider} driver failed to re-create it: ${(err as Error).message}` +
+          (terminateWarning ? `. ${terminateWarning}` : ""),
+        updatedAt: new Date(),
+      })
+      .where(eq(provisionedRuntimes.id, row.id));
+    throw Object.assign(err as Error, { status: 502 });
+  }
+}
+
+/**
+ * Start (or wake) a runtime.
+ *
+ * Two shapes, chosen by the driver's `stopSemantics`:
+ *   - `resumable` (docker, cloudflare) — start the instance that is already
+ *     there. Throws 400 if such a driver has no start() support.
+ *   - `terminal` (modal) — there is nothing to start, so this re-creates the
+ *     instance against the same anchor. See reprovisionRuntime.
  *
  * Leaves the runtime `starting`, never `online`: see the comment on the write.
  * A wake takes the same path, so an asleep runtime goes asleep → starting →
@@ -339,6 +478,24 @@ export async function startRuntime(userId: string, id: string): Promise<void> {
       { status: 502 }
     );
   }
+  // A driver whose stop is terminal has no start to call — Modal's terminate is
+  // irreversible — so a restart on such a substrate IS a create, against the
+  // anchor that carries the workspace. Manifest-driven rather than
+  // provider-specific: any future terminal substrate gets this for free, and the
+  // console's Start button needs no idea which kind it is talking to.
+  //
+  // The condition is the MANIFEST, not the missing method. A resumable driver
+  // that happens to lack start() keeps its 400: its instance survives a stop, so
+  // destroying it and building a replacement would throw away the disk the
+  // declaration promises. Conformance rule 3 now refuses such a driver outright.
+  if (provisioner.manifest.stopSemantics === "terminal") {
+    await reprovisionRuntime(
+      row,
+      "re-created: this substrate has no start, so a start is a new instance"
+    );
+    return;
+  }
+
   if (!provisioner.start) {
     throw Object.assign(
       new Error(`provider ${row.provider} does not support start`),

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -535,7 +535,11 @@ export async function startRuntime(userId: string, id: string): Promise<void> {
 export const START_TIMEOUT_MS = 2 * 60_000;
 
 const humanMs = (ms: number) =>
-  ms >= 60_000 ? `${Math.round(ms / 60_000)}m` : `${Math.round(ms / 1000)}s`;
+  ms >= 3_600_000
+    ? `${Math.round(ms / 3_600_000)}h`
+    : ms >= 60_000
+      ? `${Math.round(ms / 60_000)}m`
+      : `${Math.round(ms / 1000)}s`;
 
 /**
  * Expire runtimes that were asked to run and never came back.
@@ -860,6 +864,155 @@ export async function sweepStalledRuntimeStops(
   }
 
   return { stopped, failed };
+}
+
+/**
+ * How long before a substrate's ceiling a runtime is rotated.
+ *
+ * Long enough for a full re-create and re-enrolment (a node enrols within
+ * seconds of its container booting; START_TIMEOUT_MS allows two minutes) with
+ * room for the next 15s tick to retry if the first attempt is refused, and short
+ * enough that rotation stays a rare event rather than a routine tax on a
+ * runtime's life — every rotation is a fresh rootfs and a re-enrolment.
+ *
+ * A ceiling shorter than this margin does NOT mean "always rotate": see
+ * rotationMarginFor.
+ */
+export const ROTATION_MARGIN_MS = 30 * 60_000;
+
+/**
+ * The margin to apply to one substrate's ceiling.
+ *
+ * Straight subtraction breaks for any ceiling shorter than the margin: the
+ * threshold goes negative, every instance is born past due, and the sweeper
+ * re-creates it on every tick — a paid rotation loop with nobody in it. That is
+ * not hypothetical. The Modal driver takes a MODAL_MAX_LIFETIME_MS override
+ * whose stated purpose is verifying rotation in ten minutes rather than a day,
+ * and ten minutes is a third of this margin.
+ *
+ * So the margin never exceeds half the ceiling: a short-lived substrate rotates
+ * at the midpoint of its instance's life, which is the same shape of promise
+ * (replace it with time to spare) at a smaller scale.
+ */
+function rotationMarginFor(ceilingMs: number): number {
+  return Math.min(ROTATION_MARGIN_MS, ceilingMs / 2);
+}
+
+/**
+ * Rotate runtimes the substrate is about to destroy for age.
+ *
+ * The third sweep on the same tick, and the same idea one step further out:
+ * sweepStalledRuntimeStarts handles a runtime that never arrived,
+ * sweepStalledRuntimeStops one that would not leave, and this one a runtime the
+ * PLATFORM is about to kill while it is working perfectly.
+ *
+ * Modal is why it exists — a hard 24-hour sandbox lifetime, no warning
+ * callback, no way to extend it and no way back afterwards, so an unrotated
+ * Modal station simply dies once a day. Nothing here knows that, though: it is
+ * written against `manifest.maxLifetimeMs`, the same number the driver hands its
+ * substrate as the instance's own timeout, so a substrate with no ceiling is
+ * skipped entirely and one added tomorrow is covered without an edit here.
+ *
+ * Deliberately narrow. Each of these is a refusal to do something expensive:
+ *   - Only `online` and `starting`. A `stopped` or `asleep` runtime must NEVER
+ *     be rotated: re-creating one starts an instance nobody asked for that bills
+ *     wall-clock until a human notices, and age alone would always say it is
+ *     due, because a stopped runtime only gets older. `stopping` is an operator
+ *     mid-stop and `error`/`destroyed` already need a human; none of them is
+ *     improved by a new instance appearing on the meter.
+ *   - Only rows with an externalId and an externalStartedAt. Without the second
+ *     there is no age to judge, and both ways of guessing are wrong in the same
+ *     direction: created_at rotates every pre-existing row immediately, and
+ *     treating null as zero does too.
+ *   - AGE ONLY. The substrate is never asked whether the instance is alive. A
+ *     sandbox that died in its first minute will die the same way again, and
+ *     re-creating it would rebuild it every fifteen seconds, billing each
+ *     attempt, with nobody watching. The node going offline already surfaces
+ *     that, and Start is one click for the human who looks.
+ *   - Every write is a compare-and-set on the status that was read, so an
+ *     operator stopping a runtime mid-sweep wins, and two overlapping ticks
+ *     rotate once — two live instances on one anchor is the corruption case.
+ *
+ * @param now injectable clock for tests.
+ * @returns the ids actually rotated.
+ */
+export async function sweepExpiringRuntimes(
+  now: number = Date.now()
+): Promise<string[]> {
+  const live = await db
+    .select()
+    .from(provisionedRuntimes)
+    .where(
+      and(
+        inArray(provisionedRuntimes.status, ["online", "starting"]),
+        isNotNull(provisionedRuntimes.externalId),
+        isNotNull(provisionedRuntimes.externalStartedAt)
+      )
+    );
+
+  const rotated: string[] = [];
+
+  for (const row of live) {
+    const provisioner = getProvisionerUnguarded(row.provider);
+    const ceiling = provisioner?.manifest.maxLifetimeMs ?? null;
+    // No ceiling declared (docker, cloudflare), no registered driver to ask, or
+    // a nonsense zero: nothing here destroys an instance for age, so rotating
+    // one would throw away a working workspace to solve a problem that
+    // substrate does not have.
+    if (!ceiling || ceiling <= 0) continue;
+
+    const age = now - row.externalStartedAt!.getTime();
+    if (age < ceiling - rotationMarginFor(ceiling)) continue;
+
+    const reason =
+      `re-created before this substrate's ${humanMs(ceiling)} instance lifetime ` +
+      `ceiling destroyed it` +
+      (provisioner!.manifest.workspaceStorage === "rootfs"
+        ? " — the instance's disk does not survive, so check the workspace"
+        : " — the workspace is anchored outside the instance and carries over");
+
+    // Claim the row first, and claim it on the status we read. The status write
+    // IS the lock: a concurrent stop, or a second tick that overlaps this one,
+    // finds the row already moved and leaves it alone.
+    const claimed = await db
+      .update(provisionedRuntimes)
+      .set({ status: "provisioning", statusReason: reason, updatedAt: new Date(now) })
+      .where(
+        and(
+          eq(provisionedRuntimes.id, row.id),
+          eq(provisionedRuntimes.status, row.status)
+        )
+      )
+      .returning({ id: provisionedRuntimes.id });
+    if (claimed.length === 0) continue;
+
+    try {
+      await reprovisionRuntime(row, reason);
+      rotated.push(row.id);
+      console.log(
+        `[runtime-sweeper] ${row.id} rotated ahead of the ${humanMs(ceiling)} ${row.provider} ceiling`
+      );
+    } catch (err) {
+      // The platform is going to destroy this instance within the margin and the
+      // hub could not replace it. Leaving it `online` would be the console
+      // asserting health right up to the moment it vanishes.
+      await db
+        .update(provisionedRuntimes)
+        .set({
+          status: "error",
+          statusReason:
+            `could not re-create this runtime before its ${humanMs(ceiling)} ` +
+            `lifetime ceiling: ${(err as Error).message}`,
+          updatedAt: new Date(now),
+        })
+        .where(eq(provisionedRuntimes.id, row.id));
+      console.error(
+        `[runtime-sweeper] ${row.id} rotation failed: ${(err as Error).message}`
+      );
+    }
+  }
+
+  return rotated;
 }
 
 // Re-export for convenience (routes use this)

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -192,7 +192,22 @@ export async function createRuntime(
 
     await db
       .update(provisionedRuntimes)
-      .set({ externalId, runtime: runtime ?? null, updatedAt: new Date() })
+      .set({
+        externalId,
+        runtime: runtime ?? null,
+        // The instance clock starts where the instance does: the substrate has
+        // just accepted this one. It is set HERE, beside the externalId, and
+        // not at insert time, because until provision() resolves there is no
+        // instance to date — a failed provision must leave this null.
+        //
+        // Every later write of externalId has to set this too. A substrate that
+        // replaces the instance (Modal terminates a sandbox at its 24h ceiling
+        // and the hub re-creates against the same volume) would otherwise keep
+        // the age of the instance it replaced, and be rotated again on the very
+        // next sweep — for ever.
+        externalStartedAt: new Date(),
+        updatedAt: new Date(),
+      })
       .where(eq(provisionedRuntimes.id, id));
 
     const [row] = await db

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -49,23 +49,48 @@ const prefixedId = (prefix: string) =>
   `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
 
 /**
- * Resolve the container image for a given harness.
- * Image resolution lives in the service layer so drivers are image-agnostic —
- * they receive the resolved image via ProvisionSpec.image.
+ * Resolve the container image for a harness on a given provider.
  *
- * Env overrides allow operators to pin specific image tags per harness:
- *   NODE_AGENT_OPENCODE_IMAGE — opencode harness (default: agentpod-node-opencode:local)
- *   NODE_AGENT_PI_IMAGE       — pi harness      (default: agentpod-node-pi:local)
- *   NODE_AGENT_IMAGE          — generic / no harness (default: agentpod-node:local)
+ * Image resolution lives in the service layer so drivers stay image-agnostic —
+ * they always receive the resolved image via ProvisionSpec.image and never read
+ * env themselves.
+ *
+ * It is provider-scoped because two enabled substrates need different
+ * references for the same harness: Docker runs `agentpod-node-opencode:local`
+ * from the host daemon, while Modal pulls from a registry and runs linux/amd64
+ * only. One variable cannot serve both, and the failure mode when it tries is
+ * silent — a sandbox that never boots, a runtime stuck in `provisioning`, and a
+ * sweeper message two minutes later that names nothing.
+ *
+ * Resolution order, first non-empty hit wins:
+ *   NODE_AGENT_<PROVIDER>_<HARNESS>_IMAGE   e.g. NODE_AGENT_MODAL_OPENCODE_IMAGE
+ *   NODE_AGENT_<HARNESS>_IMAGE              e.g. NODE_AGENT_OPENCODE_IMAGE
+ *   the built-in local default
+ *
+ * With no provider-scoped variable set, this resolves exactly what it resolved
+ * before — Docker and Cloudflare are unchanged, which is checked against the
+ * documented variable names in runtimes-image.test.ts.
+ *
+ * The provider-scoped name is not free-form: `NODE_AGENT_MODAL_IMAGE` is the
+ * same variable `config.ts` reads and `validate-config.ts` refuses to boot
+ * without. The two must stay in step, or an operator satisfies the boot check
+ * and Modal is still handed a tag it cannot pull.
  */
-function imageForHarness(harness: string): string {
-  if (harness === "opencode") {
-    return process.env.NODE_AGENT_OPENCODE_IMAGE ?? "agentpod-node-opencode:local";
-  }
-  if (harness === "pi") {
-    return process.env.NODE_AGENT_PI_IMAGE ?? "agentpod-node-pi:local";
-  }
-  return process.env.NODE_AGENT_IMAGE ?? "agentpod-node:local";
+export function imageForHarness(harness: string, provider: string): string {
+  const suffix = harness === "opencode" ? "_OPENCODE" : harness === "pi" ? "_PI" : "";
+  const scope = provider.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+  const fallback =
+    suffix === "_OPENCODE"
+      ? "agentpod-node-opencode:local"
+      : suffix === "_PI"
+        ? "agentpod-node-pi:local"
+        : "agentpod-node:local";
+
+  return (
+    process.env[`NODE_AGENT_${scope}${suffix}_IMAGE`] ||
+    process.env[`NODE_AGENT${suffix}_IMAGE`] ||
+    fallback
+  );
 }
 
 export type RuntimeRow = typeof provisionedRuntimes.$inferSelect;
@@ -192,7 +217,7 @@ export async function createRuntime(
       resourceTier: (req.resourceTier ?? "small") as "small" | "medium" | "large",
       hubUrl,
       enrollToken,
-      image: imageForHarness(harness),
+      image: imageForHarness(harness, provider),
     });
 
     await db
@@ -411,9 +436,10 @@ export async function reprovisionRuntime(
       resourceTier: row.resourceTier as "small" | "medium" | "large",
       hubUrl,
       enrollToken: token,
-      // One argument today; Task 12 makes image resolution provider-aware and
-      // updates this call and createRuntime's together.
-      image: imageForHarness(row.harness ?? "none"),
+      // Provider-scoped: a re-provision is the path a rotating substrate takes
+      // every 24 hours, so it must resolve the same reference the original
+      // create did — and Modal's reference is not Docker's.
+      image: imageForHarness(row.harness ?? "none", row.provider),
     });
 
     await db

--- a/apps/hub/src/utils/validate-config.test.ts
+++ b/apps/hub/src/utils/validate-config.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect } from "bun:test";
 import { collectConfigErrors } from "./validate-config";
 import { config } from "../config";
+import { join } from "node:path";
 
 /** Swallow the dev-secret warnings the default config legitimately emits. */
 const quiet = () => {};
@@ -56,5 +57,226 @@ describe("validateConfig — CLOUDFLARE_SANDBOX_IMAGE", () => {
         withCloudflare({ enabled: false, sandboxImage: "" }) as typeof config
       )
     ).toHaveLength(0);
+  });
+});
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+/**
+ * Modal is the first substrate the hub can misconfigure into silence rather
+ * than into an error. A missing token fails loudly on the first call; a missing
+ * or local IMAGE does not — Modal pulls from a registry, so `agentpod-node:local`
+ * produces a sandbox that never boots, a runtime that sits in `provisioning`,
+ * and a sweeper message two minutes later that names nothing. And an unset
+ * PROVISIONING_HUB_URL breaks nothing until the first 24-hour rotation, a day
+ * after anyone was watching.
+ *
+ * All four are therefore boot refusals, and all four are conditional on the
+ * provider being enabled: the live hub runs `docker, cloudflare` and must keep
+ * booting untouched.
+ */
+
+const withModal = (
+  over: Partial<typeof config.modal>,
+  provisioningHubUrl = "https://hub.example"
+) =>
+  ({
+    ...config,
+    modal: { ...config.modal, ...over },
+    provisioningHubUrl,
+  }) as typeof config;
+
+const fieldsFor = (cfg: typeof config) =>
+  collectConfigErrors(cfg, quiet).map((e) => e.field);
+
+const messageFor = (cfg: typeof config, field: string) =>
+  collectConfigErrors(cfg, quiet).find((e) => e.field === field)?.message ?? "";
+
+const CONFIGURED = {
+  enabled: true,
+  tokenId: "tok-id",
+  tokenSecret: "tok-secret",
+  image: "ghcr.io/example/agentpod-node-modal:v1",
+} as const;
+
+describe("validateConfig — modal", () => {
+  it("accepts a fully configured Modal hub", () => {
+    const fields = fieldsFor(withModal(CONFIGURED));
+    expect(fields).not.toContain("MODAL_TOKEN_ID");
+    expect(fields).not.toContain("MODAL_TOKEN_SECRET");
+    expect(fields).not.toContain("NODE_AGENT_MODAL_IMAGE");
+    expect(fields).not.toContain("PROVISIONING_HUB_URL");
+  });
+
+  it("requires both tokens, reported together", () => {
+    const fields = fieldsFor(
+      withModal({ ...CONFIGURED, tokenId: "", tokenSecret: "" })
+    );
+    expect(fields).toContain("MODAL_TOKEN_ID");
+    expect(fields).toContain("MODAL_TOKEN_SECRET");
+  });
+
+  it("reports each half of the pair on its own", () => {
+    // The interesting deploy is half-configured, not empty. Reporting the pair
+    // as one error would send an operator to re-check a variable that was
+    // already right; reporting neither until both are missing is worse.
+    const idOnly = fieldsFor(withModal({ ...CONFIGURED, tokenSecret: "" }));
+    expect(idOnly).toContain("MODAL_TOKEN_SECRET");
+    expect(idOnly).not.toContain("MODAL_TOKEN_ID");
+
+    const secretOnly = fieldsFor(withModal({ ...CONFIGURED, tokenId: "" }));
+    expect(secretOnly).toContain("MODAL_TOKEN_ID");
+    expect(secretOnly).not.toContain("MODAL_TOKEN_SECRET");
+  });
+
+  it("names the flag that made each variable required", () => {
+    // The whole value of a boot refusal over a stack trace is that it tells an
+    // operator which switch put them here.
+    const fields = ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET", "NODE_AGENT_MODAL_IMAGE"];
+    const broken = withModal({ enabled: true, tokenId: "", tokenSecret: "", image: "" });
+    for (const field of fields) {
+      expect(messageFor(broken, field)).toMatch(/ENABLE_MODAL_PROVISIONING/);
+    }
+  });
+
+  it("requires a registry image Modal can actually pull", () => {
+    // The Docker-first default is `agentpod-node:local`, which Modal cannot
+    // pull. Unset or local, the runtime provisions "successfully" and then
+    // never produces a node — a two-minute wait ending in a sweeper message
+    // that names nothing.
+    expect(fieldsFor(withModal({ ...CONFIGURED, image: "" }))).toContain(
+      "NODE_AGENT_MODAL_IMAGE"
+    );
+    expect(
+      fieldsFor(withModal({ ...CONFIGURED, image: "agentpod-node:local" }))
+    ).toContain("NODE_AGENT_MODAL_IMAGE");
+  });
+
+  it("requires PROVISIONING_HUB_URL, because rotation runs without a request", () => {
+    // A rotating substrate re-creates instances on a timer. With no request to
+    // take an origin from, an unset value would turn every 24h rotation into an
+    // error — a day after anyone was watching.
+    expect(fieldsFor(withModal(CONFIGURED, ""))).toContain("PROVISIONING_HUB_URL");
+  });
+
+  it("leaves a hub with Modal disabled alone", () => {
+    // Conditional for the same reason as the Cloudflare rule above: a hub that
+    // never registers this driver must not need its variables to boot.
+    const fields = fieldsFor(
+      withModal({ enabled: false, tokenId: "", tokenSecret: "", image: "" }, "")
+    );
+    expect(fields).not.toContain("MODAL_TOKEN_ID");
+    expect(fields).not.toContain("MODAL_TOKEN_SECRET");
+    expect(fields).not.toContain("NODE_AGENT_MODAL_IMAGE");
+    expect(fields).not.toContain("PROVISIONING_HUB_URL");
+  });
+
+  // ── The rules above are exercised against a hand-built config object, which
+  // never runs config.ts's env parsing. That leaves the VARIABLE NAMES untested
+  // — an operator can set every documented variable correctly and still be
+  // refused, and no object-level test can see it. These two load config in a
+  // CHILD PROCESS with a controlled environment, which is the only way to
+  // observe module-scope env parsing from a suite that shares one module
+  // registry.
+
+  /** Real config, loaded fresh under `overrides` (a `null` value unsets). */
+  const collectInChild = (overrides: Record<string, string | null>) => {
+    const hubRoot = join(import.meta.dir, "..", "..");
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) env[key] = value;
+    }
+    // Every Modal variable starts UNSET, so a test that wants one says so.
+    for (const key of [
+      "ENABLE_MODAL_PROVISIONING",
+      "MODAL_TOKEN_ID",
+      "MODAL_TOKEN_SECRET",
+      "MODAL_APP_NAME",
+      "NODE_AGENT_MODAL_IMAGE",
+      "NODE_AGENT_IMAGE",
+      "PROVISIONING_HUB_URL",
+    ]) {
+      delete env[key];
+    }
+    env.NODE_ENV = "development";
+    // Set because the built-in default is 33 characters and therefore always an
+    // error — a pre-existing quirk unrelated to Modal, and the only thing
+    // standing between these hubs and a clean boot.
+    env.ENCRYPTION_KEY = "k7Qm2xR9tP4wL6vB8nZ3sJ5hD1yF0gC-";
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value === null) delete env[key];
+      else env[key] = value;
+    }
+
+    const script = `
+      const { collectConfigErrors } = await import(${JSON.stringify(
+        join(hubRoot, "src", "utils", "validate-config.ts")
+      )});
+      const { config } = await import(${JSON.stringify(
+        join(hubRoot, "src", "config.ts")
+      )});
+      console.log(JSON.stringify({
+        modal: config.modal,
+        provisioningHubUrl: config.provisioningHubUrl,
+        fields: collectConfigErrors(undefined, () => {}).map((e) => e.field),
+      }));
+    `;
+    const proc = Bun.spawnSync(["bun", "-e", script], {
+      cwd: hubRoot,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // A child that died took the assertion with it — say so rather than
+    // reporting a confusing parse failure.
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+    return JSON.parse(proc.stdout.toString().trim().split("\n").at(-1)!) as {
+      modal: { enabled: boolean; tokenId: string; tokenSecret: string; image: string; appName: string };
+      provisioningHubUrl: string;
+      fields: string[];
+    };
+  };
+
+  it("boots the live hub's shape — docker + cloudflare, ENABLE_MODAL_PROVISIONING UNSET", () => {
+    // The deployment this must not break does not set the flag to "false"; it
+    // has never heard of it. That distinction is invisible to a test that
+    // hand-builds `{ enabled: false }`.
+    const result = collectInChild({
+      ENABLE_DOCKER_PROVISIONING: "true",
+      ENABLE_CLOUDFLARE_SANDBOXES: "true",
+      CLOUDFLARE_SANDBOX_IMAGE: "agentpod-node-opencode:local",
+      ENABLE_MODAL_PROVISIONING: null,
+    });
+    expect(result.modal.enabled).toBe(false);
+    expect(result.fields).not.toContain("MODAL_TOKEN_ID");
+    expect(result.fields).not.toContain("MODAL_TOKEN_SECRET");
+    expect(result.fields).not.toContain("NODE_AGENT_MODAL_IMAGE");
+    expect(result.fields).not.toContain("PROVISIONING_HUB_URL");
+    // And nothing else refuses either: this hub boots.
+    expect(result.fields).toEqual([]);
+  });
+
+  it("boots a Modal hub configured with the documented variable names", () => {
+    // This is the test that catches a config.ts reading the wrong env var —
+    // e.g. taking the image from Docker's NODE_AGENT_IMAGE. Every rule above
+    // would still pass, and an operator who set exactly what DEPLOYMENT.md says
+    // would be refused at boot with a message naming a variable they had set.
+    const result = collectInChild({
+      ENABLE_MODAL_PROVISIONING: "true",
+      MODAL_TOKEN_ID: "ak-live-id",
+      MODAL_TOKEN_SECRET: "as-live-secret",
+      NODE_AGENT_MODAL_IMAGE: "ghcr.io/example/agentpod-node-modal:v1",
+      MODAL_APP_NAME: "agentpod-prod",
+      PROVISIONING_HUB_URL: "https://hub.example",
+    });
+    expect(result.modal).toEqual({
+      enabled: true,
+      tokenId: "ak-live-id",
+      tokenSecret: "as-live-secret",
+      image: "ghcr.io/example/agentpod-node-modal:v1",
+      appName: "agentpod-prod",
+    });
+    expect(result.provisioningHubUrl).toBe("https://hub.example");
+    expect(result.fields).toEqual([]);
   });
 });

--- a/apps/hub/src/utils/validate-config.ts
+++ b/apps/hub/src/utils/validate-config.ts
@@ -135,6 +135,62 @@ export function collectConfigErrors(
     });
   }
 
+  // Conditional for the same reason as the Cloudflare rule above: a hub that
+  // never talks to Modal must not be stopped from booting by Modal's variables.
+  // The live hub runs `docker, cloudflare` and has never heard of
+  // ENABLE_MODAL_PROVISIONING; unset must stay indistinguishable from off.
+  //
+  // Why refuse to boot at all, when two of these already fail elsewhere? The
+  // death is not new — createModalApi() calls requireCredentials() during
+  // registration, so a hub with the flag on and no tokens already dies at
+  // startup, just with an uncaught stack trace instead of a sentence naming the
+  // variable. validateConfig() runs first (src/index.ts) and swaps one for the
+  // other. The other two variables are why this is more than cosmetic:
+  // NODE_AGENT_MODAL_IMAGE and PROVISIONING_HUB_URL do not fail at boot at all.
+  // They fail silently, later, on somebody else's runtime.
+  if (cfg.modal.enabled) {
+    if (!cfg.modal.tokenId) {
+      errors.push({
+        field: "MODAL_TOKEN_ID",
+        message:
+          "Required when ENABLE_MODAL_PROVISIONING=true. Create it in the Modal " +
+          "dashboard. Note: on Modal's Starter plan a token is WORKSPACE-WIDE — " +
+          "per-resource scoping needs the $250/mo Team plan — so use a workspace " +
+          "dedicated to AgentPod.",
+      });
+    }
+    // Reported separately from the id, not as one "credentials are missing"
+    // error: half-configured is the deploy an operator actually produces, and a
+    // combined message would send them to re-check the half that was right.
+    if (!cfg.modal.tokenSecret) {
+      errors.push({
+        field: "MODAL_TOKEN_SECRET",
+        message:
+          "Required when ENABLE_MODAL_PROVISIONING=true, alongside MODAL_TOKEN_ID.",
+      });
+    }
+    if (!cfg.modal.image || !cfg.modal.image.includes("/")) {
+      errors.push({
+        field: "NODE_AGENT_MODAL_IMAGE",
+        message:
+          "Required when ENABLE_MODAL_PROVISIONING=true, and it must be a registry " +
+          "reference Modal can pull (linux/amd64, carrying python and pip). The " +
+          "Docker default `agentpod-node:local` is meaningless to Modal: the sandbox " +
+          "never boots and the runtime sits in `provisioning` until it is expired. " +
+          "See docs/DEPLOYMENT.md.",
+      });
+    }
+    if (!cfg.provisioningHubUrl) {
+      errors.push({
+        field: "PROVISIONING_HUB_URL",
+        message:
+          "Required when ENABLE_MODAL_PROVISIONING=true: Modal destroys a sandbox at " +
+          "24 hours, so the hub re-creates it on a timer with no request to take an " +
+          "origin from. Unset, every rotation fails a day after anyone was watching.",
+      });
+    }
+  }
+
   return errors;
 }
 

--- a/apps/node-agent/deploy/Dockerfile.modal
+++ b/apps/node-agent/deploy/Dockerfile.modal
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1
+
+# node-agent image for the Modal provisioner.
+#
+# Three things Modal requires that our other images do not provide, each fatal
+# on its own:
+#
+#   1. python3 and pip must be present in the image. Modal's runtime is Python
+#      and the driver pulls the image with `images.fromRegistry(tag)` and
+#      nothing else (apps/hub/src/services/provisioner/modal-api.ts) — it does
+#      NOT ask Modal to inject a standalone python, so the image must carry one.
+#      An image without it does not boot, and the failure surfaces only as a
+#      sandbox that never enrols.
+#   2. Any ENTRYPOINT must end in `exec "$@"` so Modal's runtime can take over
+#      the container's command. Ours never can: /node-entrypoint.sh enrols and
+#      then execs its own run loop, ignoring "$@" entirely. Dockerfile.base sets
+#      no ENTRYPOINT (each harness layer picks its own), so there is nothing to
+#      undo here — the explicit clear below is a guard against a future base
+#      acquiring one, since the failure it would cause is silent. The driver
+#      passes /modal-entrypoint.sh as the sandbox COMMAND instead
+#      (MODAL_ENTRYPOINT in apps/hub/src/services/provisioner/modal.ts).
+#   3. linux/amd64 only. Build with --platform. On an Apple Silicon machine the
+#      default build is arm64, Modal rejects it, and the build runs under
+#      emulation — slow, and worth waiting for rather than working around.
+#
+# BUILD. Both stages must be amd64, including the base: `FROM agentpod-node:base`
+# resolves from the local image store, and a base built for the host's arm64
+# fails the build (or, worse on a mixed store, silently supplies the wrong
+# architecture). BASE_IMAGE exists so an Apple Silicon dev can build an amd64
+# base under its own tag instead of clobbering the arm64 `agentpod-node:base`
+# that the Docker provisioner runs locally:
+#
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.base \
+#     -t agentpod-node:base-amd64 --load apps/node-agent
+#   docker buildx build --platform linux/amd64 \
+#     --build-arg BASE_IMAGE=agentpod-node:base-amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.modal \
+#     -t agentpod-node-modal:local --load apps/node-agent
+#
+# On an amd64 host the default BASE_IMAGE is right and only --platform matters.
+#
+# PUSH (the tag becomes NODE_AGENT_MODAL_IMAGE):
+#
+#   docker buildx build --platform linux/amd64 \
+#     --build-arg BASE_IMAGE=agentpod-node:base-amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.modal \
+#     -t ghcr.io/<owner>/agentpod-node-modal:<version> --push apps/node-agent
+#
+# The repository must be PUBLIC: `createModalApi` calls
+# `images.fromRegistry(tag)` with no Secret, so Modal cannot authenticate to a
+# private registry. Extend the adapter first if that changes.
+#
+# There is no CI pipeline for this image, as for none of the images here — they
+# are hand-built and pushed. Don't infer one from the tag.
+ARG BASE_IMAGE=agentpod-node:base
+FROM ${BASE_IMAGE}
+
+# python3-pip rather than just python3: Modal expects pip present, and on Debian
+# trixie pip is a separate package. It is externally managed (PEP 668), so
+# anything installing into it needs a venv or --break-system-packages; that is a
+# property of the distro, not of this image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# The sandbox's main process. A wrapper: it anchors the workspace and node
+# identity and then execs the fleet's own /node-entrypoint.sh, so enrol-then-run
+# keeps a single definition. See the script for what "anchors" means and why
+# each part is not merely assumed.
+COPY deploy/modal-entrypoint.sh /modal-entrypoint.sh
+RUN chmod +x /modal-entrypoint.sh
+
+# test-modal-entrypoint.sh is deliberately NOT copied in — a production image
+# should not ship its own test. It runs against the built image by bind mount:
+#
+#   mkdir -p /tmp/fake-volume
+#   docker run --rm --platform linux/amd64 \
+#     -v "$PWD/apps/node-agent/deploy":/t -v /tmp/fake-volume:/workspace \
+#     --entrypoint sh agentpod-node-modal:local /t/test-modal-entrypoint.sh
+#
+# The bind mount stands in for the Modal Volume, which is why the test can check
+# the mount-evidence branch as well as the missing-workspace one.
+
+# The mount point for the runtime's Modal Volume, created so the path exists
+# even in a sandbox started without one — the wrapper then reports that the
+# workspace is not a real mount instead of dying on a missing directory.
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Cleared on purpose: see (2) above. The driver supplies the command.
+ENTRYPOINT []

--- a/apps/node-agent/deploy/modal-entrypoint.sh
+++ b/apps/node-agent/deploy/modal-entrypoint.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# The sandbox's main process on Modal.
+#
+# Passed as the sandbox COMMAND, not baked as an image ENTRYPOINT: Modal
+# requires any ENTRYPOINT to end in `exec "$@"` so its runtime can take over the
+# container's command, and the fleet's entrypoint does not — it enrols and then
+# execs its own run loop, ignoring "$@" entirely. Dockerfile.modal therefore
+# ships no ENTRYPOINT and the driver passes ["/modal-entrypoint.sh"] as the
+# command (MODAL_ENTRYPOINT in apps/hub/src/services/provisioner/modal.ts).
+#
+# THIS IS A WRAPPER, NOT A REPLACEMENT. With no arguments it anchors the
+# sandbox and then execs the fleet's own /node-entrypoint.sh, byte-for-byte the
+# script every other node-agent image runs, so the enrol-then-run sequence has
+# exactly one definition and nothing to drift. Arguments override the inner
+# command, which is what makes the wrapper testable without a hub
+# (test-modal-entrypoint.sh) and what lets an operator boot an anchored shell.
+#
+# WHAT NEEDS ANCHORING HERE, and why each one is not simply assumed:
+#
+#   /workspace  — the Modal Volume the driver mounts (mountPath in modal.ts).
+#                 It is the ONLY thing that outlives a sandbox: `terminate` is
+#                 irreversible, the platform destroys every sandbox at 24 hours,
+#                 and the hub rotates them before it does. Anything written
+#                 elsewhere is written in sand. Unlike the Fly image this needs
+#                 no symlink — Modal mounts the Volume AT the hardcoded path
+#                 (/workspace is fixed in internal/descriptor/opencode.go), so
+#                 the workspace is a real directory here and the node-agent's
+#                 filepath.WalkDir disk-usage probe reports a true size rather
+#                 than the near-zero a symlinked workspace reports on Fly.
+#
+#   HOME        — must stay OFF the Volume. The node-agent writes its node id
+#                 and node secret to os.UserConfigDir()/agentpod-node/config.json
+#                 with no env override (internal/config/config.go), and
+#                 os.UserConfigDir() is $XDG_CONFIG_HOME, else $HOME/.config,
+#                 else an ERROR that DefaultPath() discards — leaving the
+#                 RELATIVE path "agentpod-node/config.json", which resolves
+#                 against the working directory. The working directory here is
+#                 the Volume. So a sandbox launched with no HOME would write a
+#                 live node secret into shared, long-lived storage that outlives
+#                 every sandbox and that nothing in this system protects. That is
+#                 the opposite of the design (see modal.ts: HOME stays on the
+#                 disposable rootfs so each sandbox re-enrols with a freshly
+#                 minted runtime-bound token), and it would happen silently.
+#                 Whether Modal populates HOME is not something we get to assume,
+#                 so this pins it.
+set -e
+
+# Overridable so the tests can stand a temporary directory in for the Volume;
+# the driver never sets it, and the default is the path the driver mounts.
+WORKSPACE="${AGENTPOD_WORKSPACE_PATH:-/workspace}"
+
+# Where node identity is allowed to live: the rootfs, which dies with the
+# sandbox. Not a Volume path, on purpose. See the HOME note above.
+ROOTFS_HOME="/root"
+
+# ── The workspace must be there before anything is written into it ───────────
+# Refusing here rather than pressing on: a sandbox that enrols and serves a
+# station whose workspace is not the Volume looks exactly like a working station
+# right up to the moment the 24-hour ceiling takes the user's work. A container
+# that exits with a legible log leaves the runtime visibly stuck in
+# `provisioning` instead, which the hub's stalled-start sweeper reports.
+if [ ! -d "$WORKSPACE" ]; then
+  echo "[modal] FATAL: $WORKSPACE is missing or is not a directory." >&2
+  echo "[modal] It is where the driver mounts the runtime's Modal Volume, and" >&2
+  echo "[modal] the Volume is the only storage that survives a sandbox." >&2
+  exit 1
+fi
+
+if [ ! -w "$WORKSPACE" ]; then
+  echo "[modal] FATAL: $WORKSPACE is not writable." >&2
+  echo "[modal] The workspace Volume must be writable by the node-agent." >&2
+  exit 1
+fi
+
+# ── Mount evidence, reported and NOT enforced ────────────────────────────────
+# A mounted Volume is a different filesystem from the rootfs, so its device id
+# differs. Deliberately a warning rather than a refusal: on Modal the Volume is
+# mounted as part of sandbox creation, so a sandbox that exists at all was
+# created with its mount (a mount failure fails the create, and the driver
+# surfaces that) — the Fly case, where a machine boots happily without the mount
+# it was configured with, does not arise the same way. And the probe itself is
+# unverified against Modal's gVisor runtime, so enforcing it would risk refusing
+# to boot every sandbox on an assumption. A line in the log costs nothing and
+# tells live verification which it is.
+WORKSPACE_DEV="$(stat -c %d "$WORKSPACE" 2>/dev/null || echo unknown)"
+ROOTFS_DEV="$(stat -c %d / 2>/dev/null || echo unknown)"
+if [ "$WORKSPACE_DEV" = "$ROOTFS_DEV" ]; then
+  echo "[modal] WARNING: $WORKSPACE does not look like a mounted Volume — it is" >&2
+  echo "[modal] on the same filesystem as the rootfs. Work written there is lost" >&2
+  echo "[modal] when this sandbox is destroyed, which the platform does within" >&2
+  echo "[modal] 24 hours." >&2
+else
+  echo "[modal] workspace $WORKSPACE is a separate filesystem from the rootfs"
+fi
+
+# ── Node identity stays on the disposable rootfs ─────────────────────────────
+if [ -z "${HOME:-}" ]; then
+  # Without this the node-agent's config path is relative and lands in the
+  # Volume — a node secret in shared storage. See the HOME note above.
+  HOME="$ROOTFS_HOME"
+  echo "[modal] HOME was unset; pinned to $ROOTFS_HOME so node credentials stay" >&2
+  echo "[modal] on the sandbox rootfs rather than in the shared Volume." >&2
+else
+  case "$HOME" in
+    "$WORKSPACE" | "$WORKSPACE"/*)
+      echo "[modal] HOME=$HOME is inside the Volume; pinned to $ROOTFS_HOME." >&2
+      echo "[modal] The node id and node secret must not be written to storage" >&2
+      echo "[modal] that outlives the sandbox holding them." >&2
+      HOME="$ROOTFS_HOME"
+      ;;
+  esac
+fi
+export HOME
+mkdir -p "$HOME"
+
+cd "$WORKSPACE"
+
+# No arguments is the production case: the driver passes only this script, and
+# the fleet's own entrypoint (enrol, then exec the run loop) takes it from here.
+if [ "$#" -eq 0 ]; then
+  set -- /node-entrypoint.sh
+fi
+
+exec "$@"

--- a/apps/node-agent/deploy/test-modal-entrypoint.sh
+++ b/apps/node-agent/deploy/test-modal-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+# Tests for modal-entrypoint.sh.
+#
+# POSIX sh with no framework, because it has to run INSIDE the built image —
+# /workspace is an absolute path and a dev laptop's / is not writable, so the
+# only place the real path can be exercised is a container:
+#
+#   docker run --rm --platform linux/amd64 \
+#     -v "$PWD/apps/node-agent/deploy":/t -v /tmp/fake-volume:/workspace \
+#     --entrypoint sh agentpod-node-modal:local /t/test-modal-entrypoint.sh
+#
+# The bind mount at /workspace stands in for the Modal Volume: it is a real
+# mount on a different filesystem, which is what the mount-evidence check reads.
+# The script resolves the wrapper relative to itself, so mount the directory.
+#
+# Exits non-zero on the first failure, and reports how many tests actually ran —
+# a suite that skipped everything must not read as a pass.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$HERE/modal-entrypoint.sh"
+FAILURES=0
+RAN=0
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+  RAN=$((RAN + 1))
+}
+
+pass() {
+  echo "ok: $1"
+  RAN=$((RAN + 1))
+}
+
+check() {
+  # check <description> <haystack> <needle>
+  if printf '%s' "$2" | grep -q "$3"; then
+    pass "$1"
+  else
+    fail "$1 — expected to find '$3' in: $2"
+  fi
+}
+
+# Every run below where the wrapper is EXPECTED to succeed ends in `|| true`.
+# Without it `set -e` turns a non-zero wrapper inside an assignment into a
+# silent abort of the whole suite: non-zero overall, but with no named failure
+# and every later check skipped. What the wrapper did is asserted from its
+# output, so swallowing the status there costs nothing — the runs that are
+# expected to FAIL are checked with `if ... ; then fail`, which keeps the status.
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# An inner command that reports everything the wrapper is supposed to have set.
+cat >"$TMP/inner.sh" <<'INNER'
+#!/bin/sh
+echo "HOME=$HOME"
+echo "PWD=$(pwd -P)"
+echo "ARGS=$*"
+INNER
+chmod +x "$TMP/inner.sh"
+
+# ── It refuses when the workspace is not there ───────────────────────────────
+# A sandbox whose Volume is not where the driver mounts it would serve a station
+# backed by the rootfs, and the platform destroys the rootfs within 24 hours.
+# Looking healthy until the user's work disappears is the worst available
+# failure; exiting with a legible log is the best.
+if AGENTPOD_WORKSPACE_PATH="$TMP/not-mounted" sh "$WRAPPER" "$TMP/inner.sh" \
+  >"$TMP/out" 2>"$TMP/err"; then
+  fail "ran with no workspace directory at all"
+else
+  check "refuses when the workspace directory is missing, and says why" \
+    "$(cat "$TMP/err")" "is missing or is not a directory"
+fi
+
+# ── A file where the directory should be is the same refusal ─────────────────
+: >"$TMP/workspace-is-a-file"
+if AGENTPOD_WORKSPACE_PATH="$TMP/workspace-is-a-file" sh "$WRAPPER" "$TMP/inner.sh" \
+  >"$TMP/out" 2>"$TMP/err"; then
+  fail "ran with a file where the workspace directory should be"
+else
+  check "refuses when the workspace path is not a directory" \
+    "$(cat "$TMP/err")" "is missing or is not a directory"
+fi
+
+# ── It refuses a workspace it cannot write ───────────────────────────────────
+# Needs a user who is not root, since root writes through permission bits.
+mkdir -p "$TMP/unwritable"
+chmod 500 "$TMP/unwritable"
+chmod 755 "$TMP"
+if [ "$(id -u)" = "0" ] && command -v su >/dev/null 2>&1 &&
+  su nobody -s /bin/sh -c 'true' >/dev/null 2>&1; then
+  if su nobody -s /bin/sh -c \
+    "AGENTPOD_WORKSPACE_PATH='$TMP/unwritable' sh '$WRAPPER' '$TMP/inner.sh'" \
+    >"$TMP/out" 2>"$TMP/err"; then
+    fail "ran with an unwritable workspace"
+  else
+    check "refuses an unwritable workspace, and says why" \
+      "$(cat "$TMP/err")" "is not writable"
+  fi
+else
+  echo "SKIP: cannot drop privileges here, unwritable-workspace case not covered"
+fi
+chmod 700 "$TMP/unwritable"
+
+# ── It warns when the workspace is not on its own filesystem ─────────────────
+# The mount-evidence line, which live verification reads out of the sandbox log.
+mkdir -p "$TMP/same-fs"
+OUT="$(AGENTPOD_WORKSPACE_PATH="$TMP/same-fs" sh "$WRAPPER" "$TMP/inner.sh" 2>&1 || true)"
+check "warns when the workspace shares the rootfs filesystem" \
+  "$OUT" "does not look like a mounted Volume"
+
+# ── It runs the inner command in the workspace ───────────────────────────────
+mkdir -p "$TMP/mount"
+OUT="$(AGENTPOD_WORKSPACE_PATH="$TMP/mount" sh "$WRAPPER" "$TMP/inner.sh" hello there 2>/dev/null || true)"
+check "runs the inner command with the workspace as its working directory" \
+  "$OUT" "PWD=$(cd "$TMP/mount" && pwd -P)$"
+check "passes the inner command its arguments" "$OUT" "ARGS=hello there$"
+
+# ── HOME never lands on the Volume ───────────────────────────────────────────
+# os.UserConfigDir() with no HOME returns an error the node-agent discards,
+# leaving a RELATIVE config path that resolves against the working directory —
+# which is the Volume. That would write a live node secret into storage shared
+# by every future sandbox.
+OUT="$(env -u HOME sh -c \
+  "AGENTPOD_WORKSPACE_PATH='$TMP/mount' sh '$WRAPPER' '$TMP/inner.sh'" 2>/dev/null || true)"
+check "pins HOME to the rootfs when the sandbox provides none" "$OUT" "HOME=/root$"
+
+OUT="$(HOME="$TMP/mount/home" AGENTPOD_WORKSPACE_PATH="$TMP/mount" \
+  sh "$WRAPPER" "$TMP/inner.sh" 2>/dev/null || true)"
+check "moves HOME off the Volume when it points inside it" "$OUT" "HOME=/root$"
+
+ERR="$(HOME="$TMP/mount/home" AGENTPOD_WORKSPACE_PATH="$TMP/mount" \
+  sh "$WRAPPER" "$TMP/inner.sh" 2>&1 >/dev/null || true)"
+check "says why it moved HOME" "$ERR" "must not be written to storage"
+
+# A HOME the sandbox set for itself, outside the Volume, is left alone: this
+# wrapper's job is keeping credentials off shared storage, not owning HOME.
+mkdir -p "$TMP/elsewhere"
+OUT="$(HOME="$TMP/elsewhere" AGENTPOD_WORKSPACE_PATH="$TMP/mount" \
+  sh "$WRAPPER" "$TMP/inner.sh" 2>/dev/null || true)"
+check "leaves a HOME outside the Volume alone" "$OUT" "HOME=$TMP/elsewhere$"
+
+# ── Inside the image only: the real path and the real default inner ──────────
+if [ -d /workspace ] && [ -x /node-entrypoint.sh ]; then
+  OUT="$(sh "$WRAPPER" "$TMP/inner.sh" 2>/dev/null || true)"
+  check "defaults to the /workspace the driver mounts" "$OUT" "PWD=/workspace$"
+
+  ERR="$(sh "$WRAPPER" "$TMP/inner.sh" 2>&1 >/dev/null || true)"
+  if printf '%s' "$ERR" | grep -q "does not look like a mounted Volume"; then
+    fail "warned about the mount even though /workspace is a real mount — run this with -v <dir>:/workspace"
+  else
+    pass "does not warn when /workspace is a real mount"
+  fi
+
+  # No arguments is the production case. The evidence that it really reached the
+  # fleet entrypoint is the node-agent's own refusal: /node-entrypoint.sh runs
+  # `/agentpod-node enroll`, which without hub/token fails with this message.
+  set +e
+  OUT="$(sh "$WRAPPER" 2>&1)"
+  STATUS=$?
+  set -e
+  if [ "$STATUS" -eq 0 ]; then
+    fail "no-argument run succeeded without a hub — it cannot have run enroll"
+  else
+    check "with no arguments it execs the fleet's /node-entrypoint.sh" \
+      "$OUT" "enroll requires"
+  fi
+else
+  echo "SKIP: not running inside the image — /workspace default and the"
+  echo "SKIP: default inner command are not covered. Run this in the container."
+fi
+
+echo "ran $RAN checks"
+if [ "$FAILURES" -gt 0 ]; then
+  echo "$FAILURES failure(s)"
+  exit 1
+fi
+echo "all modal-entrypoint tests passed"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -141,6 +141,30 @@ PROVISIONING_HUB_URL=https://hub.<your-domain>
 # CLOUDFLARE_SANDBOX_IMAGE=agentpod-node-opencode:local
 # RUNTIME_CALLBACK_TOKEN=<shared secret for the sleep callback>
 # CLOUDFLARE_INSTANCE_TIER=large
+
+# Modal provisioner: leave off unless you have read the cost note in OPERATING.md.
+# Modal bills wall-clock at roughly 3x standard Modal rates for as long as a
+# sandbox exists, which makes a mostly-idle station its worst case.
+# ENABLE_MODAL_PROVISIONING=false
+# The hub refuses to boot with ENABLE_MODAL_PROVISIONING=true and any of
+# MODAL_TOKEN_ID / MODAL_TOKEN_SECRET / NODE_AGENT_MODAL_IMAGE /
+# PROVISIONING_HUB_URL missing. The refusal names the variable.
+# MODAL_TOKEN_ID=<from the Modal dashboard>
+# MODAL_TOKEN_SECRET=<from the Modal dashboard>
+# A PUBLIC registry image Modal can pull: linux/amd64, carrying python and pip.
+# Build it with apps/node-agent/deploy/Dockerfile.modal.
+# NODE_AGENT_MODAL_IMAGE=ghcr.io/<owner>/agentpod-node-modal:v0.1.0
+# Only covers the Generic harness. Set these too if you provision an
+# OpenCode or Pi runtime on Modal — otherwise it falls back to the local
+# Docker tag and the driver refuses the provision.
+# NODE_AGENT_MODAL_OPENCODE_IMAGE=ghcr.io/<owner>/agentpod-node-modal-opencode:v0.1.0
+# NODE_AGENT_MODAL_PI_IMAGE=ghcr.io/<owner>/agentpod-node-modal-pi:v0.1.0
+# Modal App the sandboxes are grouped under. Grouping only; carries no state.
+# MODAL_APP_NAME=agentpod
+# Shortens the lifetime ceiling for a rotation drill. Optional, clamped to 24h,
+# and not validated at boot — see "Modal provisioner" in docs/OPERATING.md
+# before setting it.
+# MODAL_MAX_LIFETIME_MS=86400000
 EOF
 chmod 600 /etc/agentpod/hub.env
 ```
@@ -149,6 +173,11 @@ chmod 600 /etc/agentpod/hub.env
 > - `BETTER_AUTH_SECRET`: ≥ 32 characters.
 > - `ENCRYPTION_KEY`: **exactly** 32 bytes. Using `openssl rand -hex 16` produces 32 hex characters = 32 ASCII bytes.
 > - `CLOUDFLARE_SANDBOX_IMAGE`: required whenever `ENABLE_CLOUDFLARE_SANDBOXES=true`, and it must be the image the worker was deployed with (what `imageForHarness` returns for the harness you provision). The Cloudflare driver advertises a **fixed** image and refuses a spec asking for a different one — but only when it knows this value. Unset, it advertises "fixed" and provisions whatever it is handed. Boot validation now fails instead.
+> - Modal: `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `NODE_AGENT_MODAL_IMAGE` and `PROVISIONING_HUB_URL` are **all** required whenever `ENABLE_MODAL_PROVISIONING=true`, and the hub exits at startup without them, naming each one. That is deliberate: two of the four would otherwise fail silently, later, on somebody else's runtime.
+> - `NODE_AGENT_MODAL_IMAGE` must be a **public registry** reference. The driver pulls it with `images.fromRegistry(tag)` and no Modal Secret, so a private repository cannot be authenticated to and a local Docker tag like `agentpod-node:local` gives Modal nothing to pull. Boot validation rejects any value without a registry host in it; a private-but-well-formed tag passes validation and then fails at provision time.
+> - `NODE_AGENT_MODAL_IMAGE` covers the **Generic** harness only. A Modal runtime created with the OpenCode or Pi harness resolves `NODE_AGENT_MODAL_OPENCODE_IMAGE` / `NODE_AGENT_MODAL_PI_IMAGE` first, then the un-scoped `NODE_AGENT_OPENCODE_IMAGE` / `NODE_AGENT_PI_IMAGE`, then the local Docker default. Boot validation does not check these, so provision either fails with "not a registry reference Modal can pull", or — worse — silently hands Modal whatever your Docker deployment set.
+> - `PROVISIONING_HUB_URL` is required for Modal (not merely recommended, as it is for Docker) because Modal destroys every sandbox at 24 hours and the hub re-creates them on a timer, with no incoming request to take an origin from. It must be reachable **from inside a Modal sandbox** — a public URL or a tunnel, never `localhost`.
+> - On Modal's Starter plan an API token is **workspace-wide**; scoping a token per environment requires Modal's Team plan (~$250/month). Use a Modal workspace dedicated to AgentPod.
 > - Never commit this file to source control.
 
 ---

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -319,6 +319,134 @@ Open the runtime's detail panel → **Destroy**. This stops and removes the cont
 
 Available in the UI if `ENABLE_CLOUDFLARE_SANDBOXES=true` is set in the hub env. Status: **live-unverified in v0.1.0** — use Docker for production provisioning.
 
+### Modal provisioner
+
+Available in the **New runtime** provider list if `ENABLE_MODAL_PROVISIONING=true` is set in the hub env. Configuration: see the `── Provisioning ──` block in `docs/DEPLOYMENT.md`.
+
+#### Cost, before anything else
+
+Modal **Sandboxes** carry roughly a **3× premium over standard Modal compute**, and they bill **wall-clock for as long as the sandbox exists** — not CPU burned. A sandbox sitting at 0% CPU waiting for its operator costs the same as one working flat out. A minimal always-on runtime is about **$21/month**; **Volumes bill separately**, on stored bytes, and keep billing until they are deleted.
+
+A mostly-idle fleet is therefore Modal's worst case, and AgentPod fleets are mostly idle. Modal earns its place for short, bursty, isolated work — a runtime you create, use, and destroy the same day. For a long-lived station that sits waiting for someone to open a terminal, Docker is cheaper by a wide margin and Cloudflare sleeps when idle where Modal does not.
+
+> Pricing figures are Modal's published rates read on **2026-08-13**. Re-check them before turning this on; nothing in the hub reads Modal's price list, and nothing here will tell you if it moves.
+
+#### What a Modal runtime actually is
+
+**A rolling series of disposable sandboxes anchored by one named Volume.** The Volume is named `agentpod-<runtime id>`, holds the workspace at `/workspace`, and outlives every sandbox. The sandbox is disposable and always will be.
+
+That shape is not an optimisation. Probed against a real Modal account on **2026-08-13**:
+
+- `terminate` is **irreversible**, and Modal has **no start verb at all**. Every restart is a new sandbox with a new id and a fresh root filesystem.
+- Every sandbox is destroyed by the platform at **24 hours**, however healthy it is, with **no warning and no callback**. Nothing in Modal's API rotates for you.
+- A Volume mounted **by name** does carry a workspace from one sandbox to the next — a different sandbox id read back a sentinel the previous one wrote. This single fact is what makes Modal usable.
+- Modal's **idle** timer is opt-in and off by default, and AgentPod never opts in. A busy-but-quiet station is not reaped the way a Cloudflare sandbox was on 2026-08-12.
+
+Anything written outside `/workspace` — including anything in `$HOME` — is written in sand. That is deliberate for `$HOME`: the node-agent's `config.json` holds the node id and node secret, and keeping it on the disposable root filesystem means no credential is ever left at rest in shared storage. Every new sandbox enrols afresh, the hub resumes the same node with a rotated secret, and the runtime keeps its node id and its history.
+
+#### The 24-hour ceiling, and rotation
+
+Left alone, a Modal station would simply die once a day. The hub does not leave it alone.
+
+`sweepExpiringRuntimes` runs on the existing 15-second sweeper tick and re-creates a runtime's sandbox **30 minutes before the ceiling**, i.e. at about 23h30m of instance age. It re-provisions with the **same runtime id**, so the volume name is the same and the workspace is re-attached; the station re-enrols and **keeps its node id**.
+
+What you see, per runtime, roughly once a day:
+
+1. The status goes to **`provisioning`** for a moment as the sweeper claims the row, then to **`starting`**, both carrying the `statusReason`:
+   *"re-created before this substrate's 24h instance lifetime ceiling destroyed it — the workspace is anchored outside the instance and carries over"*.
+2. The runtime returns to **`online`** once the new sandbox's node-agent enrols — usually within seconds.
+3. Files under `/workspace` carry over. **Processes do not.** Anything running inside the sandbox — a long-lived agent session, a dev server, a `tmux` you left attached — is gone. Treat a Modal station as something that restarts nightly.
+
+Rotation is deliberately narrow, and each narrowing is a refusal to spend money:
+
+- **Only `online` and `starting` rows rotate.** A `stopped`, `asleep`, `stopping`, `error` or `destroyed` runtime is never rotated. Age alone would always say a stopped runtime is due, and resurrecting one starts a sandbox nobody asked for that bills wall-clock until a human notices.
+- **Age only.** The substrate is never asked whether the sandbox is alive. A sandbox that crashed in its first minute will crash the same way again, and re-creating it would rebuild and re-bill it every 15 seconds with nobody watching. The node going offline already surfaces that; **Start** is one click for the human who looks.
+- **If the re-create fails**, the runtime goes to `error` with a reason naming the ceiling, rather than staying `online` and asserting health up to the moment it vanishes.
+
+#### `MODAL_MAX_LIFETIME_MS` — read this before setting it
+
+Optional, in milliseconds, clamped to 24 hours: it can only ever **shorten** the ceiling. It is read by the driver at hub startup, is **not** validated at boot, and an unset or unparseable value falls back to 24 hours silently. It is also handed to Modal as the sandbox's own timeout, so shortening it genuinely makes Modal kill the sandbox sooner — which is what makes it honest for a rotation drill.
+
+The rotation margin is **`min(30 minutes, ceiling ÷ 2)`**, not a flat 30 minutes. So:
+
+| Ceiling | Rotates at instance age |
+|---|---|
+| 24h (default) | 23h30m |
+| 2h | 1h30m |
+| 60m | 30m (the midpoint) |
+| 30m | 15m (the midpoint) |
+| 10m | 5m (the midpoint) |
+
+Anything **60 minutes or less rotates at the midpoint**. The clamp is deliberate and load-bearing: with a flat 30-minute margin, any ceiling under 30 minutes makes the rotation threshold negative — every instance is born past due, and the hub bills a brand-new sandbox on **every 15-second tick**, forever, with no human in the loop.
+
+To rehearse rotation without waiting a day, set `MODAL_MAX_LIFETIME_MS=1800000` (30 minutes) and restart the hub. Rotation is then due at **15 minutes** of instance age, so a runtime created just now waits 15 minutes; one that has already been up longer than that rotates on the next tick. Unset the variable afterwards — leaving it on makes every station restart every quarter of an hour and re-enrol each time.
+
+#### Stop, Start, Destroy — what each one takes
+
+Modal has no reversible stop, so these verbs do not mean quite what they mean on Docker.
+
+| Action | Sandbox | Volume (`/workspace`) | Notes |
+|---|---|---|---|
+| **Stop** | terminated, permanently | untouched | The runtime keeps its identity and its files. Reaches `stopped` only once the driver polls Modal and confirms — never merely because the stop call returned. |
+| **Start** | a **new** sandbox | re-attached by name | There is no start verb on Modal; the hub re-provisions against the same runtime id. New container, same workspace, same node id, rotated node secret. |
+| **Destroy** | terminated | **deleted** | The only action that takes your work, and it is not recoverable. |
+
+**Where the buttons are.** For a Modal runtime, use the **Runtimes** page (`/runtimes`). **Start** appears when the runtime is `stopped` or `error`; **Stop** appears when it is `online`; **Destroy** appears in every state but `provisioning` and `destroyed`. The Stop/Start buttons on a *node's* detail panel are Docker-only — a provisioned Modal node shows just **Destroy** there.
+
+**A leaked Volume bills forever and the console cannot show it.** Destroy terminates the sandbox first and deletes the Volume second, and tolerates "already gone" on both — the 24-hour ceiling means the sandbox really is often gone already. Any *other* failure leaves the runtime un-destroyed with its external id intact, on purpose, so that retrying **Destroy** converges. If a destroy ever reports an error, retry it, and then check the Modal dashboard for a Volume named `agentpod-<runtime id>`. Once the runtime row is gone, nothing in AgentPod knows that Volume exists.
+
+#### Credentials and RBAC
+
+`MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`, from the Modal dashboard, in the hub environment.
+
+**On Modal's Starter plan a token is workspace-wide.** Scoping a token per environment requires Modal's **Team plan (~$250/month)**. There is no way to engineer around this from the hub's side: on Starter, the hub's token can see and destroy everything in that Modal workspace. Use a Modal workspace dedicated to AgentPod and nothing else.
+
+These tokens create infrastructure in a Modal workspace. They cannot reach an enrolled node — enrolment is outbound-dialled and SSH runs from your own machine.
+
+#### The image
+
+Modal pulls from a registry, runs **linux/amd64 only**, and requires **python and pip** in the image. Build it from `apps/node-agent/deploy/Dockerfile.modal` and set `NODE_AGENT_MODAL_IMAGE` to the pushed tag.
+
+Three things are non-negotiable, each fatal on its own and each failing quietly:
+
+1. **python3 and pip must be present.** The driver pulls the image and nothing else; Modal does not inject a python. Without it the sandbox never boots and the only symptom is a runtime stuck in `provisioning` until the sweeper expires it two minutes later.
+2. **`ENTRYPOINT` must be empty.** Modal requires any image `ENTRYPOINT` to end in `exec "$@"` so its runtime can take over the command, and the fleet's entrypoint never can — it enrols and then execs its own run loop. `Dockerfile.modal` clears `ENTRYPOINT` and the driver passes `/modal-entrypoint.sh` as the sandbox **command** instead.
+3. **linux/amd64 only.** On Apple Silicon the default build is arm64 and Modal rejects it — and the **base** must be amd64 too, or the build fails. `Dockerfile.modal` takes `ARG BASE_IMAGE` so you can build an amd64 base under its own tag instead of clobbering the arm64 `agentpod-node:base` your local Docker provisioner runs.
+
+```bash
+# amd64 base (Apple Silicon: this runs under emulation and is slow — wait it out)
+docker buildx build --platform linux/amd64 \
+  -f apps/node-agent/deploy/Dockerfile.base \
+  -t agentpod-node:base-amd64 --load apps/node-agent
+
+# the Modal layer, pushed to a PUBLIC repository
+docker buildx build --platform linux/amd64 \
+  --build-arg BASE_IMAGE=agentpod-node:base-amd64 \
+  -f apps/node-agent/deploy/Dockerfile.modal \
+  -t ghcr.io/<owner>/agentpod-node-modal:v0.1.0 --push apps/node-agent
+```
+
+**The repository must be public.** The driver calls Modal's `images.fromRegistry(tag)` with no Secret, so Modal has no credential to authenticate to a private registry with. A private tag passes the hub's boot check — it looks like a registry reference — and then fails at provision time.
+
+These images are **hand-built and pushed by convention; there is no CI pipeline for any of them.** Do not infer one from the tag.
+
+To sanity-check a built image before pushing, run its entrypoint test against a bind mount standing in for the Volume:
+
+```bash
+mkdir -p /tmp/fake-volume
+docker run --rm --platform linux/amd64 \
+  -v "$PWD/apps/node-agent/deploy":/t -v /tmp/fake-volume:/workspace \
+  --entrypoint sh agentpod-node-modal:local /t/test-modal-entrypoint.sh
+```
+
+#### When a Modal runtime does not come up
+
+- **Hub exits at startup naming a `MODAL_*` variable** — working as designed. Set the variable it names; the check is in `apps/hub/src/utils/validate-config.ts`.
+- **Provision fails with "not a registry reference Modal can pull"** — the resolved image had no registry host. Most often this is a runtime created with the OpenCode or Pi harness while only `NODE_AGENT_MODAL_IMAGE` was set; set `NODE_AGENT_MODAL_OPENCODE_IMAGE` / `NODE_AGENT_MODAL_PI_IMAGE` too.
+- **Stuck in `provisioning`, then `error` after two minutes** — the sandbox booted but never enrolled. Read the sandbox's logs in the Modal dashboard. The usual causes are an image without python, an arm64 image, and a `PROVISIONING_HUB_URL` the sandbox cannot reach.
+- **`[modal] WARNING: /workspace does not look like a mounted Volume`** in the sandbox log — work written there will be lost at the next rotation. Do not use that station.
+- **Every Modal runtime reports trouble at once** — suspect the credentials, not the fleet. An expired `MODAL_TOKEN_SECRET` fails every call. The driver deliberately refuses to translate an unreachable substrate into `stopped`, so this surfaces as `error`, loudly, rather than as a fleet that has quietly gone quiet.
+
 ---
 
 ## 5. Cmd-K palette

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       isomorphic-git:
         specifier: ^1.40.4
         version: 1.40.4
+      modal:
+        specifier: 0.9.0
+        version: 0.9.0
       nanoid:
         specifier: ^5.1.16
         version: 5.1.16
@@ -517,6 +520,36 @@ packages:
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    resolution: {integrity: sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    resolution: {integrity: sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    resolution: {integrity: sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
+    cpu: [x64]
+    os: [win32]
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
@@ -2333,6 +2366,9 @@ packages:
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
+  abort-controller-x@0.5.0:
+    resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2634,6 +2670,13 @@ packages:
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+
+  cbor-extract@2.2.2:
+    resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
+    hasBin: true
+
+  cbor-x@1.6.5:
+    resolution: {integrity: sha512-yO64CxnSh6kp+pHNRK9IfwnMvCB+c8HvmUjQY/9l9YRF0/cAPka/tUHLwS64QqUpFCq3/OtbKziVJYXH2EaRig==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4323,6 +4366,9 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  modal@0.9.0:
+    resolution: {integrity: sha512-kCXcdJkhbJorf/q/6T9Wdlg6in9JmRnCNQnV6rVBMyeqNV/iXI6BYk4IzY4cvZ6dbauNeDMjk/Q08cbxvoIaXg==}
+
   mode-watcher@1.1.0:
     resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
     peerDependencies:
@@ -4369,11 +4415,21 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  nice-grpc-common@2.0.4:
+    resolution: {integrity: sha512-gOEXlD6ShXZMZ8k+49wm/bA2j1+3IKbEFV9WYREJcvZV4kM5L1KkILYTX9VYBzZF2OuYCe1wp8c82bQkvR0fHw==}
+
+  nice-grpc@2.1.17:
+    resolution: {integrity: sha512-pu9xYPlWSeqoYQOCqb2ftQqZi/P2DaI70PSuwnxvoyIRiilaOVtktyPe6LmuXegWB4Ic1sPuDGCnCCASbwzK0w==}
+
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
 
   node-mock-http@1.0.5:
     resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
@@ -5223,6 +5279,9 @@ packages:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
 
+  ts-error@1.0.6:
+    resolution: {integrity: sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==}
+
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -5423,6 +5482,10 @@ packages:
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@14.0.1:
@@ -6038,6 +6101,24 @@ snapshots:
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    optional: true
 
   '@chevrotain/types@11.1.2': {}
 
@@ -7492,6 +7573,8 @@ snapshots:
 
   '@xterm/xterm@5.5.0': {}
 
+  abort-controller-x@0.5.0: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -7883,6 +7966,22 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@8.0.0: {}
+
+  cbor-extract@2.2.2:
+    dependencies:
+      node-gyp-build-optional-packages: 5.1.1
+    optionalDependencies:
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.2
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.2
+    optional: true
+
+  cbor-x@1.6.5:
+    optionalDependencies:
+      cbor-extract: 2.2.2
 
   ccount@2.0.1: {}
 
@@ -10088,6 +10187,15 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  modal@0.9.0:
+    dependencies:
+      cbor-x: 1.6.5
+      long: 5.3.2
+      nice-grpc: 2.1.17
+      protobufjs: 7.6.5
+      smol-toml: 1.7.1
+      uuid: 11.1.1
+
   mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)):
     dependencies:
       runed: 0.25.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))
@@ -10120,11 +10228,26 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
+  nice-grpc-common@2.0.4:
+    dependencies:
+      ts-error: 1.0.6
+
+  nice-grpc@2.1.17:
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.4
+
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
 
   node-fetch-native@1.6.7: {}
+
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-mock-http@1.0.5: {}
 
@@ -11180,6 +11303,8 @@ snapshots:
 
   ts-dedent@2.3.0: {}
 
+  ts-error@1.0.6: {}
+
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -11363,6 +11488,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.1.1: {}
 
   uuid@14.0.1: {}
 


### PR DESCRIPTION
The Modal driver, complete through Task 14 of `docs/superpowers/plans/2026-08-13-modal-driver.md`. **Task 15 — live verification — is deliberately not done.**

Modal was chosen as the second driver because it is the hardest test of whether the manifest generalises: terminal stop, a hard 24-hour ceiling, and no start verb at all.

## The manifest held

`assertConforms` accepts the Modal driver **with no production change and no new manifest field**. Rotation is generic — `sweepExpiringRuntimes` reads `manifest.maxLifetimeMs`, so no provider name appears in it, and `startRuntime` branches once on `stopSemantics === "terminal"`.

## The design, from probes on a real account (2026-08-13)

A Modal runtime is **a rolling series of sandboxes anchored by a named Volume**. Measured: sandbox 1 wrote a sentinel and terminated; sandbox 2 with a different `sandboxId` mounted the same Volume by name and read it back. That turns the 24-hour ceiling from data loss into daily re-enrolment churn, which the runtime-bound token already handles.

The JS SDK works on Bun with no shim, pinned at exact `0.9.0` — it is 0.x and churns (`timeout` → `timeoutMs` is rejected by a runtime guard).

## Modal stress-tested the conformance suite and found two gaps

- **Rule 3 was one-directional** — it checked *terminal ⇒ no start*, never *resumable ⇒ has start*. Inert until Task 8 made `startRuntime` branch on that field, at which point a `resumable` driver with no `start()` would call `undefined`. Closed in the same task; inverting the new rule fails 16 tests including real Docker and Cloudflare.
- **`maxLifetimeMs` is still undeclared territory** — no rule checks that a driver declaring a ceiling passes a matching timeout to its substrate. Pinned at the driver level for Modal; recorded as a conformance task.

## Bugs found that were not Modal's

- **`agentpod-node` writes its config to a *relative* path when `HOME` is unset** — `os.UserConfigDir()` errors and `config.DefaultPath()` discards the error. In a sandbox that resolves against the working directory, which is the Volume: **a live node secret written into shared storage that outlives every sandbox.** The wrapper pins `HOME`.
- **`config.ts`'s default `ENCRYPTION_KEY` is 33 characters** against a rule requiring 32, so a bare environment cannot boot. Pre-existing, unrelated, left alone — worth an issue.

## Every task found a defect in its own plan

Fourteen for fourteen. The sharpest: a **rotation threshold that went negative** for any ceiling under 30 minutes — including the ten-minute override whose stated purpose is testing rotation — which would have destroyed and re-created a sandbox **every 15-second tick, billing each one**. Also a migration that omitted the drizzle snapshot (breaking the next `db:generate`), a credential test that would have constructed a **live `ModalClient`**, a test titled *"sets no idle timer"* that asserted nothing of the kind, and a call-site mutation (`imageForHarness(harness, "docker")` hardcoded in the rotation path) that passed all 65 tests.

Six plan tests were vacuous under mutation. Every guard on this branch was mutation-checked in both directions.

## Not verified

No Modal sandbox was created by this work. Open until Task 15: that Modal accepts an image with no ENTRYPOINT; that apt's python3+pip satisfy its runtime; whether Modal populates `HOME`; that a station enrols and rotation fires. **The image is not pushed** — Modal pulls with no Secret, so it needs a **public** registry.

## One open ruling

`ModalNotFoundError` currently maps to `stopped`; the plan and a comment in `sweepStalledRuntimeStops` say `unknown`. Conformance is indifferent by construction. The discriminator is one call: poll a terminated sandbox and see whether it answers an exit code or NotFound.

**661 hub tests pass**, ~50s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW