### PR TITLE
fix(hub): give Fly machines swap, sized per tier, inside config.init

### DIFF
--- a/apps/hub/src/services/provisioner/fly-fake-substrate.ts
+++ b/apps/hub/src/services/provisioner/fly-fake-substrate.ts
@@ -23,6 +23,8 @@
  *     the same reason — the pinning is to a host in that region
  *   - a region the account's plan does not cover is refused with Fly's own
  *     wording (measured 2026-08-12: "bom" refused, "sin" accepted)
+ *   - `swap_size_mb` is honoured ONLY inside `config.init`, and SILENTLY
+ *     DROPPED anywhere else — 200, a machine that boots, and no swap in it
  *   - `wait?state=` answers 408 when the machine is not in that state
  *   - waiting for `stopped` REQUIRES instance_id
  *   - a start gives the machine a NEW instance id, as a real restart does
@@ -80,6 +82,18 @@ export interface FlyFakeSubstrate {
   fetchImpl: typeof globalThis.fetch;
   calls: Array<{ method: string; path: string; body: unknown }>;
   apps: Map<string, FakeApp>;
+}
+
+/**
+ * What Fly keeps of a machine config: everything, minus a `swap_size_mb` asked
+ * for at the top level, which it accepts and discards. See the call site.
+ */
+function dropUnhonouredSwap(
+  config: Record<string, unknown>
+): Record<string, unknown> {
+  if (!("swap_size_mb" in config)) return config;
+  const { swap_size_mb: _dropped, ...kept } = config;
+  return kept;
 }
 
 export function createFlyFakeSubstrate(
@@ -201,7 +215,16 @@ export function createFlyFakeSubstrate(
         id,
         instance_id: `inst${nextId}`,
         state: "started",
-        config,
+        // Measured 2026-08-13: `swap_size_mb` counts only inside `config.init`.
+        // Asked for at the config top level, Fly answers 200, boots the
+        // machine, and the guest reports `SwapTotal: 0 kB` — no error, at
+        // create or at update. Asked for as a sibling of `config` it never
+        // reaches the machine at all, which the `spec` destructure above
+        // already models by reading nothing else. Storing the config verbatim
+        // would make a
+        // driver that guessed wrong indistinguishable from one that got it
+        // right, which is #278's wedge waiting to be reintroduced.
+        config: dropUnhonouredSwap(config),
         region,
       });
       return json({ id, instance_id: `inst${nextId}`, state: "started" }, 200);

--- a/apps/hub/src/services/provisioner/fly.test.ts
+++ b/apps/hub/src/services/provisioner/fly.test.ts
@@ -429,6 +429,101 @@ describe("FlyMachinesProvisioner — provision", () => {
   });
 });
 
