### PR TITLE
fix(update): honest status on a failed update, no reboot when already current (#296)

### DIFF
--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -57,11 +57,28 @@ export const getFleet = () =>
 
 export const listNodes = () => http<NodeSummary[]>("/api/nodes");
 
-export const updateNode = (id: string) =>
-  http<{ ok: boolean; updating?: boolean; tag?: string; error?: string }>(
-    `/api/nodes/${id}/update`,
-    { method: "POST" }
-  );
+/**
+ * Ask a node to self-update.
+ *
+ * `updating` is the load-bearing field: false means the node was already on
+ * the latest release and did NOT restart, so the caller must stop showing
+ * "updating…" and say so instead. A node-side failure is a non-2xx and throws
+ * an ApiError carrying the node's own message (issue #296).
+ *
+ * `force` re-applies the current release — the escape hatch for a node whose
+ * binary is corrupt but whose reported version is current.
+ */
+export const updateNode = (id: string, opts?: { force?: boolean }) =>
+  http<{
+    ok: boolean;
+    updating?: boolean;
+    tag?: string;
+    currentVersion?: string;
+    reason?: string;
+    error?: string;
+  }>(`/api/nodes/${id}/update${opts?.force ? "?force=1" : ""}`, {
+    method: "POST",
+  });
 
 // ─── Runtime endpoints ────────────────────────────────────────────────────────
 

--- a/apps/console/src/lib/components/fleet/AgentTable.svelte
+++ b/apps/console/src/lib/components/fleet/AgentTable.svelte
@@ -238,7 +238,14 @@
     updatingNodes[nodeId] = true;
     try {
       const result = await updateNode(nodeId);
-      if (result.ok) {
+      if (result.ok && result.updating === false) {
+        // The node was already on the latest release and did not restart, so
+        // nothing will ever clear a spinner here (issue #296).
+        delete updatingNodes[nodeId];
+        toast.success("Already up to date", {
+          description: `This node is running ${result.tag ?? "the latest release"}.`,
+        });
+      } else if (result.ok) {
         // Keep "updating…" state — node will blip offline→online on the new version
         // and the next fleet refresh will clear updateAvailable.
       } else {

--- a/apps/console/src/lib/components/fleet/AgentTable.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/AgentTable.svelte.test.ts
@@ -173,6 +173,33 @@ test("Update button calls updateNode(nodeId) and enters updating state", async (
   expect(api.updateNode).toHaveBeenCalledWith(agentWithUpdate.nodeId);
 });
 
+// Issue #296: a node already on the latest release answers updating:false and
+// does NOT restart. Nothing will bring it offline→online, so the button would
+// sit on "Updating…" forever if the no-op were treated like a started update.
+test("Update on an already-current node leaves 'updating…' instead of hanging on it", async () => {
+  const { toast } = await import("svelte-sonner");
+  vi.spyOn(api, "updateNode").mockResolvedValue({
+    ok: true,
+    updating: false,
+    tag: "v0.1.25",
+    currentVersion: "v0.1.25",
+    reason: "already up to date",
+  });
+
+  const { getByRole } = render(AgentTable, { props: { agents: [agentWithUpdate] } });
+
+  await fireEvent.click(getByRole("button", { name: /^update$/i }));
+
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalledWith(
+      "Already up to date",
+      expect.objectContaining({ description: expect.stringContaining("v0.1.25") })
+    );
+  });
+  // The button is clickable again rather than stuck mid-update.
+  expect(getByRole("button", { name: /^update$/i })).toBeTruthy();
+});
+
 test("agents from two different nodes produce two group headers", () => {
   const agent3 = makeAgent({
     stationId: "s3",

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte
@@ -185,7 +185,14 @@
     updatingNodes[id] = true;
     try {
       const result = await updateNode(id);
-      if (result.ok) {
+      if (result.ok && result.updating === false) {
+        // The node was already on the latest release and did not restart, so
+        // nothing will ever clear a spinner here (issue #296).
+        delete updatingNodes[id];
+        toast.success("Already up to date", {
+          description: `This node is running ${result.tag ?? "the latest release"}.`,
+        });
+      } else if (result.ok) {
         // Keep "updating…" state — the node will blip offline→online on the new
         // version and the next nodes refresh will clear updateAvailable.
       } else {

--- a/apps/console/src/routes/nodes/[id]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/+page.svelte
@@ -58,7 +58,14 @@
     updating = true;
     try {
       const result = await updateNode(node.id);
-      if (result.ok) {
+      if (result.ok && result.updating === false) {
+        // The node was already on the latest release and did not restart, so
+        // nothing will ever clear a spinner here (issue #296).
+        updating = false;
+        toast.success("Already up to date", {
+          description: `This node is running ${result.tag ?? "the latest release"}.`,
+        });
+      } else if (result.ok) {
         // Keep "updating…" state — the node will blip offline→online on the
         // new version; next refresh clears updateAvailable.
       } else {

--- a/apps/hub/src/routes/nodes.ts
+++ b/apps/hub/src/routes/nodes.ts
@@ -13,6 +13,51 @@ type RequestFn = (
   params: unknown
 ) => Promise<{ ok: boolean; data?: unknown; error?: string }>;
 
+/** What the node's "update" verb answers inside the broker envelope's `data`. */
+type UpdateResult = {
+  ok?: boolean;
+  error?: string;
+  updating?: boolean;
+  tag?: string;
+  currentVersion?: string;
+  reason?: string;
+};
+
+// ─── Error-to-status helper ───────────────────────────────────────────────────
+
+/**
+ * Map a node-side update failure onto a status.
+ *
+ * Same split every other broker-proxying route in the hub uses (node-posture,
+ * station-cleanup, station-changeset, station-lifecycle): the node not being
+ * reachable is a conflict with the fleet's current state and retryable as-is,
+ * everything else is an upstream failure. 5xx stays reserved for "the hub
+ * itself broke" only in the 500 sense — 502 explicitly says the failure came
+ * from the node, not from here.
+ */
+function brokerErrorStatus(error: string | undefined): 409 | 502 {
+  if (error === "node offline" || error === "node disconnected") return 409;
+  return 502;
+}
+
+/**
+ * Read the `force` flag from either `?force=1` (convenient from curl) or a
+ * `{"force":true}` JSON body. An absent or unparseable body is not an error —
+ * the console posts no body at all.
+ */
+async function readForce(c: {
+  req: { query(k: string): string | undefined; json(): Promise<unknown> };
+}): Promise<boolean> {
+  const q = c.req.query("force");
+  if (q === "1" || q === "true") return true;
+  const body = await c.req.json().catch(() => null);
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    (body as { force?: unknown }).force === true
+  );
+}
+
 // ─── Factory (allows broker injection for unit tests) ─────────────────────────
 
 /**
@@ -31,21 +76,66 @@ export function createNodeRoutes(deps?: { request?: RequestFn }) {
        */
       .get("/", async (c) => c.json(await listNodes(c.get("user").id)))
       /**
-       * POST /api/nodes/:id/update
+       * POST /api/nodes/:id/update  [?force=1  |  body {"force":true}]
        *
-       * Sends an "update" RPC to the node via the broker.  The node
-       * self-updates in-process and exits so systemd/Restart=always can
-       * bring it back on the new binary.
+       * Sends an "update" RPC to the node via the broker. When the node is
+       * behind the latest release it self-updates in-process and exits so
+       * systemd/Restart=always can bring it back on the new binary; when it is
+       * already current it answers `updating:false` and stays up. `force`
+       * re-applies the current release — the escape hatch for a corrupt binary.
        *
-       * Returns the raw broker result:
-       *   { ok: true,  updating: true, tag: "<latest>" }  — update kicked off
-       *   { ok: false, error: "node offline" }             — node not connected
-       *   { ok: false, error: "timeout" }                  — no response in 15 s
+       * The status answers "did the update happen", not "did the WebSocket
+       * round-trip happen" (issue #296). The route used to return the broker
+       * envelope verbatim, so a node that refused the verb answered
+       * `HTTP 200 {"ok":false,"error":"descriptor: unknown verb \"update\""}` —
+       * success to any caller that checks the status, while the node did
+       * nothing. That is a bad failure to hide, because the symptom of a
+       * silently failed update is nothing at all: the node keeps running the
+       * old binary and looks healthy.
+       *
+       *   200 { ok: true, updating: true,  tag, currentVersion }  — update started
+       *   200 { ok: true, updating: false, tag, reason }          — already current, no restart
+       *   409 { ok: false, error: "node offline" }                — not connected
+       *   502 { ok: false, error: "<what the node said>" }        — node refused or failed
+       *
+       * The node's own error text is passed through rather than replaced with
+       * status copy: `descriptor: unknown verb "update"` IS the diagnosis, and
+       * the console surfaces a hub-supplied `error` field in its toast.
        */
       .post("/:id/update", async (c) => {
         const nodeId = c.req.param("id");
-        const r = await _request(nodeId, "update", {});
-        return c.json(r);
+        const force = await readForce(c);
+        const r = await _request(nodeId, "update", { force });
+
+        // The RPC never reached the node, or the node rejected the frame.
+        if (!r.ok) {
+          return c.json(
+            { ok: false as const, error: r.error ?? "update failed" },
+            brokerErrorStatus(r.error)
+          );
+        }
+
+        // The round-trip succeeded but the update itself did not — e.g. the
+        // download 404'd or the checksum did not match. Same class of lie as
+        // the envelope case if it were reported as 200.
+        const data = (r.data ?? {}) as UpdateResult;
+        if (data.ok === false) {
+          return c.json(
+            { ok: false as const, error: data.error ?? "update failed" },
+            502
+          );
+        }
+
+        // Flattened: the node's payload arrives nested under `data`, so a
+        // caller reading `body.updating` off the envelope always saw undefined
+        // and could not tell a started update from a no-op.
+        return c.json({
+          ok: true as const,
+          updating: data.updating ?? false,
+          tag: data.tag,
+          currentVersion: data.currentVersion,
+          reason: data.reason,
+        });
       })
   );
 }

--- a/apps/hub/tests/unit/nodes-update-route.test.ts
+++ b/apps/hub/tests/unit/nodes-update-route.test.ts
@@ -1,9 +1,20 @@
 /**
- * Unit Tests: POST /api/nodes/:id/update (self-update slice 3)
+ * Unit Tests: POST /api/nodes/:id/update
  *
- * Verifies that the route:
- *   1. Calls broker.request(nodeId, "update", {}) and returns its result.
- *   2. Reflects an offline-node error from the broker.
+ * The route brokers an "update" RPC to the node. Two things it must get right
+ * (issue #296):
+ *
+ *   1. HTTP status must reflect whether the UPDATE happened, not whether the
+ *      WebSocket round-trip happened. The route used to return the broker
+ *      envelope verbatim, so a node that refused the verb answered
+ *      `HTTP 200 {"ok":false,"error":"descriptor: unknown verb \"update\""}` —
+ *      success to any caller that checks the status, while the node did
+ *      nothing. The symptom of a silently failed update is nothing at all: the
+ *      node keeps running the old binary and looks healthy.
+ *
+ *   2. The node's payload must survive to the caller, flattened. The real
+ *      broker nests it under `data`, so `body.updating` was always undefined —
+ *      a caller could not tell an update that started from one that no-opped.
  *
  * No database or live WebSocket required — the broker is injected via the
  * createNodeRoutes() factory.
@@ -19,20 +30,21 @@ import type { AuthUser } from "../../src/auth/middleware";
 const TEST_USER_ID = "user-unit-001";
 const TEST_NODE_ID = "node-unit-abc123";
 
-// ─── Helper ───────────────────────────────────────────────────────────────────
+type BrokerResult = { ok: boolean; data?: unknown; error?: string };
+type RequestFn = (
+  nodeId: string,
+  verb: string,
+  params: unknown
+) => Promise<BrokerResult>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
  * Build a minimal Hono test app that mounts createNodeRoutes() under
  * /api/nodes, with a fake auth middleware that stamps TEST_USER_ID on
  * every request.
  */
-function makeTestApp(
-  mockRequest: (
-    nodeId: string,
-    verb: string,
-    params: unknown
-  ) => Promise<{ ok: boolean; data?: unknown; error?: string }>
-) {
+function makeTestApp(mockRequest: RequestFn) {
   const routes = createNodeRoutes({ request: mockRequest });
 
   return new Hono()
@@ -46,67 +58,177 @@ function makeTestApp(
     .route("/api/nodes", routes);
 }
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
-
-test("POST /api/nodes/:id/update → calls broker.request(nodeId, 'update', {}) and returns its result", async () => {
+/** A broker stub that always answers `result` and records every call. */
+function stubBroker(result: BrokerResult) {
   const calls: Array<[string, string, unknown]> = [];
-
-  const mockRequest = async (
-    nodeId: string,
-    verb: string,
-    params: unknown
-  ): Promise<{ ok: boolean; updating?: boolean; tag?: string }> => {
+  const request: RequestFn = async (nodeId, verb, params) => {
     calls.push([nodeId, verb, params]);
-    return { ok: true, updating: true, tag: "v0.1.3" };
+    return result;
   };
+  return { request, calls };
+}
 
-  const testApp = makeTestApp(mockRequest);
+async function postUpdate(mockRequest: RequestFn, path = "") {
+  return makeTestApp(mockRequest).request(
+    `/api/nodes/${TEST_NODE_ID}/update${path}`,
+    { method: "POST", headers: { "Content-Type": "application/json" } }
+  );
+}
 
-  const res = await testApp.request(`/api/nodes/${TEST_NODE_ID}/update`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+// ─── Success path ─────────────────────────────────────────────────────────────
+
+test("POST /api/nodes/:id/update → brokers update to the node and flattens the node's payload", async () => {
+  const { request, calls } = stubBroker({
+    ok: true,
+    // The real broker envelope nests the node's result under `data`.
+    data: { ok: true, updating: true, tag: "v0.1.26", currentVersion: "v0.1.25" },
   });
 
+  const res = await postUpdate(request);
   expect(res.status).toBe(200);
 
-  // Broker must have been called exactly once with the right args
   expect(calls).toHaveLength(1);
   const [calledNodeId, calledVerb, calledParams] = calls[0]!;
   expect(calledNodeId).toBe(TEST_NODE_ID);
   expect(calledVerb).toBe("update");
-  expect(calledParams).toEqual({});
+  expect(calledParams).toEqual({ force: false });
 
-  // The broker result is returned verbatim
-  const body = (await res.json()) as {
-    ok: boolean;
-    updating?: boolean;
-    tag?: string;
-  };
+  const body = (await res.json()) as Record<string, unknown>;
   expect(body.ok).toBe(true);
   expect(body.updating).toBe(true);
-  expect(body.tag).toBe("v0.1.3");
+  expect(body.tag).toBe("v0.1.26");
+  expect(body.currentVersion).toBe("v0.1.25");
 });
 
-test("POST /api/nodes/:id/update → offline node (broker returns error) is reflected", async () => {
-  const mockRequest = async (
-    _nodeId: string,
-    _verb: string,
-    _params: unknown
-  ): Promise<{ ok: boolean; error?: string }> => ({
-    ok: false,
-    error: "node offline",
+test("POST /api/nodes/:id/update → an already-current node is 200 with updating:false, not an implied restart", async () => {
+  const { request } = stubBroker({
+    ok: true,
+    data: {
+      ok: true,
+      updating: false,
+      tag: "v0.1.25",
+      currentVersion: "v0.1.25",
+      reason: "already up to date",
+    },
   });
 
-  const testApp = makeTestApp(mockRequest);
-
-  const res = await testApp.request(`/api/nodes/${TEST_NODE_ID}/update`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-  });
-
+  const res = await postUpdate(request);
   expect(res.status).toBe(200);
 
-  const body = (await res.json()) as { ok: boolean; error?: string };
+  const body = (await res.json()) as Record<string, unknown>;
+  expect(body.ok).toBe(true);
+  // The distinguishing bit: nothing happened, and the console can say so.
+  expect(body.updating).toBe(false);
+  expect(body.tag).toBe("v0.1.25");
+  expect(body.reason).toBe("already up to date");
+});
+
+// ─── force ────────────────────────────────────────────────────────────────────
+
+test("POST /api/nodes/:id/update?force=1 → forwards force to the node", async () => {
+  const { request, calls } = stubBroker({
+    ok: true,
+    data: { ok: true, updating: true, tag: "v0.1.25" },
+  });
+
+  const res = await postUpdate(request, "?force=1");
+  expect(res.status).toBe(200);
+  expect(calls[0]![2]).toEqual({ force: true });
+  expect(((await res.json()) as Record<string, unknown>).updating).toBe(true);
+});
+
+test("POST /api/nodes/:id/update with {force:true} body → forwards force to the node", async () => {
+  const { request, calls } = stubBroker({
+    ok: true,
+    data: { ok: true, updating: true, tag: "v0.1.25" },
+  });
+
+  const res = await makeTestApp(request).request(
+    `/api/nodes/${TEST_NODE_ID}/update`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ force: true }),
+    }
+  );
+
+  expect(res.status).toBe(200);
+  expect(calls[0]![2]).toEqual({ force: true });
+});
+
+// ─── Failure paths: the envelope ──────────────────────────────────────────────
+
+test("POST /api/nodes/:id/update → a node that refuses the verb is NOT a 2xx, and its error survives", async () => {
+  // Measured on the live hub 2026-08-13 against an agent predating the verb.
+  const nodeError = 'descriptor: unknown verb "update"';
+  const { request } = stubBroker({ ok: false, error: nodeError });
+
+  const res = await postUpdate(request);
+
+  // The single most important assertion in this file: the update did not
+  // happen, so the status must not say it did.
+  expect(res.status).not.toBe(200);
+  expect(res.status).toBeGreaterThanOrEqual(400);
+  // Upstream (the node) failed, not the hub — 502, matching every other
+  // broker-proxying route in the hub.
+  expect(res.status).toBe(502);
+
+  const body = (await res.json()) as { ok?: boolean; error?: string };
+  expect(body.ok).toBe(false);
+  // The message is genuinely useful — it is the whole diagnosis — so it must
+  // reach the caller verbatim rather than being flattened into status copy.
+  expect(body.error).toBe(nodeError);
+});
+
+test("POST /api/nodes/:id/update → an offline node is 409, not 502 and not 200", async () => {
+  const { request } = stubBroker({ ok: false, error: "node offline" });
+
+  const res = await postUpdate(request);
+  expect(res.status).toBe(409);
+
+  const body = (await res.json()) as { ok?: boolean; error?: string };
   expect(body.ok).toBe(false);
   expect(body.error).toBe("node offline");
+});
+
+test("POST /api/nodes/:id/update → a disconnected node is 409", async () => {
+  const { request } = stubBroker({ ok: false, error: "node disconnected" });
+  expect((await postUpdate(request)).status).toBe(409);
+});
+
+test("POST /api/nodes/:id/update → a timeout is 502", async () => {
+  const { request } = stubBroker({ ok: false, error: "timeout" });
+
+  const res = await postUpdate(request);
+  expect(res.status).toBe(502);
+  expect(((await res.json()) as { error?: string }).error).toBe("timeout");
+});
+
+// ─── Failure paths: inside the envelope ───────────────────────────────────────
+
+test("POST /api/nodes/:id/update → a node-side failure inside a delivered envelope is 502, not 200", async () => {
+  // The node reached the download and failed there. The RPC round-trip
+  // succeeded (envelope ok:true) but the update did not.
+  const nodeError = "selfupdate: checksum mismatch for agentpod-node-linux-arm64";
+  const { request } = stubBroker({ ok: true, data: { ok: false, error: nodeError } });
+
+  const res = await postUpdate(request);
+  expect(res.status).toBe(502);
+
+  const body = (await res.json()) as { ok?: boolean; error?: string };
+  expect(body.ok).toBe(false);
+  expect(body.error).toBe(nodeError);
+});
+
+// ─── Guard: the mapping must not swallow successes ────────────────────────────
+
+test("POST /api/nodes/:id/update → a successful update is still a 200", async () => {
+  for (const data of [
+    { ok: true, updating: true, tag: "v0.1.26" },
+    { ok: true, updating: false, tag: "v0.1.26", reason: "already up to date" },
+  ]) {
+    const { request } = stubBroker({ ok: true, data });
+    const res = await postUpdate(request);
+    expect(res.status).toBe(200);
+  }
 });

--- a/apps/node-agent/internal/gateway/update_handler.go
+++ b/apps/node-agent/internal/gateway/update_handler.go
@@ -12,6 +12,10 @@ import (
 // updateHandler wraps an inner Handler and intercepts the "update" verb to
 // trigger an in-process self-update via selfupdate.Apply, then exits so that
 // the system supervisor (e.g. systemd Restart=always) can start the new binary.
+//
+// The exit is conditional on selfupdate.Apply having actually swapped a
+// binary: an update request against a node already on the latest release
+// answers {"ok":true,"updating":false} and leaves the process alone.
 type updateHandler struct {
 	inner   Handler
 	version string
@@ -48,9 +52,41 @@ func (h *updateHandler) Handle(
 		return h.inner.Handle(ctx, verb, p, emit)
 	}
 
-	res, err := h.apply(ctx, selfupdate.Options{CurrentVersion: h.version})
+	// `{"force":true}` re-applies the release the node is already running —
+	// the escape hatch for a corrupt binary whose reported version is current.
+	// Unreadable params are simply "no options given": failing an update over
+	// a malformed payload would be worse than ignoring it.
+	var params struct {
+		Force bool `json:"force"`
+	}
+	if len(p) > 0 {
+		_ = json.Unmarshal(p, &params)
+	}
+
+	res, err := h.apply(ctx, selfupdate.Options{
+		CurrentVersion: h.version,
+		Force:          params.Force,
+	})
 	if err != nil {
 		return map[string]any{"ok": false, "error": err.Error()}, false, nil
+	}
+
+	out := map[string]any{
+		"ok":             true,
+		"updating":       res.Updated,
+		"tag":            res.LatestTag,
+		"currentVersion": res.CurrentVersion,
+	}
+	if res.Reason != "" {
+		out["reason"] = res.Reason
+	}
+
+	// Nothing was swapped — the node is already on the latest release, so
+	// exiting would restart it to arrive exactly where it started. On Fly that
+	// restart is a full VM reboot, costing the station its uptime and every
+	// in-flight session on it (issue #296).
+	if !res.Updated {
+		return out, false, nil
 	}
 
 	// Respond to the hub before exiting so it can mark the node as updating.
@@ -60,7 +96,7 @@ func (h *updateHandler) Handle(
 		h.exit(0)
 	}()
 
-	return map[string]any{"ok": true, "updating": true, "tag": res.LatestTag}, false, nil
+	return out, false, nil
 }
 
 // HandleFrame forwards inbound terminal input/resize frames to the inner handler

--- a/apps/node-agent/internal/gateway/update_handler_noop_test.go
+++ b/apps/node-agent/internal/gateway/update_handler_noop_test.go
@@ -1,0 +1,171 @@
+package gateway
+
+// Issue #296: the hub-triggered "update" verb restarted a node that was
+// already on the latest release. The node re-downloaded, re-swapped and
+// bounced the service to arrive exactly where it started — and on Fly that
+// bounce is a full VM reboot, so an idle click on Update costs a station its
+// uptime and every in-flight session on it.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/selfupdate"
+)
+
+// newTestUpdateHandler builds an updateHandler whose apply is `fake` and whose
+// exit signals the returned channel instead of killing the test binary.
+func newTestUpdateHandler(
+	version string,
+	fake func(context.Context, selfupdate.Options) (selfupdate.Result, error),
+) (*updateHandler, chan int) {
+	exited := make(chan int, 1)
+	h := &updateHandler{
+		inner:   HandlerFunc(func(context.Context, string, json.RawMessage, func(int, string, bool, string) error) (any, bool, error) { return nil, false, nil }),
+		version: version,
+		apply:   fake,
+		exit:    func(code int) { exited <- code },
+		delay:   0,
+	}
+	return h, exited
+}
+
+// handleUpdate runs the update verb and returns the result map plus whether
+// the process exited. The exit path is a goroutine, so "did not exit" is
+// asserted by waiting — long enough that a slow scheduler cannot fake a pass.
+func handleUpdate(t *testing.T, h *updateHandler, exited chan int, params string) (map[string]any, bool) {
+	t.Helper()
+
+	result, streamed, err := h.Handle(context.Background(), "update", json.RawMessage(params), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamed {
+		t.Error("update must return streamed=false so the dispatcher emits a res frame the hub can resolve")
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any result, got %T", result)
+	}
+
+	select {
+	case <-exited:
+		return m, true
+	case <-time.After(500 * time.Millisecond):
+		return m, false
+	}
+}
+
+func TestUpdateHandler_AlreadyCurrentDoesNotRestart(t *testing.T) {
+	var gotOpts selfupdate.Options
+	h, exited := newTestUpdateHandler("v0.1.25", func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		// What Apply returns for a node already on the latest release.
+		return selfupdate.Result{
+			CurrentVersion: opts.CurrentVersion,
+			LatestTag:      "v0.1.25",
+			Updated:        false,
+			Reason:         "already up to date",
+		}, nil
+	})
+
+	m, didExit := handleUpdate(t, h, exited, `{}`)
+
+	if didExit {
+		t.Error("the process exited — an already-current node must not restart (on Fly that is a full VM reboot)")
+	}
+	if m["ok"] != true {
+		t.Errorf("ok: got %v want true — being already current is a success, not a failure", m["ok"])
+	}
+	if m["updating"] != false {
+		t.Errorf("updating: got %v want false — nothing was applied, so the response must not imply work happened", m["updating"])
+	}
+	if m["tag"] != "v0.1.25" {
+		t.Errorf("tag: got %v want \"v0.1.25\"", m["tag"])
+	}
+	if m["currentVersion"] != "v0.1.25" {
+		t.Errorf("currentVersion: got %v want \"v0.1.25\"", m["currentVersion"])
+	}
+	if m["reason"] != "already up to date" {
+		t.Errorf("reason: got %v want \"already up to date\" — the console needs it to say so", m["reason"])
+	}
+	if gotOpts.CurrentVersion != "v0.1.25" {
+		t.Errorf("CurrentVersion passed to Apply: got %q want \"v0.1.25\"", gotOpts.CurrentVersion)
+	}
+	if gotOpts.Force {
+		t.Error("Force must default to false")
+	}
+}
+
+func TestUpdateHandler_BehindStillRestarts(t *testing.T) {
+	h, exited := newTestUpdateHandler("v0.1.9", func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{
+			CurrentVersion: opts.CurrentVersion,
+			LatestTag:      "v0.1.24",
+			Updated:        true,
+		}, nil
+	})
+
+	m, didExit := handleUpdate(t, h, exited, `{}`)
+
+	if !didExit {
+		t.Error("a node behind the latest release must still swap and exit for the supervisor to restart it")
+	}
+	if m["ok"] != true {
+		t.Errorf("ok: got %v want true", m["ok"])
+	}
+	if m["updating"] != true {
+		t.Errorf("updating: got %v want true", m["updating"])
+	}
+	if m["tag"] != "v0.1.24" {
+		t.Errorf("tag: got %v want \"v0.1.24\"", m["tag"])
+	}
+}
+
+// The escape hatch: `{"force":true}` re-applies the current release. Without
+// it there is no way to recover a node whose binary is corrupt but whose
+// reported version is current.
+func TestUpdateHandler_ForceIsForwardedAndRestarts(t *testing.T) {
+	var gotOpts selfupdate.Options
+	h, exited := newTestUpdateHandler("v0.1.25", func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		if !opts.Force {
+			return selfupdate.Result{LatestTag: "v0.1.25", Reason: "already up to date"}, nil
+		}
+		return selfupdate.Result{CurrentVersion: opts.CurrentVersion, LatestTag: "v0.1.25", Updated: true}, nil
+	})
+
+	m, didExit := handleUpdate(t, h, exited, `{"force":true}`)
+
+	if !gotOpts.Force {
+		t.Fatal("Force from the request params was not forwarded to selfupdate.Apply")
+	}
+	if !didExit {
+		t.Error("a forced update must still exit so the supervisor restarts the process")
+	}
+	if m["updating"] != true {
+		t.Errorf("updating: got %v want true", m["updating"])
+	}
+}
+
+// A params payload the handler cannot read must not fail the update and must
+// not be read as force — it is simply "no options given".
+func TestUpdateHandler_UnreadableParamsDefaultToNoForce(t *testing.T) {
+	for _, params := range []string{``, `null`, `"nonsense"`} {
+		var gotOpts selfupdate.Options
+		h, exited := newTestUpdateHandler("v0.1.9", func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+			gotOpts = opts
+			return selfupdate.Result{CurrentVersion: opts.CurrentVersion, LatestTag: "v0.1.24", Updated: true}, nil
+		})
+
+		m, _ := handleUpdate(t, h, exited, params)
+		if gotOpts.Force {
+			t.Errorf("params %q: Force must be false", params)
+		}
+		if m["ok"] != true {
+			t.Errorf("params %q: ok: got %v want true", params, m["ok"])
+		}
+	}
+}

--- a/apps/node-agent/internal/selfupdate/apply_noop_test.go
+++ b/apps/node-agent/internal/selfupdate/apply_noop_test.go
@@ -1,0 +1,185 @@
+package selfupdate
+
+// Issue #296: Apply must not re-apply a release the node is already running.
+//
+// The hub-triggered "update" verb calls Apply, and Apply used to download,
+// verify and swap unconditionally. On a node already on the latest release
+// that is a pointless binary swap followed by a restart — on Fly, a full VM
+// reboot that costs the station its uptime and every in-flight session.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// countingUpdateServer is makeUpdateServer plus a download counter, so a test
+// can prove that a short-circuited Apply performed no download at all.
+func countingUpdateServer(tag string, content []byte, hash string, downloads *int) *httptest.Server {
+	asset := assetName(runtime.GOOS, runtime.GOARCH)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/rakeshgangwar/agentpod/releases/latest":
+			json.NewEncoder(w).Encode(struct {
+				TagName string `json:"tag_name"`
+			}{tag})
+		case fmt.Sprintf("/rakeshgangwar/agentpod/releases/download/%s/%s", tag, asset):
+			*downloads++
+			w.Write(content)
+		case fmt.Sprintf("/rakeshgangwar/agentpod/releases/download/%s/SHA256SUMS", tag):
+			fmt.Fprintf(w, "%s  %s\n", hash, asset)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// applyFixture wires a counting release server and a stand-in target binary,
+// and returns the target path plus a pointer to the download count.
+func applyFixture(t *testing.T, tag string, content []byte) (*httptest.Server, string, *int) {
+	t.Helper()
+	downloads := 0
+	srv := countingUpdateServer(tag, content, binaryHash(content), &downloads)
+	t.Cleanup(srv.Close)
+
+	target := filepath.Join(t.TempDir(), "agentpod-node")
+	if err := os.WriteFile(target, []byte("RUNNING"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return srv, target, &downloads
+}
+
+func TestApply_AlreadyCurrentIsANoOp(t *testing.T) {
+	const latestTag = "v0.1.25"
+	content := []byte("BINARY_NEW")
+	srv, target, downloads := applyFixture(t, latestTag, content)
+
+	res, err := Apply(context.Background(), Options{
+		CurrentVersion:    latestTag,
+		APIBase:           srv.URL,
+		DLBase:            srv.URL,
+		HTTPClient:        srv.Client(),
+		targetPathForTest: target,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Updated {
+		t.Error("Updated: got true, want false — the node is already on the latest release")
+	}
+	if res.LatestTag != latestTag {
+		t.Errorf("LatestTag: got %q want %q — the caller still needs the resolved tag", res.LatestTag, latestTag)
+	}
+	if res.CurrentVersion != latestTag {
+		t.Errorf("CurrentVersion: got %q want %q", res.CurrentVersion, latestTag)
+	}
+	if res.Reason != "already up to date" {
+		t.Errorf("Reason: got %q want %q", res.Reason, "already up to date")
+	}
+	if *downloads != 0 {
+		t.Errorf("downloads: got %d want 0 — an up-to-date node must not re-download its own binary", *downloads)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "RUNNING" {
+		t.Errorf("target was swapped (%q) — an up-to-date node's binary must be left alone", got)
+	}
+}
+
+// The comparison is numeric, not lexical. v0.1.9 sorts AFTER v0.1.24 as a
+// string, so a comparator built on string ordering would call this node
+// current and strand it two releases behind.
+func TestApply_BehindStillApplies(t *testing.T) {
+	const latestTag = "v0.1.24"
+	content := []byte("BINARY_NEW")
+	srv, target, downloads := applyFixture(t, latestTag, content)
+
+	res, err := Apply(context.Background(), Options{
+		CurrentVersion:    "v0.1.9", // lexically LATER than v0.1.24, numerically earlier
+		APIBase:           srv.URL,
+		DLBase:            srv.URL,
+		HTTPClient:        srv.Client(),
+		targetPathForTest: target,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Updated {
+		t.Fatal("Updated: got false, want true — v0.1.9 is behind v0.1.24 and must update")
+	}
+	if *downloads != 1 {
+		t.Errorf("downloads: got %d want 1", *downloads)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != string(content) {
+		t.Errorf("target: got %q want %q", got, content)
+	}
+}
+
+// A version string the comparator cannot read (the default build stamps the
+// literal "dev", and the pre-`update` agents in the fleet report an empty
+// version) must fall through to applying. Refusing to update because the
+// version is unreadable would strand exactly the nodes most in need of one.
+func TestApply_UnreadableCurrentVersionStillApplies(t *testing.T) {
+	const latestTag = "v0.1.25"
+	content := []byte("BINARY_NEW")
+
+	for _, current := range []string{"dev", ""} {
+		t.Run("current="+current, func(t *testing.T) {
+			srv, target, downloads := applyFixture(t, latestTag, content)
+
+			res, err := Apply(context.Background(), Options{
+				CurrentVersion:    current,
+				APIBase:           srv.URL,
+				DLBase:            srv.URL,
+				HTTPClient:        srv.Client(),
+				targetPathForTest: target,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !res.Updated {
+				t.Error("Updated: got false, want true — an unreadable current version must not suppress the update")
+			}
+			if *downloads != 1 {
+				t.Errorf("downloads: got %d want 1", *downloads)
+			}
+		})
+	}
+}
+
+func TestApply_ForceAppliesEvenWhenCurrent(t *testing.T) {
+	const latestTag = "v0.1.25"
+	content := []byte("BINARY_NEW")
+	srv, target, downloads := applyFixture(t, latestTag, content)
+
+	res, err := Apply(context.Background(), Options{
+		CurrentVersion:    latestTag,
+		Force:             true,
+		APIBase:           srv.URL,
+		DLBase:            srv.URL,
+		HTTPClient:        srv.Client(),
+		targetPathForTest: target,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Updated {
+		t.Fatal("Updated: got false, want true — Force must re-apply the current release")
+	}
+	if *downloads != 1 {
+		t.Errorf("downloads: got %d want 1", *downloads)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != string(content) {
+		t.Errorf("target: got %q want %q", got, content)
+	}
+}

--- a/apps/node-agent/internal/selfupdate/selfupdate.go
+++ b/apps/node-agent/internal/selfupdate/selfupdate.go
@@ -281,13 +281,35 @@ func applyTag(ctx context.Context, opts Options, tag string) (Result, error) {
 	}, nil
 }
 
-// Apply resolves the latest GitHub release tag, then downloads, verifies, and
-// atomically swaps the binary. It does NOT restart the service — the caller is
-// responsible for exiting so that the supervisor (e.g. systemd Restart=always)
-// can start the new binary.
+// upToDate reports whether the running version is at or ahead of tag, i.e.
+// whether applying tag would be pointless work.
 //
-// This is the preferred entry point for programmatic callers such as the
-// gateway "update" verb handler.
+// A version the comparator cannot read (the default build stamps the literal
+// "dev", and the pre-`update`-verb agents in the fleet report nothing at all)
+// is deliberately NOT up to date: refusing to update because the version is
+// unreadable would strand exactly the nodes most in need of an update.
+func upToDate(currentVersion, tag string) bool {
+	cmp, err := CompareVersions(currentVersion, tag)
+	return err == nil && cmp >= 0
+}
+
+// Apply resolves the latest GitHub release tag and, unless the node is already
+// running it, downloads, verifies, and atomically swaps the binary. It does
+// NOT restart the service — the caller is responsible for exiting so that the
+// supervisor (e.g. systemd Restart=always) can start the new binary.
+//
+// The version comparison lives HERE, on the node, rather than in the hub that
+// triggers the update (issue #296). The node is the only authority on which
+// binary is actually running: the hub's agent_version column is whatever the
+// node last reported, it is empty for exactly the stale agents this matters
+// for, and it can go out of date between the hub deciding and the node acting.
+// Deciding here also means every trigger of an update — the hub's button, a
+// future bulk rollout, `agentpod-node update` — gets the same answer.
+//
+// Callers MUST branch on Result.Updated: when it is false nothing was swapped,
+// so restarting the process buys nothing and costs the node its uptime (on Fly
+// a restart is a full VM reboot). Options.Force re-applies the current release
+// anyway, which is the escape hatch for a corrupt binary on a current version.
 func Apply(ctx context.Context, opts Options) (Result, error) {
 	// Apply defaults.
 	if opts.HTTPClient == nil {
@@ -305,39 +327,12 @@ func Apply(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	return applyTag(ctx, opts, tag)
-}
-
-// Update orchestrates a full self-update: resolve latest tag, compare to
-// current version, download+verify the binary, swap it in, restart the service.
-func Update(ctx context.Context, opts Options) (Result, error) {
-	// Apply defaults.
-	if opts.HTTPClient == nil {
-		opts.HTTPClient = http.DefaultClient
-	}
-	if opts.APIBase == "" {
-		opts.APIBase = "https://api.github.com"
-	}
-	if opts.DLBase == "" {
-		opts.DLBase = "https://github.com"
-	}
-	if opts.RunCommand == nil {
-		opts.RunCommand = func(name string, args ...string) error {
-			return exec.Command(name, args...).Run()
-		}
-	}
-
-	tag, err := LatestTag(ctx, opts.HTTPClient, opts.APIBase)
-	if err != nil {
-		return Result{}, err
-	}
-
 	res := Result{
 		CurrentVersion: opts.CurrentVersion,
 		LatestTag:      tag,
 	}
 
-	if tag == opts.CurrentVersion && !opts.Force {
+	if !opts.Force && upToDate(opts.CurrentVersion, tag) {
 		res.Reason = "already up to date"
 		return res, nil
 	}
@@ -347,15 +342,36 @@ func Update(ctx context.Context, opts Options) (Result, error) {
 		return res, nil
 	}
 
-	updated, err := applyTag(ctx, opts, tag)
+	return applyTag(ctx, opts, tag)
+}
+
+// Update orchestrates a full self-update: resolve latest tag, compare to
+// current version, download+verify the binary, swap it in, restart the service.
+//
+// It is Apply plus the restart, and shares Apply's up-to-date short-circuit so
+// the CLI path and the hub-triggered path can never disagree about whether an
+// update is needed.
+func Update(ctx context.Context, opts Options) (Result, error) {
+	if opts.RunCommand == nil {
+		opts.RunCommand = func(name string, args ...string) error {
+			return exec.Command(name, args...).Run()
+		}
+	}
+
+	res, err := Apply(ctx, opts)
 	if err != nil {
 		return Result{}, err
+	}
+	if !res.Updated {
+		// Nothing was swapped (already current, or CheckOnly) — there is
+		// nothing for a restart to pick up.
+		return res, nil
 	}
 
 	// Restart the service. Even if this fails the binary has been updated.
 	if err := restartService(runtime.GOOS, opts.RunCommand); err != nil {
-		return updated, err
+		return res, err
 	}
 
-	return updated, nil
+	return res, nil
 }

--- a/apps/node-agent/internal/selfupdate/version.go
+++ b/apps/node-agent/internal/selfupdate/version.go
@@ -1,0 +1,103 @@
+package selfupdate
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CompareVersions reports how release tag `a` relates to release tag `b`:
+// negative when a is older, zero when they are the same version, positive
+// when a is newer. A non-numeric version component is an error — never a
+// silent "same", which would suppress a needed update.
+//
+// Why this exists in Go when the repo already has a comparator
+// ------------------------------------------------------------
+// fly/node-image/check-version-pin.sh (#292) is the repo's reference answer to
+// "which of these two release tags is newer", and it is deliberately correct
+// about the case a string compare gets wrong: lexically "v0.1.9" > "v0.1.24",
+// so string ordering would call a two-release-stale agent current.
+//
+// A shipped agentpod-node binary cannot call that script. It lives in the Fly
+// image directory, is not part of any release artifact, and the nodes that
+// most need this comparison (a Raspberry Pi, a Modal container) never have the
+// repo on disk. So a Go implementation is unavoidable.
+//
+// What is avoidable is a SECOND, subtly different comparator. This function is
+// a deliberate port with identical semantics, and
+// TestCompareVersions_AgreesWithCheckVersionPinScript runs both over one table
+// and fails if they ever disagree. Change one, change the other.
+//
+// Semantics, matching the script exactly:
+//   - a leading "v" is optional and ignored
+//   - everything from the first "-" is a pre-release suffix, compared last
+//   - the numeric part is compared component-wise and NUMERICALLY, over as
+//     many components as the longer side has; a missing component is 0, so
+//     v0.1 and v0.1.0 are the same version and "" is 0.0.0 (behind every real
+//     release, which is the safe direction — it lets an update proceed)
+//   - on a numeric tie a pre-release precedes the release it leads to, so
+//     v0.1.25-rc1 is older than v0.1.25; two pre-releases compare as strings
+func CompareVersions(a, b string) (int, error) {
+	aNum, aPre := splitVersion(a)
+	bNum, bPre := splitVersion(b)
+
+	aParts := strings.Split(aNum, ".")
+	bParts := strings.Split(bNum, ".")
+	n := max(len(aParts), len(bParts))
+
+	for i := 0; i < n; i++ {
+		ai, err := versionComponent(aParts, i, a)
+		if err != nil {
+			return 0, err
+		}
+		bi, err := versionComponent(bParts, i, b)
+		if err != nil {
+			return 0, err
+		}
+		if ai != bi {
+			if ai < bi {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+
+	// Numerically equal: a pre-release precedes the release it leads to
+	// (semver), which keeps v0.1.25-rc1 from passing as v0.1.25.
+	switch {
+	case aPre != "" && bPre == "":
+		return -1, nil
+	case aPre == "" && bPre != "":
+		return 1, nil
+	case aPre == bPre:
+		return 0, nil
+	case aPre < bPre:
+		return -1, nil
+	default:
+		return 1, nil
+	}
+}
+
+// splitVersion strips an optional leading "v" and splits off everything from
+// the first "-" as the pre-release suffix.
+func splitVersion(v string) (numeric, pre string) {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.Index(v, "-"); i != -1 {
+		return v[:i], v[i+1:]
+	}
+	return v, ""
+}
+
+// versionComponent returns component i of parts as an integer. A component
+// past the end, or an empty one, is 0; anything non-numeric is an error
+// naming the original version string.
+func versionComponent(parts []string, i int, original string) (int, error) {
+	if i >= len(parts) || parts[i] == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(parts[i])
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("selfupdate: not a numeric version: %q", original)
+	}
+	return n, nil
+}

--- a/apps/node-agent/internal/selfupdate/version_test.go
+++ b/apps/node-agent/internal/selfupdate/version_test.go
@@ -1,0 +1,145 @@
+package selfupdate
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// checkVersionPinScript is the POSIX sh comparator that guards the Fly image
+// pins (issue #292). It is the repo's pre-existing answer to "which of these
+// two release tags is newer", and CompareVersions must agree with it — see
+// TestCompareVersions_AgreesWithCheckVersionPinScript.
+const checkVersionPinScript = "../../../../fly/node-image/check-version-pin.sh"
+
+// versionCases are the (a, b) pairs both comparators must agree on.
+// `want` uses the shell script's vocabulary so the differential test can
+// compare strings directly.
+var versionCases = []struct {
+	a, b string
+	want string
+}{
+	// The case that makes a lexical comparison wrong: "v0.1.9" > "v0.1.24"
+	// as strings, so a string compare would call a two-release-stale agent
+	// current and skip the update it actually needs.
+	{"v0.1.9", "v0.1.24", "older"},
+	{"v0.1.24", "v0.1.9", "newer"},
+
+	{"v0.1.25", "v0.1.25", "same"},
+	{"v0.1.24", "v0.1.25", "older"},
+	{"v0.1.25", "v0.1.24", "newer"},
+
+	// A missing "v" prefix is the same version.
+	{"0.1.25", "v0.1.25", "same"},
+	{"v0.1.25", "0.1.25", "same"},
+
+	// A missing component is zero.
+	{"v0.1", "v0.1.0", "same"},
+	{"v0.1.0", "v0.1", "same"},
+	{"v0.1", "v0.1.1", "older"},
+
+	{"v0.2.0", "v0.1.99", "newer"},
+	{"v1.0.0", "v0.9.9", "newer"},
+	{"v0.9.9", "v1.0.0", "older"},
+
+	// Pre-releases precede the release they lead to (semver).
+	{"v0.1.25-rc1", "v0.1.25", "older"},
+	{"v0.1.25", "v0.1.25-rc1", "newer"},
+	{"v0.1.25-rc1", "v0.1.25-rc1", "same"},
+	{"v0.1.25-rc1", "v0.1.25-rc2", "older"},
+	{"v0.1.25-rc2", "v0.1.25-rc1", "newer"},
+	{"v0.1.26", "v0.1.25-rc1", "newer"},
+
+	// A missing or partial version reads as zeroes, so it is BEHIND every real
+	// release — which is the safe direction: it lets the update proceed. The
+	// pre-`update`-verb agents in the fleet report an empty version.
+	{"", "v0.1.25", "older"},
+	{"v0.1.25", "", "newer"},
+	{"v..1", "v0.1.25", "older"},
+}
+
+// relationOf maps CompareVersions' int result onto the shell script's words.
+func relationOf(cmp int) string {
+	switch {
+	case cmp < 0:
+		return "older"
+	case cmp > 0:
+		return "newer"
+	default:
+		return "same"
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	for _, tc := range versionCases {
+		cmp, err := CompareVersions(tc.a, tc.b)
+		if err != nil {
+			t.Errorf("CompareVersions(%q, %q): unexpected error: %v", tc.a, tc.b, err)
+			continue
+		}
+		if got := relationOf(cmp); got != tc.want {
+			t.Errorf("CompareVersions(%q, %q) = %s, want %s", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// A non-numeric version must be an error, never a silent "same" — "same"
+// would suppress a needed update. The agent's own default build version is
+// the literal "dev" (cmd/agentpod-node/main.go), so this is the everyday case
+// on a locally built binary, not a corner case. check-version-pin.sh exits 2
+// on the same inputs; this is the Go spelling of that.
+func TestCompareVersions_NonNumericIsAnError(t *testing.T) {
+	// Each of these makes check-version-pin.sh exit 2 against "v0.1.25".
+	// "v1.2.3.beta" deliberately is NOT here: both comparators short-circuit
+	// on the first differing component (1 > 0) and never look at "beta".
+	for _, v := range []string{"dev", "v0.1.x", "latest", "v0.1.25.beta"} {
+		if _, err := CompareVersions(v, "v0.1.25"); err == nil {
+			t.Errorf("CompareVersions(%q, \"v0.1.25\"): want an error, got nil", v)
+		}
+		if _, err := CompareVersions("v0.1.25", v); err == nil {
+			t.Errorf("CompareVersions(\"v0.1.25\", %q): want an error, got nil", v)
+		}
+	}
+}
+
+// The repo already had a correct comparator before this one existed:
+// fly/node-image/check-version-pin.sh --compare A B. A shipped Go binary
+// cannot shell out to a script that lives in the Fly image directory and is
+// not part of a release artifact, so a Go implementation is unavoidable — but
+// "unavoidable" must not become "subtly different". This test runs both over
+// the same table and requires the answers to match exactly.
+func TestCompareVersions_AgreesWithCheckVersionPinScript(t *testing.T) {
+	script, err := filepath.Abs(checkVersionPinScript)
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	if _, err := os.Stat(script); err != nil {
+		t.Skipf("%s not present in this checkout: %v", checkVersionPinScript, err)
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no POSIX sh available: %v", err)
+	}
+
+	for _, tc := range versionCases {
+		out, err := exec.Command(sh, script, "--compare", tc.a, tc.b).Output()
+		if err != nil {
+			t.Fatalf("check-version-pin.sh --compare %s %s: %v", tc.a, tc.b, err)
+		}
+		shellSays := strings.TrimSpace(string(out))
+
+		cmp, err := CompareVersions(tc.a, tc.b)
+		if err != nil {
+			t.Errorf("CompareVersions(%q, %q): unexpected error: %v", tc.a, tc.b, err)
+			continue
+		}
+		if got := relationOf(cmp); got != shellSays {
+			t.Errorf(
+				"comparators disagree on (%q, %q): Go says %s, check-version-pin.sh says %s",
+				tc.a, tc.b, got, shellSays,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #296.

Two defects in the node update path, both measured on the live hub on 2026-08-13: a failed update reported HTTP 200, and updating an already-current node rebooted it for nothing.

## 1. The response is now honest

`routes/nodes.ts` returned the broker envelope verbatim, so transport success and operation success were the same thing. A node whose agent predates the `update` verb answered:

```
HTTP 200 {"ok":false,"error":"descriptor: unknown verb \"update\""}
```

**Status chosen: 409 for `node offline` / `node disconnected`, 502 for everything else the node said.**

Why: this is the exact split every other broker-proxying route in the hub already uses — `node-posture.ts`, `station-cleanup.ts`, `station-changeset.ts`, `station-lifecycle.ts` all carry the same `brokerErrorStatus()` helper, and `apps/hub/CLAUDE.md` states the rule ("Observe routes proxy to the node via broker and 502 on node-side failure"). Introducing a different vocabulary for this one route would mean the console needs a second mental model for the same situation.

It also answers the "node refused/could not" vs "hub failed" question the issue asks for, in a way HTTP already has words for. 502 Bad Gateway says *the upstream failed*, which is precisely the claim being made — the hub worked, the node did not. 500 stays reserved for the hub itself throwing. 409 separates the one node-side condition that is not a fault at all: the node simply is not connected, nothing is broken, and retrying the identical request later is the fix.

**The message survives.** The body is `{ok:false, error:"<what the node said>"}`, not status copy. `descriptor: unknown verb "update"` *is* the diagnosis, and the console's `apiError()` already lifts a hub-supplied `error` field into its toast, so it reaches the operator unchanged.

**Also fixed: the same lie one layer in.** When the node reached the download and failed there (checksum mismatch, 404), the envelope was `{ok:true, data:{ok:false, error}}` — the round-trip succeeded, the update did not, and the route returned 200. That is now a 502 too.

**Also fixed: the success payload was unreadable.** The node's result arrives nested under `data`, so `body.updating` was always `undefined` and no caller could distinguish a started update from anything else. The route now flattens it: `{ok, updating, tag, currentVersion, reason}`.

## 2. Already-current nodes are left alone

`selfupdate.Apply` downloaded, verified and swapped unconditionally, and the handler always exited. On Fly that exit is a full VM reboot, so an idle click on Update cost a station its uptime and every in-flight session — to arrive exactly where it started.

`Apply` now resolves the tag, compares it with the running version, and returns `Updated:false` / `Reason:"already up to date"` without touching the binary. The handler answers `{"ok":true,"updating":false,"tag":…,"currentVersion":…,"reason":…}` and **does not exit**. The restart is gated on `Result.Updated`, so the no-op and the exit can never drift apart.

`Force` is the escape hatch (`{"force":true}` in the body, or `?force=1` at the hub) — the recovery path for a node whose binary is corrupt but whose reported version is current.

`Update()` is now `Apply` plus the restart. It previously did its own `tag == opts.CurrentVersion` string comparison; folding it into `Apply` means the CLI path and the hub-triggered path cannot disagree about whether an update is needed, and `Update` picks up the numeric comparison for free.

### Where the version comparison lives, and why

**On the node, in `selfupdate.Apply`** — not in the hub.

- **The node is the only authority on which binary is actually running.** The hub's `agent_version` column is whatever the node last reported. It is empty or stale for exactly the agents this matters for — the issue notes the local `agentpod-node:local` image carries an empty `agent_version` and its binary does not even know the `version` subcommand.
- **The hub's copy can be wrong by the time the node acts.** Between the hub deciding and the node applying, the node may have self-updated on its own timer. Comparing where the action happens removes the race.
- **Every trigger gets the same answer.** The console button, `agentpod-node update`, and any future bulk rollout (#295) all route through `Apply`. Deciding in the hub route would protect one caller and leave the others applying unconditionally — which is the shape of bug this PR is fixing.
- **The machinery was already there.** `Options.Force` / `CheckOnly` existed and `Update()` used them; the hub-triggered path just did not.

### Version comparison: one comparator, not two

`v0.1.9` vs `v0.1.24` sorts wrong lexically, and #292 already put a correct comparator in `fly/node-image/check-version-pin.sh`.

A shipped `agentpod-node` binary cannot call that script — it lives in the Fly image directory, is not part of any release artifact, and the nodes that most need this comparison (a Pi, a Modal container) never have the repo on disk. So a Go implementation is unavoidable. What *is* avoidable is a second, subtly different one, so `selfupdate.CompareVersions` is a deliberate port with identical semantics, and `TestCompareVersions_AgreesWithCheckVersionPinScript` **shells out to `check-version-pin.sh --compare A B` and requires both to agree on every case in a shared table** — including the `v0.1.9 < v0.1.24` case, the missing-`v` case, the missing-component case, and pre-release ordering. If either comparator is ever changed alone, that test fails. (It skips when the script or a POSIX `sh` is absent.)

Two behaviours worth calling out, both matching the script exactly (verified against it):

- An empty or partial version reads as zeroes, so it is behind every real release — the safe direction, because it lets the update proceed. The pre-`update`-verb agents report an empty version.
- A non-numeric version (`dev`, the default build stamp) is an **error**, and `Apply` treats an unreadable version as *not* up to date. Refusing to update because the version is unreadable would strand exactly the nodes most in need of one.

## Console

Three Update buttons (`AgentTable`, `NodesOverview`, the node detail page) set an "Updating…" spinner and relied on the node bouncing offline→online to clear it. On `updating:false` nothing ever bounces, so they would have spun forever. They now clear the spinner and say "Already up to date" with the tag. This is not a pre-existing bug — it is a regression this PR would have introduced.

## Which half takes effect when

| Half | Reaches the fleet |
|---|---|
| **Hub** — status mapping, flattened payload, `force` plumbing | **On deploy.** Works against every node, including ones that still restart unconditionally. |
| **Node-agent** — the short-circuit, `Force` in the verb, `CompareVersions` | **Needs a release.** Until nodes run the new binary they keep applying unconditionally; the hub just reports it truthfully. |
| **Console** — "Already up to date" | On the next Pages deploy. Inert until the node-agent release lands, since no node returns `updating:false` before then. |

Worth noting the deploy order is safe in either direction: a new hub against old nodes gets honest 502s instead of false 200s, and a new node against an old hub still works because the old route passed the payload through.

## Tests

TDD throughout — every test written first and confirmed failing for the right reason (the comparator tests failed on `undefined: CompareVersions`; the handler test failed on "the process exited"; nine of ten hub route tests failed on `Received: 200`).

- `cd apps/hub && DATABASE_URL=… bun test` → **803 pass, 0 fail** (795 before; the update-route file went 2 → 10 tests)
- `cd apps/node-agent && go test -race ./...` → **all packages ok**
- `cd packages/contract && bun test` → 108 pass, 0 fail
- `cd apps/console && pnpm check` → 0 errors; `pnpm build` → ok
- `apps/hub` `bun run typecheck` → **15 errors, unchanged** from the known-red baseline, none in `nodes.ts`

Coverage asked for by the issue: an `ok:false` envelope is not a 2xx; the error message survives to the caller; an already-current node neither downloads nor swaps nor restarts; `force` still applies; a genuinely-behind node still updates.

On the known Go flake (#293, `TestBuildRegistry_ThreadsClaudeCodeACPKeys` with empty `PATH`): it appeared once, passed on re-run, and was not touched.

Console note: this machine has 132 pre-existing console test failures unrelated to this branch (jsdom/localStorage). Measured baseline with the console changes stashed: **132 failed / 586 passed**. With them: **132 failed / 587 passed** — one new pass, no new failures. The touched file passes in isolation (29/29).

### Mutation testing

Six mutations, all killed:

| # | Mutation | Result |
|---|---|---|
| 1 | Status mapping removed — return the envelope verbatim (the old behaviour) | **5 tests fail** — verb-refused, offline, disconnected, timeout, inner-failure |
| 2 | Every response mapped to an error | **6 tests fail** — both success paths, both `force` paths, the flattening, and the inner-failure message |
| 3 | Short-circuit removed — `Apply` always applies | **2 tests fail** — `TestApply_AlreadyCurrentIsANoOp` (downloads 1 want 0, binary swapped) and the pre-existing `TestUpdate/already_up_to_date` |
| 4 | Always short-circuit — never apply, even when behind | **6 tests fail** — `BehindStillApplies`, both unreadable-version cases, `ForceAppliesEvenWhenCurrent`, `TestApply`, `TestUpdate/update_path` + `/force_same_version` |
| 5 | Handler restart gate removed — always exit | **1 test fails** — `AlreadyCurrentDoesNotRestart` ("the process exited") |
| 6 | Handler restart gate inverted — never exit | **3 tests fail** — `BehindStillRestarts`, `ForceIsForwardedAndRestarts`, and the pre-existing `TestUpdateHandler_UpdateVerb` |

Mutations 5 and 6 are the handler-level counterpart of 3 and 4: the handler stubs `Apply`, so the short-circuit and the restart gate are covered independently rather than one masking the other.

## Not done

No deploy, no live hub or fleet changes, no Fly or Modal resources created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
