### PR TITLE
chore(fly): pin the node-agent to v0.1.26

### DIFF
--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.25
+ARG AGENTPOD_VERSION=v0.1.26
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.25
+ARG AGENTPOD_VERSION=v0.1.26
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
Mechanical bump so the v0.1.26 fixes reach Fly images.

v0.1.26 carries #273 (hermes duplicate gateway), #231 (opencode detect-log flood) and #296's node-side short-circuit. Fly images download a *released* binary — unlike Modal, which builds from source — so none of those reach a Fly station until this pin moves.

`check-version-pin.sh` now reports `ok: … pins v0.1.26 (current release)` for both Dockerfiles.

This is the manual half of #290 again: the guard correctly refuses to publish a stale image, but nothing updates the pin, so every release needs this PR.