### PR TITLE
fix(ci): give each published image its own build context

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -10,10 +10,13 @@
 # provisioner uses), and a hand-pushed image records nothing about which commit
 # produced it.
 #
-# NOTE: GHCR packages are created private. The first run of each image needs a
-# one-time visibility change to **public** in the GitHub UI, because Modal calls
+# NOTE: the published package MUST end up public — Modal calls
 # `images.fromRegistry(tag)` with no Secret and cannot authenticate to a private
-# registry. Fly can use private registries but is simpler public too.
+# registry. Measured on the first Fly run: the package came out `public` with no
+# UI step needed. Re-check with
+# `gh api '/user/packages?package_type=container'` after adding a new image
+# rather than assuming, since this is an account-level default, not a guarantee
+# of this workflow.
 name: publish-images
 
 on:
@@ -43,11 +46,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `context` is per image and is NOT cosmetic: Fly's Dockerfile COPYs
+          # repo-root-relative paths (apps/node-agent/..., fly/node-image/...),
+          # while Dockerfile.modal COPYs `deploy/...` relative to apps/node-agent.
+          # Building Modal from the repo root fails at COPY, not at push.
           - name: fly
             dockerfile: fly/node-image/Dockerfile
+            context: .
             image: agentpod-node-opencode-fly
           - name: modal
             dockerfile: apps/node-agent/deploy/Dockerfile.modal
+            context: apps/node-agent
             image: agentpod-node-modal
     steps:
       - name: Skip images not selected
@@ -98,7 +107,7 @@ jobs:
             -t "${ref}:latest" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
-            .
+            "${{ matrix.context }}"
           docker push "${ref}:${{ inputs.tag }}"
           docker push "${ref}:latest"
           echo "published ${ref}:${{ inputs.tag }} from ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/node-agent/deploy/Dockerfile.modal
+++ b/apps/node-agent/deploy/Dockerfile.modal
@@ -51,8 +51,9 @@
 # `images.fromRegistry(tag)` with no Secret, so Modal cannot authenticate to a
 # private registry. Extend the adapter first if that changes.
 #
-# There is no CI pipeline for this image, as for none of the images here — they
-# are hand-built and pushed. Don't infer one from the tag.
+# Published by .github/workflows/publish-images.yml (manual dispatch). That
+# workflow builds with context `apps/node-agent`, which is what the COPY below
+# assumes — building this file from the repo root fails.
 ARG BASE_IMAGE=agentpod-node:base
 FROM ${BASE_IMAGE}
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -428,7 +428,7 @@ docker buildx build --platform linux/amd64 \
 
 **The repository must be public.** The driver calls Modal's `images.fromRegistry(tag)` with no Secret, so Modal has no credential to authenticate to a private registry with. A private tag passes the hub's boot check — it looks like a registry reference — and then fails at provision time.
 
-These images are **hand-built and pushed by convention; there is no CI pipeline for any of them.** Do not infer one from the tag.
+**Prefer the CI pipeline over the hand-build above.** `.github/workflows/publish-images.yml` (Actions → publish-images → Run workflow, choose `fly`/`modal`/`all` and a tag) builds natively on an amd64 runner, pushes to GHCR, and verifies what it published — for Modal, that `python3` and `pip` exist and `ENTRYPOINT` is empty. It also stamps the source commit as an image label, which a hand-built tag records nowhere. The commands above remain accurate for building locally when iterating on a Dockerfile.
 
 To sanity-check a built image before pushing, run its entrypoint test against a bind mount standing in for the Volume:
 


### PR DESCRIPTION
The first Modal publish attempt failed. `Dockerfile.modal` COPYs `deploy/modal-entrypoint.sh` — relative to `apps/node-agent` — but the workflow built every image from the repo root:

```
#8 ERROR: failed to calculate checksum ... "/deploy/modal-entrypoint.sh": not found
```

Fly's Dockerfile is root-relative (`apps/node-agent/...`, `fly/node-image/...`), so it published fine and Modal could not. One context cannot serve both, so context moves into the matrix.

## Verified before merge, not after

Dispatched from this branch (`gh workflow run --ref fix-publish-images-context`): [run 31668390578](https://github.com/rakeshgangwar/agentpod/actions/runs/31668390578) — success, every step green including `Verify what was published`, which runs `python3 --version`, `pip --version` and the empty-`ENTRYPOINT` assertion against the pushed image.

`ghcr.io/rakeshgangwar/agentpod-node-modal:v0.1.24` is published, and `gh api /user/packages` reports both `agentpod-node-modal` and `agentpod-node-opencode-fly` as `public` — which Modal requires, since `images.fromRegistry()` is called with no Secret.

## Stale claims corrected

Three comments this pipeline made false:

- `Dockerfile.modal` and `docs/OPERATING.md` both said these images are hand-built with **no CI pipeline** and not to infer one. OPERATING.md now leads with the workflow and keeps the manual commands for local Dockerfile iteration.
- The workflow header warned that GHCR packages need a one-time manual flip to public. The first Fly run showed they come out public already; the note now records that measurement plus the command to re-check, rather than a step nobody needs to take.