### PR TITLE
fix(fly): resolve the node-agent release at publish time, fail on a stale pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,25 @@ jobs:
       - name: Test the Modal image entrypoint wrapper
         run: sh apps/node-agent/deploy/test-modal-entrypoint.sh
 
+      # The Fly images bake in a RELEASED node-agent binary rather than
+      # compiling one, so they carry a version pin — and a pin nobody is forced
+      # to move goes stale silently (issue #290: both Fly images sat on v0.1.22
+      # while the fleet ran v0.1.24, so no node-agent fix could reach a Fly
+      # station at all). These two steps are that forcing function. They live in
+      # this job for the same reason as the ones above: it is a required check,
+      # and a job of its own would not gate.
+      - name: Test the Fly node-agent pin check
+        run: sh fly/node-image/test-version-pin.sh
+
+      # Resolves the latest release from the GitHub API and fails when either
+      # Fly Dockerfile's ARG default is behind it. Expected to turn red on the
+      # first PR after a node-agent release: bumping both ARGs is the fix, and
+      # noticing here is the entire point.
+      - name: Check the Fly images pin the current node-agent release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: sh fly/node-image/check-version-pin.sh
+
   console:
     name: console
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -32,6 +32,16 @@ on:
         description: Tag to publish (e.g. v0.1.24)
         required: true
         type: string
+      # Fly images only — the Modal ones compile the node-agent from the checked
+      # out source and have no version to pin. Blank means "the latest release",
+      # resolved at build time, which is what makes a published Fly image carry
+      # the newest verified binary without anyone remembering to edit a
+      # Dockerfile (issue #290). Set it to publish a specific older release on
+      # purpose.
+      node_agent_version:
+        description: node-agent release to bake into the Fly images (blank = latest release)
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -62,6 +72,13 @@ jobs:
           #                  PATH. `none` is a bare node image.
           #   modal        — whether the Modal-specific constraints (python3,
           #                  pip, empty ENTRYPOINT) are checked.
+          #   agent_pin    — whether this image takes AGENTPOD_VERSION, i.e.
+          #                  bakes in a RELEASED binary. "yes" for the Fly
+          #                  images only; the Modal ones `go build` the agent
+          #                  from this checkout, so passing them a version would
+          #                  be a no-op build-arg and checking a pin they do not
+          #                  have would fail a Modal-only publish on a Fly-only
+          #                  concern.
           - name: fly
             dockerfile: fly/node-image/Dockerfile
             context: .
@@ -69,6 +86,7 @@ jobs:
             local_base: none
             harness: opencode
             modal: "no"
+            agent_pin: "yes"
           - name: fly-pi
             dockerfile: fly/node-image/Dockerfile.pi
             context: .
@@ -76,6 +94,7 @@ jobs:
             local_base: none
             harness: pi
             modal: "no"
+            agent_pin: "yes"
           - name: modal
             dockerfile: apps/node-agent/deploy/Dockerfile.modal
             context: apps/node-agent
@@ -83,6 +102,7 @@ jobs:
             local_base: base
             harness: none
             modal: "yes"
+            agent_pin: "no"
           - name: modal-opencode
             dockerfile: apps/node-agent/deploy/Dockerfile.modal.opencode
             context: apps/node-agent
@@ -90,6 +110,7 @@ jobs:
             local_base: opencode
             harness: opencode
             modal: "yes"
+            agent_pin: "no"
           - name: modal-pi
             dockerfile: apps/node-agent/deploy/Dockerfile.modal.pi
             context: apps/node-agent
@@ -97,6 +118,7 @@ jobs:
             local_base: pi
             harness: pi
             modal: "yes"
+            agent_pin: "no"
     steps:
       - name: Skip images not selected
         id: gate
