### PR TITLE
feat(images): Modal+OpenCode, Modal+Pi and Fly+Pi node images (#283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,13 @@ jobs:
       - name: Test the Fly image workspace wrapper
         run: sh fly/node-image/test-volume-workspace.sh
 
+      # Same reasoning as above, and newly load-bearing: modal-entrypoint.sh is
+      # now the main process of THREE published images, and it is what decides
+      # which inner entrypoint a harness image runs. A macOS dev box skips two
+      # of its checks (it cannot mkdir /root); this job does not.
+      - name: Test the Modal image entrypoint wrapper
+        run: sh apps/node-agent/deploy/test-modal-entrypoint.sh
+
   console:
     name: console
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -12,8 +12,8 @@
 #
 # NOTE: the published package MUST end up public — Modal calls
 # `images.fromRegistry(tag)` with no Secret and cannot authenticate to a private
-# registry. Measured on the first Fly run: the package came out `public` with no
-# UI step needed. Re-check with
+# registry, and Fly pulls anonymously. Measured on the first Fly run: the
+# package came out `public` with no UI step needed. Re-check with
 # `gh api '/user/packages?package_type=container'` after adding a new image
 # rather than assuming, since this is an account-level default, not a guarantee
 # of this workflow.
@@ -27,7 +27,7 @@ on:
         required: true
         default: all
         type: choice
-        options: [all, fly, modal]
+        options: [all, fly, fly-pi, modal, modal-opencode, modal-pi]
       tag:
         description: Tag to publish (e.g. v0.1.24)
         required: true
@@ -41,23 +41,62 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     strategy:
-      # Independent images: one failing must not cancel the other, or a Modal
+      # Independent images: one failing must not cancel the others, or a Modal
       # build problem hides a good Fly image.
       fail-fast: false
       matrix:
         include:
-          # `context` is per image and is NOT cosmetic: Fly's Dockerfile COPYs
-          # repo-root-relative paths (apps/node-agent/..., fly/node-image/...),
-          # while Dockerfile.modal COPYs `deploy/...` relative to apps/node-agent.
-          # Building Modal from the repo root fails at COPY, not at push.
+          # Each row carries four things that are NOT cosmetic:
+          #
+          #   context      — Fly's Dockerfiles COPY repo-root-relative paths
+          #                  (apps/node-agent/..., fly/node-image/...), while the
+          #                  Modal ones COPY `deploy/...` relative to
+          #                  apps/node-agent. Building either from the wrong
+          #                  context fails at COPY, not at push (issue #276).
+          #   local_base   — which un-published image this one is FROM, and must
+          #                  therefore be built on the runner first. `none` is
+          #                  the Fly images, which start from a public base and
+          #                  bake in a RELEASED node-agent binary instead of
+          #                  compiling one.
+          #   harness      — which harness binary the verify step must find ON
+          #                  PATH. `none` is a bare node image.
+          #   modal        — whether the Modal-specific constraints (python3,
+          #                  pip, empty ENTRYPOINT) are checked.
           - name: fly
             dockerfile: fly/node-image/Dockerfile
             context: .
             image: agentpod-node-opencode-fly
+            local_base: none
+            harness: opencode
+            modal: "no"
+          - name: fly-pi
+            dockerfile: fly/node-image/Dockerfile.pi
+            context: .
+            image: agentpod-node-pi-fly
+            local_base: none
+            harness: pi
+            modal: "no"
           - name: modal
             dockerfile: apps/node-agent/deploy/Dockerfile.modal
             context: apps/node-agent
             image: agentpod-node-modal
+            local_base: base
+            harness: none
+            modal: "yes"
+          - name: modal-opencode
+            dockerfile: apps/node-agent/deploy/Dockerfile.modal.opencode
+            context: apps/node-agent
+            image: agentpod-node-modal-opencode
+            local_base: opencode
+            harness: opencode
+            modal: "yes"
+          - name: modal-pi
+            dockerfile: apps/node-agent/deploy/Dockerfile.modal.pi
+            context: apps/node-agent
+            image: agentpod-node-modal-pi
+            local_base: pi
+            harness: pi
+            modal: "yes"
     steps:
       - name: Skip images not selected
         id: gate
@@ -84,16 +123,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Both harness images are FROM agentpod-node:base, which is not published.
-      # The runner is amd64, so this is a native build — no emulation, and no
-      # risk of clobbering a developer's local arm64 base tag.
+      # agentpod-node:base is not published anywhere, so every image that is
+      # FROM it (directly, or through a harness layer) has to build it here. The
+      # runner is amd64, so this is a native build — no emulation, and no risk
+      # of clobbering a developer's local arm64 base tag.
       - name: Build the base image
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && matrix.local_base != 'none'
         run: |
           docker build \
             --platform linux/amd64 \
             -f apps/node-agent/deploy/Dockerfile.base \
             -t agentpod-node:base \
+            apps/node-agent
+
+      # The Modal harness images are FROM the harness image rather than beside
+      # it, so that the opencode/pi version pins have ONE definition
+      # (Dockerfile.opencode, Dockerfile.pi) instead of a copy per substrate
+      # that drifts on the next bump. That makes the harness layer a build
+      # dependency, and it is equally unpublished.
+      - name: Build the harness layer this image extends
+        if: steps.gate.outputs.run == 'true' && matrix.local_base != 'none' && matrix.local_base != 'base'
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            -f "apps/node-agent/deploy/Dockerfile.${{ matrix.local_base }}" \
+            -t "agentpod-node-${{ matrix.local_base }}:local" \
             apps/node-agent
 
       - name: Build and push
@@ -113,17 +167,63 @@ jobs:
           echo "published ${ref}:${{ inputs.tag }} from ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
 
       # A pushed image nobody verified is how a broken station reaches a
-      # substrate. These are the same checks the image tasks ran locally.
+      # substrate. Every claim an image makes is checked against the image that
+      # was actually pushed, not against the Dockerfile that was supposed to
+      # produce it.
       - name: Verify what was published
         if: steps.gate.outputs.run == 'true'
         run: |
+          set -eux
           ref="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ inputs.tag }}"
+
+          # Every image: the node-agent binary is there and runs.
           docker run --rm --entrypoint /agentpod-node "$ref" version
-          if [ "${{ matrix.name }}" = "modal" ]; then
-            # Modal's runtime is Python and it takes over the entrypoint; an
-            # image missing either is accepted at push and fails at first boot.
+
+          if [ "${{ matrix.modal }}" = "yes" ]; then
+            # Modal's runtime is Python and it takes over the container command;
+            # an image missing either is accepted at push and fails at first boot.
             docker run --rm --entrypoint python3 "$ref" --version
             docker run --rm --entrypoint sh "$ref" -c 'python3 -m pip --version'
-            test -z "$(docker inspect -f '{{json .Config.Entrypoint}}' "$ref" | tr -d 'null')" \
-              || { echo "Modal image must have an empty ENTRYPOINT"; exit 1; }
+
+            # An empty ENTRYPOINT reads back as `null` when nothing ever set one
+            # and as `[]` when a harness layer's ENTRYPOINT was cleared by this
+            # image — both are empty, and only a non-empty one is the failure
+            # (Modal requires any ENTRYPOINT to end in `exec "$@"`, and ours
+            # never can). Matching on the two shapes rather than stripping
+            # characters out of the JSON, which quietly passed `[]` as truthy.
+            entrypoint="$(docker inspect -f '{{json .Config.Entrypoint}}' "$ref")"
+            case "$entrypoint" in
+              null|"[]") ;;
+              *) echo "Modal image must have an empty ENTRYPOINT, got: $entrypoint"; exit 1 ;;
+            esac
           fi
+
+          # The harness binary must be findable by a NON-LOGIN, NON-INTERACTIVE
+          # process — which is what the node-agent is, and what it spawns ACP
+          # adapters as. `env -i` throws away the image's own ENV and hands the
+          # command systemd's default PATH; an install that only works from a
+          # developer's shell (a moved npm prefix, a profile script, a
+          # user-local bin) fails here instead of failing live. This is the
+          # check that would have caught the 2026-08-12 pi-acp incident, where
+          # the adapter was spawned with a minimal PATH and could not see `pi`.
+          service_path='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+          case "${{ matrix.harness }}" in
+            opencode)
+              docker run --rm --entrypoint env "$ref" -i "PATH=$service_path" HOME=/root \
+                sh -c 'command -v opencode && opencode --version'
+              ;;
+            pi)
+              docker run --rm --entrypoint env "$ref" -i "PATH=$service_path" HOME=/root \
+                sh -c 'command -v pi && command -v pi-acp && pi --version'
+              ;;
+            none)
+              # A bare node image must NOT carry a harness: the hub resolves a
+              # separate image per harness, and one that quietly bundled a
+              # harness would make a "Generic" runtime detect stations nobody
+              # asked for.
+              docker run --rm --entrypoint sh "$ref" -c '
+                if command -v opencode >/dev/null 2>&1 || command -v pi >/dev/null 2>&1; then
+                  echo "harness-less image unexpectedly contains a harness"; exit 1
+                fi'
+              ;;
+          esac

