### PR TITLE
fix(node-agent): never start a second gateway for hermes' default profile (#273)

### DIFF
--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -64,6 +64,11 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 	caps := []string{"health", "logs", "fs.read", "fs.write", "terminal", "lifecycle", "cleanup", "acp"}
 	homeCopy := h.home
 
+	// The root gateway's messaging identity. It is also the value a profile is
+	// compared against to decide whether that profile IS the root gateway
+	// (see servesRootGateway).
+	rootMxid := h.matrixIDOf(h.home)
+
 	stations := []Station{
 		{
 			Key:           "hermes",
@@ -73,6 +78,7 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 			ParentKey:     nil,
 			WorkspacePath: &homeCopy,
 			Capabilities:  AppendChangesetCap(caps, &homeCopy),
+			MatrixId:      rootMxid,
 		},
 	}
 
@@ -92,6 +98,19 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 		wsPath := filepath.Join(profilesDir, name)
 		wsCopy := wsPath
 		profileDir := wsPath
+		mxid := h.matrixIDOf(profileDir)
+
+		// A profile that shares the root's Matrix identity IS the agent the root
+		// gateway already runs; it is a VIEW onto that gateway, not a separately
+		// startable one. Its files/logs/health stay available, but "lifecycle" is
+		// withheld so the console never offers a Start that would put a second
+		// gateway on the same messaging identity (issue #273). The root "hermes"
+		// station is the control point for that agent.
+		profileCaps := caps
+		if sameMatrixIdentity(rootMxid, mxid) {
+			profileCaps = withoutCap(caps, "lifecycle")
+		}
+
 		stations = append(stations, Station{
 			Key:           key,
 			Harness:       "hermes",
@@ -99,12 +118,75 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 			DisplayName:   name,
 			ParentKey:     &parentKey,
 			WorkspacePath: &wsCopy,
-			Capabilities:  AppendChangesetCap(caps, &wsCopy),
-			MatrixId:      MatrixIDFromProfile(profileDir, "id.agentpod.dev"),
+			Capabilities:  AppendChangesetCap(profileCaps, &wsCopy),
+			MatrixId:      mxid,
 		})
 	}
 
 	return stations, nil
+}
+
+// hermesMatrixDomain is the default Matrix homeserver domain hint passed to the
+// identity reader (the reader ignores it; kept for call-site readability).
+const hermesMatrixDomain = "id.agentpod.dev"
+
+// matrixIDOf resolves the Matrix user ID that a Hermes home or profile directory
+// is configured with (auth.json → config.yaml → .env), or nil when it cannot be
+// determined. It never reads an access token.
+func (h *hermesDescriptor) matrixIDOf(dir string) *string {
+	return MatrixIDFromProfile(dir, hermesMatrixDomain)
+}
+
+// sameMatrixIdentity reports whether both sides resolved to the SAME mxid.
+// An unresolved side (nil) is never a match, so a host whose identity we cannot
+// read behaves exactly as it did before this rule existed.
+func sameMatrixIdentity(a, b *string) bool {
+	return a != nil && b != nil && *a == *b
+}
+
+// withoutCap returns a copy of caps with name removed.
+func withoutCap(caps []string, name string) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		if c != name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// servesRootGateway reports whether key names the profile that the ROOT Hermes
+// gateway already serves — the profile a bare `hermes gateway run` (no `-p`)
+// runs, i.e. the host's default profile.
+//
+// HOW THE DEFAULT PROFILE IS IDENTIFIED: the root gateway takes its messaging
+// identity from the Hermes home root, and the default profile's directory
+// carries a byte-identical copy of that identity. So the profile whose resolved
+// Matrix user ID equals the home root's IS the root gateway's profile. That is
+// an exact identity comparison — no name guessing, no process inspection, no
+// killing by name — and it is precisely the condition under which a second
+// gateway would double-sync ONE Matrix account and answer every message twice
+// (issue #273).
+//
+// When either side cannot be resolved the answer is false, so hosts we cannot
+// read keep today's behaviour. Profiles with their own identity — the ordinary
+// case, and the majority on the live fleet — are never matched.
+//
+// This single predicate is what BOTH the station modelling (Detect withholds
+// "lifecycle") and the lifecycle verbs (Start refuses) consult, so the two can
+// never disagree.
+func (h *hermesDescriptor) servesRootGateway(key string) bool {
+	if !strings.HasPrefix(key, "hermes:") {
+		return false // the root station itself is startable as usual
+	}
+	name := strings.TrimPrefix(key, "hermes:")
+	if name == "" {
+		return false
+	}
+	return sameMatrixIdentity(
+		h.matrixIDOf(h.home),
+		h.matrixIDOf(filepath.Join(h.home, "profiles", name)),
+	)
 }
 
 // workspaceFor maps a station key to its workspace root path.
