### PR TITLE
chore(fly): pin the node-agent to v0.1.25

### DIFF
--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.24
+ARG AGENTPOD_VERSION=v0.1.25
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.24
+ARG AGENTPOD_VERSION=v0.1.25
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
Mechanical, but it unblocks Pi on Fly.

## Why now

`v0.1.25` was cut so that #286 (Pi descriptor reports its workspace as a station) exists in a *release* — Fly images download a released binary, unlike Modal which builds from source. A Fly Pi runtime built against v0.1.24 comes up `online` with **zero stations**, verified live.

## The guard did its job

The first republish attempt after tagging failed, in the real publish run:

```
FAIL: fly/node-image/Dockerfile pins AGENTPOD_VERSION=v0.1.24, which is behind
      the current node-agent release v0.1.25.
      Fix: set 'ARG AGENTPOD_VERSION=v0.1.25'
```

That is #292's staleness check working, and proving itself non-vacuous against production rather than only in a test.

After this bump, `check-version-pin.sh` reports `ok: … pins v0.1.25 (current release)` for both files.

## Follow-up worth doing

This is the half of #290 that is still manual. The guard prevents shipping a stale image; nothing *updates* the pin, so **every release blocks Fly image publishing until a human opens this PR**. Having `release-node-agent.yml` bump the `ARG` (or open this PR itself) would close the loop — the issue listed it as option 1 and it is still open work.