### PR TITLE
feat(contract): shared ecosystem-identity fixture corpus

### DIFF
--- a/fixtures/ecosystem-identity/README.md
+++ b/fixtures/ecosystem-identity/README.md
@@ -1,0 +1,82 @@
+# Ecosystem identity — shared fixture corpus
+
+Three products need the same identifiers to mean the same thing across a Bun/Postgres hub
+(AgentPod), a Cloudflare Workers/D1 board (kaambaan), and eventually a Rust client. No auth
+or contract *library* can be shared across those runtimes, and a published npm package would
+couple two deploy pipelines with very different cadences — kaambaan deploys on every merge to
+main, AgentPod deploys by hand.
+
+So: **each repo owns its own types; this corpus proves they agree.**
+
+That is not a new bet. This repo already keeps five hand-written Go mirrors of zod schemas
+honest with golden-fixture round-trip tests and no drift
+(`apps/node-agent/internal/contractfix/`). This corpus is the same mechanism aimed across a
+repo boundary instead of a language boundary.
+
+## Files
+
+| File | What it pins |
+|---|---|
+| `id_grammar.json` | What each repo mints and validates for every entity id, plus the full prefix registry and the collisions in it. |
+| `run_join_key.json` | The run join key: *kaambaan mints the work run; AgentPod executes it; no competing run id for dispatched work.* |
+
+Both are plain JSON and depend on no type from any repo. That is deliberate — a corpus that
+needed AgentPod's schemas to be readable could not be checked into kaambaan.
+
+## The negative cases are the point
+
+A corpus of only-valid examples proves almost nothing. The `mem_` vs `mbr_` drift in kaambaan
+survived for as long as both halves existed **precisely because nothing ever validated a
+minted id against the schema** — and a valid-examples-only corpus would have missed it too,
+since `mem_abc123` is a perfectly well-formed id of a nonexistent entity.
+
+So every entity carries a `reject` list: wrong prefix, too short, wrong alphabet, empty,
+prefix-only, unanchored prefix, and **a valid id of a different entity type** — the failure a
+bare `z.string()` cannot catch and the one most likely to reach production.
+
+## How AgentPod consumes it
+
+`packages/contract/src/ids.ts` holds the validators; `packages/contract/tests/ecosystem-identity.test.ts`
+drives them from these files. It runs under the `contract` CI job with everything else:
+
+```bash
+cd packages/contract && bun test
+```
+
+The test fails if a corpus entity has no validator mapped to it, so adding an entity here
+cannot silently go untested.
+
+## How kaambaan (or any peer) consumes it
+
+1. Copy `id_grammar.json` and `run_join_key.json` into the peer repo. Copy, do not symlink or
+   submodule — decoupled release cadence is the whole reason this is a file corpus rather
+   than a package.
+2. Write the equivalent test in that repo's own language and test runner: for each entity the
+   repo owns or consumes, map it to that repo's own validator and assert every `accept` value
+   parses and every `reject` value does not.
+3. Skip entities the repo has no validator for, but make the skip list explicit so a new
+   entity is a visible decision rather than silent coverage loss.
+
+A peer that disagrees then fails its own test suite instead of failing in production, which is
+the entire mechanism.
+
+## Changing the corpus
+
+These files are **hand-authored from code**, not generated. Every `grammarSource` and
+`mintSource` is a `file:line` that was read; if you cannot cite one, you are inventing a shape
+rather than recording one, and it does not belong here.
+
+When you change a grammar, expect both repos to fail until both are updated. That is the
+corpus working. The failure is cheap; the silent disagreement it replaces is not.
+
+## Deliberately out of scope
+
+**Matrix event envelopes.** The Application Service does not exist, so fixtures for it would
+be invented rather than observed. The seam is real and empty on both sides (supermessage's
+`customEvents.ts` is a renderer registry with zero renderers, whose own comment says it *"does
+not — and must not — invent those schemas"*), and this corpus takes the same position.
+
+## Background
+
+`docs/strategy/2026-08-13-ecosystem-identity-decisions.md` — the four decisions this serves,
+and the "how two repos share one contract" question left open there that this answers.

--- a/fixtures/ecosystem-identity/id_grammar.json
+++ b/fixtures/ecosystem-identity/id_grammar.json
@@ -1,0 +1,303 @@
+{
+  "corpus": "ecosystem-identity/id-grammar",
+  "version": 1,
+  "authoredAt": "2026-08-13",
+  "authoredFrom": "code, not documentation — every `grammarSource` and `mintSource` is a file:line that was read",
+  "purpose": "Two repos with separate release cadences must agree on what an identifier means. Neither can import the other's types, so this corpus is the shared artefact: each repo checks it in, maps the entities it owns or consumes onto its own validators, and proves acceptance and rejection against these lists. A repo that disagrees with a peer fails its own test suite rather than failing in production.",
+  "howToRead": {
+    "grammar": "The regex EVERY validator in the suite must implement for this entity. A validator that accepts less will reject a peer's legitimate id; one that accepts more lets a mis-wired id through.",
+    "mintedAs": "The narrower shape the minter actually produces today. Informational: it documents the gap between what is minted and what is accepted, which is where drift hides.",
+    "accept": "Values a validator MUST accept. `mint: true` marks values that also satisfy `mintedAs`.",
+    "reject": "Values a validator MUST reject. These are the point of the corpus — the `mem_`/`mbr_` drift in kaambaan survived because nothing ever validated a minted id against a schema, and a corpus of only-valid examples would have missed it too."
+  },
+
+  "entities": [
+    {
+      "entity": "kaambaan.tenant",
+      "owner": "kaambaan",
+      "prefix": "tnt",
+      "grammar": "^tnt_[A-Za-z0-9]{6,}$",
+      "grammarSource": "kaambaan packages/contract/src/ids.ts:7-12 — idSchema('tnt')",
+      "mintedAs": "^tnt_[0-9a-f]{16}$",
+      "mintSource": "kaambaan apps/api/src/ids.ts:2 newId(), called at apps/api/src/db/catalog.ts:45",
+      "accept": [
+        { "value": "tnt_5f2b8c1a9d3e4076", "mint": true, "note": "canonical: what newId('tnt') produces" },
+        { "value": "tnt_Aa0Bb1", "mint": false, "note": "shortest and mixed-case: minted ids are never like this, but the declared grammar accepts it, so a peer that rejects it is wrong about kaambaan's contract" }
+      ],
+      "reject": [
+        { "value": "tenant_5f2b8c1a9d3e4076", "reason": "wrong-prefix", "note": "the spelled-out word, not the declared prefix" },
+        { "value": "usr_a1b2c3d4e5f60718", "reason": "other-entity", "note": "a perfectly valid id of a different entity — this is the failure that a bare z.string() cannot catch" },
+        { "value": "tnt_ab", "reason": "too-short" },
+        { "value": "tnt_abc-12", "reason": "wrong-alphabet", "note": "hyphen; kaambaan's alphabet is base62 with no separators" },
+        { "value": "tnt_", "reason": "prefix-only" },
+        { "value": "5f2b8c1a9d3e4076", "reason": "no-prefix" },
+        { "value": "tnt5f2b8c1a9d3e4076", "reason": "no-separator" },
+        { "value": "tnts_5f2b8c1a9d3e4076", "reason": "prefix-not-anchored", "note": "catches a regex missing its leading ^ or matching the prefix as a substring" },
+        { "value": "xtnt_5f2b8c1a9d3e4076", "reason": "prefix-not-anchored" },
+        { "value": "tnt_5f2b8c1a9d3e4076\n", "reason": "trailing-newline", "note": "some regex flavours let `$` match before a trailing newline; a suite-wide id must not" },
+        { "value": " tnt_5f2b8c1a9d3e4076", "reason": "leading-whitespace" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "kaambaan.user",
+      "owner": "kaambaan",
+      "prefix": "usr",
+      "grammar": "^usr_[A-Za-z0-9]{6,}$",
+      "grammarSource": "kaambaan packages/contract/src/ids.ts:13 — idSchema('usr')",
+      "mintedAs": "^usr_[0-9a-f]{16}$",
+      "mintSource": "kaambaan apps/api/src/db/catalog.ts:36 — newId('usr')",
+      "note": "This is the principal id on the kaambaan side. AgentPod's user id is NOT this shape — see agentpod.user. There is no mapping between them anywhere in either repo today.",
+      "accept": [
+        { "value": "usr_a1b2c3d4e5f60718", "mint": true }
+      ],
+      "reject": [
+        { "value": "user_a1b2c3d4e5f60718", "reason": "wrong-prefix" },
+        { "value": "tnt_5f2b8c1a9d3e4076", "reason": "other-entity" },
+        { "value": "f47ac10b-58cc-4372-a567-0e02b2c3d479", "reason": "wrong-alphabet", "note": "an AgentPod user id, which is a bare UUID. Handing one to kaambaan as a principal is a real, reachable mistake once a bridge exists." },
+        { "value": "usr_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "kaambaan.membership",
+      "owner": "kaambaan",
+      "prefix": "mbr",
+      "grammar": "^mbr_[A-Za-z0-9]{6,}$",
+      "grammarSource": "kaambaan packages/contract/src/ids.ts:15 — idSchema('mbr')",
+      "mintedAs": "^mbr_[0-9a-f]{16}$",
+      "mintSource": "kaambaan apps/api/src/db/catalog.ts:48 — newId('mbr')",
+      "note": "The regression case. The contract declared `mem_` while the API minted `mbr_`; nothing validated a minted id against the schema, so the two disagreed for as long as both existed. Fixed in kaambaan 7740f06. This entry exists so it cannot recur silently in either repo.",
+      "accept": [
+        { "value": "mbr_0c4b4f289d3a51b6", "mint": true }
+      ],
+      "reject": [
+        { "value": "mem_0c4b4f289d3a51b6", "reason": "wrong-prefix", "note": "the abbreviation the contract used to declare. Must stay rejected." },
+        { "value": "member_0c4b4f289d3a51b6", "reason": "wrong-prefix" },
+        { "value": "mbr_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "kaambaan.agent",
+      "owner": "kaambaan",
+      "prefix": "agt",
+      "grammar": "^agt_[A-Za-z0-9]{6,}$",
+      "grammarSource": "kaambaan packages/contract/src/ids.ts:17 — idSchema('agt')",
+      "mintedAs": "^agt_[0-9a-f]{16}$",
+      "mintSource": "kaambaan apps/api/src/db/catalog.ts:60 — newId('agt')",
+      "note": "The agent is a principal in its own right (ecosystem decision 3), so this id — not a human's — is what attribution hangs off for dispatched work.",
+      "accept": [
+        { "value": "agt_9f1c2ab04d7e6b3a", "mint": true }
+      ],
+      "reject": [
+        { "value": "agent_9f1c2ab04d7e6b3a", "reason": "wrong-prefix" },
+        { "value": "kbn_9f1c2ab04d7e6b3a4c5d6e7f8091a2b3c4d5e6f70819", "reason": "credential-not-identifier", "note": "`kbn_` is kaambaan's AGENT BEARER TOKEN (apps/api/src/auth/agent-token.ts:10), not an agent id. It is 48 hex chars and is a secret. A validator that accepts it here would let a credential be stored in an id column." },
+        { "value": "agt_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "kaambaan.run",
+      "owner": "kaambaan",
+      "prefix": "run",
+      "grammar": "^run_[A-Za-z0-9]{6,}$",
+      "grammarSource": "kaambaan packages/contract/src/ids.ts:21 — idSchema('run')",
+      "mintedAs": "^run_[0-9a-f]{16}$",
+      "mintSource": "kaambaan apps/api/src/ids.ts:2 newId(), called at apps/api/src/board/board-do.ts:1253 (claim → INSERT INTO runs)",
+      "note": "The join key. Kaambaan mints the work run; AgentPod executes it and must never mint a rival id for the same attempt. See run_join_key.json — and see `knownConflicts` below, because AgentPod has reserved the same `run_` prefix for its own primary key.",
+      "accept": [
+        { "value": "run_e074a2160c4b4f28", "mint": true, "note": "canonical claim result" },
+        { "value": "run_Aa0Bb1", "mint": false, "note": "kaambaan's own test suite asserts this parses (packages/contract/test/ids.test.ts:8). AgentPod must not be stricter than the minter's contract about an id it did not mint." }
+      ],
+      "reject": [
+        { "value": "task_e074a2160c4b4f28", "reason": "other-entity" },
+        { "value": "card_3d4e5f6071829304", "reason": "other-entity" },
+        { "value": "run_", "reason": "prefix-only" },
+        { "value": "run_abc", "reason": "too-short" },
+        { "value": "run_e074a216-0c4b", "reason": "wrong-alphabet" },
+        { "value": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2", "reason": "other-entity", "note": "an AgentPod ACP session id. The bridge spike today correlates a kaambaan run to an AgentPod session in a console.log line and nothing else (kaambaan/../bridge/spike/src/bridge.ts:30-31), so confusing the two is exactly the mistake in reach." },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.node",
+      "owner": "agentpod",
+      "prefix": "node",
+      "grammar": "^node_[0-9a-f]{20}$",
+      "grammarSource": "NONE — AgentPod had no id validator of any kind before this corpus. Every id field in packages/contract/src is a bare z.string(). The grammar here is derived from the mint site and this corpus is its first enforcement.",
+      "mintedAs": "^node_[0-9a-f]{20}$",
+      "mintSource": "agentpod apps/hub/src/services/enrollment.ts:12 prefixedId(), called at :185 — `crypto.randomUUID().replace(/-/g,'').slice(0,20)`",
+      "note": "20 lowercase hex, not kaambaan's 16. The two repos use different lengths from the same underlying source (a UUID with its hyphens stripped). Nothing forces them to agree and nothing has noticed.",
+      "accept": [
+        { "value": "node_9f1c2ab04d7e6b3a5c88", "mint": true }
+      ],
+      "reject": [
+        { "value": "node_9f1c2ab04d7e6b3a", "reason": "too-short", "note": "16 hex — kaambaan's length. A kaambaan-shaped id must not pass as an AgentPod node id." },
+        { "value": "node_9F1C2AB04D7E6B3A5C88", "reason": "wrong-alphabet", "note": "uppercase hex is never minted; accepting it means two spellings of the same id can both exist as distinct primary keys" },
+        { "value": "node_9f1c2ab0-4d7e-6b3a-5c88-000000000000", "reason": "wrong-alphabet", "note": "hyphenated UUID — the shape AgentPod's OTHER id family uses (see agentpod.station)" },
+        { "value": "nodes_9f1c2ab04d7e6b3a5c88", "reason": "prefix-not-anchored" },
+        { "value": "rt_3d4e5f60718293a4b5c6", "reason": "other-entity" },
+        { "value": "node_", "reason": "prefix-only" },
+        { "value": "node_9f1c2ab04d7e6b3a5c88\n", "reason": "trailing-newline" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.runtime",
+      "owner": "agentpod",
+      "prefix": "rt",
+      "grammar": "^rt_[0-9a-f]{20}$",
+      "grammarSource": "NONE before this corpus — RuntimeSummary.id is z.string() (packages/contract/src/runtime.ts:197)",
+      "mintedAs": "^rt_[0-9a-f]{20}$",
+      "mintSource": "agentpod apps/hub/src/services/runtimes.ts:54-55 prefixedId(), called at :155 — prefixedId('rt')",
+      "note": "Do not confuse `rt_…` (AgentPod's runtime, a provisioned container/machine) with `runtimes.externalId`, which is the SUBSTRATE's handle (e.g. a Fly app/machine pair) and has no suite-wide grammar at all.",
+      "accept": [
+        { "value": "rt_3d4e5f60718293a4b5c6", "mint": true }
+      ],
+      "reject": [
+        { "value": "runtime_3d4e5f60718293a4b5c6", "reason": "wrong-prefix" },
+        { "value": "rt_3d4e5f60718293a4b5", "reason": "too-short", "note": "19 hex" },
+        { "value": "rt_3d4e5f60718293a4b5c6d", "reason": "too-long", "note": "21 hex — catches a regex missing its trailing $" },
+        { "value": "node_9f1c2ab04d7e6b3a5c88", "reason": "other-entity" },
+        { "value": "rt_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.enrollmentToken",
+      "owner": "agentpod",
+      "prefix": "etk",
+      "grammar": "^etk_[0-9a-f]{20}$",
+      "grammarSource": "NONE before this corpus",
+      "mintedAs": "^etk_[0-9a-f]{20}$",
+      "mintSource": "agentpod apps/hub/src/services/enrollment.ts:58 — prefixedId('etk')",
+      "note": "The enrollment token ROW id. The token itself is a different thing with a different shape — `enr_` + 20 hex + 32 hex (enrollment.ts:54) — and is a secret. They are kept apart here so a validator cannot be written that blurs them.",
+      "accept": [
+        { "value": "etk_7b2e9a103c5d4e8fb012", "mint": true }
+      ],
+      "reject": [
+        { "value": "enr_7b2e9a103c5d4e8fb0125f2b8c1a9d3e40760c4b4f289d3a51b6", "reason": "credential-not-identifier", "note": "the enrollment token secret, which starts with a different prefix and is 52 hex long" },
+        { "value": "etk_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.station",
+      "owner": "agentpod",
+      "prefix": "station",
+      "grammar": "^station_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "grammarSource": "NONE before this corpus",
+      "mintedAs": "^station_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "mintSource": "agentpod apps/hub/src/services/station-registry.ts:50 — `station_${crypto.randomUUID()}` (hyphens KEPT)",
+      "note": "A second, incompatible AgentPod grammar: prefix + a hyphenated UUID. Note what this means across the seam — kaambaan's own id schema is `^<prefix>_[A-Za-z0-9]{6,}$`, whose alphabet has no hyphen, so kaambaan's contract would REJECT every AgentPod station id it was ever handed. That is a live disagreement, not a hypothetical.",
+      "accept": [
+        { "value": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90", "mint": true }
+      ],
+      "reject": [
+        { "value": "station_4a1482de9c3f4b178a550d6e2f7c1b90", "reason": "wrong-alphabet", "note": "hyphens stripped — the shape node_/rt_ use. Both spellings would name the same UUID; only one is minted." },
+        { "value": "station_4a1482de-9c3f-4b17-8a55", "reason": "too-short" },
+        { "value": "station_4A1482DE-9C3F-4B17-8A55-0D6E2F7C1B90", "reason": "wrong-alphabet", "note": "uppercase" },
+        { "value": "station_", "reason": "prefix-only" },
+        { "value": "codex:4a1482de", "reason": "other-entity", "note": "a station KEY (harness:hash), which is what the node-agent reports and is not an id at all — see StationHealthReport.key" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.acpSession",
+      "owner": "agentpod",
+      "prefix": "acps",
+      "grammar": "^acps_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "grammarSource": "NONE before this corpus — AcpSessionRow.id is z.string() (packages/contract/src/acp-session.ts)",
+      "mintedAs": "^acps_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "mintSource": "agentpod apps/hub/src/services/acp-sessions.ts:641 — `acps_${crypto.randomUUID()}`",
+      "note": "The session is the ONLY identity on the ACP wire today: neither AcpClientMsg nor AcpServerMsg carries a run or correlation id. A dispatched run is therefore currently observable only as 'some session on some station'.",
+      "accept": [
+        { "value": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2", "mint": true }
+      ],
+      "reject": [
+        { "value": "acp_3d4e5f60", "reason": "other-entity", "note": "`acp_<8 hex>` is a DIFFERENT id: the node-agent's process-local ACP session id (apps/node-agent/internal/acp/manager.go:40-46, 32 bits of entropy, collision-retried in-process). The hub's `acps_<uuid>` doubles as the node-side instance discriminator (acp-sessions.ts:688-691), so both prefixes are live in the same subsystem and differ by one character." },
+        { "value": "run_e074a2160c4b4f28", "reason": "other-entity", "note": "a kaambaan run id" },
+        { "value": "acps_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.user",
+      "owner": "agentpod",
+      "prefix": null,
+      "grammar": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "grammarSource": "NONE before this corpus",
+      "mintedAs": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "mintSource": "agentpod Better Auth — `advanced.generateId: () => crypto.randomUUID()` at apps/hub/src/auth/drizzle-auth.ts:249 (the live config; apps/hub/src/auth/index.ts:171 is a legacy duplicate). The override applies to every Better Auth model, so user/session/account/verification ids all take this shape. Admin-created users bypass Better Auth entirely and call crypto.randomUUID() directly at apps/hub/src/routes/admin.ts:432 — same grammar by coincidence, not by shared code.",
+      "note": "THE HEADLINE DISAGREEMENT. AgentPod's principal id carries no prefix and is not type-legible: a bare UUID says nothing about what it identifies. kaambaan's principal is `usr_<16 hex>`. The two cannot be exchanged, and no mapping table exists in either repo. There is also no organization id to map: the Better Auth organization plugin is NOT installed (plugin list at apps/hub/src/auth/drizzle-auth.ts:110-123) and 'organization' appears nowhere in apps/hub/src or in any of the 35 migrations. Ecosystem decision 2 (`mxid → Principal` must be minted by an explicit link, never inferred) applies here identically: the AgentPod↔kaambaan principal link must be minted, not derived from a matching email.",
+      "accept": [
+        { "value": "f47ac10b-58cc-4372-a567-0e02b2c3d479", "mint": true }
+      ],
+      "reject": [
+        { "value": "usr_a1b2c3d4e5f60718", "reason": "other-entity", "note": "a kaambaan principal. Nothing today would stop one being written into an AgentPod user column." },
+        { "value": "user_f47ac10b-58cc-4372-a567-0e02b2c3d479", "reason": "wrong-prefix", "note": "there is no prefix; adding one is as wrong as omitting a required one" },
+        { "value": "f47ac10b58cc4372a5670e02b2c3d479", "reason": "wrong-alphabet", "note": "hyphens stripped" },
+        { "value": "f47ac10b-58cc-4372-a567", "reason": "too-short" },
+        { "value": "", "reason": "empty" }
+      ]
+    }
+  ],
+
+  "prefixRegistry": {
+    "note": "Every prefix either repo claims, so a new collision is visible the moment it is added. `status` records what is true in code, which is not always what a table declares.",
+    "claims": [
+      { "prefix": "tnt", "owner": "kaambaan", "entity": "tenant", "status": "declared-and-minted" },
+      { "prefix": "usr", "owner": "kaambaan", "entity": "user", "status": "declared-and-minted" },
+      { "prefix": "mbr", "owner": "kaambaan", "entity": "membership", "status": "declared-and-minted" },
+      { "prefix": "brd", "owner": "kaambaan", "entity": "board", "status": "declared-and-minted" },
+      { "prefix": "agt", "owner": "kaambaan", "entity": "agent", "status": "declared-and-minted" },
+      { "prefix": "tok", "owner": "kaambaan", "entity": "token", "status": "declared-and-minted" },
+      { "prefix": "card", "owner": "kaambaan", "entity": "card", "status": "declared-and-minted" },
+      { "prefix": "ctx", "owner": "kaambaan", "entity": "context", "status": "declared-and-minted" },
+      { "prefix": "ref", "owner": "kaambaan", "entity": "reference", "status": "declared-and-minted" },
+      { "prefix": "gate", "owner": "kaambaan", "entity": "gate", "status": "declared-and-minted" },
+      { "prefix": "run", "owner": "kaambaan", "entity": "run", "status": "declared-and-minted" },
+      { "prefix": "task", "owner": "kaambaan", "entity": "task", "status": "declared-never-minted", "note": "TaskId exists in kaambaan's contract and Run.taskId references it, but no newId('task') call exists and the runs table stores card_id. Declared but unreachable." },
+      { "prefix": "evt", "owner": "kaambaan", "entity": "event", "status": "declared-never-minted", "note": "EventId is declared; activities are keyed by an AUTOINCREMENT seq instead (board-do.ts activities table)." },
+      { "prefix": "push", "owner": "kaambaan", "entity": "pushConfig", "status": "minted-never-declared", "note": "SAME CLASS AS THE mem_/mbr_ BUG, still open. newId('push') at apps/api/src/board/board-do.ts:1023 mints a prefix absent from ID_PREFIXES and from every schema in packages/contract/src/ids.ts. Found by this corpus; not fixed here, because kaambaan is not this repo's to change." },
+      { "prefix": "kbn", "owner": "kaambaan", "entity": "agentBearerToken", "status": "credential", "note": "a secret, not an identifier — apps/api/src/auth/agent-token.ts:10, 48 hex chars" },
+
+      { "prefix": "node", "owner": "agentpod", "entity": "node", "status": "minted-never-declared" },
+      { "prefix": "rt", "owner": "agentpod", "entity": "runtime", "status": "minted-never-declared" },
+      { "prefix": "etk", "owner": "agentpod", "entity": "enrollmentToken", "status": "minted-never-declared" },
+      { "prefix": "station", "owner": "agentpod", "entity": "station", "status": "minted-never-declared" },
+      { "prefix": "acps", "owner": "agentpod", "entity": "acpSession", "status": "minted-never-declared" },
+      { "prefix": "acp", "owner": "agentpod", "entity": "nodeLocalAcpSession", "status": "minted-never-declared", "note": "node-agent only — `acp_<8 hex>`, apps/node-agent/internal/acp/manager.go:40-46. One character away from the hub's `acps_`, and the hub's id is passed to the node as the instance discriminator, so both live in the same subsystem." },
+      { "prefix": "audit", "owner": "agentpod", "entity": "auditEntry", "status": "minted-never-declared", "note": "apps/hub/src/services/audit.ts:94 — `audit_${crypto.randomUUID()}`, hyphenated-UUID family" },
+      { "prefix": "enr", "owner": "agentpod", "entity": "enrollmentTokenSecret", "status": "credential" },
+      { "prefix": "chg", "owner": "agentpod", "entity": "change", "status": "reserved-never-minted", "note": "only appears as a test literal in packages/contract/src/run.test.ts:76; Change is a reserved schema with no writer" },
+      { "prefix": "run", "owner": "agentpod", "entity": "acpRun", "status": "reserved-never-minted", "note": "COLLISION — see knownConflicts" }
+    ],
+    "knownConflicts": [
+      {
+        "prefix": "run",
+        "claimedBy": ["kaambaan", "agentpod"],
+        "detail": "kaambaan mints `run_<16 hex>` for a work run (apps/api/src/board/board-do.ts:1253). AgentPod reserves the SAME prefix for acp_runs.id — apps/hub/src/db/schema/acp.ts:69 carries the comment `\"run_\" + uuid-ish` directly above a primary key whose neighbouring column comment reads `We never mint a rival id`. Nothing mints an AgentPod run id yet, so nothing is broken today; the moment something does, a `run_…` value is ambiguous about which system it came from, and the acp_runs_external_idx reverse join (schema/acp.ts:88) becomes unsafe to reason about. Resolving this is a decision for both repos, not a fix this corpus can make. Recorded so it cannot be forgotten."
+      }
+    ]
+  },
+
+  "openDisagreements": [
+    "Principal shape: kaambaan `usr_<16 hex>`; AgentPod a bare unprefixed UUID. No mapping exists in either repo.",
+    "Token length: kaambaan takes 16 hex from a UUID, AgentPod takes 20. Same source, different slice, no reason recorded in either.",
+    "Alphabet: AgentPod has TWO families — `<prefix>_<20 hex>` (node, rt, etk) and `<prefix>_<hyphenated UUID>` (station, acps, audit). kaambaan's declared alphabet is base62 with no hyphen, so it would reject every id in AgentPod's second family.",
+    "Tenancy: kaambaan pins every principal to exactly one tenant at the storage layer; AgentPod has no tenant concept at all, so no AgentPod id carries tenancy. Out of scope here, flagged because it is the largest remaining modelling decision (see docs/strategy/2026-08-13-ecosystem-identity-decisions.md).",
+    "Prefix `run` is claimed by both repos — see prefixRegistry.knownConflicts."
+  ]
+}

--- a/fixtures/ecosystem-identity/run_join_key.json
+++ b/fixtures/ecosystem-identity/run_join_key.json
@@ -1,0 +1,179 @@
+{
+  "corpus": "ecosystem-identity/run-join-key",
+  "version": 1,
+  "authoredAt": "2026-08-13",
+
+  "invariant": "Kaambaan mints the work run; AgentPod executes it; there is no competing run id for dispatched work.",
+
+  "enforcement": {
+    "status": "carried-in-schema-only",
+    "summary": "AgentPod has already reserved the field, in both the database and the contract, with comments naming kaambaan explicitly. Nothing writes it, nothing reads it, and no API accepts it. The invariant is a design intent with a place to live, not a behaviour.",
+    "whatExists": [
+      "agentpod apps/hub/src/db/schema/acp.ts:75-76 — `external_run_id` and `external_source` columns on `acp_runs`, really in the database via migration 0028_outgoing_magneto.sql, with `acp_runs_external_idx` on external_run_id (:88) for the reverse join from the board's side.",
+      "agentpod packages/contract/src/run.ts:60-63 — `Run.externalRunId` and `Run.externalSource`, both optional.",
+      "agentpod packages/contract/src/run.ts:18-27 — `RunState` is A2A's TaskState verbatim, chosen so no translation table to kaambaan's state machine is needed."
+    ],
+    "whatDoesNot": [
+      "Nothing inserts into `acp_runs`. Grepping apps/hub for `acpRuns` outside the schema file finds only a unit test asserting column shape. `acp_sessions` by contrast is live (acp-sessions.ts:641 mints `acps_<uuid>`); there is no equivalent line for runs, so AgentPod does not currently mint a run id at all.",
+      "No route accepts an external run id. `POST /api/stations/:id/acp/sessions` takes `{mode}` and nothing else (apps/hub/src/routes/station-acp.ts:112).",
+      "The ACP wire carries no run or correlation id: neither AcpClientMsg nor AcpServerMsg in packages/contract/src/acp-session.ts has one. The session id is the only identity on the wire.",
+      "The bridge spike holds kaambaan's runId (apps/bridge/spike/src/kaambaan.ts:14-20, and every call is POST /v1/boards/{board}/runs/{runId}/{action}) but never sends it to AgentPod. The kaambaan-run → AgentPod-session correlation exists as a console.log line at apps/bridge/spike/src/bridge.ts:30-31 and nowhere else. The only identity that does flow is the reverse direction and unstructured: the station and ACP session ids are written into kaambaan as free text in an activity body and as a handoff JSON blob (bridge.ts:79-93).",
+      "kaambaan has no notion of AgentPod at all — zero occurrences of the string in its source or docs — so the dispatch path this invariant governs does not exist on either side yet."
+    ],
+    "consequence": "Every case below is an INTENDED shape, validated against AgentPod's `Run` schema, not an observed wire capture. When the write path lands, these fixtures are what it must satisfy. Until then they hold the shape still."
+  },
+
+  "openConflict": {
+    "prefix": "run",
+    "detail": "AgentPod reserves the same `run_` prefix kaambaan mints with. apps/hub/src/db/schema/acp.ts:69 comments its primary key `\"run_\" + uuid-ish`, two lines above the comment `We never mint a rival id`. Nothing mints it yet, so nothing is broken; the day something does, a bare `run_…` value no longer says which system produced it, and the reverse join through acp_runs_external_idx stops being self-describing. Resolving this needs a decision in both repos. Recorded, not fixed.",
+    "alsoRecordedIn": "id_grammar.json → prefixRegistry.knownConflicts"
+  },
+
+  "cases": [
+    {
+      "name": "dispatched_run",
+      "mustParse": true,
+      "why": "The whole point: a run that came from a kaambaan claim carries the board's id and says who minted it. AgentPod's own `id` is a separate, local key — it does not, and must not, restate kaambaan's.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "run_e074a2160c4b4f28",
+        "externalSource": "kaambaan",
+        "state": "working",
+        "startSeq": 4,
+        "endSeq": null,
+        "startedAt": "2026-08-13T10:00:00.000Z",
+        "endedAt": null
+      }
+    },
+    {
+      "name": "local_run_no_board_attached",
+      "mustParse": true,
+      "why": "The console must keep working with no board attached at all, which is why the external pair is optional rather than required (run.ts:48-54). A regression that made externalRunId mandatory would break every hand-driven Chat session in the fleet.",
+      "value": {
+        "id": "run_3d4e5f60718293a4b5c6",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "state": "submitted",
+        "startSeq": 0,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "dispatched_run_from_another_orchestrator",
+      "mustParse": true,
+      "why": "`externalSource` is deliberately open so AgentPod is not kaambaan-only. A validator that hard-codes the literal \"kaambaan\" would make the field a boolean with extra steps and lock the hub to one board.",
+      "value": {
+        "id": "run_7b2e9a103c5d4e8fb012",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "wf-2026-08-13-0042",
+        "externalSource": "temporal",
+        "state": "working",
+        "startSeq": 11,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "completed_dispatched_run",
+      "mustParse": true,
+      "why": "Closing a run must fill both the sequence and the timestamp. A run is a prompt-turn, so endSeq is the seq of the event that closed it — a permission request mid-attempt does not close it.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "run_e074a2160c4b4f28",
+        "externalSource": "kaambaan",
+        "state": "completed",
+        "startSeq": 4,
+        "endSeq": 37,
+        "startedAt": "2026-08-13T10:00:00.000Z",
+        "endedAt": "2026-08-13T10:04:12.000Z"
+      }
+    },
+
+    {
+      "name": "external_run_id_without_a_source",
+      "mustParse": false,
+      "why": "An external run id that does not say who minted it is unattributable, and — because both repos claim the `run_` prefix — indistinguishable from AgentPod's own key. The reverse join through acp_runs_external_idx would return a row that cannot be traced to a board. The two fields are one fact and must arrive together.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "run_e074a2160c4b4f28",
+        "state": "working",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "external_source_without_a_run_id",
+      "mustParse": false,
+      "why": "The mirror image: naming an orchestrator with no id from it records an origin nothing can be joined back to.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalSource": "kaambaan",
+        "state": "working",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "empty_external_run_id",
+      "mustParse": false,
+      "why": "An empty string is not 'no external run'; absent is. Accepting it writes a falsy value into an indexed column that then joins to nothing.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "",
+        "externalSource": "kaambaan",
+        "state": "working",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "invented_run_state",
+      "mustParse": false,
+      "why": "RunState is A2A's vocabulary verbatim so the board needs no translation table. `errored` was the earlier in-house proposal and must not parse; kaambaan spells `canceled` with one l for the same reason.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "run_e074a2160c4b4f28",
+        "externalSource": "kaambaan",
+        "state": "errored",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "double_l_cancelled",
+      "mustParse": false,
+      "why": "The spelling trap. A2A and kaambaan both use one l; a hub that accepted both would produce runs the board cannot classify.",
+      "value": {
+        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "state": "cancelled",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    }
+  ],
+
+  "runStates": {
+    "note": "A2A TaskState, adopted verbatim by both repos. Listed here so a rename in either is a failing test in both rather than a silent divergence.",
+    "all": ["submitted", "working", "input-required", "auth-required", "completed", "rejected", "failed", "canceled"],
+    "terminal": ["completed", "rejected", "failed", "canceled"],
+    "interrupted": ["input-required", "auth-required"],
+    "sources": [
+      "agentpod packages/contract/src/run.ts:18-31",
+      "kaambaan packages/contract/src/primitives.ts:7-21 — `TaskState`, verified identical member-for-member and order-for-order on 2026-08-13"
+    ]
+  }
+}

--- a/packages/contract/src/ecosystem-identity.test.ts
+++ b/packages/contract/src/ecosystem-identity.test.ts
@@ -1,0 +1,243 @@
+/**
+ * AgentPod's half of the shared ecosystem-identity fixture corpus.
+ *
+ * The corpus lives at `fixtures/ecosystem-identity/` — plain JSON, depending on
+ * no type from any repo, so kaambaan can check in the *same files* and write the
+ * equivalent test in its own runtime. See that directory's README.
+ *
+ * Why a fixture corpus rather than a shared package: a published package would
+ * couple two deploy pipelines with very different cadences. This repo already
+ * keeps five hand-written Go mirrors honest the same way
+ * (apps/node-agent/internal/contractfix), which is the evidence the approach is
+ * enough.
+ *
+ * The negative cases are the point. kaambaan's `mem_`/`mbr_` drift survived
+ * because nothing ever validated a minted id against the schema — and a corpus
+ * of only-valid examples would have missed it too, because `mem_abc123` is a
+ * perfectly well-formed id of an entity that does not exist.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ZodType } from "zod";
+
+import {
+  KaambaanTenantId,
+  KaambaanUserId,
+  KaambaanMembershipId,
+  KaambaanAgentId,
+  KaambaanRunId,
+  NodeId,
+  RuntimeId,
+  EnrollmentTokenId,
+  StationId,
+  AcpSessionId,
+  UserId,
+} from "./ids";
+import { Run, RunState, TERMINAL_RUN_STATES, INTERRUPTED_RUN_STATES } from "./run";
+
+const CORPUS_DIR = join(import.meta.dir, "../../../fixtures/ecosystem-identity");
+
+const readCorpus = <T>(file: string): T =>
+  JSON.parse(readFileSync(join(CORPUS_DIR, file), "utf8")) as T;
+
+// ─── id_grammar.json ─────────────────────────────────────────────────────────
+
+type IdCase = { value: string; mint?: boolean; note?: string };
+type RejectCase = { value: string; reason: string; note?: string };
+type Entity = {
+  entity: string;
+  owner: string;
+  prefix: string | null;
+  grammar: string;
+  mintedAs: string;
+  accept: IdCase[];
+  reject: RejectCase[];
+};
+type IdGrammar = {
+  entities: Entity[];
+  prefixRegistry: {
+    claims: Array<{ prefix: string; owner: string; entity: string; status: string }>;
+    knownConflicts: Array<{ prefix: string; claimedBy: string[] }>;
+  };
+};
+
+const grammar = readCorpus<IdGrammar>("id_grammar.json");
+
+/**
+ * Corpus entity name → the AgentPod validator that must satisfy it.
+ *
+ * Every entity in the corpus must appear here or in SKIPPED. An unmapped entity
+ * fails the coverage test below, so adding one to the corpus cannot silently go
+ * untested — which is the failure mode the corpus exists to prevent.
+ */
+const VALIDATORS: Record<string, ZodType> = {
+  // kaambaan-owned. AgentPod consumes these across the seam and must be neither
+  // stricter nor looser than the minter's own declared contract.
+  "kaambaan.tenant": KaambaanTenantId,
+  "kaambaan.user": KaambaanUserId,
+  "kaambaan.membership": KaambaanMembershipId,
+  "kaambaan.agent": KaambaanAgentId,
+  "kaambaan.run": KaambaanRunId,
+
+  // AgentPod-owned. AgentPod is the only minter, so these are pinned to exactly
+  // what the mint sites produce.
+  "agentpod.node": NodeId,
+  "agentpod.runtime": RuntimeId,
+  "agentpod.enrollmentToken": EnrollmentTokenId,
+  "agentpod.station": StationId,
+  "agentpod.acpSession": AcpSessionId,
+  "agentpod.user": UserId,
+};
+
+/** Entities AgentPod deliberately has no validator for. Empty, and a decision each time. */
+const SKIPPED: readonly string[] = [];
+
+describe("ecosystem identity corpus — coverage", () => {
+  test("every corpus entity is either validated or explicitly skipped", () => {
+    const unmapped = grammar.entities
+      .map((e) => e.entity)
+      .filter((name) => !(name in VALIDATORS) && !SKIPPED.includes(name));
+
+    // A new entity landing in the corpus with no validator is silent coverage
+    // loss — exactly how `mem_`/`mbr_` stayed wrong. Map it or skip it on purpose.
+    expect(unmapped).toEqual([]);
+  });
+
+  test("the corpus is not empty and covers both repos", () => {
+    const owners = new Set(grammar.entities.map((e) => e.owner));
+    expect(owners).toEqual(new Set(["kaambaan", "agentpod"]));
+  });
+});
+
+describe("ecosystem identity corpus — id grammar", () => {
+  for (const entity of grammar.entities) {
+    const schema = VALIDATORS[entity.entity];
+    if (!schema) continue;
+
+    describe(entity.entity, () => {
+      test("accepts every id the corpus says it must", () => {
+        for (const c of entity.accept) {
+          expect(
+            { value: c.value, accepted: schema.safeParse(c.value).success },
+            // Rejecting a peer's legitimate id is as much a break as accepting a
+            // bad one: it makes the seam unusable in one direction.
+            `${entity.entity} must accept ${JSON.stringify(c.value)}${c.note ? ` — ${c.note}` : ""}`,
+          ).toEqual({ value: c.value, accepted: true });
+        }
+      });
+
+      test("rejects every id the corpus says it must", () => {
+        for (const c of entity.reject) {
+          expect(
+            { value: c.value, accepted: schema.safeParse(c.value).success },
+            `${entity.entity} must reject ${JSON.stringify(c.value)} (${c.reason})${c.note ? ` — ${c.note}` : ""}`,
+          ).toEqual({ value: c.value, accepted: false });
+        }
+      });
+
+      test("the corpus carries negative cases at all", () => {
+        // A valid-examples-only entry would pass every test above while proving
+        // nothing. Guard the guard.
+        expect(entity.accept.length).toBeGreaterThan(0);
+        expect(entity.reject.length).toBeGreaterThan(0);
+      });
+
+      test("every canonical mint value satisfies the declared mint grammar", () => {
+        // Keeps `mintedAs` honest against the example values, so the recorded
+        // shape cannot drift from the recorded evidence.
+        const mintRe = new RegExp(entity.mintedAs);
+        for (const c of entity.accept.filter((x) => x.mint)) {
+          expect(mintRe.test(c.value), `${c.value} must match ${entity.mintedAs}`).toBe(true);
+        }
+      });
+    });
+  }
+});
+
+describe("ecosystem identity corpus — prefix registry", () => {
+  test("no prefix is claimed by two owners except the recorded conflicts", () => {
+    const byPrefix = new Map<string, Set<string>>();
+    for (const c of grammar.prefixRegistry.claims) {
+      byPrefix.set(c.prefix, (byPrefix.get(c.prefix) ?? new Set()).add(c.owner));
+    }
+    const contested = [...byPrefix.entries()]
+      .filter(([, owners]) => owners.size > 1)
+      .map(([prefix]) => prefix)
+      .sort();
+    const known = grammar.prefixRegistry.knownConflicts.map((c) => c.prefix).sort();
+
+    // A NEW collision must fail here. `run` is already recorded: kaambaan mints
+    // it, and AgentPod reserves it for acp_runs.id in a schema comment two lines
+    // above "We never mint a rival id". Nothing mints AgentPod's yet, so nothing
+    // is broken — but the day one does, a bare `run_…` stops saying which system
+    // produced it.
+    expect(contested).toEqual(known);
+  });
+
+  test("`run` is a known, unresolved conflict rather than a resolved one", () => {
+    const conflict = grammar.prefixRegistry.knownConflicts.find((c) => c.prefix === "run");
+    expect(conflict?.claimedBy.sort()).toEqual(["agentpod", "kaambaan"]);
+  });
+});
+
+// ─── run_join_key.json ───────────────────────────────────────────────────────
+
+type RunCase = { name: string; mustParse: boolean; why: string; value: unknown };
+type RunJoinKey = {
+  invariant: string;
+  enforcement: { status: string };
+  cases: RunCase[];
+  runStates: { all: string[]; terminal: string[]; interrupted: string[] };
+};
+
+const joinKey = readCorpus<RunJoinKey>("run_join_key.json");
+
+describe("ecosystem identity corpus — run join key", () => {
+  test("records that nothing enforces the invariant yet", () => {
+    // Honest bookkeeping. `acp_runs.external_run_id` and `Run.externalRunId`
+    // exist and are indexed, but nothing inserts into acp_runs, no route accepts
+    // an external run id, and the bridge spike correlates a kaambaan run to an
+    // AgentPod session in a console.log line and nowhere else. When a write path
+    // lands, this string changes and this test is the reminder to change it.
+    expect(joinKey.enforcement.status).toBe("carried-in-schema-only");
+  });
+
+  for (const c of joinKey.cases) {
+    test(`${c.mustParse ? "accepts" : "rejects"}: ${c.name}`, () => {
+      expect(Run.safeParse(c.value).success, c.why).toBe(c.mustParse);
+    });
+  }
+
+  test("the corpus carries both directions", () => {
+    expect(joinKey.cases.some((c) => c.mustParse)).toBe(true);
+    expect(joinKey.cases.some((c) => !c.mustParse)).toBe(true);
+  });
+
+  test("a dispatched run keeps kaambaan's id verbatim through a parse", () => {
+    // The invariant in one assertion: the board's id survives, and AgentPod's own
+    // `id` is a separate local key rather than a restatement of it.
+    const dispatched = joinKey.cases.find((c) => c.name === "dispatched_run")!;
+    const parsed = Run.parse(dispatched.value);
+    expect(parsed.externalRunId).toBe("run_e074a2160c4b4f28");
+    expect(parsed.externalSource).toBe("kaambaan");
+    expect(parsed.id).not.toBe(parsed.externalRunId);
+  });
+
+  test("kaambaan's run id in the fixture is valid by kaambaan's own grammar", () => {
+    // The cross-repo half: the value AgentPod carries must be one kaambaan would
+    // have minted and would accept back.
+    const dispatched = joinKey.cases.find((c) => c.name === "dispatched_run")!;
+    const parsed = Run.parse(dispatched.value);
+    expect(KaambaanRunId.safeParse(parsed.externalRunId).success).toBe(true);
+  });
+
+  test("RunState matches the corpus's A2A vocabulary exactly", () => {
+    // Both repos adopt A2A verbatim so no translation table is needed. A rename
+    // in either is a failing test in both.
+    expect(RunState.options).toEqual(joinKey.runStates.all as never);
+    expect([...TERMINAL_RUN_STATES]).toEqual(joinKey.runStates.terminal as never);
+    expect([...INTERRUPTED_RUN_STATES]).toEqual(joinKey.runStates.interrupted as never);
+  });
+});

--- a/packages/contract/src/ids.ts
+++ b/packages/contract/src/ids.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+/**
+ * Identifier grammars — AgentPod's, and the kaambaan ones AgentPod consumes.
+ *
+ * Before this module there was **no id-shape validator anywhere in AgentPod**:
+ * every id field in this package is a bare `z.string()`, every id column is
+ * `text().primaryKey()` with no CHECK, and no route validates a path param.
+ * Prefixes existed only as minting conventions and schema comments.
+ *
+ * That is the same hole that let kaambaan declare `mem_` while its API minted
+ * `mbr_` for as long as both existed. Nothing validated a minted id against a
+ * schema, so nothing could notice.
+ *
+ * Each schema here is pinned by the shared corpus at
+ * `fixtures/ecosystem-identity/id_grammar.json`, which both repos check in and
+ * test against. Change a grammar here without changing it there and
+ * `tests/ecosystem-identity.test.ts` fails.
+ *
+ * These are **not** yet applied to the existing contract shapes. Retrofitting
+ * `NodeSummary.id` and friends would reject rows already in the database if any
+ * predates the current mint sites, so adoption is a separate, evidence-led step.
+ * What this module buys today is that the grammars are written down once,
+ * executable, and cross-checked against the peer repo.
+ */
+
+// ─── kaambaan ────────────────────────────────────────────────────────────────
+
+/**
+ * kaambaan's id grammar, mirrored: `<prefix>_<base62, at least 6>`.
+ *
+ * Deliberately **not** narrowed to the 16 lowercase hex characters
+ * `newId()` actually produces (kaambaan apps/api/src/ids.ts). AgentPod does not
+ * mint these and must not be stricter than the minter's own declared contract —
+ * kaambaan's test suite asserts `run_Aa0Bb1` parses, so a hub that rejected it
+ * would make the seam unusable in one direction over a shape kaambaan considers
+ * legal.
+ *
+ * Source: kaambaan packages/contract/src/ids.ts:7-10.
+ */
+const kaambaanId = (prefix: string) =>
+  z.string().regex(new RegExp(`^${prefix}_[A-Za-z0-9]{6,}$`), `expected a "${prefix}_…" id`);
+
+export const KaambaanTenantId = kaambaanId("tnt");
+export const KaambaanUserId = kaambaanId("usr");
+/** `mbr`, not `mem` — the drift this corpus exists to make impossible. */
+export const KaambaanMembershipId = kaambaanId("mbr");
+export const KaambaanAgentId = kaambaanId("agt");
+/**
+ * The run join key. kaambaan mints the work run; AgentPod executes it and never
+ * mints a rival id for the same attempt (see `Run.externalRunId` in ./run.ts).
+ */
+export const KaambaanRunId = kaambaanId("run");
+
+// ─── AgentPod ────────────────────────────────────────────────────────────────
+
+/**
+ * AgentPod mints two incompatible id shapes and has never written either down.
+ *
+ * `<prefix>_<20 lowercase hex>` — a UUID with its hyphens stripped, truncated to
+ * 20 — comes from a helper duplicated verbatim in two services
+ * (apps/hub/src/services/enrollment.ts:11-12 and .../runtimes.ts:54-55).
+ *
+ * Note the length disagreement with kaambaan, which slices the same source to 16.
+ * Neither repo records a reason. Pinning both here is what makes the difference
+ * visible rather than incidental.
+ */
+const truncatedUuidId = (prefix: string) =>
+  z.string().regex(new RegExp(`^${prefix}_[0-9a-f]{20}$`), `expected a "${prefix}_…" id`);
+
+const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+/**
+ * `<prefix>_<hyphenated UUID>` — the second family, inlined at each mint site
+ * rather than shared (station-registry.ts:50, acp-sessions.ts:641, audit.ts:94).
+ *
+ * The hyphen matters across the seam: kaambaan's declared alphabet is base62
+ * with no separator, so kaambaan's own contract would reject every AgentPod
+ * station id it was ever handed. That is a live disagreement, recorded in the
+ * corpus under `openDisagreements`.
+ *
+ * The UUID version nibble is deliberately not pinned. Every mint site uses
+ * `crypto.randomUUID()` (v4) today, but pinning it would turn a future move to
+ * v7 into a false failure about a shape that is still perfectly well-formed.
+ */
+const uuidSuffixedId = (prefix: string) =>
+  z.string().regex(new RegExp(`^${prefix}_${UUID}$`), `expected a "${prefix}_…" id`);
+
+export const NodeId = truncatedUuidId("node");
+export const RuntimeId = truncatedUuidId("rt");
+/**
+ * The enrollment-token **row** id. The token itself is a different thing with a
+ * different shape — `enr_` + 20 hex + 32 hex (enrollment.ts:53-54) — and is a
+ * secret. Kept apart so no validator can blur an identifier into a credential.
+ */
+export const EnrollmentTokenId = truncatedUuidId("etk");
+
+export const StationId = uuidSuffixedId("station");
+export const AcpSessionId = uuidSuffixedId("acps");
+export const AuditEntryId = uuidSuffixedId("audit");
+
+/**
+ * AgentPod's principal id: a bare UUID with no prefix at all.
+ *
+ * Better Auth's `advanced.generateId` is overridden to `crypto.randomUUID()`
+ * (apps/hub/src/auth/drizzle-auth.ts:249), which applies to user, session,
+ * account and verification alike; admin-created users call `crypto.randomUUID()`
+ * directly (apps/hub/src/routes/admin.ts:432) — the same grammar by coincidence,
+ * not by shared code.
+ *
+ * kaambaan's principal is `usr_<16 hex>`. The two cannot be exchanged and no
+ * mapping exists in either repo. Per ecosystem decision 2, that mapping must be
+ * minted by an explicit link when it arrives — never inferred from a matching
+ * email or a lookalike localpart.
+ */
+export const UserId = z.string().regex(new RegExp(`^${UUID}$`), "expected a bare UUID user id");

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -1,5 +1,6 @@
 export const CONTRACT_VERSION = "0.0.1";
 
+export * from "./ids";
 export * from "./node";
 export * from "./gateway";
 export * from "./station";

--- a/packages/contract/src/run.test.ts
+++ b/packages/contract/src/run.test.ts
@@ -60,6 +60,16 @@ describe("Run — a station attempt", () => {
     expect(r.externalSource).toBe("kaambaan");
   });
 
+  test("rejects an external run id with no source, and a source with no id", () => {
+    // Regression: both fields were independently optional, so a run could record
+    // kaambaan's id without saying it was kaambaan's. Because both repos claim
+    // the `run_` prefix, an unattributed `run_…` is indistinguishable from
+    // AgentPod's own key, and the acp_runs_external_idx reverse join returns a
+    // row that cannot be traced to a board.
+    expect(Run.safeParse({ ...base, externalRunId: "run_e074a2160c4b4f28" }).success).toBe(false);
+    expect(Run.safeParse({ ...base, externalSource: "kaambaan" }).success).toBe(false);
+  });
+
   test("endSeq and endedAt are absent while the run is live", () => {
     const r = Run.parse(base);
     expect(r.endSeq).toBeNull();

--- a/packages/contract/src/run.ts
+++ b/packages/contract/src/run.ts
@@ -51,8 +51,16 @@ export const isRunInterrupted = (s: RunState): boolean =>
  * §10 calls the highest-leverage ordering risk. The console must keep working
  * with no board attached at all, which is why it is optional rather than
  * required.
+ *
+ * The two external fields are **one fact and arrive together**, enforced below.
+ * An `externalRunId` with no source is unattributable — and because both repos
+ * currently claim the `run_` prefix (kaambaan mints it; `acp_runs.id` reserves
+ * it in a schema comment), a bare `run_…` does not say which system produced it.
+ * The reverse join the board needs, `acp_runs_external_idx`, would then return a
+ * row that cannot be traced back to a board. A source with no id is the mirror
+ * image: an origin nothing can be joined to.
  */
-export const Run = z.object({
+const Run_ = z.object({
   id: z.string().min(1),
   sessionId: z.string().min(1),
   stationId: z.string().min(1),
@@ -72,6 +80,15 @@ export const Run = z.object({
   startedAt: z.string(),
   endedAt: z.string().nullable().default(null),
 });
+
+export const Run = Run_.refine(
+  (r) => (r.externalRunId === undefined) === (r.externalSource === undefined),
+  {
+    message:
+      "externalRunId and externalSource must both be present or both absent — an external run id with no source cannot be joined back to the orchestrator that minted it",
+    path: ["externalSource"],
+  },
+);
 export type Run = z.infer<typeof Run>;
 
 // ─── Change ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
First slice of a **shared fixture corpus** that keeps AgentPod and kaambaan agreeing on identity and run identifiers without coupling their deploy pipelines.

Closes the "how two repos share one contract" question left open in `docs/strategy/2026-08-13-ecosystem-identity-decisions.md`. The approach is the one this repo already has evidence for: each repo owns its own types, and a corpus of golden fixtures proves they agree — the same mechanism that has kept five hand-written Go mirrors honest in `internal/contractfix` with no drift, aimed across a repo boundary instead of a language boundary.

`fixtures/ecosystem-identity/` is plain JSON depending on no type from any repo, so kaambaan can check in **the same files** and write the equivalent test in its own runtime. Copy, don't submodule — decoupled cadence is the whole point.

---

## What id grammar each repo actually uses

Established from code. Every claim below is a `file:line` that was read.

### kaambaan — one grammar, uniformly applied

| | |
|---|---|
| Declared | `^<prefix>_[A-Za-z0-9]{6,}$` — `packages/contract/src/ids.ts:7-10` |
| Minted | `<prefix>_<16 lowercase hex>` — `apps/api/src/ids.ts:2`, a UUID with hyphens stripped, sliced to 16 |
| Prefixes | `tnt usr mbr brd agt tok card task run ref gate evt ctx` |

### AgentPod — no validator at all, and two incompatible mint families

**There was no id-shape validator anywhere in this repo.** Every id in `packages/contract/src` is a bare `z.string()`, every id column is `text().primaryKey()` with no CHECK, and `zValidator("param", …)` appears zero times. Prefixes existed only as minting conventions and schema comments.

| Family | Shape | Mint site |
|---|---|---|
| truncated-UUID | `<prefix>_<20 lowercase hex>` | `apps/hub/src/services/enrollment.ts:11-12` (`node`, `etk`) and `apps/hub/src/services/runtimes.ts:54-55` (`rt`) — the helper is **duplicated verbatim**, not shared |
| hyphenated-UUID | `<prefix>_<full dashed UUID>` | `station-registry.ts:50`, `acp-sessions.ts:641`, `audit.ts:94` — inlined at each site |
| bare UUID | no prefix at all | Better Auth `advanced.generateId: () => crypto.randomUUID()`, `apps/hub/src/auth/drizzle-auth.ts:249` (live config; `auth/index.ts:171` is a legacy duplicate). Admin-created users call `crypto.randomUUID()` directly at `routes/admin.ts:432` — same grammar by coincidence, not shared code. |

No organization ids exist: the Better Auth organization plugin is not installed (`drizzle-auth.ts:110-123`) and "organization" appears in no source file and none of the 35 migrations.

## Do they agree? No — four disagreements

1. **Principals disagree outright.** kaambaan `usr_<16 hex>`; AgentPod a bare unprefixed UUID that is not type-legible. They cannot be exchanged and **no mapping exists in either repo**. Decision 2 applies identically: the link must be minted, never inferred from a matching email.
2. **Alphabet.** kaambaan's declared alphabet is base62 with no separator, so kaambaan's own contract **would reject every AgentPod `station_`/`acps_`/`audit_` id it was ever handed**. Live, not hypothetical.
3. **Length.** Both slice the same source — a UUID with hyphens stripped — kaambaan to 16, AgentPod to 20. Neither repo records a reason.
4. **Prefix `run` is claimed by both.** kaambaan mints it (`board-do.ts:1253`). AgentPod reserves it for `acp_runs.id` at `apps/hub/src/db/schema/acp.ts:69`, commented `"run_" + uuid-ish` — **two lines above the comment "We never mint a rival id"**. Nothing mints AgentPod's yet so nothing is broken; the day one does, a bare `run_…` stops saying which system produced it and the `acp_runs_external_idx` reverse join stops being self-describing. Recorded as a known conflict, not fixed — that needs a decision in both repos. A **new** collision fails the test.

### Bonus finding in kaambaan (not fixed — not this repo's to change)

`newId('push')` at `apps/api/src/board/board-do.ts:1023` mints a prefix absent from `ID_PREFIXES` and from every schema in `packages/contract/src/ids.ts`. **This is the same class as the `mem_`/`mbr_` bug that was just fixed, still open.** Symmetrically, `task` and `evt` are declared but never minted — `Run.taskId` references `TaskId` while the `runs` table stores `card_id`. All recorded in `prefixRegistry`.

## What carries the run join key today

*Invariant: kaambaan mints the work run; AgentPod executes it; no competing run ID for dispatched work.*

**The field exists. Nothing carries a value into it.**

Reserved, in both DB and contract, with comments naming kaambaan explicitly:
- `apps/hub/src/db/schema/acp.ts:75-76` — `external_run_id` + `external_source` on `acp_runs`, really in the DB via migration `0028_outgoing_magneto.sql`, with `acp_runs_external_idx` (`:88`) for the board's reverse join.
- `packages/contract/src/run.ts:60-63` — `Run.externalRunId` / `externalSource`, both optional.
- `RunState` is A2A's `TaskState` verbatim, verified member-for-member and order-for-order against kaambaan's `packages/contract/src/primitives.ts:7-21`, so no translation table is needed.

Nothing writes it:
- **Nothing inserts into `acp_runs`.** Grepping outside the schema file finds only a unit test asserting column shape. `acp_sessions` is live (`acp-sessions.ts:641` mints `acps_<uuid>`); there is no equivalent line for runs, so AgentPod does not mint a run id at all today.
- No route accepts an external run id — `POST /api/stations/:id/acp/sessions` takes `{mode}` and nothing else (`routes/station-acp.ts:112`).
- The ACP wire carries no run or correlation id: neither `AcpClientMsg` nor `AcpServerMsg` has one. The session id is the only identity on the wire.
- The bridge spike holds kaambaan's `runId` but never sends it. The kaambaan-run → AgentPod-session correlation exists as a **`console.log` line** at `apps/bridge/spike/src/bridge.ts:30-31` and nowhere else. The only identity that does flow is the reverse direction and unstructured: station and session ids written into kaambaan as free text in an activity body and a handoff blob (`bridge.ts:79-93`).
- kaambaan has **zero occurrences of "agentpod"** in its source or docs.

So `run_join_key.json` encodes the *intended* shape, with `enforcement.status: "carried-in-schema-only"` and a test that pins that string — when a write path lands, that test is the reminder to change it.

### One hole the corpus found, and this closes

`externalRunId` and `externalSource` were **independently** optional, so a run could carry kaambaan's id without saying it was kaambaan's. Because both repos claim `run_`, an unattributed `run_…` is indistinguishable from AgentPod's own key, and the reverse join returns a row that cannot be traced to a board. They are now one fact that must arrive together (`run.ts`), with a regression test.

## Mutation-test results — both directions

| Direction | Mutation | Result |
|---|---|---|
| **Loosen** | dropped the `^${prefix}_` anchor from the AgentPod hex grammar, so any 20-hex tail passes any prefix | **3 tests failed** — `agentpod.node`, `agentpod.runtime`, `agentpod.enrollmentToken` → "rejects every id the corpus says it must" (59 pass / 3 fail) |
| **Tighten** | narrowed kaambaan's grammar from `[A-Za-z0-9]{6,}` to the `[0-9a-f]{16}` it actually mints, rejecting shapes kaambaan's own contract declares legal | **2 tests failed** — `kaambaan.tenant`, `kaambaan.run` → "accepts every id the corpus says it must" (60 pass / 2 fail) |

Both mutations reverted; suite green. The tighten direction matters as much as the loosen one — rejecting a peer's legitimate id makes the seam unusable in one direction, and kaambaan's own suite asserts `run_Aa0Bb1` parses.

The corpus also guards itself: an entity added with no validator mapped fails a coverage test, and an entity with no `reject` cases fails a "carries negative cases at all" test.

## Verification

| | |
|---|---|
| `cd packages/contract && bun test` | **171 pass, 0 fail** (was 108) |
| `cd apps/hub && DATABASE_URL=… bun test` | **841 pass, 0 fail** |
| `apps/hub bun run typecheck` | **exactly 15** — the known-red pre-existing count, none added |
| `packages/contract bun run typecheck` | 4 pre-existing `TS6059` — unchanged (test placed in `src/`, matching the majority convention, so it adds none) |
| `bun run scripts/emit-go-fixtures.ts --check` | ✓ fixtures match the contract |
| `go test ./internal/contractfix/...` | ok |
| `apps/console pnpm check` | 0 errors, 0 warnings |

TDD: the test was written first and failed on the missing module, then failed on the two paired-presence cases before the refinement landed.

## Out of scope, deliberately

**Matrix event envelopes.** The Application Service does not exist, so fixtures for it would be invented rather than observed — the same position supermessage's `customEvents.ts` takes about its own empty registry.

Not deployed. kaambaan not modified.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