@@ -151,18 +233,36 @@ func (h *hermesDescriptor) Health(key string) (Health, error) {
 	// Disk usage from the shared async cache — never walk on the request path.
 	health.DiskBytes = diskUsage(workspace)
 
+	// A profile that IS the root gateway's profile has no process of its own:
+	// report the ROOT gateway's liveness and metrics (it is literally the same
+	// process) and say so in the note, so the console does not show a live agent
+	// as "stopped" beside a Start button it deliberately no longer offers.
+	probeKey := key
+	rootGatewayView := h.servesRootGateway(key)
+	if rootGatewayView {
+		probeKey = "hermes"
+	}
+
 	// Best-effort process check via pgrep.
-	health.Running, _ = hermesProcessRunning(key)
+	health.Running, _ = hermesProcessRunning(probeKey)
 
 	// Live process metrics: best-effort — when the profile is running, resolve
 	// its PID and gather CPU/memory/uptime. Hermes runs a separate process per
 	// profile, so these are honest PER-AGENT numbers. Any failure leaves the
 	// metric fields nil; Health() never fails on a ps hiccup.
 	if health.Running {
-		if pid, err := hermesPID(key); err == nil {
+		if pid, err := hermesPID(probeKey); err == nil {
 			health.PID = &pid
 			health.CpuPct, health.MemBytes, health.UptimeSec = gatherPidMetrics(pid)
 		}
+	}
+
+	if rootGatewayView {
+		note := "served by the root Hermes gateway (station \"hermes\") — not separately startable"
+		if health.PID != nil {
+			note = fmt.Sprintf("served by the root Hermes gateway (station \"hermes\", PID %d) — not separately startable", *health.PID)
+		}
+		health.Note = &note
 	}
 
 	return health, nil
@@ -243,6 +343,13 @@ func hermesProcessRunning(key string) (bool, error) {
 // Stop implements Lifecycle. It prefers "systemctl --user stop <unit>" when
 // the unit is registered in the user session, falling back to the pgrep/SIGTERM
 // path for installations that do not use systemd user units.
+//
+// Stop is deliberately NOT guarded by servesRootGateway: for a profile key it can
+// only ever reach a per-profile gateway — "hermes-gateway-<name>.service", or a
+// process whose argv carries "-p <name> gateway" — and the root gateway matches
+// neither (it runs unit "hermes-gateway.service" with no profile selector). It
+// therefore cannot stop the agent it is a view onto. Reaching it at all requires
+// the "lifecycle" capability, which Detect withholds for such a profile.
 func (h *hermesDescriptor) Stop(key string) error {
 	unit := hermesUnitName(key)
 	if hermesUnitKnown(unit) {
@@ -264,6 +371,19 @@ func (h *hermesDescriptor) Stop(key string) error {
 // Configure the start command by passing it to NewHermes or by setting
 // hermesStartCmd in the node config file.
 func (h *hermesDescriptor) Start(key string) error {
+	// A profile that IS the root gateway's profile has no gateway of its own to
+	// start: every launch path below would put a SECOND gateway on the same
+	// Matrix identity, and the two would answer every incoming message
+	// independently (issue #273). Refuse before any of them — including the
+	// systemd and startCmd paths, which duplicate just as effectively as the
+	// native fallback.
+	if h.servesRootGateway(key) {
+		return fmt.Errorf(
+			"hermes: %q is the profile the root gateway already runs (same Matrix identity); "+
+				"starting it would run a second gateway on that identity — use the \"hermes\" station instead",
+			key,
+		)
+	}
 	unit := hermesUnitName(key)
 	if hermesUnitKnown(unit) {
 		return exec.Command("systemctl", "--user", "start", unit).Run()

--- a/apps/node-agent/internal/descriptor/hermes_default_profile_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_default_profile_test.go
@@ -1,0 +1,305 @@
+package descriptor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for #273.
+//
+// On a host where a Hermes profile IS the default gateway — i.e. the profile
+// the root `hermes gateway run` (no `-p`) already serves — the node-agent
+// modelled that one agent as TWO startable stations ("hermes" and
+// "hermes:<name>"). Starting the profile station spawned a SECOND gateway on
+// the same Matrix identity, so the agent answered every message twice. It ran
+// for six weeks on molt-bot.
+//
+// How the default profile is identified (see hermesDescriptor.servesRootGateway):
+// the Hermes home root and the profile directory resolve to the SAME Matrix
+// user ID. The root gateway takes its messaging identity from the home root,
+// and the default profile's directory carries a byte-identical copy of it —
+// that identity match IS the duplication (two gateways syncing one account).
+// Profiles with their own identity are untouched.
+
+// defaultProfileHome builds a Hermes home shaped like the affected host:
+//
+//	<home>/.env                          MATRIX_USER_ID=@buddhimaan:…   (root)
+//	<home>/profiles/buddhimaan/.env      MATRIX_USER_ID=@buddhimaan:…   (the default profile)
+//	<home>/profiles/analyst-echo/.env    MATRIX_USER_ID=@analyst-echo:… (an ordinary profile)
+//
+// Both .env files also carry an access token, which must never be read.
+func defaultProfileHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	writeEnv := func(dir, mxid string) {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		body := fmt.Sprintf("MATRIX_HOMESERVER=https://id.agentpod.dev\nMATRIX_USER_ID=%s\nMATRIX_ACCESS_TOKEN=syt_SECRET_TOKEN\n", mxid)
+		if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(body), 0o600); err != nil {
+			t.Fatalf("write .env in %s: %v", dir, err)
+		}
+	}
+	writeEnv(home, "@buddhimaan:id.agentpod.dev")
+	writeEnv(filepath.Join(home, "profiles", "buddhimaan"), "@buddhimaan:id.agentpod.dev")
+	writeEnv(filepath.Join(home, "profiles", "analyst-echo"), "@analyst-echo:id.agentpod.dev")
+	return home
+}
+
+// findStation returns the station with the given key, failing the test if absent.
+func findStation(t *testing.T, stations []Station, key string) Station {
+	t.Helper()
+	for _, s := range stations {
+		if s.Key == key {
+			return s
+		}
+	}
+	t.Fatalf("station %q not found in %+v", key, stations)
+	return Station{}
+}
+
+// TestHermesDetect_DefaultProfileStationDropsLifecycleCap proves the station
+// modelling side of the rule: the profile that IS the root gateway is still
+// listed (its files stay browsable) but no longer advertises "lifecycle", so
+// the console offers no Start/Stop/Restart for it — the root "hermes" station
+// is the control point for that agent.
+//
+// The DIRECTION THAT MUST NOT REGRESS is asserted in the same test: an ordinary
+// profile keeps "lifecycle" exactly as before.
+func TestHermesDetect_DefaultProfileStationDropsLifecycleCap(t *testing.T) {
+	home := defaultProfileHome(t)
+
+	stations, err := NewHermes(home).Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	root := findStation(t, stations, "hermes")
+	if !slices.Contains(root.Capabilities, "lifecycle") {
+		t.Errorf("root station must keep lifecycle; caps = %v", root.Capabilities)
+	}
+	if root.MatrixId == nil || *root.MatrixId != "@buddhimaan:id.agentpod.dev" {
+		t.Errorf("root station must publish the home's matrix identity, got %v", root.MatrixId)
+	}
+
+	def := findStation(t, stations, "hermes:buddhimaan")
+	if slices.Contains(def.Capabilities, "lifecycle") {
+		t.Errorf("the default-gateway profile must NOT advertise lifecycle; caps = %v", def.Capabilities)
+	}
+	// It stays a real station: files, logs, health remain available.
+	for _, want := range []string{"health", "logs", "fs.read", "terminal"} {
+		if !slices.Contains(def.Capabilities, want) {
+			t.Errorf("default-gateway profile lost capability %q; caps = %v", want, def.Capabilities)
+		}
+	}
+
+	other := findStation(t, stations, "hermes:analyst-echo")
+	if !slices.Contains(other.Capabilities, "lifecycle") {
+		t.Errorf("an ordinary profile must KEEP lifecycle; caps = %v", other.Capabilities)
+	}
+}
+
+// TestHermesStart_DefaultProfileRefusesToSpawnSecondGateway is the core
+// regression: Start on the default-gateway profile must refuse rather than
+// launch `hermes -p <name> gateway run --replace`. The guard runs BEFORE every
+// launch path (systemd unit, startCmd, native fallback), so no path can spawn
+// the duplicate.
+func TestHermesStart_DefaultProfileRefusesToSpawnSecondGateway(t *testing.T) {
+	home := defaultProfileHome(t)
+
+	t.Run("native fallback path", func(t *testing.T) {
+		dir := t.TempDir()
+		hermesArgs := filepath.Join(dir, "hermes.args")
+		sysdArgs := filepath.Join(dir, "systemd-run.args")
+		writeRecorderStub(t, filepath.Join(dir, "hermes"), hermesArgs)
+		writeRecorderStub(t, filepath.Join(dir, "systemd-run"), sysdArgs)
+		t.Setenv("PATH", dir) // no systemctl → unit unknown → native fallback would fire
+
+		lc := NewHermes(home).(Lifecycle)
+		err := lc.Start("hermes:buddhimaan")
+		if err == nil {
+			t.Fatal("Start on the default-gateway profile must return an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "hermes") {
+			t.Errorf("error should name the station/root gateway, got %q", err)
+		}
+		assertNoStubRan(t, hermesArgs, sysdArgs)
+	})
+
+	t.Run("startCmd configured", func(t *testing.T) {
+		dir := t.TempDir()
+		marker := filepath.Join(dir, "startcmd-ran")
+		writeFakeSystemctl(t, dir, false /* unit absent */)
+		prependPath(t, dir)
+
+		h := &hermesDescriptor{home: home, startCmd: "touch " + marker}
+		if err := h.Start("hermes:buddhimaan"); err == nil {
+			t.Fatal("Start must refuse even with a startCmd configured")
+		}
+		assertNoStubRan(t, marker)
+	})
+
+	t.Run("systemd unit present", func(t *testing.T) {
+		dir := t.TempDir()
+		sysLog := writeFakeSystemctl(t, dir, true /* unit known */)
+		prependPath(t, dir)
+
+		h := &hermesDescriptor{home: home}
+		if err := h.Start("hermes:buddhimaan"); err == nil {
+			t.Fatal("Start must refuse even when a per-profile unit exists")
+		}
+		if strings.Contains(readLog(t, sysLog), " start ") {
+			t.Errorf("systemctl start must not run for the default-gateway profile; log:\n%s", readLog(t, sysLog))
+		}
+	})
+}
+
+// TestHermesStart_OrdinaryProfileStillStarts is the regression guarding the
+// OTHER direction: a profile that is NOT the default gateway must start exactly
+// as it did before — this is the behaviour real fleet hosts depend on (13
+// per-profile gateways on molt-bot alone).
+func TestHermesStart_OrdinaryProfileStillStarts(t *testing.T) {
+	home := defaultProfileHome(t)
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "hermes.args")
+	writeRecorderStub(t, filepath.Join(dir, "hermes"), argsFile)
+	t.Setenv("PATH", dir) // no systemd-run, no systemctl → plain detached fallback
+
+	lc := NewHermes(home).(Lifecycle)
+	if err := lc.Start("hermes:analyst-echo"); err != nil {
+		t.Fatalf("Start on an ordinary profile: %v", err)
+	}
+
+	got := waitForStubArgs(t, argsFile)
+	want := "-p analyst-echo gateway run --replace"
+	if got != want {
+		t.Errorf("ordinary profile start args:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestHermesStart_UnknownRootIdentityLeavesProfilesStartable proves the guard
+// is inert when the identities cannot be compared: a home with no resolvable
+// Matrix identity flags nothing, so every profile behaves exactly as it does
+// today. Without this, a host whose identity lives somewhere we cannot read
+// would silently lose the ability to start its profiles.
+func TestHermesStart_UnknownRootIdentityLeavesProfilesStartable(t *testing.T) {
+	home := t.TempDir() // no .env / auth.json / config.yaml anywhere
+	profile := filepath.Join(home, "profiles", "buddhimaan")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatalf("mkdir profile: %v", err)
+	}
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "hermes.args")
+	writeRecorderStub(t, filepath.Join(dir, "hermes"), argsFile)
+	t.Setenv("PATH", dir)
+
+	lc := NewHermes(home).(Lifecycle)
+	if err := lc.Start("hermes:buddhimaan"); err != nil {
+		t.Fatalf("Start with unresolvable identities must behave as before: %v", err)
+	}
+	if got := waitForStubArgs(t, argsFile); got != "-p buddhimaan gateway run --replace" {
+		t.Errorf("unexpected start args %q", got)
+	}
+}
+
+// TestHermesHealth_DefaultProfileReportsRootGateway proves the health view
+// agrees with the lifecycle rule: the default-gateway profile reports the ROOT
+// gateway's liveness (it is the same process) and carries a note saying so, so
+// the console does not show a live agent as "stopped" with no way to start it.
+//
+// An ordinary profile keeps its own per-process reading and no note.
+func TestHermesHealth_DefaultProfileReportsRootGateway(t *testing.T) {
+	home := defaultProfileHome(t)
+
+	// pgrep stub: matches ONLY the broad root pattern ("hermes"), never a
+	// per-profile pattern — exactly the situation on the affected host, where the
+	// root gateway runs and no `-p <name> gateway` process exists. It reports this
+	// test process's PID so the metrics lookup (real `ps`) succeeds.
+	dir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$2" in
+  hermes) echo %d; exit 0 ;;
+  *) exit 1 ;;
+esac
+`, os.Getpid())
+	if err := os.WriteFile(filepath.Join(dir, "pgrep"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write pgrep stub: %v", err)
+	}
+	prependPath(t, dir) // keep the real `ps` reachable
+
+	d := NewHermes(home)
+
+	def, err := d.Health("hermes:buddhimaan")
+	if err != nil {
+		t.Fatalf("Health(default profile): %v", err)
+	}
+	if !def.Running {
+		t.Error("default-gateway profile must report the root gateway's liveness (running)")
+	}
+	if def.PID == nil || *def.PID != os.Getpid() {
+		t.Errorf("default-gateway profile must report the root gateway PID, got %v", def.PID)
+	}
+	if def.Note == nil || !strings.Contains(*def.Note, "gateway") {
+		t.Errorf("default-gateway profile must carry an explanatory note, got %v", def.Note)
+	}
+
+	other, err := d.Health("hermes:analyst-echo")
+	if err != nil {
+		t.Fatalf("Health(ordinary profile): %v", err)
+	}
+	if other.Running {
+		t.Error("an ordinary profile must NOT inherit the root gateway's liveness")
+	}
+	if other.Note != nil {
+		t.Errorf("an ordinary profile must not gain a note, got %q", *other.Note)
+	}
+}
+
+// TestMatrixIDFromProfile_ReadsEnvUserIDOnly proves the identity reader also
+// covers the deployment shape used on the fleet (identity in .env), and that it
+// reads ONLY MATRIX_USER_ID — never MATRIX_ACCESS_TOKEN.
+func TestMatrixIDFromProfile_ReadsEnvUserIDOnly(t *testing.T) {
+	dir := t.TempDir()
+	body := "# comment\nMATRIX_ACCESS_TOKEN=syt_SECRET_TOKEN\nexport MATRIX_USER_ID=\"@buddhimaan:id.agentpod.dev\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	got := MatrixIDFromProfile(dir, "id.agentpod.dev")
+	if got == nil || *got != "@buddhimaan:id.agentpod.dev" {
+		t.Fatalf("want mxid from .env, got %v", got)
+	}
+	if strings.Contains(*got, "SECRET") {
+		t.Fatalf("token leaked: %q", *got)
+	}
+
+	// A .env with only a token yields nothing at all.
+	tokenOnly := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tokenOnly, ".env"), []byte("MATRIX_ACCESS_TOKEN=syt_SECRET_TOKEN\n"), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	if mxid := MatrixIDFromProfile(tokenOnly, "id.agentpod.dev"); mxid != nil {
+		t.Fatalf("want nil when only a token is present, got %q", *mxid)
+	}
+}
+
+// assertNoStubRan waits briefly and fails if any of the given marker files
+// appeared. Launch paths are detached, so absence needs a settle window.
+func assertNoStubRan(t *testing.T, markers ...string) {
+	t.Helper()
+	time.Sleep(300 * time.Millisecond)
+	for _, m := range markers {
+		if b, err := os.ReadFile(m); err == nil && len(b) > 0 {
+			t.Errorf("a launch path ran (%s recorded %q) — no gateway may be spawned for the default profile", filepath.Base(m), strings.TrimSpace(string(b)))
+		} else if err == nil {
+			t.Errorf("a launch path ran (%s exists) — no gateway may be spawned for the default profile", filepath.Base(m))
+		}
+	}
+}

--- a/apps/node-agent/internal/descriptor/matrix.go
+++ b/apps/node-agent/internal/descriptor/matrix.go
@@ -12,19 +12,29 @@ import (
 var mxidRe = regexp.MustCompile(`^@[^:]+:.+$`)
 
 // MatrixIDFromProfile reads the Matrix user ID (mxid) for an agent profile.
-// It tries auth.json first (reading ONLY the user_id field), then falls back
-// to config.yaml. It validates the value matches the mxid shape ^@[^:]+:.+$
-// and returns nil if not found, invalid, or on any error.
+// It tries auth.json first (reading ONLY the user_id field), then config.yaml,
+// then .env (reading ONLY MATRIX_USER_ID). It validates the value matches the
+// mxid shape ^@[^:]+:.+$ and returns nil if not found, invalid, or on any error.
 //
-// SECURITY: access_token and all other fields are never read, logged, or returned.
+// The .env source matters on the deployed fleet: there the Matrix identity of a
+// Hermes home/profile lives in its .env as MATRIX_USER_ID, while auth.json holds
+// only credential_pool/providers and config.yaml has no matrix section. Without
+// it this function returns nil on real hosts (see issue #273).
+//
+// SECURITY: access_token / MATRIX_ACCESS_TOKEN and all other fields are never
+// read, logged, or returned.
 // Missing file / bad JSON / missing field → nil, never panic.
 func MatrixIDFromProfile(profileDir, _ string) *string {
 	// Try auth.json first.
 	if mxid := mxidFromAuthJSON(profileDir); mxid != nil {
 		return mxid
 	}
-	// Fall back to config.yaml.
-	return mxidFromConfigYAML(profileDir)
+	// Then config.yaml.
+	if mxid := mxidFromConfigYAML(profileDir); mxid != nil {
+		return mxid
+	}
+	// Finally .env.
+	return mxidFromEnvFile(profileDir)
 }
 
 // mxidFromAuthJSON reads ONLY the user_id field from auth.json.
@@ -103,6 +113,36 @@ func mxidFromConfigYAML(profileDir string) *string {
 		// Strip surrounding quotes if present.
 		value = strings.Trim(value, `"'`)
 
+		if m := validateMXID(value); m != nil {
+			return m
+		}
+	}
+	return nil
+}
+
+// mxidFromEnvFile extracts MATRIX_USER_ID from a dotenv-style .env file.
+//
+// Only the MATRIX_USER_ID key is ever considered: every other line — including
+// MATRIX_ACCESS_TOKEN — is skipped before its value is even split out, which is
+// the security boundary for this source.
+func mxidFromEnvFile(profileDir string) *string {
+	data, err := os.ReadFile(filepath.Join(profileDir, ".env"))
+	if err != nil {
+		return nil
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Allow the `export KEY=VALUE` form used by shell-sourced env files.
+		trimmed = strings.TrimPrefix(trimmed, "export ")
+		key, value, found := strings.Cut(trimmed, "=")
+		if !found || strings.TrimSpace(key) != "MATRIX_USER_ID" {
+			continue // never look at any other key's value
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
 		if m := validateMXID(value); m != nil {
 			return m
 		}


### PR DESCRIPTION
Fixes #273.

A Hermes profile that **is** the host's default gateway was modelled as a second startable station, and starting it spawned a second gateway on the same Matrix identity — two independent sessions answering every incoming message with two different replies. It ran for six weeks on `molt-bot` (Jul 01 → Aug 13) and doubled that agent's model spend.

## How the default profile is identified

By **messaging identity**, not by name and not by inspecting processes:

> The profile whose resolved Matrix user ID equals the Hermes **home root's** Matrix user ID is the profile the root gateway (`hermes gateway run`, no `-p`) already serves.

The root gateway takes its identity from the home root, and the default profile's directory carries a byte-identical copy of it — that is exactly what #273 documented on the affected host (`@buddhimaan:id.agentpod.dev` in both `~/.hermes/.env` and `~/.hermes/profiles/buddhimaan/.env`, with a byte-identical token; every other profile has its own). The identity match *is* the harm: two gateways syncing one Matrix account.

Both sides are resolved by the same reader, `MatrixIDFromProfile` (`descriptor/matrix.go`), which this PR extends with a `.env` source reading **only** `MATRIX_USER_ID`. That was necessary: on the fleet the identity lives in `.env`, while `auth.json` holds only `credential_pool`/`providers` and `config.yaml` has no matrix section, so the function returned `nil` on real hosts. `MATRIX_ACCESS_TOKEN` is skipped before its value is ever split out — the security boundary of the existing `auth.json` reader is preserved. The root `hermes` station now also publishes its `MatrixId`, which previously was never set, so the comparison has two sides.

`servesRootGateway(key)` is a **single predicate** consulted by both paths, so detection and lifecycle cannot drift apart:

- `Detect()` — withholds the `lifecycle` capability for that profile.
- `Start()` — refuses **before every launch path** (systemd unit, operator `startCmd`, and the native `systemd-run` fallback). All three duplicate equally, so guarding only the fallback would have left two ways to reproduce the bug.

`Stop()` is deliberately not guarded, and the code says why: for a profile key it can only ever reach `hermes-gateway-<name>.service` or a process whose argv carries `-p <name> gateway`, and the root gateway matches neither (unit `hermes-gateway.service`, no profile selector). It cannot stop the agent it is a view onto, and the hub gates the whole verb on the `lifecycle` capability anyway.

**Nothing is killed or matched heuristically by name.** The rule is a string equality between two config-derived identities; no new cleanup path, no pgrep-based "find the other gateway".

## Why non-default profiles are unaffected

- A profile with its own Matrix identity never matches, so its `lifecycle` capability, its `Start` (systemd unit / `startCmd` / native fallback), its `Stop` and its health reading are byte-for-byte the behaviour of `main`. This is the case for 13 of the 14 profiles on `molt-bot`.
- If **either** side fails to resolve (no `.env`/`auth.json`/`config.yaml`, unreadable, malformed, or not mxid-shaped), the predicate is `false` and nothing is flagged. A host whose identity we cannot read keeps today's behaviour exactly, rather than losing the ability to start its profiles. There is a dedicated test for this.
- The root `hermes` station is never flagged — it stays fully startable.

## What a user now sees for such a profile station

The station is still listed and still browsable — `health`, `logs`, `fs.read`, `fs.write`, `terminal`, `cleanup`, `acp` are unchanged — but:

- **No Start / Stop / Restart.** The console gates those buttons on the `lifecycle` capability (`stations/[stationId]/+page.svelte`), and the hub 403s the verb without it. Following #291's lesson: an advertised capability that must not be used is itself a defect, so the capability is withheld rather than the button being made to fail.
- **Honest status.** Health for that profile reports the *root gateway's* liveness and PID (it is literally the same process) plus a note rendered in the health panel: `served by the root Hermes gateway (station "hermes", PID …) — not separately startable`. Without this the console would show a live, replying agent as "stopped" next to no way to start it. This mirrors the existing OpenClaw treatment of shared-gateway sub-stations.

The control point for that agent is the root `hermes` station, which is where it always actually was.

## Tests

TDD: `apps/node-agent/internal/descriptor/hermes_default_profile_test.go` was written first and failed for the right reasons (no `MatrixId` on root, `lifecycle` still advertised, `Start` returned `nil` on all three launch paths, no health note, `.env` identity unresolved). Both directions are covered — the default profile must not become a second startable gateway, **and** an ordinary profile must keep launching `hermes -p <name> gateway run --replace` exactly as before.

`cd apps/node-agent && go test -race ./...` is fully green.

### Mutation results (both directions)

| Mutation | Result |
| --- | --- |
| **Remove the guard (1)** — delete the `servesRootGateway` check from `Start()` | **FAILS** — `TestHermesStart_DefaultProfileRefusesToSpawnSecondGateway` fails on all three subtests (`native fallback path`, `startCmd configured`, `systemd unit present`) |
| **Remove the guard (2)** — stop withholding `lifecycle` in `Detect()` | **FAILS** — `TestHermesDetect_DefaultProfileStationDropsLifecycleCap`: `the default-gateway profile must NOT advertise lifecycle; caps = [health logs fs.read fs.write terminal lifecycle cleanup acp]` |
| **Make the guard unconditional** — `servesRootGateway` returns `true` for every profile key | **FAILS** — `TestHermesStart_OrdinaryProfileStillStarts`, `TestHermesStart_UnknownRootIdentityLeavesProfilesStartable`, `TestHermesHealth_DefaultProfileReportsRootGateway` (its ordinary-profile half), plus the pre-existing `TestHermesStart_KnownUnit_UsesSystemctl`, `TestHermesStart_AbsentUnit_FallsBackToStartCmd`, `TestHermesStart_NativeFallbackLaunchesGatewayRun`, `TestHermesStart_UsesSystemdRunWhenAvailable` |

Neither mutation is survivable, in either direction.

Unrelated: `TestBuildRegistry_ThreadsClaudeCodeACPKeys` (#293) flaked once during this work on an empty `PATH`; it passes on re-run and on unmodified `main`. Not touched here.

## Note for the operator — the live `molt-bot` orphan (not done here, nothing on the fleet was touched)

The duplicate from this bug is a **transient systemd unit**, created by `startDetached` as `systemd-run --collect --quiet <abs bin> -p <name> gateway run --replace`. It lands in `system.slice` reparented to PID 1, so it is invisible to `systemctl --user`. Identify it without guessing:

```sh
# 1. List transient units and find the one whose ExecStart is a hermes profile gateway.
systemctl list-units 'run-r*'
systemctl show -p Id -p MainPID -p ExecStart -p ActiveEnterTimestamp run-r<hash>.service

# 2. Confirm it is the duplicate, i.e. the profile shares the root's identity:
grep '^MATRIX_USER_ID' ~/.hermes/.env ~/.hermes/profiles/<name>/.env    # must be equal
```

Equal identities + a separate `-p <name> gateway run` process = the duplicate. Remove it with:

```sh
systemctl stop run-r<hash>.service    # --collect reaps the unit with it
```

Stopping the unit is cleaner than killing the PID, and nothing auto-restarts it (lifecycle actions are on-demand from the hub). Before this fix, any Start/Restart on that station from the console recreated it immediately; once the node-agent on that host is updated to this build, the console no longer offers the button and the node refuses the verb, so it cannot come back. The root gateway is untouched throughout — it runs `hermes-gateway.service` with no profile selector, which none of the commands above match.

Follow-up worth considering separately (from #273's "minimum viable" suggestion): `startDetached` records nothing about the transient unit it creates, which is why this duplicate was only traceable through the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