+/**
+ * Swap. #278: a machine with none does not OOM-kill a process when memory
+ * spikes — it WEDGES. Measured 2026-08-13 on a live `small` runtime: two
+ * opencode processes reached 855 MB on a 962 MB machine, and from that moment
+ * every broker verb 502'd on the 15s timeout, heartbeats stopped, Fly's own
+ * `machine exec` answered `deadline_exceeded`, and Fly still reported
+ * `state: started` — so `restart: always` never fired, because nothing had
+ * exited. Only `flyctl machine restart` recovered it, and the console blamed
+ * the hub, which was healthy throughout.
+ */
+describe("FlyMachinesProvisioner — swap", () => {
+  it("asks for swap INSIDE config.init, the ONE place Fly honours it", async () => {
+    // THE NESTING IS THE ASSERTION. Do not "simplify" this to
+    // `config.swap_size_mb` — that is the bug this test exists to prevent, not
+    // a tidier spelling of it.
+    //
+    // Measured against a real Fly account on 2026-08-13: `swap_size_mb` at the
+    // config top level, and as a top-level sibling of `config`, is SILENTLY
+    // DROPPED. Fly answers 200, the machine boots, and the guest reports
+    // `SwapTotal: 0 kB`. No error is returned, at create or at update. Nested
+    // inside `init` it is honoured and echoed back: 512 → SwapTotal 524284 kB
+    // as a real partition (/dev/vdc in /proc/swaps), 256 → 262140 kB, unset →
+    // 0 kB.
+    //
+    // So a test asserting the field at the config top level would go green
+    // while every machine this driver creates shipped with no swap at all, and
+    // the only symptom would be the next wedged VM.
+    const { driver, fake } = flyDriver();
+    await driver.provision(SPEC);
+
+    const create = fake.calls.find((c) => c.path.endsWith("/machines"))!;
+    const body = create.body as {
+      config: { init?: Record<string, unknown> } & Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    expect(body.config.init).toMatchObject({ swap_size_mb: 512 });
+    // ...and nowhere else, because "nowhere else" is where Fly ignores it.
+    expect(body.config).not.toHaveProperty("swap_size_mb");
+    expect(body).not.toHaveProperty("swap_size_mb");
+  });
+
+  it("sizes swap per tier, as a fraction of that tier's RAM", async () => {
+    // Sizes are read back off the SAME request body, so this pins the
+    // relationship (swap is a fraction of RAM, never larger than it) rather
+    // than restating the guest table — the tier→memory mapping is #279's to
+    // change.
+    const expected = { small: 512, medium: 1024, large: 2048 } as const;
+
+    for (const tier of ["small", "medium", "large"] as const) {
+      const { driver, fake } = flyDriver();
+      await driver.provision({ ...SPEC, runtimeId: `rt_swap_${tier}`, resourceTier: tier });
+
+      const create = fake.calls.find((c) => c.path.endsWith("/machines"))!;
+      const config = (create.body as {
+        config: { init: { swap_size_mb: number }; guest: { memory_mb: number } };
+      }).config;
+
+      expect(config.init.swap_size_mb).toBe(expected[tier]);
+      // Every tier gets some. A tier with none is a tier that can wedge.
+      expect(config.init.swap_size_mb).toBeGreaterThan(0);
+      // Never MORE than RAM: on a 1-CPU shared machine, swap bigger than
+      // memory trades a wedge for hours of unusable thrashing.
+      expect(config.init.swap_size_mb).toBeLessThanOrEqual(config.guest.memory_mb);
+    }
+  });
+
+  it("leaves the swap on the machine Fly kept, not just on the request", async () => {
+    // The fake models Fly's silent drop, so this only passes if the driver put
+    // the field where Fly actually reads it. It is the unit-test stand-in for
+    // the live check — reading SwapTotal out of the guest — that the fix's
+    // fleet verification does for real.
+    const { driver, fake } = flyDriver();
+    const { externalId } = await driver.provision(SPEC);
+    const { app, machineId } = parseFlyExternalId(externalId);
+
+    const kept = fake.apps.get(app)!.machines.get(machineId)!.config as {
+      init?: { swap_size_mb?: number };
+    };
+    expect(kept.init?.swap_size_mb).toBe(512);
+  });
+
+  it("does not disturb the rest of the machine config", async () => {
+    // `init` is a new block in this request; the fields that were already
+    // load-bearing (no services, restart always, the mount) stay put.
+    const { driver, fake } = flyDriver();
+    await driver.provision(SPEC);
+
+    const create = fake.calls.find((c) => c.path.endsWith("/machines"))!;
+    const config = (create.body as { config: Record<string, unknown> }).config;
+    expect(config).not.toHaveProperty("services");
+    expect(config.restart).toEqual({ policy: "always" });
+    expect(config.mounts).toHaveLength(1);
+  });
+});
+
 describe("FlyMachinesProvisioner — start", () => {
   it("starts the machine and waits for it to be started", async () => {
     const { driver, fake } = flyDriver();
@@ -1039,6 +1134,33 @@ describe("the Fly fake substrate is unfriendly where Fly is", () => {
       `/v1/apps/a/machines/${machine.id}/wait?state=stopped`
     );
     expect(without.status).toBe(400);
+  });
+
+  it("SILENTLY DROPS swap_size_mb asked for anywhere but inside `init`", async () => {
+    // Measured 2026-08-13. This is the unfriendliest thing the fake does, and
+    // the most valuable: real Fly answers 200 and boots a machine with
+    // `SwapTotal: 0 kB` when the field is at the config top level or a sibling
+    // of `config`. There is no error to notice. A fake that stored the config
+    // verbatim would let a driver ship swapless machines with a green suite,
+    // which is exactly how #278's wedge would come back.
+    const fake = createFlyFakeSubstrate();
+    await newApp(fake);
+    const res = await call(fake, "POST", "/v1/apps/a/machines", {
+      region: "sin",
+      swap_size_mb: 256,
+      config: { swap_size_mb: 512, init: { swap_size_mb: 1024 } },
+    });
+    expect(res.status).toBe(200);
+
+    const id = ((await res.json()) as { id: string }).id;
+    const kept = (await (
+      await call(fake, "GET", `/v1/apps/a/machines/${id}`)
+    ).json()) as { config: { swap_size_mb?: number; init?: { swap_size_mb?: number } } };
+
+    expect(kept.config).not.toHaveProperty("swap_size_mb");
+    // Nested in `init` it survives — and is echoed back, which is how the live
+    // probe read the value off a machine flyctl had created.
+    expect(kept.config.init?.swap_size_mb).toBe(1024);
   });
 
   it("404s everything about an app it has deleted", async () => {

--- a/apps/hub/src/services/provisioner/fly.ts
+++ b/apps/hub/src/services/provisioner/fly.ts
@@ -67,6 +67,44 @@ const FLY_TIERS: Record<
 /** Seconds to give Fly's `wait?state=` endpoint before it answers 408. */
 const WAIT_TIMEOUT_S = 60;
 
+/**
+ * Swap per tier: HALF the tier's RAM. #278.
+ *
+ * A Fly machine gets no swap unless it is asked for, and a guest with none does
+ * not degrade under memory pressure — it WEDGES. Measured 2026-08-13 on a live
+ * `small` runtime: two opencode processes reached 855 MB on a 962 MB machine,
+ * and from that moment every broker verb 502'd on the 15s timeout, heartbeats
+ * stopped, Fly's own `machine exec` answered `deadline_exceeded`, and Fly still
+ * reported `state: started` — so `restart: always` never fired, because nothing
+ * had exited. Only `flyctl machine restart` recovered it, and the console
+ * blamed the hub, which had been healthy the whole time. With swap the same
+ * spike either finishes slowly or the kernel kills ONE process, and a policy of
+ * always-restart brings that back.
+ *
+ * Why a fraction of RAM and not more. Swap is here to convert a hard ceiling
+ * into a soft one, not to pretend the machine is bigger than it is. These are
+ * 1–4 shared vCPUs on network-attached storage: a working set that genuinely
+ * exceeds RAM by a large margin does not run slowly on swap, it thrashes, and a
+ * station thrashing for an hour is worse for the operator than one that OOM-
+ * killed a process and restarted — the wedge this issue is about, wearing a
+ * different hat. Half of RAM is the conventional sizing for a machine of this
+ * shape, it is enough to absorb the measured spike (855 MB on a 962 MB guest
+ * overshoots by well under 512 MB), and it keeps the kernel's OOM killer as the
+ * backstop rather than something swap defers indefinitely.
+ *
+ * Sized against tier RAM, so it is a table rather than a ratio computed from
+ * FLY_TIERS: the guest sizes are the subject of a separate change (#279), and a
+ * swap number should be a decision someone made, not a multiplication that
+ * silently follows a memory bump.
+ *
+ * WHERE this lands in the request is not a detail — see createMachine.
+ */
+const FLY_TIER_SWAP_MB: Record<ResourceTier, number> = {
+  small: 512,
+  medium: 1024,
+  large: 2048,
+};
+
 // ─── External id ──────────────────────────────────────────────────────────────
 
 /**
@@ -423,6 +461,20 @@ export class FlyMachinesProvisioner implements RuntimeProvisioner {
         // Honoured per machine — the input Cloudflare had to refuse.
         image: spec.image,
         guest,
+        // SWAP GOES INSIDE `init`, AND NOWHERE ELSE. Measured 2026-08-13
+        // against a real account: `swap_size_mb` at the config top level — the
+        // obvious guess — is SILENTLY DROPPED. Fly answers 200, the machine
+        // boots, and the guest reports `SwapTotal: 0 kB`; same for passing it
+        // as a sibling of `config`, on create or on update. There is no error
+        // to notice, so the only symptom of getting this wrong is the next
+        // wedged VM (#278). Nested here it is honoured and echoed back: 512 →
+        // SwapTotal 524284 kB, arriving as a real partition (/dev/vdc in
+        // /proc/swaps), 256 → 262140 kB, unset → 0 kB.
+        //
+        // No `cmd`/`entrypoint` alongside it: the image's own are what should
+        // run, and naming them here would freeze the node image's entrypoint
+        // into the hub.
+        init: { swap_size_mb: FLY_TIER_SWAP_MB[spec.resourceTier] },
         env: {
           AGENTPOD_HUB_URL: spec.hubUrl,
           // NOTE: never logged from this module. Do not add a log statement


### PR DESCRIPTION
Fixes #278.

A Fly machine gets no swap unless it is asked for, and a guest with none does not degrade under memory pressure — it wedges. The node-agent stops answering broker verbs, heartbeats stop, Fly's own `machine exec` answers `deadline_exceeded`, and Fly still reports `state: started`, so `restart: always` never fires because nothing exited. Only `flyctl machine restart` recovers it. With swap, the same spike either finishes slowly or the kernel OOM-kills one process — and `restart: always` brings that back.

## The wire format, as measured

`swap_size_mb` is honoured in exactly one place: **nested inside `config.init`**.

```json
"config": {
  "guest": { "cpu_kind": "shared", "cpus": 1, "memory_mb": 1024 },
  "init":  { "swap_size_mb": 512 }
}
```

Measured against a real Fly account on 2026-08-13:

- At `config.swap_size_mb`, or as a top-level sibling of `config`, it is **silently dropped** — 200 response, machine boots, guest reports `SwapTotal: 0 kB`. No error, at create or at update.
- Nested in `init`, Fly echoes it back and the guest honours it: 512 → `SwapTotal: 524284 kB`, arriving as a real partition (`/dev/vdc` in `/proc/swaps`); 256 → `262140 kB`; unset → `0 kB`.

**Why the nesting is the assertion.** Because the wrong placement is accepted and discarded, a test asserting `config.swap_size_mb` would go green while every machine this driver creates shipped with no swap at all — and the only symptom would be the next wedged VM. So the critical test asserts the field inside `init`, asserts it is *not* at the config top level or on the request root, and carries a comment saying so, in case someone later reads it as a needlessly deep spelling of the same thing.

The fake substrate now models the drop too (`dropUnhonouredSwap`): a fake that stored the machine config verbatim would make a driver that guessed wrong indistinguishable from one that got it right. This follows the file's existing rule of being unfriendly exactly where Fly is.

## Sizing: half of RAM

`FLY_TIER_SWAP_MB` = small 512, medium 1024, large 2048 MB.

A fraction of RAM, deliberately not a multiple of it. Swap here converts a hard ceiling into a soft one; it is not a way to pretend the machine is bigger. These are 1–4 shared vCPUs on network-attached storage, and a working set that genuinely exceeds RAM by a wide margin does not run slowly on swap, it thrashes — a station thrashing for an hour is the same wedge this issue is about, wearing a different hat. Half of RAM is the conventional sizing for a machine of this shape, comfortably absorbs the measured spike (855 MB on a 962 MB guest), and leaves the kernel's OOM killer as the backstop rather than something swap defers indefinitely.

It is a table rather than `memory_mb / 2` on purpose: guest sizes are #279's to change, and a swap number should be a decision someone made rather than a multiplication that silently follows a memory bump. The tier→guest map and `supportedTiers` are untouched here, to stay out of #279's way.

## Tests

TDD: the four swap tests plus the fake-substrate fidelity test were written first and failed for the right reason (no `init` block in the outgoing body; fake stored swap verbatim).

**Mutation tests, both directions — required to fail, and both did:**

| mutation | result |
|---|---|
| (a) move `swap_size_mb` from `init` to the `config` top level | **FAIL** — 3 tests, including `asks for swap INSIDE config.init, the ONE place Fly honours it` (`config.init` undefined), `sizes swap per tier`, and `leaves the swap on the machine Fly kept` (the fake discarded it, as Fly does) |
| (b) remove `swap_size_mb` entirely | **FAIL** — the same 3 tests |

Suites:

- `cd apps/hub && DATABASE_URL=… bun test` → **757 pass, 0 fail** (752 before, +5 new).
- `bun run typecheck` → no new errors; only the pre-existing known-red `stations.ts` ones.
- `packages/contract` untouched — no frame or API shape changed.

Not deployed, and no Fly resources were created by this change; the probe behind these numbers was run and cleaned up under #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