--- a/apps/hub/src/services/runtimes-image.ts
+++ b/apps/hub/src/services/runtimes-image.ts
@@ -1,0 +1,101 @@
+/**
+ * Which container image a harness runs on a given provider.
+ *
+ * Lifted out of runtimes.ts so it can be imported by BOOT-TIME code
+ * (utils/validate-config.ts) without dragging in the database layer: the whole
+ * point of the boot check is to run before anything else, and a config
+ * validator that first opens a Postgres pool is a validator that cannot report
+ * a bad config on a hub whose database is down. runtimes.ts re-exports
+ * `imageForHarness`, so every existing importer is unaffected.
+ *
+ * Image resolution lives in the service layer so drivers stay image-agnostic —
+ * they always receive the resolved image via ProvisionSpec.image and never read
+ * env themselves.
+ */
+
+/**
+ * The env-var infix for a harness: `""` for the generic node image,
+ * `_OPENCODE`, `_PI`. Unknown harnesses resolve to the generic scope rather
+ * than inventing a variable name nobody documents.
+ */
+function suffixFor(harness: string): string {
+  return harness === "opencode" ? "_OPENCODE" : harness === "pi" ? "_PI" : "";
+}
+
+/** `modal` → `MODAL`; anything a provider name can legally contain is folded. */
+function scopeFor(provider: string): string {
+  return provider.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
+/**
+ * The provider-scoped variable that names this harness's image on this
+ * provider — `NODE_AGENT_MODAL_PI_IMAGE`, `NODE_AGENT_FLY_OPENCODE_IMAGE`, …
+ *
+ * Exported so the boot check and the resolver cannot drift: a validator that
+ * tells an operator to set a variable the resolver never reads is worse than no
+ * validator, because the operator sets it and believes they are done.
+ */
+export function providerImageEnvVar(harness: string, provider: string): string {
+  return `NODE_AGENT_${scopeFor(provider)}${suffixFor(harness)}_IMAGE`;
+}
+
+/** The un-scoped fallback: `NODE_AGENT_OPENCODE_IMAGE`, … */
+export function harnessImageEnvVar(harness: string): string {
+  return `NODE_AGENT${suffixFor(harness)}_IMAGE`;
+}
+
+/**
+ * Can a substrate that PULLS its images do anything with this reference?
+ *
+ * Deliberately the same weak test the Modal driver applies before it creates a
+ * sandbox (`spec.image.includes("/")`), and deliberately not tightened into
+ * "the first segment must contain a dot or a colon": `rakeshgangwar/agentpod-node-modal:v1`
+ * is a perfectly pullable Docker Hub reference, and a stricter rule would
+ * refuse to boot a hub whose images are on Docker Hub. What it catches is the
+ * one thing that is always wrong — a bare local tag such as
+ * `agentpod-node-opencode:local`, which exists only in a developer's own Docker
+ * daemon and gives a registry-pulling substrate nothing to fetch.
+ */
+export function isPullableFromRegistry(image: string): boolean {
+  return image.includes("/");
+}
+
+/**
+ * Resolve the container image for a harness on a given provider.
+ *
+ * It is provider-scoped because two enabled substrates need different
+ * references for the same harness: Docker runs `agentpod-node-opencode:local`
+ * from the host daemon, while Modal pulls from a registry and runs linux/amd64
+ * only. One variable cannot serve both, and the failure mode when it tries is
+ * silent — a sandbox that never boots, a runtime stuck in `provisioning`, and a
+ * sweeper message two minutes later that names nothing.
+ *
+ * Resolution order, first non-empty hit wins:
+ *   NODE_AGENT_<PROVIDER>_<HARNESS>_IMAGE   e.g. NODE_AGENT_MODAL_OPENCODE_IMAGE
+ *   NODE_AGENT_<HARNESS>_IMAGE              e.g. NODE_AGENT_OPENCODE_IMAGE
+ *   the built-in local default
+ *
+ * With no provider-scoped variable set, this resolves exactly what it resolved
+ * before — Docker and Cloudflare are unchanged, which is checked against the
+ * documented variable names in runtimes-image.test.ts.
+ *
+ * The provider-scoped name is not free-form: `NODE_AGENT_MODAL_IMAGE` is the
+ * same variable `config.ts` reads and `validate-config.ts` refuses to boot
+ * without. The two must stay in step, or an operator satisfies the boot check
+ * and Modal is still handed a tag it cannot pull.
+ */
+export function imageForHarness(harness: string, provider: string): string {
+  const suffix = suffixFor(harness);
+  const fallback =
+    suffix === "_OPENCODE"
+      ? "agentpod-node-opencode:local"
+      : suffix === "_PI"
+        ? "agentpod-node-pi:local"
+        : "agentpod-node:local";
+
+  return (
+    process.env[providerImageEnvVar(harness, provider)] ||
+    process.env[harnessImageEnvVar(harness)] ||
+    fallback
+  );
+}

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -40,6 +40,7 @@ import {
   providerManifests,
   isProviderEnabled,
 } from "./provisioner/registry";
+import { imageForHarness } from "./runtimes-image";
 import { HARNESS_MIN_MEMORY_MB, tierFitsHarness } from "@agentpod/contract";
 import type { ProvisionedRuntime, ResourceTier } from "@agentpod/contract";
 import type { RuntimeProvisioner, RuntimeState } from "./provisioner/types";
@@ -50,49 +51,12 @@ const prefixedId = (prefix: string) =>
   `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
 
 /**
- * Resolve the container image for a harness on a given provider.
- *
- * Image resolution lives in the service layer so drivers stay image-agnostic —
- * they always receive the resolved image via ProvisionSpec.image and never read
- * env themselves.
- *
- * It is provider-scoped because two enabled substrates need different
- * references for the same harness: Docker runs `agentpod-node-opencode:local`
- * from the host daemon, while Modal pulls from a registry and runs linux/amd64
- * only. One variable cannot serve both, and the failure mode when it tries is
- * silent — a sandbox that never boots, a runtime stuck in `provisioning`, and a
- * sweeper message two minutes later that names nothing.
- *
- * Resolution order, first non-empty hit wins:
- *   NODE_AGENT_<PROVIDER>_<HARNESS>_IMAGE   e.g. NODE_AGENT_MODAL_OPENCODE_IMAGE
- *   NODE_AGENT_<HARNESS>_IMAGE              e.g. NODE_AGENT_OPENCODE_IMAGE
- *   the built-in local default
- *
- * With no provider-scoped variable set, this resolves exactly what it resolved
- * before — Docker and Cloudflare are unchanged, which is checked against the
- * documented variable names in runtimes-image.test.ts.
- *
- * The provider-scoped name is not free-form: `NODE_AGENT_MODAL_IMAGE` is the
- * same variable `config.ts` reads and `validate-config.ts` refuses to boot
- * without. The two must stay in step, or an operator satisfies the boot check
- * and Modal is still handed a tag it cannot pull.
+ * Image resolution now lives in ./runtimes-image.ts, so that boot-time config
+ * validation can ask the same question without importing this module and, with
+ * it, the database layer. Re-exported because every caller and both test files
+ * reach it through here.
  */
-export function imageForHarness(harness: string, provider: string): string {
-  const suffix = harness === "opencode" ? "_OPENCODE" : harness === "pi" ? "_PI" : "";
-  const scope = provider.toUpperCase().replace(/[^A-Z0-9]/g, "_");
-  const fallback =
-    suffix === "_OPENCODE"
-      ? "agentpod-node-opencode:local"
-      : suffix === "_PI"
-        ? "agentpod-node-pi:local"
-        : "agentpod-node:local";
-
-  return (
-    process.env[`NODE_AGENT_${scope}${suffix}_IMAGE`] ||
-    process.env[`NODE_AGENT${suffix}_IMAGE`] ||
-    fallback
-  );
-}
+export { imageForHarness };
 
 export type RuntimeRow = typeof provisionedRuntimes.$inferSelect;
 

--- a/apps/hub/src/utils/validate-config.test.ts
+++ b/apps/hub/src/utils/validate-config.test.ts
@@ -201,7 +201,14 @@ describe("validateConfig — modal", () => {
       "MODAL_TOKEN_SECRET",
       "MODAL_APP_NAME",
       "NODE_AGENT_MODAL_IMAGE",
+      "NODE_AGENT_MODAL_OPENCODE_IMAGE",
+      "NODE_AGENT_MODAL_PI_IMAGE",
+      "NODE_AGENT_FLY_IMAGE",
+      "NODE_AGENT_FLY_OPENCODE_IMAGE",
+      "NODE_AGENT_FLY_PI_IMAGE",
       "NODE_AGENT_IMAGE",
+      "NODE_AGENT_OPENCODE_IMAGE",
+      "NODE_AGENT_PI_IMAGE",
       "PROVISIONING_HUB_URL",
       "ENABLE_CLOUDFLARE_SANDBOXES",
       "CLOUDFLARE_SANDBOX_IMAGE",
@@ -275,6 +282,25 @@ describe("validateConfig — modal", () => {
     expect(result.fields).toEqual([]);
   });
 
+  it("REFUSES a Modal hub that set only the generic image (issue #283)", () => {
+    // The variables below are exactly what DEPLOYMENT.md used to ask for, and
+    // they produced a hub that booted and then answered 502 for the two
+    // harnesses the console offers. Driven through real env parsing because the
+    // subject is the VARIABLE NAMES: a rule that reported a name the resolver
+    // does not read would send an operator to set something with no effect.
+    const result = collectInChild({
+      ENABLE_MODAL_PROVISIONING: "true",
+      MODAL_TOKEN_ID: "ak-live-id",
+      MODAL_TOKEN_SECRET: "as-live-secret",
+      NODE_AGENT_MODAL_IMAGE: "ghcr.io/example/agentpod-node-modal:v1",
+      PROVISIONING_HUB_URL: "https://hub.example",
+    });
+    expect(result.fields).toEqual([
+      "NODE_AGENT_MODAL_OPENCODE_IMAGE",
+      "NODE_AGENT_MODAL_PI_IMAGE",
+    ]);
+  });
+
   it("boots a Modal hub configured with the documented variable names", () => {
     // This is the test that catches a config.ts reading the wrong env var —
     // e.g. taking the image from Docker's NODE_AGENT_IMAGE. Every rule above
@@ -285,6 +311,9 @@ describe("validateConfig — modal", () => {
       MODAL_TOKEN_ID: "ak-live-id",
       MODAL_TOKEN_SECRET: "as-live-secret",
       NODE_AGENT_MODAL_IMAGE: "ghcr.io/example/agentpod-node-modal:v1",
+      NODE_AGENT_MODAL_OPENCODE_IMAGE:
+        "ghcr.io/example/agentpod-node-modal-opencode:v1",
+      NODE_AGENT_MODAL_PI_IMAGE: "ghcr.io/example/agentpod-node-modal-pi:v1",
       MODAL_APP_NAME: "agentpod-prod",
       PROVISIONING_HUB_URL: "https://hub.example",
     });
@@ -385,5 +414,187 @@ describe("fly provisioning config", () => {
       fly: { ...config.fly, enabled: false, apiToken: "", volumeSizeGb: 0 },
     } as typeof config;
     expect(flyErrors(live)).toEqual([]);
+  });
+});
+
+// ─── Per-harness images on the substrates that PULL them ─────────────────────
+
+/**
+ * The gap issue #283 was found through: a hub with Modal enabled and only
+ * `NODE_AGENT_MODAL_IMAGE` set boots cleanly, offers OpenCode and Pi in the New
+ * Runtime dialog (the console offers all three harnesses for every provider),
+ * and then answers 502 the moment anyone picks one — because
+ * `imageForHarness("opencode", "modal")` falls through to the local Docker tag
+ * and the driver refuses it as "not a registry reference Modal can pull".
+ *
+ * WHY THE RESOLVED IMAGE, NOT THE PRESENCE OF A VARIABLE. The rule asks the
+ * SAME function the provisioner asks. An operator who points the un-scoped
+ * `NODE_AGENT_PI_IMAGE` at a registry reference has genuinely configured Pi
+ * everywhere, and a check that demanded the provider-scoped name would refuse a
+ * working hub — while a check that merely counted variables would pass a hub
+ * whose variable holds `agentpod-node-pi:local`.
+ *
+ * WHY MODAL REFUSES THE BOOT AND FLY ONLY REPORTS. Not squeamishness: after
+ * this change every advertised harness HAS a published Modal image
+ * (agentpod-node-modal, -modal-opencode, -modal-pi), so demanding all three
+ * costs a Modal operator three lines they can actually satisfy. Fly has no
+ * generic (harness-less) image published at all, so a fatal rule there would
+ * make `ENABLE_FLY_PROVISIONING=true` unbootable no matter what the operator
+ * did — turning a substrate that serves OpenCode and Pi perfectly well into a
+ * hub that will not start. When a Fly generic image exists, this becomes fatal
+ * for Fly too, and the test below is where that change gets recorded.
+ */
+describe("validateConfig — per-harness images on registry-pulling providers", () => {
+  const LOCAL_DEFAULTS: Record<string, string> = {
+    none: "agentpod-node:local",
+    opencode: "agentpod-node-opencode:local",
+    pi: "agentpod-node-pi:local",
+  };
+
+  /**
+   * A stand-in for imageForHarness keyed `"<provider>:<harness>"`, falling back
+   * to the same local defaults production falls back to. Injected rather than
+   * driven through process.env so these tests cannot be broken by a developer's
+   * apps/hub/.env — the real variable NAMES are covered in the child-process
+   * tests further down, which is the only place they can be.
+   */
+  const resolving =
+    (images: Record<string, string>) => (harness: string, provider: string) =>
+      images[`${provider}:${harness}`] ?? LOCAL_DEFAULTS[harness] ?? "agentpod-node:local";
+
+  /**
+   * Image errors only. The built-in ENCRYPTION_KEY default is 33 characters and
+   * is therefore always an error in a hand-built config — a pre-existing quirk
+   * (see collectInChild above) that has nothing to do with images and would
+   * otherwise sit in every assertion here.
+   */
+  const errorsWith = (cfg: typeof config, images: Record<string, string>) =>
+    collectConfigErrors(cfg, quiet, resolving(images)).filter((e) =>
+      e.field.startsWith("NODE_AGENT_")
+    );
+
+  const warningsWith = (cfg: typeof config, images: Record<string, string>) => {
+    const warnings: string[] = [];
+    collectConfigErrors(cfg, (m) => warnings.push(m), resolving(images));
+    return warnings;
+  };
+
+  const modalHub = (over: Partial<typeof config.modal> = {}) =>
+    ({
+      ...config,
+      modal: {
+        ...config.modal,
+        enabled: true,
+        tokenId: "tok-id",
+        tokenSecret: "tok-secret",
+        image: "ghcr.io/example/agentpod-node-modal:v1",
+        ...over,
+      },
+      provisioningHubUrl: "https://hub.example",
+    }) as typeof config;
+
+  const flyHub = (over: Partial<typeof config.fly> = {}) =>
+    ({
+      ...config,
+      fly: { ...config.fly, enabled: true, apiToken: "fly-token", volumeSizeGb: 3, ...over },
+    }) as typeof config;
+
+  const MODAL_IMAGES = {
+    "modal:none": "ghcr.io/example/agentpod-node-modal:v1",
+    "modal:opencode": "ghcr.io/example/agentpod-node-modal-opencode:v1",
+    "modal:pi": "ghcr.io/example/agentpod-node-modal-pi:v1",
+  };
+
+  it("REFUSES a Modal hub that cannot serve a harness the console offers", () => {
+    // Exactly the live failure in #283: the generic image is set, the other two
+    // are not, and nothing said so until a user clicked Create.
+    const fields = errorsWith(modalHub(), {
+      "modal:none": "ghcr.io/example/agentpod-node-modal:v1",
+    }).map((e) => e.field);
+    expect(fields).toContain("NODE_AGENT_MODAL_OPENCODE_IMAGE");
+    expect(fields).toContain("NODE_AGENT_MODAL_PI_IMAGE");
+  });
+
+  it("names the harness, the substrate and the variable that closes the gap", () => {
+    // A boot refusal is only worth having if the operator can act on it without
+    // reading the source.
+    const error = errorsWith(modalHub(), {}).find(
+      (e) => e.field === "NODE_AGENT_MODAL_PI_IMAGE"
+    )!;
+    expect(error.message).toMatch(/pi/);
+    expect(error.message).toMatch(/ENABLE_MODAL_PROVISIONING/);
+    expect(error.message).toMatch(/agentpod-node-pi:local/);
+  });
+
+  it("accepts a Modal hub with every advertised harness pointed at a registry", () => {
+    const fields = errorsWith(modalHub(), MODAL_IMAGES).map((e) => e.field);
+    expect(fields).not.toContain("NODE_AGENT_MODAL_OPENCODE_IMAGE");
+    expect(fields).not.toContain("NODE_AGENT_MODAL_PI_IMAGE");
+  });
+
+  it("accepts an un-scoped variable that is itself a registry reference", () => {
+    // NODE_AGENT_OPENCODE_IMAGE=ghcr.io/... serves Docker and Modal at once —
+    // documented, legitimate, and invisible to a rule that counted variables
+    // instead of asking what the provisioner would actually be handed.
+    const fields = errorsWith(modalHub(), {
+      ...MODAL_IMAGES,
+      "modal:opencode": "ghcr.io/example/shared-opencode:v1",
+    }).map((e) => e.field);
+    expect(fields).not.toContain("NODE_AGENT_MODAL_OPENCODE_IMAGE");
+  });
+
+  it("says nothing about harness images when Modal is disabled", () => {
+    // Every deployment today. A hub that never registers the driver must not be
+    // stopped from booting by that driver's variables.
+    const fields = errorsWith(modalHub({ enabled: false }), {}).map((e) => e.field);
+    expect(fields).not.toContain("NODE_AGENT_MODAL_OPENCODE_IMAGE");
+    expect(fields).not.toContain("NODE_AGENT_MODAL_PI_IMAGE");
+  });
+
+  it("REPORTS a Fly harness with no registry image, without refusing the boot", () => {
+    const cfg = flyHub();
+    const images = { "fly:opencode": "ghcr.io/example/agentpod-node-opencode-fly:v1" };
+    const warnings = warningsWith(cfg, images).join("\n");
+    // Pi and the generic image are unconfigured, so both are named...
+    expect(warnings).toMatch(/NODE_AGENT_FLY_PI_IMAGE/);
+    expect(warnings).toMatch(/NODE_AGENT_FLY_IMAGE/);
+    // ...the one that IS configured is not...
+    expect(warnings).not.toMatch(/NODE_AGENT_FLY_OPENCODE_IMAGE/);
+    // ...and the hub still boots, which is the whole difference from Modal.
+    expect(errorsWith(cfg, images).map((e) => e.field)).toEqual([]);
+  });
+
+  it("says nothing about Fly harness images when Fly is off", () => {
+    expect(warningsWith(flyHub({ enabled: false }), {}).join("\n")).not.toMatch(
+      /NODE_AGENT_FLY/
+    );
+  });
+
+  it("reports nothing when every Fly harness resolves to a registry image", () => {
+    const warnings = warningsWith(flyHub(), {
+      "fly:none": "ghcr.io/example/agentpod-node-fly:v1",
+      "fly:opencode": "ghcr.io/example/agentpod-node-opencode-fly:v1",
+      "fly:pi": "ghcr.io/example/agentpod-node-pi-fly:v1",
+    }).join("\n");
+    expect(warnings).not.toMatch(/NODE_AGENT_FLY/);
+  });
+
+  it("leaves the live hub — docker + cloudflare, local tags everywhere — alone", () => {
+    // The rule is about substrates that PULL. Docker's images come from the
+    // host daemon and Cloudflare's is baked into the deployed worker
+    // (imageBinding: "fixed", covered by CLOUDFLARE_SANDBOX_IMAGE), so a local
+    // tag is correct for both and must never be reported here.
+    const live = {
+      ...config,
+      cloudflare: {
+        ...config.cloudflare,
+        enabled: true,
+        sandboxImage: "agentpod-node-opencode:local",
+      },
+      modal: { ...config.modal, enabled: false },
+      fly: { ...config.fly, enabled: false },
+    } as typeof config;
+    expect(errorsWith(live, {}).map((e) => e.field)).toEqual([]);
+    expect(warningsWith(live, {}).join("\n")).not.toMatch(/NODE_AGENT_/);
   });
 });

--- a/apps/hub/src/utils/validate-config.ts
+++ b/apps/hub/src/utils/validate-config.ts
@@ -1,4 +1,11 @@
+import { RuntimeHarness } from "@agentpod/contract";
 import { config } from "../config";
+import {
+  harnessImageEnvVar,
+  imageForHarness,
+  isPullableFromRegistry,
+  providerImageEnvVar,
+} from "../services/runtimes-image";
 
 export interface ValidationError {
   field: string;
@@ -7,6 +14,111 @@ export interface ValidationError {
 
 /** Where non-fatal advice goes. Injectable so tests are not noisy. */
 type Warn = (message: string) => void;
+
+/**
+ * How the hub resolves a harness's image on a provider. Injectable for the same
+ * reason `warn` is: the rules below must be exercisable against a config object
+ * without a test's answers depending on the developer's own environment.
+ * Production passes the real resolver — the SAME one createRuntime hands to the
+ * driver, which is the entire point of checking it here.
+ */
+type ResolveImage = (harness: string, provider: string) => string;
+
+/**
+ * Substrates that PULL their images, and what a missing one costs there.
+ *
+ * Docker is absent because its images come from the host daemon, where a local
+ * tag is exactly right. Cloudflare is absent because its image is baked into
+ * the deployed worker (`imageBinding: "fixed"`) and is covered by
+ * CLOUDFLARE_SANDBOX_IMAGE above — a per-harness variable would be a fiction
+ * there, since the driver refuses any image but the deployed one.
+ *
+ * `fatal` differs between the two, and not out of squeamishness:
+ *
+ *   Modal — every harness the console advertises has a published image
+ *   (agentpod-node-modal, -modal-opencode, -modal-pi), so a Modal operator can
+ *   satisfy this in three lines. Refusing the boot is what turns issue #283's
+ *   failure ("502 The provisioning driver failed", discovered by a user
+ *   clicking Create) into a sentence at startup naming the variable.
+ *
+ *   Fly — there is NO generic (harness-less) Fly image published. A fatal rule
+ *   would therefore make ENABLE_FLY_PROVISIONING=true unbootable no matter what
+ *   the operator did, taking down a substrate that serves OpenCode and Pi
+ *   perfectly well. So Fly is reported at boot instead. When a generic Fly image
+ *   exists, flip this to true — that is the whole change.
+ */
+const REGISTRY_PULLING_PROVIDERS: readonly {
+  provider: string;
+  flag: string;
+  fatal: boolean;
+  enabled: (cfg: typeof config) => boolean;
+  /** Harnesses covered by a rule of their own, so they are not reported twice. */
+  alreadyChecked: readonly string[];
+}[] = [
+  {
+    provider: "modal",
+    flag: "ENABLE_MODAL_PROVISIONING",
+    fatal: true,
+    enabled: (cfg) => cfg.modal.enabled,
+    // NODE_AGENT_MODAL_IMAGE is a config field with its own rule above;
+    // reporting the same variable twice would read as two separate problems.
+    alreadyChecked: ["none"],
+  },
+  {
+    provider: "fly",
+    flag: "ENABLE_FLY_PROVISIONING",
+    fatal: false,
+    enabled: (cfg) => cfg.fly.enabled,
+    // Fly has no image rule of its own, so its generic image is checked here or
+    // nowhere.
+    alreadyChecked: [],
+  },
+];
+
+/**
+ * Every harness the console offers for EVERY provider — the New Runtime dialog
+ * lists all of them regardless of substrate, so every one of them is a promise
+ * the hub has to keep. Read from the contract rather than copied, so adding a
+ * harness to `RuntimeHarness` automatically extends this check instead of
+ * silently adding a fourth way to answer 502.
+ */
+const ADVERTISED_HARNESSES: readonly string[] = RuntimeHarness.options;
+
+/**
+ * "The image this provider would actually be handed for this harness is a local
+ * Docker tag, and this provider cannot pull those."
+ *
+ * The check asks the resolver, not the environment: an operator who points the
+ * un-scoped NODE_AGENT_PI_IMAGE at a registry reference has configured Pi for
+ * every provider, and demanding the provider-scoped variable on top would
+ * refuse a hub that works.
+ */
+function harnessImageProblems(
+  provider: string,
+  flag: string,
+  resolveImage: ResolveImage,
+  skipHarnesses: readonly string[] = []
+): ValidationError[] {
+  const problems: ValidationError[] = [];
+  for (const harness of ADVERTISED_HARNESSES) {
+    if (skipHarnesses.includes(harness)) continue;
+    const resolved = resolveImage(harness, provider);
+    if (isPullableFromRegistry(resolved)) continue;
+    problems.push({
+      field: providerImageEnvVar(harness, provider),
+      message:
+        `The ${provider} substrate pulls its images from a registry, but the ` +
+        `"${harness}" harness resolves to "${resolved}" — a tag that exists only in a ` +
+        `local Docker daemon. The console offers every harness for every provider, so ` +
+        `a runtime created with "${harness}" on ${provider} fails at provision time. ` +
+        `Set ${providerImageEnvVar(harness, provider)} to a public registry reference, ` +
+        `or point the un-scoped ${harnessImageEnvVar(harness)} at one. This substrate ` +
+        `is enabled by ${flag}=true; unset it and nothing here applies. ` +
+        `See docs/DEPLOYMENT.md.`,
+    });
+  }
+  return problems;
+}
 
 function hasMinimumEntropy(value: string, minLength: number = 32): boolean {
   if (value.length < minLength) return false;
@@ -39,7 +151,8 @@ function hasMinimumEntropy(value: string, minLength: number = 32): boolean {
  */
 export function collectConfigErrors(
   cfg: typeof config = config,
-  warn: Warn = console.warn
+  warn: Warn = console.warn,
+  resolveImage: ResolveImage = imageForHarness
 ): ValidationError[] {
   const errors: ValidationError[] = [];
   const isProduction = cfg.nodeEnv === "production";
@@ -220,6 +333,27 @@ export function collectConfigErrors(
         `Must be at least 1 (got ${cfg.fly.volumeSizeGb}). The workspace lives on this volume ` +
         "because the Fly rootfs does not survive a stop.",
     });
+  }
+
+  // ── Per-harness images on the substrates that pull them ────────────────────
+  //
+  // Issue #283: the hub checked NODE_AGENT_MODAL_IMAGE and nothing else, so a
+  // Modal hub booted clean while being unable to serve either harness the
+  // console offers. The generic image is a config-object value and is already
+  // checked above; the per-harness variables are read by nothing except the
+  // resolver, so this asks the resolver.
+  for (const { provider, flag, fatal, enabled, alreadyChecked } of REGISTRY_PULLING_PROVIDERS) {
+    if (!enabled(cfg)) continue;
+
+    const problems = harnessImageProblems(provider, flag, resolveImage, alreadyChecked);
+
+    if (fatal) {
+      errors.push(...problems);
+    } else {
+      for (const problem of problems) {
+        warn(`⚠️  WARNING: ${problem.field}: ${problem.message}`);
+      }
+    }
   }
 
   return errors;

--- a/apps/node-agent/deploy/Dockerfile.modal.opencode
+++ b/apps/node-agent/deploy/Dockerfile.modal.opencode
@@ -1,0 +1,91 @@
+# syntax=docker/dockerfile:1
+
+# Modal runtime image: node-agent + the OpenCode harness.
+#
+# Dockerfile.modal is the SAME image without a harness — it is `agentpod-node:base`
+# plus python/pip, and it can therefore only run a bare node. That is why
+# `provider=modal, harness=opencode` answered 502 on the live hub (issue #283):
+# with no Modal-scoped OpenCode image to resolve, imageForHarness() fell back to
+# the local Docker tag and the driver refused it before creating a sandbox.
+#
+# BUILT ON TOP OF THE HARNESS IMAGE, NOT BESIDE IT. `FROM agentpod-node-opencode`
+# means the opencode version pin, the BUN_INSTALL_BIN placement and the
+# deliberate absence of sqlite3 have exactly one definition (Dockerfile.opencode)
+# rather than a copy here that drifts on the next version bump. This file adds
+# only what MODAL needs on top of a working harness image.
+#
+# BUILD CONTEXT IS apps/node-agent, and both parents must exist as amd64:
+#
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.base \
+#     -t agentpod-node:base --load apps/node-agent
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.opencode \
+#     -t agentpod-node-opencode:local --load apps/node-agent
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.modal.opencode \
+#     -t ghcr.io/<owner>/agentpod-node-modal-opencode:<version> --push apps/node-agent
+#
+# On Apple Silicon the intermediate tags above are the arm64 ones the local
+# Docker provisioner runs, so pass --build-arg BASE_IMAGE=<your amd64 tag>
+# rather than clobbering them. See Dockerfile.modal for the full explanation.
+#
+# The pushed tag becomes NODE_AGENT_MODAL_OPENCODE_IMAGE, and the hub now
+# REFUSES TO BOOT with ENABLE_MODAL_PROVISIONING=true and no registry reference
+# for it (apps/hub/src/utils/validate-config.ts) — the console offers OpenCode
+# for every provider, so an unset variable is a promise the hub cannot keep.
+#
+# The repository must be PUBLIC: `images.fromRegistry(tag)` is called with no
+# Secret, so Modal cannot authenticate to a private registry.
+#
+# Published by .github/workflows/publish-images.yml (manual dispatch).
+ARG BASE_IMAGE=agentpod-node-opencode:local
+FROM ${BASE_IMAGE}
+
+# The three things Modal requires, each fatal on its own — python3 + pip in the
+# image, an empty ENTRYPOINT, and linux/amd64. Dockerfile.modal carries the full
+# reasoning for all three; this file repeats the mechanics, not the essay.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# The sandbox's main process: anchors /workspace and HOME, then execs the inner
+# entrypoint. Byte-identical to the one the generic Modal image runs.
+COPY deploy/modal-entrypoint.sh /modal-entrypoint.sh
+RUN chmod +x /modal-entrypoint.sh
+
+# WHICH inner entrypoint, declared by the image because the driver cannot know.
+# Modal passes the identical command ["/modal-entrypoint.sh"] to every image it
+# starts, so an OpenCode image that did not say this would run the generic
+# enrol-then-run script and never start `opencode serve` — leaving a station
+# whose Health panel reads "stopped", whose lifecycle Stop/Start verbs are not
+# advertised (they are gated on AGENTPOD_OPENCODE_SUPERVISED, which that script
+# exports), and whose project list is empty because nothing seeded the
+# discovery directory the descriptor enumerates.
+ENV AGENTPOD_INNER_ENTRYPOINT=/node-opencode-entrypoint.sh
+# This is the ONE thing in this image that rests on Modal honouring an image's
+# ENV in a sandbox. If it ever did not, the failure is quiet and specific: the
+# station enrols and looks healthy, its Health panel reports opencode stopped,
+# and no `opencode serve` appears in the sandbox log. That is the first thing to
+# check on a live boot of this image — the wrapper's behaviour itself is covered
+# by deploy/test-modal-entrypoint.sh.
+
+# KNOWN COST, stated rather than discovered later: opencode keeps its session
+# state under $HOME/.local/share/opencode, and on Modal HOME must stay on the
+# disposable rootfs — the Volume holds the workspace and must never hold node
+# credentials (see modal-entrypoint.sh). Modal destroys every sandbox within 24
+# hours and the hub rotates before it does, so an OpenCode station on Modal
+# keeps its FILES across a rotation and loses its conversation history. Fly,
+# whose HOME lives on the volume, keeps both.
+
+# The mount point for the runtime's Modal Volume, created so the path exists
+# even in a sandbox started without one — the wrapper then reports that the
+# workspace is not a real mount instead of dying on a missing directory.
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Cleared on purpose, and here it is CLEARING something: Dockerfile.opencode
+# sets ENTRYPOINT ["/node-opencode-entrypoint.sh"], which Modal's runtime cannot
+# take over (it does not end in `exec "$@"`). An image that inherited it is
+# accepted at push and fails at first boot. The driver supplies the command.
+ENTRYPOINT []

--- a/apps/node-agent/deploy/Dockerfile.modal.pi
+++ b/apps/node-agent/deploy/Dockerfile.modal.pi
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1
+
+# Modal runtime image: node-agent + the Pi harness.
+#
+# Before this image, Pi could not run on ANY provisioned substrate: the fleet
+# had a Pi descriptor and a Pi Docker image, and neither Modal nor Fly had an
+# image to pull (issue #283).
+#
+# BUILT ON TOP OF THE HARNESS IMAGE, NOT BESIDE IT. `FROM agentpod-node-pi`
+# means the Node 24 source, the `@earendil-works/pi-coding-agent@0.84.1` and
+# `pi-acp@0.0.33` pins and the --ignore-scripts/ripgrep pairing have exactly one
+# definition (Dockerfile.pi). This file adds only what MODAL needs on top.
+#
+# BUILD CONTEXT IS apps/node-agent, and both parents must exist as amd64:
+#
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.base \
+#     -t agentpod-node:base --load apps/node-agent
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.pi \
+#     -t agentpod-node-pi:local --load apps/node-agent
+#   docker buildx build --platform linux/amd64 \
+#     -f apps/node-agent/deploy/Dockerfile.modal.pi \
+#     -t ghcr.io/<owner>/agentpod-node-modal-pi:<version> --push apps/node-agent
+#
+# On Apple Silicon the intermediate tags above are the arm64 ones the local
+# Docker provisioner runs, so pass --build-arg BASE_IMAGE=<your amd64 tag>
+# rather than clobbering them. See Dockerfile.modal for the full explanation.
+#
+# The pushed tag becomes NODE_AGENT_MODAL_PI_IMAGE, and the hub now REFUSES TO
+# BOOT with ENABLE_MODAL_PROVISIONING=true and no registry reference for it.
+#
+# The repository must be PUBLIC: `images.fromRegistry(tag)` is called with no
+# Secret, so Modal cannot authenticate to a private registry.
+#
+# Published by .github/workflows/publish-images.yml (manual dispatch).
+ARG BASE_IMAGE=agentpod-node-pi:local
+FROM ${BASE_IMAGE}
+
+# WHERE `pi` AND `pi-acp` HAVE TO BE, and why an image is the wrong place to be
+# clever about it. When the node-agent starts an ACP session it spawns the
+# adapter itself, and a spawned process gets the node-agent's PATH — which, for
+# a non-login, non-interactive service, is a minimal one. On 2026-08-12 a live
+# macOS node spawned pi-acp with env=nil, the adapter could not see
+# /opt/homebrew/bin/pi, and the session died; 21 unit tests, a container gate
+# and four green CI checks all missed it, because every one of them ran with a
+# developer's PATH. internal/descriptor/pi.go now prepends the resolved `pi`
+# directory to the child's PATH and falls back to the well-known dirs
+# (/usr/local/bin, /usr/bin, ...) when PATH misses it — but that only works if
+# the binaries are actually in one of them.
+#
+# They are, and not by accident: the NodeSource nodejs package (installed in
+# Dockerfile.pi) uses /usr as its npm prefix, so `npm install -g` links the
+# `pi` and `pi-acp` shims into /usr/bin. No ENV PATH, no profile script, no
+# shell: a process started with the sparsest imaginable environment still finds
+# them. Anything that moved the npm prefix (a `--prefix`, an NPM_CONFIG_PREFIX,
+# a user-local install) would put them somewhere only an interactive shell can
+# see and reintroduce exactly that bug — which is why the publish workflow
+# resolves `pi` under an explicit minimal PATH rather than trusting this
+# comment.
+
+# The three things Modal requires, each fatal on its own — python3 + pip in the
+# image, an empty ENTRYPOINT, and linux/amd64. Dockerfile.modal carries the full
+# reasoning for all three; this file repeats the mechanics, not the essay.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# The sandbox's main process: anchors /workspace and HOME, then execs the inner
+# entrypoint. Byte-identical to the one the generic Modal image runs.
+COPY deploy/modal-entrypoint.sh /modal-entrypoint.sh
+RUN chmod +x /modal-entrypoint.sh
+
+# No AGENTPOD_INNER_ENTRYPOINT here, unlike the OpenCode image: Pi has no
+# daemon — it is invoked per command — so the wrapper's default,
+# /node-entrypoint.sh (enrol, then run), is the right inner command. That is the
+# same reason Dockerfile.pi ships no supervision loop of its own.
+
+# The mount point for the runtime's Modal Volume, created so the path exists
+# even in a sandbox started without one — the wrapper then reports that the
+# workspace is not a real mount instead of dying on a missing directory.
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Cleared on purpose, and here it is CLEARING something: Dockerfile.pi sets
+# ENTRYPOINT ["/node-entrypoint.sh"], which Modal's runtime cannot take over (it
+# does not end in `exec "$@"`). An image that inherited it is accepted at push
+# and fails at first boot. The driver supplies the command.
+ENTRYPOINT []

--- a/apps/node-agent/deploy/modal-entrypoint.sh
+++ b/apps/node-agent/deploy/modal-entrypoint.sh
@@ -117,8 +117,18 @@ cd "$WORKSPACE"
 
 # No arguments is the production case: the driver passes only this script, and
 # the fleet's own entrypoint (enrol, then exec the run loop) takes it from here.
+#
+# WHICH inner entrypoint is the IMAGE's business, not the driver's. Modal takes
+# over the container command, so every Modal image gets the identical argv
+# ["/modal-entrypoint.sh"] (MODAL_ENTRYPOINT in modal.ts) — the driver has no
+# idea which harness it is starting, and teaching it would mean the hub knowing
+# the internal layout of every image it pulls. An image whose harness needs a
+# different inner script therefore declares it as an ENV: the OpenCode image
+# sets AGENTPOD_INNER_ENTRYPOINT=/node-opencode-entrypoint.sh, because
+# `opencode serve` is a daemon and needs that script's supervision loop, while
+# Pi and the generic image have no daemon and the default is correct for them.
 if [ "$#" -eq 0 ]; then
-  set -- /node-entrypoint.sh
+  set -- "${AGENTPOD_INNER_ENTRYPOINT:-/node-entrypoint.sh}"
 fi
 
 exec "$@"

--- a/apps/node-agent/deploy/test-modal-entrypoint.sh
+++ b/apps/node-agent/deploy/test-modal-entrypoint.sh
@@ -118,6 +118,27 @@ check "runs the inner command with the workspace as its working directory" \
   "$OUT" "PWD=$(cd "$TMP/mount" && pwd -P)$"
 check "passes the inner command its arguments" "$OUT" "ARGS=hello there$"
 
+# ── The image chooses its own inner entrypoint ───────────────────────────────
+# Every Modal image is started with the same argv, so the harness layer declares
+# its inner script as an ENV instead. Without this the OpenCode image would run
+# the generic entrypoint and never start the supervised `opencode serve` the
+# station's health check and lifecycle verbs are built around.
+cat >"$TMP/declared.sh" <<'DECLARED'
+#!/bin/sh
+echo "RAN=declared"
+DECLARED
+chmod +x "$TMP/declared.sh"
+
+OUT="$(AGENTPOD_INNER_ENTRYPOINT="$TMP/declared.sh" AGENTPOD_WORKSPACE_PATH="$TMP/mount" \
+  sh "$WRAPPER" 2>/dev/null || true)"
+check "execs the inner entrypoint the image declared" "$OUT" "RAN=declared$"
+
+# An explicit argument still wins, so the test and operator paths are unchanged.
+OUT="$(AGENTPOD_INNER_ENTRYPOINT="$TMP/declared.sh" AGENTPOD_WORKSPACE_PATH="$TMP/mount" \
+  sh "$WRAPPER" "$TMP/inner.sh" hello 2>/dev/null || true)"
+check "an explicit argument still overrides the declared inner entrypoint" \
+  "$OUT" "ARGS=hello$"
+
 # ── HOME never lands on the Volume ───────────────────────────────────────────
 # os.UserConfigDir() with no HOME returns an error the node-agent discards,
 # leaving a RELATIVE config path that resolves against the working directory —

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -147,18 +147,18 @@ PROVISIONING_HUB_URL=https://hub.<your-domain>
 # sandbox exists, which makes a mostly-idle station its worst case.
 # ENABLE_MODAL_PROVISIONING=false
 # The hub refuses to boot with ENABLE_MODAL_PROVISIONING=true and any of
-# MODAL_TOKEN_ID / MODAL_TOKEN_SECRET / NODE_AGENT_MODAL_IMAGE /
-# PROVISIONING_HUB_URL missing. The refusal names the variable.
+# MODAL_TOKEN_ID / MODAL_TOKEN_SECRET / PROVISIONING_HUB_URL / the THREE image
+# variables below missing. The refusal names the variable.
 # MODAL_TOKEN_ID=<from the Modal dashboard>
 # MODAL_TOKEN_SECRET=<from the Modal dashboard>
-# A PUBLIC registry image Modal can pull: linux/amd64, carrying python and pip.
-# Build it with apps/node-agent/deploy/Dockerfile.modal.
-# NODE_AGENT_MODAL_IMAGE=ghcr.io/<owner>/agentpod-node-modal:v0.1.0
-# Only covers the Generic harness. Set these too if you provision an
-# OpenCode or Pi runtime on Modal — otherwise it falls back to the local
-# Docker tag and the driver refuses the provision.
-# NODE_AGENT_MODAL_OPENCODE_IMAGE=ghcr.io/<owner>/agentpod-node-modal-opencode:v0.1.0
-# NODE_AGENT_MODAL_PI_IMAGE=ghcr.io/<owner>/agentpod-node-modal-pi:v0.1.0
+# PUBLIC registry images Modal can pull: linux/amd64, carrying python and pip.
+# One per harness the console offers, because the console offers all three for
+# every provider — a missing one is a 502 the first time somebody picks it.
+# Built by .github/workflows/publish-images.yml from Dockerfile.modal,
+# Dockerfile.modal.opencode and Dockerfile.modal.pi.
+# NODE_AGENT_MODAL_IMAGE=ghcr.io/<owner>/agentpod-node-modal:v0.1.24
+# NODE_AGENT_MODAL_OPENCODE_IMAGE=ghcr.io/<owner>/agentpod-node-modal-opencode:v0.1.24
+# NODE_AGENT_MODAL_PI_IMAGE=ghcr.io/<owner>/agentpod-node-modal-pi:v0.1.24
 # Modal App the sandboxes are grouped under. Grouping only; carries no state.
 # MODAL_APP_NAME=agentpod
 # Shortens the lifetime ceiling for a rotation drill. Optional, clamped to 24h,
@@ -182,8 +182,12 @@ PROVISIONING_HUB_URL=https://hub.<your-domain>
 # Fly pulls from a registry, so the local Docker tags above are meaningless to
 # it. Provider-scoped names win over the un-scoped ones, which lets one hub run
 # Docker and Fly on different images. See "Fly Machines settings" below.
-# NODE_AGENT_FLY_IMAGE=ghcr.io/<owner>/agentpod-node-fly:v0.1.0
-# NODE_AGENT_FLY_OPENCODE_IMAGE=ghcr.io/<owner>/agentpod-node-opencode-fly:v0.1.0
+# A harness with no registry image here is REPORTED at boot (⚠️ naming the
+# variable) rather than refused, because no generic Fly image is published —
+# a hub that serves only OpenCode and Pi on Fly is a working hub.
+# NODE_AGENT_FLY_IMAGE=<no image published yet: a Generic Fly runtime cannot work>
+# NODE_AGENT_FLY_OPENCODE_IMAGE=ghcr.io/<owner>/agentpod-node-opencode-fly:v0.1.24
+# NODE_AGENT_FLY_PI_IMAGE=ghcr.io/<owner>/agentpod-node-pi-fly:v0.1.24
 EOF
 chmod 600 /etc/agentpod/hub.env
 ```
@@ -192,9 +196,9 @@ chmod 600 /etc/agentpod/hub.env
 > - `BETTER_AUTH_SECRET`: ≥ 32 characters.
 > - `ENCRYPTION_KEY`: **exactly** 32 bytes. Using `openssl rand -hex 16` produces 32 hex characters = 32 ASCII bytes.
 > - `CLOUDFLARE_SANDBOX_IMAGE`: required whenever `ENABLE_CLOUDFLARE_SANDBOXES=true`, and it must be the image the worker was deployed with (what `imageForHarness` returns for the harness you provision). The Cloudflare driver advertises a **fixed** image and refuses a spec asking for a different one — but only when it knows this value. Unset, it advertises "fixed" and provisions whatever it is handed. Boot validation now fails instead.
-> - Modal: `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `NODE_AGENT_MODAL_IMAGE` and `PROVISIONING_HUB_URL` are **all** required whenever `ENABLE_MODAL_PROVISIONING=true`, and the hub exits at startup without them, naming each one. That is deliberate: two of the four would otherwise fail silently, later, on somebody else's runtime.
+> - Modal: `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `NODE_AGENT_MODAL_IMAGE`, `NODE_AGENT_MODAL_OPENCODE_IMAGE`, `NODE_AGENT_MODAL_PI_IMAGE` and `PROVISIONING_HUB_URL` are **all** required whenever `ENABLE_MODAL_PROVISIONING=true`, and the hub exits at startup without them, naming each one. That is deliberate: most of them would otherwise fail silently, later, on somebody else's runtime.
 > - `NODE_AGENT_MODAL_IMAGE` must be a **public registry** reference. The driver pulls it with `images.fromRegistry(tag)` and no Modal Secret, so a private repository cannot be authenticated to and a local Docker tag like `agentpod-node:local` gives Modal nothing to pull. Boot validation rejects any value without a registry host in it; a private-but-well-formed tag passes validation and then fails at provision time.
-> - `NODE_AGENT_MODAL_IMAGE` covers the **Generic** harness only. A Modal runtime created with the OpenCode or Pi harness resolves `NODE_AGENT_MODAL_OPENCODE_IMAGE` / `NODE_AGENT_MODAL_PI_IMAGE` first, then the un-scoped `NODE_AGENT_OPENCODE_IMAGE` / `NODE_AGENT_PI_IMAGE`, then the local Docker default. Boot validation does not check these, so provision either fails with "not a registry reference Modal can pull", or — worse — silently hands Modal whatever your Docker deployment set.
+> - `NODE_AGENT_MODAL_IMAGE` covers the **Generic** harness only. A Modal runtime created with the OpenCode or Pi harness resolves `NODE_AGENT_MODAL_OPENCODE_IMAGE` / `NODE_AGENT_MODAL_PI_IMAGE` first, then the un-scoped `NODE_AGENT_OPENCODE_IMAGE` / `NODE_AGENT_PI_IMAGE`, then the local Docker default. **Boot validation now checks all three** (issue #283): the console offers every harness for every provider, so a Modal hub that can only serve Generic is a hub advertising two runtimes it cannot create. Whatever the resolved image is — provider-scoped variable, un-scoped variable, or default — it must contain a registry host, or the hub exits naming the variable that would fix it. Pointing the un-scoped `NODE_AGENT_OPENCODE_IMAGE` at a registry reference satisfies both Docker and Modal and is a legitimate way to answer it.
 > - `PROVISIONING_HUB_URL` is required for Modal (not merely recommended, as it is for Docker) because Modal destroys every sandbox at 24 hours and the hub re-creates them on a timer, with no incoming request to take an origin from. It must be reachable **from inside a Modal sandbox** — a public URL or a tunnel, never `localhost`.
 > - On Modal's Starter plan an API token is **workspace-wide**; scoping a token per environment requires Modal's Team plan (~$250/month). Use a Modal workspace dedicated to AgentPod.
 > - Never commit this file to source control.
@@ -220,7 +224,8 @@ hub box needs no `flyctl` install and no Fly login.
 > - `FLY_VOLUME_SIZE_GB` (default `3`): the size of the volume each runtime gets. **The workspace lives on this volume**, because the Fly rootfs is wiped on every stop→start (measured 2026-08-12). Minimum 1; the hub refuses to boot below that. A **blank** value (`FLY_VOLUME_SIZE_GB=`) means the default, exactly as leaving the line out does — an unfilled variable is not a configured one. Anything else that is not a whole number — `3.5`, `12gb`, `three` — is an error: the hub throws `Invalid integer for environment variable: FLY_VOLUME_SIZE_GB` at startup rather than truncating it, and it does that whether or not Fly is enabled, because config is parsed before anything knows which substrates you use. Fly sizes volumes in whole gigabytes.
 > - `FLY_ORG_SLUG` (default `personal`) and `FLY_APP_PREFIX` (default `agentpod`): the organisation apps are created in, and the app-name prefix. A runtime `rt_3f2a…` becomes the Fly app `agentpod-rt-3f2a…` — that prefix is what makes `flyctl apps list` legible and what the cost audit in OPERATING greps for, so change it only if you must.
 > - **The Fly image must be registry-qualified** — e.g. `ghcr.io/rakeshgangwar/agentpod-node-opencode-fly:v0.1.22`. Fly pulls from a registry, so the default bare tag `agentpod-node-opencode:local` exists only on your Docker host and the machine create fails on the pull. `imageForHarness()` resolves it provider-first: `NODE_AGENT_FLY_OPENCODE_IMAGE`, then the un-scoped `NODE_AGENT_OPENCODE_IMAGE`, then the local default. Setting the **provider-scoped** name is the safe choice on a hub that also runs Docker, because it leaves the Docker tag alone. Setting the un-scoped `NODE_AGENT_OPENCODE_IMAGE` also works — a registry-qualified tag is fine for Docker too, since the daemon pulls it — and is what lets one variable serve both providers.
-> - **The image is built by hand, and there is no CI pipeline for it — by convention, like every other node-agent image in this repo.** `fly/node-image/README.md` has the `docker buildx … --push` line. Two things it will not let you skip: `--platform linux/amd64` (Fly Machines are amd64; an arm64 image built on an Apple laptop dies at boot with `exec format error`) and making the registry package **public** (Fly pulls anonymously). The tag in `NODE_AGENT_FLY_OPENCODE_IMAGE` / `NODE_AGENT_OPENCODE_IMAGE` is the only record of which build the fleet is running.
+> - **Which Fly images exist.** `agentpod-node-opencode-fly` (`fly/node-image/Dockerfile`) and `agentpod-node-pi-fly` (`fly/node-image/Dockerfile.pi`) — OpenCode and Pi. There is **no generic (harness-less) Fly image**, so a Fly runtime created with the **Generic** harness cannot work; the hub says so at boot with a `⚠️ WARNING` naming `NODE_AGENT_FLY_IMAGE`, and reports the same for any other harness whose resolved image is a local Docker tag. It is a report rather than a refusal precisely because of that gap: a fatal rule would make `ENABLE_FLY_PROVISIONING=true` unbootable no matter what you set, taking down a substrate that serves OpenCode and Pi perfectly well.
+> - **The images are published by CI, not by hand:** `.github/workflows/publish-images.yml` (manual dispatch — pick the image and the tag). It builds `linux/amd64` on an amd64 runner and then verifies the image it pushed: the `agentpod-node` binary runs, and the harness binary is resolvable from a *minimal service PATH*. Building by hand still works (`fly/node-image/README.md` has the `docker buildx … --push` line) and the same two things will not let you skip them: `--platform linux/amd64` (Fly Machines are amd64; an arm64 image built on an Apple laptop dies at boot with `exec format error`) and making the registry package **public** (Fly pulls anonymously). The tag in `NODE_AGENT_FLY_OPENCODE_IMAGE` / `NODE_AGENT_FLY_PI_IMAGE` is the record of which build the fleet is running.
 
 ---
 
@@ -477,6 +482,11 @@ env $(grep -v '^#' /etc/agentpod/hub.env | grep -v '^$' | xargs) \
 # working directory, so you would be validating a different environment than
 # systemd passes.
 ```
+
+`() => {}` swallows the WARNINGS, and Fly's per-harness image gaps are warnings
+(see the Fly notes above). Pass `console.warn` instead of the empty function to
+see them — `[]` from the command above means "this hub boots", not "every
+harness the console offers can actually be provisioned".
 
 If the console changed: rebuild locally with `PUBLIC_HUB_URL=https://hub.<your-domain> pnpm --filter @agentpod/console build` and redeploy `apps/console/build/` to Cloudflare Pages (Wrangler or push to the connected branch).
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -403,9 +403,19 @@ Modal has no reversible stop, so these verbs do not mean quite what they mean on
 
 These tokens create infrastructure in a Modal workspace. They cannot reach an enrolled node — enrolment is outbound-dialled and SSH runs from your own machine.
 
-#### The image
+#### The images — one per harness
 
-Modal pulls from a registry, runs **linux/amd64 only**, and requires **python and pip** in the image. Build it from `apps/node-agent/deploy/Dockerfile.modal` and set `NODE_AGENT_MODAL_IMAGE` to the pushed tag.
+Modal pulls from a registry, runs **linux/amd64 only**, and requires **python and pip** in the image. There are **three**, because the console offers three harnesses for every provider and each needs its own image:
+
+| Harness | Dockerfile (context `apps/node-agent`) | Published image | Hub variable |
+|---|---|---|---|
+| Generic | `deploy/Dockerfile.modal` | `agentpod-node-modal` | `NODE_AGENT_MODAL_IMAGE` |
+| OpenCode | `deploy/Dockerfile.modal.opencode` | `agentpod-node-modal-opencode` | `NODE_AGENT_MODAL_OPENCODE_IMAGE` |
+| Pi | `deploy/Dockerfile.modal.pi` | `agentpod-node-modal-pi` | `NODE_AGENT_MODAL_PI_IMAGE` |
+
+**The hub refuses to boot if any of the three is missing** (issue #283 — before that check, a Modal hub booted clean and answered 502 the first time anyone picked OpenCode or Pi). The harness images are built `FROM` the ordinary harness images, so the opencode/pi version pins live in `Dockerfile.opencode` / `Dockerfile.pi` only.
+
+The OpenCode image sets `AGENTPOD_INNER_ENTRYPOINT=/node-opencode-entrypoint.sh`: Modal starts every image with the same command, so an image whose harness needs a supervision loop has to say so itself. **Known cost:** on Modal, `$HOME` stays on the disposable rootfs (the Volume must never hold node credentials), so an OpenCode station on Modal keeps its *files* across the 24-hour rotation and loses its *conversation history*. Fly, whose `$HOME` is on the volume, keeps both.
 
 Three things are non-negotiable, each fatal on its own and each failing quietly:
 
@@ -428,7 +438,14 @@ docker buildx build --platform linux/amd64 \
 
 **The repository must be public.** The driver calls Modal's `images.fromRegistry(tag)` with no Secret, so Modal has no credential to authenticate to a private registry with. A private tag passes the hub's boot check — it looks like a registry reference — and then fails at provision time.
 
-**Prefer the CI pipeline over the hand-build above.** `.github/workflows/publish-images.yml` (Actions → publish-images → Run workflow, choose `fly`/`modal`/`all` and a tag) builds natively on an amd64 runner, pushes to GHCR, and verifies what it published — for Modal, that `python3` and `pip` exist and `ENTRYPOINT` is empty. It also stamps the source commit as an image label, which a hand-built tag records nowhere. The commands above remain accurate for building locally when iterating on a Dockerfile.
+**Prefer the CI pipeline over the hand-build above.** `.github/workflows/publish-images.yml` (Actions → publish-images → Run workflow, choose `all` or one of `fly`, `fly-pi`, `modal`, `modal-opencode`, `modal-pi`, and a tag) builds natively on an amd64 runner, pushes to GHCR, and verifies what it published:
+
+- every image — `agentpod-node version` runs;
+- Modal images — `python3` and `pip` exist and `ENTRYPOINT` is empty;
+- harness images — the harness binary is resolvable **from a minimal service PATH** with the image's own `ENV` discarded (`env -i PATH=/usr/local/sbin:…:/bin`), which is the shape of the environment the node-agent spawns an ACP adapter in;
+- the harness-less image — no harness binary is present, so a "Generic" runtime does not quietly detect stations nobody asked for.
+
+It also stamps the source commit as an image label, which a hand-built tag records nowhere. The commands above remain accurate for building locally when iterating on a Dockerfile.
 
 To sanity-check a built image before pushing, run its entrypoint test against a bind mount standing in for the Volume:
 
@@ -442,7 +459,7 @@ docker run --rm --platform linux/amd64 \
 #### When a Modal runtime does not come up
 
 - **Hub exits at startup naming a `MODAL_*` variable** — working as designed. Set the variable it names; the check is in `apps/hub/src/utils/validate-config.ts`.
-- **Provision fails with "not a registry reference Modal can pull"** — the resolved image had no registry host. Most often this is a runtime created with the OpenCode or Pi harness while only `NODE_AGENT_MODAL_IMAGE` was set; set `NODE_AGENT_MODAL_OPENCODE_IMAGE` / `NODE_AGENT_MODAL_PI_IMAGE` too.
+- **Provision fails with "not a registry reference Modal can pull"** — the resolved image had no registry host. This used to be the OpenCode/Pi case, and the hub now refuses to boot rather than letting a user find it; reaching it today means an image variable holds a registry-shaped tag that Modal still cannot pull (a private repository, or a typo in the host).
 - **Stuck in `provisioning`, then `error` after two minutes** — the sandbox booted but never enrolled. Read the sandbox's logs in the Modal dashboard. The usual causes are an image without python, an arm64 image, and a `PROVISIONING_HUB_URL` the sandbox cannot reach.
 - **`[modal] WARNING: /workspace does not look like a mounted Volume`** in the sandbox log — work written there will be lost at the next rotation. Do not use that station.
 - **Every Modal runtime reports trouble at once** — suspect the credentials, not the fleet. An expired `MODAL_TOKEN_SECRET` fails every call. The driver deliberately refuses to translate an unreachable substrate into `stopped`, so this surfaces as `error`, loudly, rather than as a fleet that has quietly gone quiet.
@@ -457,6 +474,21 @@ in [docs/DEPLOYMENT.md](./DEPLOYMENT.md#fly-machines-settings).
 Unlike Cloudflare, **all three resource tiers work and the harness image is
 honoured per machine** — Fly takes `config.guest` and `config.image` on each
 machine create, so nothing is frozen at deploy time.
+
+**Which harnesses Fly can actually run**, and it is not all of them:
+
+| Harness | Dockerfile (context = repo root) | Published image | Hub variable |
+|---|---|---|---|
+| OpenCode | `fly/node-image/Dockerfile` | `agentpod-node-opencode-fly` | `NODE_AGENT_FLY_OPENCODE_IMAGE` |
+| Pi | `fly/node-image/Dockerfile.pi` | `agentpod-node-pi-fly` | `NODE_AGENT_FLY_PI_IMAGE` |
+| Generic | — none published — | — | `NODE_AGENT_FLY_IMAGE` |
+
+The console offers **Generic** for Fly anyway, and it cannot work: there is no
+image to pull. The hub reports that at boot — `⚠️ WARNING` naming
+`NODE_AGENT_FLY_IMAGE` — rather than refusing to start, because refusing would
+make Fly unbootable for the two harnesses that *do* work. Both Fly images take
+the node-agent binary from a **release** (verified against `SHA256SUMS`) rather
+than compiling it, and both are pinned to the same version on purpose.
 
 **What the hub creates per runtime**, in this order:
 
@@ -644,7 +676,8 @@ Hermes stations that have a Matrix identity configured display the **Matrix ID**
 **A Fly runtime never comes online:**
 - `flyctl logs -a agentpod-rt-<id>`. `[fly] FATAL: /data is not mounted.` means the volume did not attach — check `flyctl volumes list -a <app>`. The wrapper refuses to run rather than write the workspace to a rootfs Fly wipes on the next stop.
 - `exec format error` means an arm64 image. Rebuild with `--platform linux/amd64` (see `fly/node-image/README.md`).
-- A pull failure means `NODE_AGENT_OPENCODE_IMAGE` is a bare local tag such as `agentpod-node-opencode:local`, or the registry package is private. Fly pulls anonymously from a registry and has no access to your Docker host.
+- A pull failure means the resolved image (`NODE_AGENT_FLY_OPENCODE_IMAGE` / `NODE_AGENT_FLY_PI_IMAGE`, else the un-scoped `NODE_AGENT_OPENCODE_IMAGE` / `NODE_AGENT_PI_IMAGE`) is a bare local tag such as `agentpod-node-opencode:local`, or the registry package is private. Fly pulls anonymously from a registry and has no access to your Docker host. The hub prints a `⚠️ WARNING` at boot for exactly this, per harness — check the startup log before assuming Fly is at fault.
+- A runtime created with the **Generic** harness cannot come up at all: no harness-less Fly image is published. Create it as OpenCode or Pi.
 - The machine can be `started` and the runtime still not online: the node-agent has to reach the hub *from Fly*, so `PROVISIONING_HUB_URL` must be a public URL, never `127.0.0.1`.
 
 **Provisioning fails with "legacy or non-paid plan":**

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1
+
+# Fly Machines runtime image: node-agent + the Pi harness.
+#
+# The sibling of fly/node-image/Dockerfile (node-agent + OpenCode). Before this
+# image, Pi could not run on ANY provisioned substrate — the fleet had a Pi
+# descriptor and a Pi Docker image, and neither Fly nor Modal had one to pull
+# (issue #283).
+#
+# BUILD CONTEXT IS THE REPOSITORY ROOT:
+#   docker buildx build --platform linux/amd64 \
+#     -f fly/node-image/Dockerfile.pi \
+#     -t ghcr.io/<owner>/agentpod-node-pi-fly:<version> --push .
+#
+# WHY THIS IS NOT `FROM agentpod-node-pi` the way the Modal Pi image is. The Fly
+# images take the node-agent binary from a RELEASE rather than compiling it, so
+# a Fly station runs exactly the binary the rest of the fleet runs, verified
+# against SHA256SUMS the same way install.sh and self-update do. That is a
+# property of this substrate's images, kept deliberately across both of them —
+# the cost is that the Pi install below is a second copy of Dockerfile.pi's, and
+# the version pins are what must be kept in step (see the pin comment there).
+
+FROM debian:trixie-slim
+
+# The same released binary the OpenCode Fly image bakes in. The two Fly images
+# are pinned together ON PURPOSE: a fleet where two stations on one substrate
+# run different node-agent builds is a fleet where "it works on the other one"
+# means nothing. Bump both, or neither.
+ARG AGENTPOD_VERSION=v0.1.22
+
+# Debian trixie: the same userland the fleet's own base image uses, so the
+# harness install below behaves identically to the Docker Pi image.
+#
+# root is what everything here needs: apt, the release download, and at runtime
+# the wrapper replacing /workspace on the rootfs.
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git procps ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+# procps provides `pgrep`, used by the Pi descriptor's running-process health
+# check; without it the station Health panel shows "process check unavailable".
+# ripgrep is here because --ignore-scripts (below) skips the postinstall that
+# would otherwise fetch Pi's own ~/.pi/agent/bin/rg; Pi's file search falls back
+# to whatever `rg` is on PATH.
+
+# Node 24 from NodeSource: Pi requires Node >= 22.19 and Debian trixie's own
+# nodejs package is older. The setup script runs its own apt-get update.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# --ignore-scripts matches Pi's own installer. Both pins are deliberate and must
+# match apps/node-agent/deploy/Dockerfile.pi: a floating tag would make two
+# builds of the same image behave differently, and pi-acp@0.0.33 is the version
+# the descriptor's ACP path is written against.
+#
+# WHERE THESE BINARIES LAND, and why it is the whole ballgame. When the
+# node-agent opens an ACP session it spawns pi-acp itself, and that child gets
+# the node-agent's PATH — a non-login, non-interactive service PATH, not an
+# operator's. On 2026-08-12 a live macOS node spawned the adapter with env=nil,
+# pi-acp could not see /opt/homebrew/bin/pi, and every session died in ~500ms;
+# 21 unit tests, a container gate and four green CI checks missed it because
+# they all ran with a developer's PATH. The NodeSource nodejs package uses /usr
+# as its npm prefix, so these two `npm install -g` shims are linked into
+# /usr/bin — on every default PATH there is, and in the well-known directories
+# internal/descriptor/pi.go probes when PATH misses them. Anything that moved
+# the prefix (--prefix, NPM_CONFIG_PREFIX, a user-local install) would hide them
+# from exactly the process that has to find them, which is why the publish
+# workflow resolves `pi` under an explicit minimal PATH instead of trusting this
+# comment.
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.84.1 \
+ && npm install -g --ignore-scripts pi-acp@0.0.33
+
+# Installed at /agentpod-node so the fleet entrypoint works unmodified.
+RUN set -eux; \
+    base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
+    curl -fsSL -o /agentpod-node "${base}/agentpod-node-linux-amd64"; \
+    curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
+    cp /agentpod-node /tmp/agentpod-node-linux-amd64; \
+    (cd /tmp && grep ' agentpod-node-linux-amd64$' SHA256SUMS | sha256sum -c -); \
+    rm -f /tmp/agentpod-node-linux-amd64 /tmp/SHA256SUMS; \
+    chmod +x /agentpod-node; \
+    /agentpod-node version
+
+# The fleet's GENERIC entrypoint — enrol, then run — copied from where it lives.
+# Unlike the OpenCode image there is no supervision loop: Pi has no daemon, it
+# is invoked per command, so there is no process to keep alive and no stop
+# sentinel to coordinate with.
+COPY apps/node-agent/deploy/node-entrypoint.sh /node-entrypoint.sh
+RUN chmod +x /node-entrypoint.sh
+
+# Workspace and identity persistence: the Fly rootfs is wiped on every
+# stop→start (measured 2026-08-12), so the wrapper points /workspace and HOME at
+# the mounted volume before handing off. HOME matters twice as much here as it
+# does for OpenCode: Pi keeps BOTH its credentials (~/.pi/agent/auth.json) and
+# the session files the descriptor enumerates to find stations under $HOME, so a
+# station whose HOME landed on the rootfs would come back from a stop having
+# forgotten every project it had.
+COPY fly/node-image/volume-workspace.sh /volume-workspace.sh
+RUN chmod +x /volume-workspace.sh
+
+# /workspace is created by the wrapper as a symlink into the volume; nothing in
+# the image should create a real directory there.
+
+ENTRYPOINT ["/volume-workspace.sh", "/node-entrypoint.sh"]

--- a/fly/node-image/README.md
+++ b/fly/node-image/README.md
@@ -1,7 +1,19 @@
-# Fly Machines runtime image
+# Fly Machines runtime images
 
-The image a `fly` provisioned runtime boots: the released `agentpod-node` binary
-plus the OpenCode harness, with its workspace anchored on a mounted Fly Volume.
+What a `fly` provisioned runtime boots: the released `agentpod-node` binary plus
+one harness, with its workspace anchored on a mounted Fly Volume.
+
+| Dockerfile | Harness | Published as | Hub variable |
+|---|---|---|---|
+| `Dockerfile` | OpenCode | `ghcr.io/rakeshgangwar/agentpod-node-opencode-fly` | `NODE_AGENT_FLY_OPENCODE_IMAGE` |
+| `Dockerfile.pi` | Pi | `ghcr.io/rakeshgangwar/agentpod-node-pi-fly` | `NODE_AGENT_FLY_PI_IMAGE` |
+
+There is no generic (harness-less) Fly image, so a **Generic** Fly runtime cannot
+work; the hub warns about it at boot naming `NODE_AGENT_FLY_IMAGE`.
+
+Both are pinned to the same `AGENTPOD_VERSION`, deliberately: two stations on one
+substrate running different node-agent builds makes "it works on the other one"
+mean nothing.
 
 ## Why the wrapper exists
 
@@ -37,12 +49,25 @@ on the volume, so identity survives on disk as well as in the hub.
 
 ## Build and push
 
-Build context is the **repository root**:
+**Prefer CI**: `.github/workflows/publish-images.yml` (Actions → publish-images →
+Run workflow → `fly` or `fly-pi`, or `all`, and a tag). It builds natively on an
+amd64 runner, pushes to GHCR, labels the image with the source commit, and then
+verifies the image it pushed — `agentpod-node version` runs, and the harness
+binary resolves from a *minimal service PATH* with the image's own `ENV`
+discarded. That last check is the one that matters here: the node-agent spawns
+ACP adapters with a service PATH, not a shell's, which is how a working-in-the-
+shell Pi install once produced sessions that died in 500 ms.
+
+By hand, with the build context at the **repository root**:
 
 ```bash
 docker buildx build --platform linux/amd64 \
   -f fly/node-image/Dockerfile \
   -t ghcr.io/rakeshgangwar/agentpod-node-opencode-fly:v0.1.22 --push .
+
+docker buildx build --platform linux/amd64 \
+  -f fly/node-image/Dockerfile.pi \
+  -t ghcr.io/rakeshgangwar/agentpod-node-pi-fly:v0.1.22 --push .
 ```
 
 `--platform linux/amd64` is required: Fly Machines are amd64, and an arm64 image
@@ -53,23 +78,24 @@ The package must be **public** — Fly pulls anonymously.
 `AGENTPOD_VERSION` selects which released binary is baked in; it defaults to the
 fleet version in the Dockerfile and is verified against `SHA256SUMS`.
 
-No CI workflow builds this image — like every other image in this repo it is
-built by hand, and the tag the hub points at is the record of which build is
-live.
-
 ## Pointing the hub at it
 
 `imageForHarness()` resolves the image for every provider, so the tag goes in
 the hub's env:
 
 ```
-NODE_AGENT_OPENCODE_IMAGE=ghcr.io/rakeshgangwar/agentpod-node-opencode-fly:v0.1.22
+NODE_AGENT_FLY_OPENCODE_IMAGE=ghcr.io/rakeshgangwar/agentpod-node-opencode-fly:v0.1.22
+NODE_AGENT_FLY_PI_IMAGE=ghcr.io/rakeshgangwar/agentpod-node-pi-fly:v0.1.22
 ```
 
-A registry-qualified tag works for Docker provisioning too (the daemon pulls
-it), which is what lets one hub run both providers. A bare local tag such as
-`agentpod-node-opencode:local` cannot work on Fly — there is no such image in
-any registry, and the machine create fails on the pull.
+The provider-scoped names are the safe choice on a hub that also runs Docker,
+because they leave the Docker tags alone. The un-scoped
+`NODE_AGENT_OPENCODE_IMAGE` works too — a registry-qualified tag is fine for
+Docker, since the daemon pulls it — and is what lets one variable serve both
+providers. A bare local tag such as `agentpod-node-opencode:local` cannot work on
+Fly: there is no such image in any registry, and the machine create fails on the
+pull. The hub warns at boot, per harness, when the image it would hand Fly is a
+local tag.
 
 ## Tests
 


### PR DESCRIPTION
Closes #283.

Modal could run **no harness at all** and neither substrate could run **Pi**. This adds the three missing images, wires them into the publish pipeline with per-image verification, and makes the hub say so at boot instead of at Create.

## The images

| # | Image | Dockerfile | Build context | FROM | Hub variable |
|---|---|---|---|---|---|
| 1 | `agentpod-node-modal-opencode` | `apps/node-agent/deploy/Dockerfile.modal.opencode` | `apps/node-agent` | `agentpod-node-opencode:local` | `NODE_AGENT_MODAL_OPENCODE_IMAGE` |
| 2 | `agentpod-node-modal-pi` | `apps/node-agent/deploy/Dockerfile.modal.pi` | `apps/node-agent` | `agentpod-node-pi:local` | `NODE_AGENT_MODAL_PI_IMAGE` |
| 3 | `agentpod-node-pi-fly` | `fly/node-image/Dockerfile.pi` | **repo root** | `debian:trixie-slim` | `NODE_AGENT_FLY_PI_IMAGE` |

**The Modal harness images are `FROM` the ordinary harness images, not beside them.** `opencode-ai@1.18.15`, `@earendil-works/pi-coding-agent@0.84.1`, `pi-acp@0.0.33`, the `--ignore-scripts`/ripgrep pairing and the deliberate absence of `sqlite3` keep exactly one definition (`Dockerfile.opencode` / `Dockerfile.pi`); these files add only what Modal needs — python3+pip, the wrapper, `ENTRYPOINT []`.

**The Fly Pi image mirrors its OpenCode sibling instead**, because Fly images take the node-agent binary from a **release** (verified against `SHA256SUMS`) rather than compiling it — a property of that substrate's images, kept across both. Both Fly images are pinned to the same `AGENTPOD_VERSION` on purpose. It anchors `/workspace` **and** `$HOME` on the volume through `volume-workspace.sh`, which matters more for Pi than for OpenCode: Pi keeps both its credentials (`~/.pi/agent/auth.json`) **and** the session files the descriptor enumerates to find stations under `$HOME`, so a station whose HOME landed on the rootfs would come back from a stop having forgotten every project it had.

### `AGENTPOD_INNER_ENTRYPOINT`

Modal starts every image with the identical command `["/modal-entrypoint.sh"]`, so the driver cannot know which harness it is booting. The OpenCode image therefore declares its own inner script (`ENV AGENTPOD_INNER_ENTRYPOINT=/node-opencode-entrypoint.sh`) — without it the image would run the generic enrol-then-run script, never start `opencode serve`, and produce a station whose Health reads stopped and whose lifecycle verbs are not advertised. Pi has no daemon, so the default is correct for it. `test-modal-entrypoint.sh` covers both branches and is **now a required CI check** (it was never wired in, and that wrapper is now the main process of three published images).

**Known cost, stated in the Dockerfile rather than discovered later:** on Modal, `$HOME` must stay on the disposable rootfs (the Volume must never hold node credentials), so an OpenCode station on Modal keeps its *files* across the 24-hour rotation and loses its *conversation history*. Fly keeps both.

## The Pi PATH gotcha

`apps/node-agent/deploy/Dockerfile.pi`'s NodeSource nodejs package uses `/usr` as its npm prefix, so `npm install -g` links `pi` and `pi-acp` into **`/usr/bin`** — on every default PATH there is, and in the well-known dirs `internal/descriptor/pi.go` probes when PATH misses them. Both new Pi Dockerfiles carry a comment explaining why that placement is load-bearing (a spawned ACP adapter gets the node-agent's *service* PATH, not an operator's) and what would break it (`--prefix`, `NPM_CONFIG_PREFIX`, a user-local install).

Rather than trusting the comment, the verify step **proves** it, throwing away the image's own ENV:

```
docker run --rm --entrypoint env "$ref" -i "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" HOME=/root \
  sh -c 'command -v pi && command -v pi-acp && pi --version'
```

Measured on native-arch probe builds of exactly these layers (no amd64 emulation): `npm config get prefix` → `/usr`, `/usr/bin/pi` and `/usr/bin/pi-acp` exist, the command above prints `0.84.1`; the OpenCode equivalent prints `/usr/local/bin/opencode` and `1.18.15` (`oven/bun:1-slim` sets `BUN_INSTALL_BIN=/usr/local/bin`, confirmed).

## `publish-images.yml`

Matrix is now `fly, fly-pi, modal, modal-opencode, modal-pi` (`all` still builds everything). Each row carries `context`, `local_base` (which unpublished image must be built on the runner first — `none` for the Fly images, which do not use `agentpod-node:base` at all, so that build no longer runs for them), `harness` and `modal`.

What "Verify what was published" checks, per image:

| Image | `agentpod-node version` | python3 + pip | empty ENTRYPOINT | harness on a minimal PATH |
|---|---|---|---|---|
| `agentpod-node-opencode-fly` | ✓ | — | — | `opencode --version` |
| `agentpod-node-pi-fly` | ✓ | — | — | `pi --version`, `pi-acp` present |
| `agentpod-node-modal` | ✓ | ✓ | ✓ | ✓ *asserts NO harness is present* |
| `agentpod-node-modal-opencode` | ✓ | ✓ | ✓ | `opencode --version` |
| `agentpod-node-modal-pi` | ✓ | ✓ | ✓ | `pi --version`, `pi-acp` present |

One fix to an existing check: the ENTRYPOINT assertion was `test -z "$(docker inspect … | tr -d 'null')"`, which passes `null` (nothing ever set one) but would **fail** `[]` (a harness layer's ENTRYPOINT cleared by this image) — the shape all three new-and-old Modal images now produce. It matches the two empty shapes explicitly instead.

## `validateConfig`

The rule: **for every provider that pulls its images, every harness the console advertises must resolve to something pullable.**

- It asks `imageForHarness` — the *same* function `createRuntime` hands the driver — not "is variable X set". An operator who points the un-scoped `NODE_AGENT_PI_IMAGE` at a registry reference has genuinely configured Pi everywhere, and a variable-counting check would refuse that working hub while passing one whose variable holds `agentpod-node-pi:local`.
- "Advertised" is `RuntimeHarness.options` from the contract, not a copy, so a fourth harness extends the check instead of adding a fourth way to answer 502.
- Pullability is the same weak test the Modal driver applies (`includes("/")`), deliberately not tightened: `owner/image:tag` on Docker Hub is pullable, and a stricter rule would refuse to boot a hub whose images live there.
- Docker and Cloudflare are excluded — local daemon, and an image baked into the deployed worker (`imageBinding: "fixed"`, already covered by `CLOUDFLARE_SANDBOX_IMAGE`).

**Modal is fatal, Fly is reported, and the asymmetry is the honest part.** After this PR every harness Modal advertises has a published image, so demanding all three costs a Modal operator three lines they can satisfy. There is **no generic (harness-less) Fly image** — producing one is not in this issue — so a fatal rule there would make `ENABLE_FLY_PROVISIONING=true` unbootable no matter what the operator set, taking down a substrate that serves OpenCode and Pi perfectly well. The table entry carries a `fatal` flag and a comment: when a generic Fly image exists, flipping it is the whole change.

What an operator sees, on a hub with Modal+Fly enabled and only the generic Modal and OpenCode Fly images set:

```
⚠️  WARNING: NODE_AGENT_FLY_IMAGE: The fly substrate pulls its images from a registry, but the "none"
harness resolves to "agentpod-node:local" — a tag that exists only in a local Docker daemon. …
  • NODE_AGENT_MODAL_OPENCODE_IMAGE: … Set NODE_AGENT_MODAL_OPENCODE_IMAGE to a public registry
reference, or point the un-scoped NODE_AGENT_OPENCODE_IMAGE at one. …
```

`imageForHarness` moved to `apps/hub/src/services/runtimes-image.ts` (re-exported from `runtimes.ts`, so every importer is unchanged) — boot validation must not open a Postgres pool to tell you a variable is wrong.

## Mutation test results

Both directions, on `apps/hub/src/utils/validate-config.test.ts` (27 tests):

| Mutation | Result |
|---|---|
| **Rule removed** (`const enabled = false`) | **4 failures** — `REFUSES a Modal hub that set only the generic image (issue #283)` (child process, real env parsing), `REFUSES a Modal hub that cannot serve a harness the console offers`, `names the harness, the substrate and the variable that closes the gap`, `REPORTS a Fly harness with no registry image, without refusing the boot` |
| **Rule always true** (`if (false) continue` — every harness reported) | **5 failures** — `boots a Modal hub configured with the documented variable names` (child process), `accepts a Modal hub with every advertised harness pointed at a registry`, `accepts an un-scoped variable that is itself a registry reference`, `reports nothing when every Fly harness resolves to a registry image`, `REPORTS a Fly harness…` (its "the configured one is not named" half) |

Both mutations reverted; suite green.

## Tests

- `apps/hub`: **772 pass / 0 fail** (63 files), with the DB override — rebased onto `main` after #282 landed (one import conflict in `runtimes.ts`, resolved; #279's harness-aware tiers filter *tiers* by harness, not harnesses by provider, so this PR's premise that the console offers all three harnesses for every provider still holds — checked, not assumed).
- `packages/contract`: 108 pass (untouched; run because validate-config now imports `RuntimeHarness`).
- `test-modal-entrypoint.sh`: 12/12 on Linux root, 11/11 as a non-root Linux user (verified in a container before gating CI on it); on macOS two pre-existing checks fail because it cannot `mkdir /root` — unchanged by this PR, confirmed against a stash.
- The existing child-process test `boots a Modal hub configured with the documented variable names` now sets all three Modal image variables. That is the visible record of the new demand, and it is the only test that can catch a rule naming a variable the resolver does not read.

## Not done, on purpose

- **No images were built for amd64 locally and the publish workflow was NOT run** — publishing is a deliberate act. Nothing was deployed and no Fly/Modal resources were created.
- **No generic Fly image.** Out of scope for #283; it is why the Fly rule reports rather than refuses, and both docs say so.
- **Observation, unrelated to images:** a freshly provisioned Pi container has **no stations** until Pi has run in a workspace at least once — `piDescriptor.Detect()` enumerates `$HOME/.pi/agent/sessions/*` and nothing seeds it. That is equally true of today's Docker Pi image, so it is pre-existing and not touched here, but Modal/Fly Pi runtimes will show the same empty station list on first boot.

## Docs

`docs/DEPLOYMENT.md` (env block + Modal/Fly constraint bullets + a note that the dry-run validation snippet swallows warnings), `docs/OPERATING.md` (per-harness image tables for both substrates, what the verify step checks, updated troubleshooting), `fly/node-image/README.md` (two images; and it no longer claims no CI workflow builds them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