@@ -122,6 +144,44 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Which node-agent RELEASE the Fly images bake in, resolved at build time
+      # instead of read from the Dockerfile's ARG default. Before this, the
+      # default WAS the published version: it said v0.1.22 for two releases, so
+      # every Fly station ran an agent missing fixes the rest of the fleet had,
+      # and republishing could not change that (issue #290). Resolving here
+      # means a Fly publish always ships the newest release, and the pin in the
+      # Dockerfile is only what a local `docker build` falls back to.
+      #
+      # Fly rows only. The Modal images compile the agent from this checkout, so
+      # this step, its build-arg and its staleness check are all skipped for
+      # them — a modal-only publish never touches any of this.
+      - name: Resolve the node-agent release for the Fly images
+        id: agent
+        if: steps.gate.outputs.run == 'true' && matrix.agent_pin == 'yes'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED: ${{ inputs.node_agent_version }}
+        run: |
+          set -eu
+          if [ -n "${REQUESTED:-}" ]; then
+            version="$REQUESTED"
+          else
+            version="$(sh fly/node-image/check-version-pin.sh --print-latest)"
+          fi
+          case "$version" in
+            v[0-9]*.[0-9]*) ;;
+            *) echo "not a vMAJOR.MINOR.PATCH node-agent version: '$version'"; exit 1 ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "baking node-agent $version into ${{ matrix.image }}" >> "$GITHUB_STEP_SUMMARY"
+
+          # The ARG defaults must not be BEHIND what is being published, or the
+          # repo goes on describing an image that no longer exists and the next
+          # local build silently produces a worse one. Requesting an older
+          # version on purpose still passes — the defaults are ahead of it, not
+          # behind.
+          sh fly/node-image/check-version-pin.sh --latest "$version"
 
       # agentpod-node:base is not published anywhere, so every image that is
       # FROM it (directly, or through a harness layer) has to build it here. The
@@ -152,16 +212,25 @@ jobs:
 
       - name: Build and push
         if: steps.gate.outputs.run == 'true'
+        env:
+          # Empty for the Modal images, whose Dockerfiles have no such ARG:
+          # passing one would be a silently ignored build-arg (or a warning
+          # nobody reads), so the argument is only added when there is one.
+          AGENT_VERSION: ${{ steps.agent.outputs.version }}
         run: |
           ref="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
-          docker build \
-            --platform linux/amd64 \
-            -f "${{ matrix.dockerfile }}" \
-            -t "${ref}:${{ inputs.tag }}" \
-            -t "${ref}:latest" \
-            --label "org.opencontainers.image.revision=${{ github.sha }}" \
-            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
-            "${{ matrix.context }}"
+          args=(
+            --platform linux/amd64
+            -f "${{ matrix.dockerfile }}"
+            -t "${ref}:${{ inputs.tag }}"
+            -t "${ref}:latest"
+            --label "org.opencontainers.image.revision=${{ github.sha }}"
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
+          )
+          if [ -n "$AGENT_VERSION" ]; then
+            args+=(--build-arg "AGENTPOD_VERSION=$AGENT_VERSION")
+          fi
+          docker build "${args[@]}" "${{ matrix.context }}"
           docker push "${ref}:${{ inputs.tag }}"
           docker push "${ref}:latest"
           echo "published ${ref}:${{ inputs.tag }} from ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
@@ -177,7 +246,19 @@ jobs:
           ref="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ inputs.tag }}"
 
           # Every image: the node-agent binary is there and runs.
-          docker run --rm --entrypoint /agentpod-node "$ref" version
+          agent_version_out="$(docker run --rm --entrypoint /agentpod-node "$ref" version)"
+
+          if [ "${{ matrix.agent_pin }}" = "yes" ]; then
+            # And for the Fly images, that it is the release this run resolved.
+            # They bake in a downloaded binary, so the version is a fact about
+            # the pushed image rather than about the checkout — which makes it
+            # the one check that catches a build-arg that never reached the
+            # Dockerfile, the failure mode that let v0.1.22 keep shipping.
+            case "$agent_version_out" in
+              "agentpod-node ${{ steps.agent.outputs.version }} "*) ;;
+              *) echo "expected node-agent ${{ steps.agent.outputs.version }}, image reports: $agent_version_out"; exit 1 ;;
+            esac
+          fi
 
           if [ "${{ matrix.modal }}" = "yes" ]; then
             # Modal's runtime is Python and it takes over the container command;

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -447,6 +447,8 @@ docker buildx build --platform linux/amd64 \
 
 It also stamps the source commit as an image label, which a hand-built tag records nowhere. The commands above remain accurate for building locally when iterating on a Dockerfile.
 
