### PR TITLE
fix(node-agent): log opencode db fallback on change of condition, not every detect cycle

### DIFF
--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -36,7 +37,10 @@ import (
 // Project path discovery: opencode.db is the preferred source (table "project",
 // column "worktree", skip row where id="global"). If the DB is absent or the
 // sqlite3 binary is unavailable, Detect falls back to enumerating
-// <dataDir>/project/ dirs and decoding the sanitised names.
+// <dataDir>/project/ dirs and decoding the sanitised names. On hosts where the
+// DB is permanently unreadable — provisioned opencode containers ship no
+// sqlite3 on purpose — that fallback IS the normal path, so it is logged on
+// change of condition only, never per detect cycle (see noteDBUnreadable).
 //
 // Decode ambiguity (fallback only): OpenCode sanitises project paths by
 // stripping the leading '/' and replacing remaining '/' with '-'. When
@@ -46,6 +50,15 @@ import (
 // scheme; non-existent decoded paths are silently filtered out.
 type openCodeDescriptor struct {
 	dataDir string // absolute path to ~/.local/share/opencode
+
+	// mu guards dbFailureReason. Detect runs on the periodic detect loop and
+	// again on every capability call that resolves a key.
+	mu sync.Mutex
+	// dbFailureReason is the last reported reason opencode.db could not be
+	// read, or "" when the DB last read fine (the initial state). It exists so
+	// the fallback is logged on a *change* of condition rather than once per
+	// detect cycle — see noteDBUnreadable.
+	dbFailureReason string
 }
 
 // NewOpenCode returns a Descriptor for the OpenCode harness.
@@ -167,13 +180,57 @@ func (o *openCodeDescriptor) loadProjectPaths() ([]string, error) {
 
 	paths, err := o.projectPathsFromDB(dbPath)
 	if err == nil {
+		o.noteDBReadable(dbPath)
 		return paths, nil
 	}
 
+	o.noteDBUnreadable(dbPath, err)
+	return o.projectPathsFromDirs()
+}
+
+// noteDBUnreadable logs that the descriptor is using the directory-enumeration
+// fallback — but only when that is *news*: the first failure, or a failure
+// whose reason differs from the one last reported.
+//
+// Detect runs every 10-60s, and on a host where the DB is permanently
+// unreadable (deploy/Dockerfile.opencode deliberately ships no sqlite3, making
+// directory enumeration the primary path there) the unchanged condition
+// previously produced one line per cycle — 83% of a real node's log volume,
+// which buried the gateway events an operator actually needs (#231).
+//
+// Suppression is per reason string, so a genuine transition (e.g. "db not
+// found" → "sqlite3 not in PATH", observed changing on a live host within a
+// minute) still logs.
+func (o *openCodeDescriptor) noteDBUnreadable(dbPath string, cause error) {
+	reason := cause.Error()
+
+	o.mu.Lock()
+	repeat := o.dbFailureReason == reason
+	o.dbFailureReason = reason
+	o.mu.Unlock()
+
+	if repeat {
+		return
+	}
 	log.Printf("opencode: could not read %s (%v); "+
 		"falling back to project/ directory enumeration "+
-		"(note: decoded paths may be ambiguous when project names contain '-')", dbPath, err)
-	return o.projectPathsFromDirs()
+		"(note: decoded paths may be ambiguous when project names contain '-'; "+
+		"repeats of this same reason are suppressed)", dbPath, cause)
+}
+
+// noteDBReadable logs recovery — the DB became readable after a fallback — so
+// the log never leaves an operator believing a node is still degraded. Silent
+// when the DB was already readable, which is the steady-state case.
+func (o *openCodeDescriptor) noteDBReadable(dbPath string) {
+	o.mu.Lock()
+	recovered := o.dbFailureReason != ""
+	o.dbFailureReason = ""
+	o.mu.Unlock()
+
+	if !recovered {
+		return
+	}
+	log.Printf("opencode: %s is readable again; resuming db-backed project discovery", dbPath)
 }
 
 // projectPathsFromDB reads project worktree paths from opencode.db via the

--- a/apps/node-agent/internal/descriptor/opencode_dblog_test.go
+++ b/apps/node-agent/internal/descriptor/opencode_dblog_test.go
@@ -1,0 +1,179 @@
+package descriptor
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression tests for #231: the opencode descriptor logged the opencode.db
+// read failure on EVERY detect cycle (every 10-60s), which accounted for 83%
+// of the log volume on a real node and made `apn logs` useless for diagnosis.
+//
+// The directory-enumeration fallback is the supported primary path in the
+// provisioned images (deploy/Dockerfile.opencode deliberately omits sqlite3),
+// so an unchanging failure is an expected steady state — not news. What is
+// still news: the first occurrence, a change in the reason, and recovery.
+
+// openCodeFallbackMarker is the distinctive part of the fallback log line.
+const openCodeFallbackMarker = "falling back to project/ directory enumeration"
+
+// openCodeRecoveryMarker is the distinctive part of the recovery log line.
+const openCodeRecoveryMarker = "readable again"
+
+// captureLog redirects the standard logger into a buffer for the duration of
+// the test.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return &buf
+}
+
+// stubSQLite3 installs a `sqlite3` shell script at the front of PATH so the
+// descriptor's DB probe has a deterministic outcome regardless of whether the
+// host actually has sqlite3 installed. Call again to change its behaviour.
+// Returns the stub directory so the same one can be rewritten later.
+func stubSQLite3(t *testing.T, dir, script string) string {
+	t.Helper()
+	if dir == "" {
+		dir = t.TempDir()
+		t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sqlite3"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write sqlite3 stub: %v", err)
+	}
+	return dir
+}
+
+// TestOpenCodeDetect_UnchangingDBFailureLogsOnce is the core #231 regression:
+// repeated detect cycles under an unchanging failure must log once, not once
+// per cycle. The fallback must still work.
+func TestOpenCodeDetect_UnchangingDBFailureLogsOnce(t *testing.T) {
+	dataDir, projPath := buildOpenCodeFixture(t) // no opencode.db in the fixture
+	buf := captureLog(t)
+
+	d := NewOpenCode(dataDir)
+	for i := 0; i < 5; i++ {
+		stations, err := d.Detect()
+		if err != nil {
+			t.Fatalf("Detect #%d: %v", i, err)
+		}
+		// The fallback is the supported path: it must keep producing the
+		// station on every cycle even though we only log about it once.
+		if len(stations) != 1 || *stations[0].WorkspacePath != projPath {
+			t.Fatalf("Detect #%d: fallback stopped working: %+v", i, stations)
+		}
+	}
+
+	if n := strings.Count(buf.String(), openCodeFallbackMarker); n != 1 {
+		t.Errorf("fallback logged %d times across 5 detect cycles, want exactly 1\n--- log ---\n%s", n, buf.String())
+	}
+}
+
+// TestOpenCodeDetect_ChangedDBFailureReasonLogsAgain: a different reason is a
+// different fact (observed changing from "db not found" to "sqlite3 not in
+// PATH" on a real host within a minute) and must be visible.
+func TestOpenCodeDetect_ChangedDBFailureReasonLogsAgain(t *testing.T) {
+	dataDir, _ := buildOpenCodeFixture(t)
+	buf := captureLog(t)
+
+	d := NewOpenCode(dataDir)
+
+	// Phase 1: no opencode.db at all.
+	for i := 0; i < 2; i++ {
+		if _, err := d.Detect(); err != nil {
+			t.Fatalf("Detect (phase 1) #%d: %v", i, err)
+		}
+	}
+	if n := strings.Count(buf.String(), openCodeFallbackMarker); n != 1 {
+		t.Fatalf("phase 1: logged %d times, want 1\n--- log ---\n%s", n, buf.String())
+	}
+	if !strings.Contains(buf.String(), "db not found") {
+		t.Errorf("phase 1: reason should say the db is missing\n--- log ---\n%s", buf.String())
+	}
+
+	// Phase 2: the db now exists but the query fails — a different reason.
+	stubSQLite3(t, "", "#!/bin/sh\nexit 5\n")
+	if err := os.WriteFile(filepath.Join(dataDir, "opencode.db"), []byte("not-sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := d.Detect(); err != nil {
+			t.Fatalf("Detect (phase 2) #%d: %v", i, err)
+		}
+	}
+
+	if n := strings.Count(buf.String(), openCodeFallbackMarker); n != 2 {
+		t.Errorf("after the reason changed: logged %d times, want 2 (once per distinct reason)\n--- log ---\n%s", n, buf.String())
+	}
+	if !strings.Contains(buf.String(), "sqlite3 query failed") {
+		t.Errorf("the new reason should be visible in the log\n--- log ---\n%s", buf.String())
+	}
+}
+
+// TestOpenCodeDetect_RecoveryIsLogged: if the db becomes readable again after
+// a fallback, that transition must not be silent — otherwise the log leaves
+// the operator believing the node is still in fallback mode forever.
+func TestOpenCodeDetect_RecoveryIsLogged(t *testing.T) {
+	dataDir, projPath := buildOpenCodeFixture(t)
+
+	// A second real project that only the DB knows about, so a successful DB
+	// read is observable in the station list (the dir fallback yields one).
+	dbOnlyPath := filepath.Join(filepath.Dir(projPath), "dbonlyproject")
+	if err := os.MkdirAll(dbOnlyPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "opencode.db"), []byte("not-sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := captureLog(t)
+	stubDir := stubSQLite3(t, "", "#!/bin/sh\nexit 5\n")
+
+	d := NewOpenCode(dataDir)
+	if _, err := d.Detect(); err != nil {
+		t.Fatalf("Detect (failing): %v", err)
+	}
+	if n := strings.Count(buf.String(), openCodeFallbackMarker); n != 1 {
+		t.Fatalf("expected 1 fallback line before recovery, got %d\n--- log ---\n%s", n, buf.String())
+	}
+
+	// The db becomes readable.
+	stubSQLite3(t, stubDir, "#!/bin/sh\nprintf '%s\\n%s\\n' '"+projPath+"' '"+dbOnlyPath+"'\n")
+
+	stations, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect (recovered): %v", err)
+	}
+	if len(stations) != 2 {
+		t.Fatalf("expected 2 stations from the db, got %d: %+v", len(stations), stations)
+	}
+	if n := strings.Count(buf.String(), openCodeRecoveryMarker); n != 1 {
+		t.Errorf("recovery logged %d times, want exactly 1\n--- log ---\n%s", n, buf.String())
+	}
+
+	// Steady state after recovery stays quiet.
+	before := buf.Len()
+	for i := 0; i < 3; i++ {
+		if _, err := d.Detect(); err != nil {
+			t.Fatalf("Detect (steady) #%d: %v", i, err)
+		}
+	}
+	if buf.Len() != before {
+		t.Errorf("steady state after recovery logged more lines:\n%s", buf.String()[before:])
+	}
+
+	// And a later relapse is news again.
+	stubSQLite3(t, stubDir, "#!/bin/sh\nexit 5\n")
+	if _, err := d.Detect(); err != nil {
+		t.Fatalf("Detect (relapse): %v", err)
+	}
+	if n := strings.Count(buf.String(), openCodeFallbackMarker); n != 2 {
+		t.Errorf("relapse after recovery: got %d fallback lines, want 2\n--- log ---\n%s", n, buf.String())
+	}
+}


