### PR TITLE
fix(hub): make the child-process config tests hermetic

### DIFF
--- a/apps/hub/src/utils/validate-config.test.ts
+++ b/apps/hub/src/utils/validate-config.test.ts
@@ -186,7 +186,15 @@ describe("validateConfig — modal", () => {
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) env[key] = value;
     }
-    // Every Modal variable starts UNSET, so a test that wants one says so.
+    // Every provisioner variable starts UNSET, so a test that wants one says so.
+    //
+    // This list must cover every variable validate-config.ts can report, not
+    // just Modal's. The child inherits this process's environment, and bun
+    // auto-loads apps/hub/.env — a developer whose .env enables Cloudflare
+    // without CLOUDFLARE_SANDBOX_IMAGE otherwise sees that field appear in
+    // every `fields` assertion here, while CI (which has no .env) stays green.
+    // A test whose subject is "exactly the documented variables, nothing else"
+    // is only meaningful if the ambient environment cannot contribute.
     for (const key of [
       "ENABLE_MODAL_PROVISIONING",
       "MODAL_TOKEN_ID",
@@ -195,6 +203,12 @@ describe("validateConfig — modal", () => {
       "NODE_AGENT_MODAL_IMAGE",
       "NODE_AGENT_IMAGE",
       "PROVISIONING_HUB_URL",
+      "ENABLE_CLOUDFLARE_SANDBOXES",
+      "CLOUDFLARE_SANDBOX_IMAGE",
+      "ENABLE_FLY_PROVISIONING",
+      "FLY_API_TOKEN",
+      "FLY_VOLUME_SIZE_GB",
+      "ENABLE_DOCKER_PROVISIONING",
     ]) {
       delete env[key];
     }
@@ -221,7 +235,12 @@ describe("validateConfig — modal", () => {
         fields: collectConfigErrors(undefined, () => {}).map((e) => e.field),
       }));
     `;
-    const proc = Bun.spawnSync(["bun", "-e", script], {
+    // --env-file=/dev/null stops bun auto-loading apps/hub/.env in the child.
+    // cwd is hubRoot, so without this the developer's own .env is layered on
+    // top of `env` INSIDE the child, after every delete above has happened —
+    // scrubbing the parent environment cannot reach it. CI has no .env, so
+    // this is also what makes a local run and a CI run the same run.
+    const proc = Bun.spawnSync(["bun", "--env-file=/dev/null", "-e", script], {
       cwd: hubRoot,
       env,
       stdout: "pipe",


### PR DESCRIPTION
`bun test` on `main` fails one test locally and passes in CI. Neither signal was trustworthy.

## Cause

`collectInChild` builds an env, deletes every `MODAL_*` variable so "a test that wants one says so", and spawns `bun -e` with `cwd: apps/hub`. Bun auto-loads `apps/hub/.env` **inside that child**, layering it on top after every delete. Scrubbing the parent environment cannot reach it.

`apps/hub/.env` is untracked, so CI has none and stayed green. A developer whose `.env` enables Cloudflare without `CLOUDFLARE_SANDBOX_IMAGE` gets that field in every `fields` assertion.

## Fix

`--env-file=/dev/null` suppresses the auto-load, making a local run and a CI run the same run. Measured both ways: without the flag the child reads `ENABLE_CLOUDFLARE_SANDBOXES=true` from `.env`; with it, `UNSET`.

The scrub list is also extended to every variable `validate-config.ts` can report (Cloudflare, Fly, Docker), which closes the same leak arriving via an exported shell variable rather than a file.

## Non-vacuity

These tests exist to catch a `config.ts` that reads the wrong env var. Repointing `config.ts:188` at `NODE_AGENT_IMAGE` still fails them (16 pass / 1 fail), so the hermeticity fix did not hollow out the assertion.

Hub suite: 752 pass, 0 fail.