+**Which node-agent a Fly image carries is resolved by the workflow, not pinned in the repo.** The Fly images bake in a *released* binary (verified against `SHA256SUMS`) rather than compiling one the way the Modal images do, so they need a version — and the workflow resolves the latest release at build time, passes it as `--build-arg AGENTPOD_VERSION=…`, and then asserts the pushed image reports that version. A Fly publish therefore always ships the newest agent, with no Dockerfile edit to remember. Leave the optional `node_agent_version` input blank for that; set it only to publish an older release on purpose. The input and the check apply to `fly`/`fly-pi` only — a Modal-only publish never reads them. (Before this, both Fly Dockerfiles hardcoded `v0.1.22` while the fleet ran `v0.1.24`, so a merged node-agent fix could not reach a Fly station at all: issue #290. CI now fails when those `ARG` defaults — which is what a hand-build uses — fall behind the latest release.)
+
 To sanity-check a built image before pushing, run its entrypoint test against a bind mount standing in for the Volume:
 
 ```bash

--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -19,7 +19,14 @@
 
 FROM oven/bun:1-slim
 
-ARG AGENTPOD_VERSION=v0.1.22
+# Kept current by fly/node-image/check-version-pin.sh, which fails the
+# node-agent CI job when this default falls behind the latest release — a stale
+# pin here means a Fly station runs an agent without the fixes everyone else
+# has, and republishing the image cannot help (issue #290). The publish workflow
+# overrides this with --build-arg, so what a published image carries is the
+# release resolved at build time; this default is what a local `docker build`
+# gets.
+ARG AGENTPOD_VERSION=v0.1.24
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -25,8 +25,11 @@ FROM debian:trixie-slim
 # The same released binary the OpenCode Fly image bakes in. The two Fly images
 # are pinned together ON PURPOSE: a fleet where two stations on one substrate
 # run different node-agent builds is a fleet where "it works on the other one"
-# means nothing. Bump both, or neither.
-ARG AGENTPOD_VERSION=v0.1.22
+# means nothing. Bump both, or neither — fly/node-image/check-version-pin.sh
+# fails CI on either half of that (a pin behind the latest release, or the two
+# files disagreeing). The publish workflow overrides this with --build-arg, so
+# this default is what a local `docker build` gets.
+ARG AGENTPOD_VERSION=v0.1.24
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.

--- a/fly/node-image/README.md
+++ b/fly/node-image/README.md
@@ -75,8 +75,21 @@ built on an Apple laptop fails at boot with an exec format error.
 
 The package must be **public** — Fly pulls anonymously.
 
-`AGENTPOD_VERSION` selects which released binary is baked in; it defaults to the
-fleet version in the Dockerfile and is verified against `SHA256SUMS`.
+`AGENTPOD_VERSION` selects which released binary is baked in, verified against
+`SHA256SUMS`.
+
+**A CI publish does not use the Dockerfile default.** `publish-images.yml`
+resolves the latest node-agent release at build time and passes it as
+`--build-arg AGENTPOD_VERSION=…`, then asserts the pushed image reports that
+version — so a published Fly image always carries the newest verified binary.
+Its optional `node_agent_version` input pins an older release on purpose.
+
+The `ARG` default is what a hand-build (the `docker buildx` lines above) gets,
+so it still matters, and `check-version-pin.sh` fails the node-agent CI job when
+either Dockerfile's default falls behind the latest release or the two disagree.
+That check exists because they went stale in exactly that way: both sat on
+v0.1.22 while the fleet ran v0.1.24, which meant no node-agent fix could reach a
+Fly station however often the image was republished (issue #290).
 
 ## Pointing the hub at it
 
@@ -99,8 +112,15 @@ local tag.
 
 ## Tests
 
-`sh fly/node-image/test-volume-workspace.sh` — runs in CI in the `node-agent`
-job.
+`sh fly/node-image/test-volume-workspace.sh` and
+`sh fly/node-image/test-version-pin.sh` — both run in CI in the `node-agent`
+job, which also runs `sh fly/node-image/check-version-pin.sh` against the live
+release list.
+
+The pin test is offline (every case passes an explicit `--latest`) and covers
+the comparison that a string compare gets backwards: `v0.1.9` is *older* than
+`v0.1.24`. `check-version-pin.sh --compare A B` prints `older|same|newer` if you
+want to check a pair by hand.
 
 The `/workspace` half of that test needs a writable `/`, so it skips on macOS.
 To run it for real, bind-mount the directory into the built image:

--- a/fly/node-image/check-version-pin.sh
+++ b/fly/node-image/check-version-pin.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+# Guard the node-agent release pin baked into the Fly images.
+#
+# The Fly images download a RELEASED agentpod-node binary and verify it against
+# SHA256SUMS, instead of compiling one the way the Modal images do. That is a
+# real supply-chain property and it stays. Its cost is a version pin, and a pin
+# nobody is forced to move goes stale silently: on 2026-08-13 both Fly images
+# still said v0.1.22 while the fleet was on v0.1.24, so the #286 Pi fix could
+# not reach a Fly station no matter how many times the image was republished
+# (issue #290).
+#
+# This script is the thing that forces the pin to move. It fails when the ARG
+# default in either Fly Dockerfile is BEHIND the latest node-agent release, or
+# when the two Dockerfiles disagree with each other.
+#
+# POSIX sh with no dependencies beyond `gh` or `curl`, because it runs in the
+# node-agent CI job next to `go test` and in the publish workflow, neither of
+# which should need a package manager.
+#
+# Usage:
+#   check-version-pin.sh                       # resolve latest release, check pins
+#   check-version-pin.sh --latest v0.1.24      # check pins against a given version
+#   check-version-pin.sh --print-latest        # print the resolved latest release
+#   check-version-pin.sh --compare A B         # print older|same|newer (A vs B)
+#   check-version-pin.sh [--latest V] FILE...  # check these Dockerfiles instead
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+die() {
+  echo "check-version-pin: $1" >&2
+  exit 2
+}
+
+# ── Version comparison ───────────────────────────────────────────────────────
+# Echoes how $1 relates to $2: older | same | newer.
+#
+# Component-wise and NUMERIC. A string comparison is wrong in exactly the case
+# that matters — lexically "v0.1.9" > "v0.1.24", so a two-release-stale pin
+# would read as current and this whole script would pass while doing nothing.
+version_relation() {
+  _a="${1#v}"
+  _b="${2#v}"
+  # Split off a -rc1 / -beta.2 suffix; the numeric part is compared first.
+  case "$_a" in *-*) _a_pre="${_a#*-}"; _a="${_a%%-*}" ;; *) _a_pre="" ;; esac
+  case "$_b" in *-*) _b_pre="${_b#*-}"; _b="${_b%%-*}" ;; *) _b_pre="" ;; esac
+
+  _i=1
+  # Compare as many components as the longer of the two has; a missing
+  # component is 0, so v0.1 and v0.1.0 are the same version.
+  _n_a=$(( $(printf '%s' "$_a" | tr -cd '.' | wc -c) + 1 ))
+  _n_b=$(( $(printf '%s' "$_b" | tr -cd '.' | wc -c) + 1 ))
+  _n=$_n_a
+  [ "$_n_b" -gt "$_n" ] && _n=$_n_b
+
+  while [ "$_i" -le "$_n" ]; do
+    _ai=$(printf '%s' "$_a" | cut -d. -f"$_i")
+    _bi=$(printf '%s' "$_b" | cut -d. -f"$_i")
+    [ -z "$_ai" ] && _ai=0
+    [ -z "$_bi" ] && _bi=0
+    case "$_ai" in *[!0-9]*) die "not a numeric version: $1" ;; esac
+    case "$_bi" in *[!0-9]*) die "not a numeric version: $2" ;; esac
+    if [ "$_ai" -lt "$_bi" ]; then echo older; return 0; fi
+    if [ "$_ai" -gt "$_bi" ]; then echo newer; return 0; fi
+    _i=$((_i + 1))
+  done
+
+  # Equal numerically: a pre-release precedes the release it leads to
+  # (semver rule), which keeps a v0.1.25-rc1 pin from passing as v0.1.25.
+  if [ -n "$_a_pre" ] && [ -z "$_b_pre" ]; then echo older; return 0; fi
+  if [ -z "$_a_pre" ] && [ -n "$_b_pre" ]; then echo newer; return 0; fi
+  if [ "$_a_pre" = "$_b_pre" ]; then echo same; return 0; fi
+  # `sort` rather than test's `<`, which is an extension dash does not have.
+  if [ "$(printf '%s\n%s\n' "$_a_pre" "$_b_pre" | sort | head -n 1)" = "$_a_pre" ]; then
+    echo older
+  else
+    echo newer
+  fi
+}
+
+# ── Reading the pin out of a Dockerfile ──────────────────────────────────────
+pin_in() {
+  [ -f "$1" ] || die "no such Dockerfile: $1"
+  _pin=$(sed -n 's/^ARG AGENTPOD_VERSION=\([^ ]*\).*$/\1/p' "$1" | head -n 1)
+  [ -n "$_pin" ] || die "$1 has no 'ARG AGENTPOD_VERSION=' default"
+  printf '%s\n' "$_pin"
+}
+
+# The repo whose releases the pin refers to is read out of the download URL in
+# the Dockerfile itself, so the check can never end up asking a different repo
+# than the build downloads from (a fork's CI included).
+repo_in() {
+  _repo=$(sed -n 's|.*https://github.com/\([^/]*/[^/]*\)/releases/download/.*|\1|p' "$1" | head -n 1)
+  [ -n "$_repo" ] || die "$1 has no github releases download URL to resolve against"
+  printf '%s\n' "$_repo"
+}
+
+# ── Resolving the latest release ─────────────────────────────────────────────
+# `gh` when it is there (CI runners and dev boxes have it), plain curl against
+# the REST API otherwise. Retried: a transient API blip must not be able to
+# quietly turn this check off, so failure to resolve is a hard error.
+resolve_latest() {
+  _repo="$1"
+  _attempt=1
+  while [ "$_attempt" -le 3 ]; do
+    if command -v gh >/dev/null 2>&1; then
+      _tag=$(gh release view --repo "$_repo" --json tagName --jq .tagName 2>/dev/null || true)
+    else
+      _tag=$(curl -fsSL "https://api.github.com/repos/$_repo/releases/latest" 2>/dev/null |
+        sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' | head -n 1)
+    fi
+    if [ -n "$_tag" ]; then
+      printf '%s\n' "$_tag"
+      return 0
+    fi
+    _attempt=$((_attempt + 1))
+    [ "$_attempt" -le 3 ] && sleep 2
+  done
+  die "could not resolve the latest release of $_repo"
+}
+
+# ── Arguments ────────────────────────────────────────────────────────────────
+LATEST=""
+MODE=check
+FILES=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --latest)
+      [ $# -ge 2 ] || die "--latest needs a version"
+      LATEST="$2"
+      shift 2
+      ;;
+    --print-latest)
+      MODE=print-latest
+      shift
+      ;;
+    --compare)
+      [ $# -ge 3 ] || die "--compare needs two versions"
+      version_relation "$2" "$3"
+      exit 0
+      ;;
+    -h | --help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      FILES="$FILES $1"
+      shift
+      ;;
+  esac
+done
+
+# Both Fly images by default. They are pinned together ON PURPOSE — two
+# stations on one substrate running different node-agent builds makes "it works
+# on the other one" mean nothing — so both are checked, and against each other.
+[ -n "$FILES" ] || FILES="$HERE/Dockerfile $HERE/Dockerfile.pi"
+
+if [ -z "$LATEST" ]; then
+  # shellcheck disable=SC2086 # deliberate word splitting of the file list
+  set -- $FILES
+  LATEST=$(resolve_latest "$(repo_in "$1")")
+fi
+
+if [ "$MODE" = print-latest ]; then
+  printf '%s\n' "$LATEST"
+  exit 0
+fi
+
+# ── The check ────────────────────────────────────────────────────────────────
+STATUS=0
+FIRST_PIN=""
+FIRST_FILE=""
+
+# shellcheck disable=SC2086 # deliberate word splitting of the file list
+for file in $FILES; do
+  pin=$(pin_in "$file")
+  rel=$(version_relation "$pin" "$LATEST")
+
+  if [ -z "$FIRST_PIN" ]; then
+    FIRST_PIN="$pin"
+    FIRST_FILE="$file"
+  elif [ "$pin" != "$FIRST_PIN" ]; then
+    echo "FAIL: $file pins $pin but $FIRST_FILE pins $FIRST_PIN — the Fly images must pin the same node-agent release" >&2
+    STATUS=1
+  fi
+
+  case "$rel" in
+    older)
+      echo "FAIL: $file pins AGENTPOD_VERSION=$pin, which is behind the current node-agent release $LATEST." >&2
+      echo "      A Fly image built from this default ships an agent without the fixes in $LATEST." >&2
+      echo "      Fix: set 'ARG AGENTPOD_VERSION=$LATEST' in $file." >&2
+      STATUS=1
+      ;;
+    same)
+      echo "ok: $file pins $pin (current release)"
+      ;;
+    newer)
+      # An unreleased pin would fail the image build at the download, not here;
+      # this is only reachable while a release is mid-flight.
+      echo "ok: $file pins $pin (ahead of the resolved release $LATEST)"
+      ;;
+  esac
+done
+
+exit $STATUS

--- a/fly/node-image/test-version-pin.sh
+++ b/fly/node-image/test-version-pin.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# Tests for check-version-pin.sh.
+#
+# POSIX sh with no framework, same as test-volume-workspace.sh, because it runs
+# in the node-agent CI job next to `go test`. Exits non-zero on the first
+# failure.
+#
+# Nothing here touches the network: every case passes an explicit --latest, so
+# the comparison logic is what is under test, not GitHub's availability.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/check-version-pin.sh"
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "ok: $1"
+}
+
+# ── Version comparison ───────────────────────────────────────────────────────
+# The case this whole script exists for: v0.1.9 vs v0.1.24 is the one a string
+# comparison gets backwards, and getting it backwards would make a stale pin
+# read as current.
+compare_is() {
+  got="$(sh "$CHECK" --compare "$1" "$2")"
+  if [ "$got" = "$3" ]; then
+    pass "$1 vs $2 -> $3"
+  else
+    fail "$1 vs $2 -> expected $3, got $got"
+  fi
+}
+
+compare_is v0.1.9 v0.1.24 older
+compare_is v0.1.24 v0.1.9 newer
+compare_is v0.1.24 v0.1.24 same
+compare_is v0.1.22 v0.1.24 older
+compare_is v0.1.24 v0.1.22 newer
+compare_is v0.2.0 v0.1.24 newer
+compare_is v0.9.9 v1.0.0 older
+compare_is v1.0.0 v0.9.9 newer
+compare_is v0.10.0 v0.9.0 newer
+compare_is 0.1.24 v0.1.24 same        # a pin written without the v
+compare_is v0.1 v0.1.0 same           # a missing component is zero
+compare_is v0.1.25-rc1 v0.1.25 older  # a pre-release precedes its release
+compare_is v0.1.25 v0.1.25-rc1 newer
+
+# A version that is not numeric must be rejected loudly rather than silently
+# compared as zero.
+if sh "$CHECK" --compare vlatest v0.1.24 >/dev/null 2>&1; then
+  fail "accepted a non-numeric version"
+else
+  pass "rejects a non-numeric version"
+fi
+
+# ── The pin check itself ─────────────────────────────────────────────────────
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+write_dockerfile() {
+  cat >"$TMP/$1" <<EOF
+FROM debian:trixie-slim
+ARG AGENTPOD_VERSION=$2
+RUN curl -fsSL -o /agentpod-node "https://github.com/rakeshgangwar/agentpod/releases/download/\${AGENTPOD_VERSION}/agentpod-node-linux-amd64"
+EOF
+}
+
+# Pin equal to latest: passes.
+write_dockerfile Dockerfile v0.1.24
+write_dockerfile Dockerfile.pi v0.1.24
+if sh "$CHECK" --latest v0.1.24 "$TMP/Dockerfile" "$TMP/Dockerfile.pi" >"$TMP/out" 2>&1; then
+  pass "pin equal to latest passes"
+else
+  fail "pin equal to latest was rejected: $(cat "$TMP/out")"
+fi
+
+# Pin behind latest: fails, and says which file and which version.
+write_dockerfile Dockerfile v0.1.22
+write_dockerfile Dockerfile.pi v0.1.22
+if sh "$CHECK" --latest v0.1.24 "$TMP/Dockerfile" "$TMP/Dockerfile.pi" >"$TMP/out" 2>&1; then
+  fail "a stale pin passed: $(cat "$TMP/out")"
+else
+  if grep -q "v0.1.22" "$TMP/out" && grep -q "v0.1.24" "$TMP/out"; then
+    pass "pin behind latest fails, naming both versions"
+  else
+    fail "stale pin failed but the message did not name the versions: $(cat "$TMP/out")"
+  fi
+fi
+
+# The lexical trap in the real check, not just in --compare: a v0.1.9 pin
+# against a v0.1.24 release must fail.
+write_dockerfile Dockerfile v0.1.9
+write_dockerfile Dockerfile.pi v0.1.9
+if sh "$CHECK" --latest v0.1.24 "$TMP/Dockerfile" "$TMP/Dockerfile.pi" >"$TMP/out" 2>&1; then
+  fail "a v0.1.9 pin passed against a v0.1.24 release: $(cat "$TMP/out")"
+else
+  pass "v0.1.9 pin fails against a v0.1.24 release"
+fi
+
+# The two Fly images must not drift apart from each other.
+write_dockerfile Dockerfile v0.1.24
+write_dockerfile Dockerfile.pi v0.1.23
+if sh "$CHECK" --latest v0.1.24 "$TMP/Dockerfile" "$TMP/Dockerfile.pi" >"$TMP/out" 2>&1; then
+  fail "mismatched pins passed: $(cat "$TMP/out")"
+else
+  pass "the two Fly images disagreeing fails"
+fi
+
+# A Dockerfile with no pin at all is an error, not a pass by omission.
+cat >"$TMP/Dockerfile.nopin" <<'EOF'
+FROM debian:trixie-slim
+RUN echo no pin here
+EOF
+if sh "$CHECK" --latest v0.1.24 "$TMP/Dockerfile.nopin" >/dev/null 2>&1; then
+  fail "a Dockerfile with no ARG default passed"
+else
+  pass "a Dockerfile with no ARG default is an error"
+fi
+
+# ── The real Dockerfiles, offline ────────────────────────────────────────────
+# Their pins must agree with each other regardless of what the latest release
+# is; the against-latest half of the check needs the network and runs in CI.
+real_pin() {
+  sed -n 's/^ARG AGENTPOD_VERSION=\([^ ]*\).*$/\1/p' "$1" | head -n 1
+}
+a="$(real_pin "$HERE/Dockerfile")"
+b="$(real_pin "$HERE/Dockerfile.pi")"
+if [ -n "$a" ] && [ "$a" = "$b" ]; then
+  pass "both Fly Dockerfiles pin $a"
+else
+  fail "Fly Dockerfile pins disagree: Dockerfile=$a Dockerfile.pi=$b"
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "$FAILURES check(s) failed"
+  exit 1
+fi
+echo "all version-pin checks passed"


### PR DESCRIPTION
Closes #290.

Both Fly Dockerfiles hardcoded `ARG AGENTPOD_VERSION=v0.1.22` while the latest node-agent release was `v0.1.24`. The Fly images download a released binary and verify it against `SHA256SUMS`, so republishing them could not pick up a merged node-agent fix — which is why Pi on Fly stayed broken after #286 shipped, while Pi on Modal (which `go build`s from source) worked after a republish.

The release download and the checksum verification stay — that is a real supply-chain property that building from source in a Dockerfile would lose. What changes is that the pin is no longer manual and silent.

## Resolution mechanism

`publish-images.yml` gained a **Fly-only** step, `Resolve the node-agent release for the Fly images`, which runs before the build:

- blank `node_agent_version` input (the default) → `sh fly/node-image/check-version-pin.sh --print-latest`, which asks the GitHub releases API (`gh release view --repo … --json tagName --jq .tagName`, falling back to `curl` on `/releases/latest` when `gh` is absent, retried 3×; failure to resolve is a hard error, never a silent skip);
- a non-blank input → that version, so an older release can be published deliberately;
- either way the value is validated as `vMAJOR.MINOR…` and exported, and the build step appends `--build-arg AGENTPOD_VERSION=<resolved>`.

The repo whose releases are consulted is parsed out of the `https://github.com/<owner>/<repo>/releases/download/` URL **in the Dockerfile being checked**, so the check can never ask a different repo than the build downloads from (a fork's CI included).

The `Verify what was published` step now also asserts, for Fly images only, that the pushed image reports the resolved version (`agentpod-node v0.1.24 linux/amd64`). That is the check that catches a build-arg which never reached the Dockerfile — the exact failure mode that let v0.1.22 keep shipping.

## Where the staleness check runs

`fly/node-image/check-version-pin.sh` fails when either Fly Dockerfile's `ARG` default is **behind** the latest release, or when the two Dockerfiles disagree with each other (they are pinned together on purpose). It runs in two places:

1. **CI, `node-agent` job** (`ci.yml`) — against the live release list, on every PR and push. That job is a required check, so it gates; a job of its own would not, which is the same reasoning the existing wrapper tests in that job carry. It is expected to go red on the first PR after a node-agent release: bumping both `ARG`s is the fix, and noticing there is the point. `sh fly/node-image/test-version-pin.sh` runs alongside it and is fully offline.
2. **The publish workflow**, for Fly rows only, against the version being baked in. Requesting an older release on purpose still passes (the defaults are *ahead* of it, not behind).

Both `ARG` defaults are bumped to `v0.1.24` in this PR — the `ARG` still matters because it is what a local `docker build` uses.

## Version comparison, and its actual output

Component-wise and numeric, because the case that matters is the one a string comparison gets backwards: lexically `"v0.1.9" > "v0.1.24"`, which would make a two-release-stale pin read as current and quietly disable this whole guard.

`sh fly/node-image/test-version-pin.sh` (run locally under both bash and dash, all green):

```
ok: v0.1.9 vs v0.1.24 -> older
ok: v0.1.24 vs v0.1.9 -> newer
ok: v0.1.24 vs v0.1.24 -> same
ok: v0.1.22 vs v0.1.24 -> older
ok: v0.1.24 vs v0.1.22 -> newer
ok: v0.2.0 vs v0.1.24 -> newer
ok: v0.9.9 vs v1.0.0 -> older
ok: v1.0.0 vs v0.9.9 -> newer
ok: v0.10.0 vs v0.9.0 -> newer
ok: 0.1.24 vs v0.1.24 -> same
ok: v0.1 vs v0.1.0 -> same
ok: v0.1.25-rc1 vs v0.1.25 -> older
ok: v0.1.25 vs v0.1.25-rc1 -> newer
ok: rejects a non-numeric version
ok: pin equal to latest passes
ok: pin behind latest fails, naming both versions
ok: v0.1.9 pin fails against a v0.1.24 release
ok: the two Fly images disagreeing fails
ok: a Dockerfile with no ARG default is an error
ok: both Fly Dockerfiles pin v0.1.24
all version-pin checks passed
```

The `v0.1.9` case is exercised twice: through `--compare` and through the full Dockerfile check, so the trap is proven in the code path that actually gates.

**The bug reproduced, then fixed.** With the pins still at v0.1.22, the check run against the live release list:

```
$ sh fly/node-image/check-version-pin.sh
FAIL: …/fly/node-image/Dockerfile pins AGENTPOD_VERSION=v0.1.22, which is behind the current node-agent release v0.1.24.
      A Fly image built from this default ships an agent without the fixes in v0.1.24.
      Fix: set 'ARG AGENTPOD_VERSION=v0.1.24' in …/fly/node-image/Dockerfile.
FAIL: …/fly/node-image/Dockerfile.pi pins AGENTPOD_VERSION=v0.1.22, which is behind …
exit=1
```

After the bump in this PR:

```
$ sh fly/node-image/check-version-pin.sh
ok: …/fly/node-image/Dockerfile pins v0.1.24 (current release)
ok: …/fly/node-image/Dockerfile.pi pins v0.1.24 (current release)
exit=0
```

Both resolution paths were exercised live and returned `v0.1.24`: with `gh`, and with `gh` removed from `PATH` (the `curl` fallback).

## What happens on a Modal-only publish

Nothing from this change runs. The matrix rows carry a new `agent_pin` field — `"yes"` for `fly`/`fly-pi`, `"no"` for `modal`, `modal-opencode`, `modal-pi` — and:

- the resolve step is `if: … && matrix.agent_pin == 'yes'`, so it is skipped, no API call is made, and no staleness check runs;
- its output is therefore empty, and the build step only appends `--build-arg` when it is non-empty (the Modal Dockerfiles have no such `ARG`, so passing one would be a silently ignored build-arg);
- the pushed-image version assertion is also `agent_pin == 'yes'` only.

A Modal-only publish can never fail on a Fly-only concern, and the `node_agent_version` input is meaningless for it — as documented in the input description.

## How this was exercised

I did not run the publish workflow (that is yours to trigger). What I did run:

- `sh fly/node-image/test-version-pin.sh` under bash **and** dash (CI's `/bin/sh`) — all cases above.
- `sh fly/node-image/check-version-pin.sh` against the live releases API, before the bump (fails, output above) and after (passes).
- `check-version-pin.sh --print-latest` → `v0.1.24`, both via `gh` and via the `curl` fallback.
- Both workflow files parsed as YAML, and **every** `run:` block in both extracted and `bash -n`'d.
- The `Resolve …` step extracted from the YAML and executed for real in three modes: blank input → `version=v0.1.24` + summary line, exit 0; `v0.1.20` → `version=v0.1.20`, pins read as "ahead of", exit 0; `latest` → `not a vMAJOR.MINOR.PATCH node-agent version: 'latest'`, exit 1.
- The `Build and push` argument assembly executed with `docker` stubbed, confirming `--build-arg AGENTPOD_VERSION=v0.1.24` is present with a version and absent without one.
- The pushed-image version assertion executed with the `docker run … version` output stubbed: `agentpod-node v0.1.24 …` → exit 0; `agentpod-node v0.1.22 …` → `expected node-agent v0.1.24, image reports: …`, exit 1.

## Test suites

Untouched by this change, confirmed green: `apps/node-agent` `go test -race ./...`, `apps/hub` `bun test` (795 pass / 0 fail, against the pgvector DB on :5434), `packages/contract` `bun test` (108 pass / 0 fail).

One flake worth flagging, unrelated to this PR (no Go was touched): `TestBuildRegistry_ThreadsClaudeCodeACPKeys` failed once with `PATH = ""` during a full-suite run and passed on re-run, both alone and in a full `./...` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