### PR DESCRIPTION
Fixes #231.

## The bug

The opencode descriptor logged the `opencode.db` read failure on **every** detect cycle (every 10–60s), even though the directory-enumeration fallback it then takes works correctly. On a real node that was **335 of the last 400 log lines (83%)**, which buried the gateway reconnect events an operator actually needs and made `apn logs` unusable while debugging a wedged Fly station.

Crucially, the fallback is **not** a degraded mode: `deploy/Dockerfile.opencode` omits `sqlite3` on purpose so that directory enumeration is the PRIMARY discovery path in provisioned images. So `sqlite3: executable file not found in $PATH` is a stable, expected condition on a whole class of hosts — not news, once you have been told once.

No image changes here; `sqlite3` stays uninstalled.

## Mechanism: suppress by last-reported reason

The descriptor (a long-lived singleton — the registry is built once in `run.go`) remembers the last reported failure reason in a mutex-guarded field and logs only on a **change of condition**:

| Transition | Logged? |
| --- | --- |
| First failure | yes, with the reason |
| Same reason again, cycle after cycle | no |
| Reason **changes** (e.g. `db not found` → `sqlite3 ... not found in $PATH`) | yes, the new reason |
| DB becomes readable again | yes, one recovery line |
| Steady state after recovery | no |
| Relapse after recovery | yes |

Why per-reason rather than a plain once-per-process latch: the reason genuinely changes on live hosts (the issue reports `exit status 5`, the Fly machine reported `executable file not found in $PATH` — a different fact), and a latch would swallow the second one silently. Why an explicit recovery line: without it the log would leave an operator believing a node is still in fallback forever after a single early failure.

It is 2 small methods and 1 field on the existing struct — no new abstraction.

The fallback log line also now says `repeats of this same reason are suppressed`, so nobody reads a single line as "it happened once".

## Tests

`apps/node-agent/internal/descriptor/opencode_dblog_test.go`, written failing first:

- `TestOpenCodeDetect_UnchangingDBFailureLogsOnce` — 5 detect cycles, unchanging failure → exactly 1 line, and asserts the fallback still produces the station on every cycle.
- `TestOpenCodeDetect_ChangedDBFailureReasonLogsAgain` — `db not found` → `sqlite3 query failed` logs a second line carrying the new reason; repeats stay suppressed.
- `TestOpenCodeDetect_RecoveryIsLogged` — recovery logs exactly once, the DB-sourced stations appear, the steady state after recovery adds no lines, and a later relapse logs again.

The sqlite3 outcome is made deterministic with a stub `sqlite3` script at the front of `PATH` (rewritten in place to flip failure ↔ success), so the tests do not depend on whether the host has sqlite3. The stub is short-lived and reaped by `exec.Output()` — no unreaped children named like pgrep targets.

## Mutation tests (both directions, plus one)

| Mutation | Result |
| --- | --- |
| Remove the suppression (always log) | **FAIL** — `UnchangingDBFailureLogsOnce`: "fallback logged 5 times across 5 detect cycles, want exactly 1"; `ChangedDBFailureReasonLogsAgain` also fails |
| Suppress unconditionally (never log, even on a changed reason or recovery) | **FAIL** — all three fail; "logged 0 times ... want exactly 1", recovery test fails |
| Plain once-per-process latch (ignores a changed reason) | **FAIL** — `ChangedDBFailureReasonLogsAgain`: "after the reason changed: logged 1 times, want 2" and "the new reason should be visible in the log" |

Not vacuous in either direction, and the third confirms the reason-change assertion is doing real work rather than riding on the once-only assertion.

## Verification

`cd apps/node-agent && go test -race ./...` fully green. The known unrelated flake #293 (`TestBuildRegistry_ThreadsClaudeCodeACPKeys`, empty `PATH`) tripped once and passed on re-run with `-count=2`; not touched here.

Not deployed — no hub, fleet, Fly or Modal changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
