### PR TITLE
fix(contract,hub): move acp_runs.id out of kaambaan's `run_` id space

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0035_acp_runs_id_space.sql
+++ b/apps/hub/src/db/drizzle-migrations/0035_acp_runs_id_space.sql
@@ -1,0 +1,12 @@
+-- acp_runs.id moves out of kaambaan's `run_` id space and into AgentPod's own,
+-- `attempt_`. There is NO data migration: no statement inserting into acp_runs
+-- exists at any commit in this repository, the table has never had a writer, and
+-- production holds zero rows — which is precisely why this was free to do now and
+-- would not have been once the bridge wrote its first run.
+--
+-- The constraints therefore validate against an empty table everywhere. They are
+-- the point of the change: the old prefix was governed by a schema comment that
+-- sat six lines above another comment promising the opposite.
+ALTER TABLE "acp_runs" ADD CONSTRAINT "acp_runs_id_is_agentpod_attempt" CHECK ("acp_runs"."id" LIKE 'attempt\_%');--> statement-breakpoint
+ALTER TABLE "acp_runs" ADD CONSTRAINT "acp_runs_external_is_not_agentpod" CHECK ("acp_runs"."external_run_id" IS NULL OR "acp_runs"."external_run_id" NOT LIKE 'attempt\_%');--> statement-breakpoint
+ALTER TABLE "acp_runs" ADD CONSTRAINT "acp_runs_external_pair" CHECK (("acp_runs"."external_run_id" IS NULL) = ("acp_runs"."external_source" IS NULL));

--- a/apps/hub/src/db/drizzle-migrations/meta/0035_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0035_snapshot.json
@@ -1,0 +1,2037 @@
+{
+  "id": "a75d60ec-8ab4-4236-838e-da04e94729f5",
+  "prevId": "291aa73b-8d31-4b07-83b1-75e5b667f1ae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1786578432361,
       "tag": "0034_runtime_external_started_at",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1786646893273,
+      "tag": "0035_acp_runs_id_space",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/acp.ts
+++ b/apps/hub/src/db/schema/acp.ts
@@ -8,7 +8,17 @@
  * ACP Slice 2 (hub sessions).
  */
 
-import { pgTable, text, integer, timestamp, jsonb, primaryKey, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  pgTable,
+  text,
+  integer,
+  timestamp,
+  jsonb,
+  primaryKey,
+  index,
+  check,
+} from "drizzle-orm/pg-core";
 
 export const acpSessions = pgTable("acp_sessions", {
   id: text("id").primaryKey(),                                        // "acps_" + uuid-ish
@@ -64,14 +74,24 @@ export const acpEvents = pgTable("acp_events", {
  *
  * Not a FK to stations.id, for the same reason acp_sessions is not: destroying a
  * throwaway runtime must not erase the record of what ran on it.
+ *
+ * **The id space is `attempt_`, not `run_`.** `run_` is kaambaan's, for the work
+ * run it mints and dispatches; this row is one prompt-turn spent executing one
+ * of those, and a claimed card takes as many prompt-turns as the work takes, so
+ * the two never counted 1:1. This file used to declare `"run_" +
+ * uuid-ish` six lines above the comment "We never mint a rival id" — it minted
+ * one in the same breath, and the two ids were indistinguishable strings. The
+ * CHECK constraints below are what enforces the split now, because the comment
+ * demonstrably did not.
  */
 export const acpRuns = pgTable("acp_runs", {
-  id: text("id").primaryKey(),                                        // "run_" + uuid-ish
+  id: text("id").primaryKey(),                                        // "attempt_" + uuid (AcpRunId)
   sessionId: text("session_id").notNull().references(() => acpSessions.id, { onDelete: "cascade" }),
   stationId: text("station_id").notNull(),
 
   // kaambaan's runId when this attempt came from a claim; null when it did not.
-  // We never mint a rival id — see packages/contract/src/run.ts.
+  // We never mint a rival id — and since the two id spaces are now disjoint,
+  // that is checked rather than asserted. See packages/contract/src/run.ts.
   externalRunId: text("external_run_id"),
   externalSource: text("external_source"),                            // "kaambaan", or another orchestrator
 
@@ -86,4 +106,24 @@ export const acpRuns = pgTable("acp_runs", {
   index("acp_runs_station_started_idx").on(t.stationId, t.startedAt.desc()),
   // The join from the board's side: given kaambaan's runId, find what ran.
   index("acp_runs_external_idx").on(t.externalRunId),
+
+  // Our own key is ours. A `run_…` here would be an orchestrator's work run
+  // standing in as this hub's primary key — the collision this table was born
+  // with. Prefix-only, deliberately: the suffix family may change, the id space
+  // may not.
+  check("acp_runs_id_is_agentpod_attempt", sql`${t.id} LIKE 'attempt\\_%'`),
+  // The mirror: an external id may be any shape an orchestrator mints (§7 keeps
+  // externalSource open), but it may never be one of ours.
+  check(
+    "acp_runs_external_is_not_agentpod",
+    sql`${t.externalRunId} IS NULL OR ${t.externalRunId} NOT LIKE 'attempt\\_%'`,
+  ),
+  // One fact, two columns: an external run id with no source cannot be joined
+  // back to the board that minted it, and a source with no id names an origin
+  // nothing points at. Enforced in the contract too (#307) — here as well
+  // because a writer can bypass the contract but not the table.
+  check(
+    "acp_runs_external_pair",
+    sql`(${t.externalRunId} IS NULL) = (${t.externalSource} IS NULL)`,
+  ),
 ]);

--- a/apps/hub/tests/integration/acp-runs-id-space.test.ts
+++ b/apps/hub/tests/integration/acp-runs-id-space.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration Test: acp_runs id-space constraints (migration 0035)
+ *
+ * `acp_runs.id` used to be spelled `run_…`, the same prefix kaambaan mints for a
+ * work run — and the schema file said so six lines above a comment reading "We
+ * never mint a rival id". Two products, one id space, indistinguishable strings.
+ *
+ * AgentPod's key is now `attempt_<uuid>`. A comment did not keep the two apart,
+ * so the database does: three CHECK constraints, exercised here against the real
+ * test Postgres rather than against drizzle's in-memory table config, because
+ * what matters is that the constraints reached the schema — a check declared in
+ * TypeScript but never migrated would pass a config assertion and enforce
+ * nothing.
+ *
+ * DATABASE_URL must point to the local Docker test-postgres on localhost:5434.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL || "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+
+import { db, rawSql } from "../../src/db/drizzle";
+import { acpSessions, acpRuns } from "../../src/db/schema/acp";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+
+const STATION_ID = "acp-runs-id-space-station";
+const SESSION_ID = "acps_11111111-2222-4333-8444-555555555555";
+const USER_ID = "acp-runs-id-space-user";
+
+const OWN_ID = "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90";
+/** A real kaambaan work run id: `run_<16 hex>`. */
+const KAAMBAAN_RUN_ID = "run_e074a2160c4b4f28";
+
+type RunRow = typeof acpRuns.$inferInsert;
+
+const runRow = (over: Partial<RunRow>): RunRow => ({
+  id: OWN_ID,
+  sessionId: SESSION_ID,
+  stationId: STATION_ID,
+  state: "working",
+  startSeq: 0,
+  startedAt: new Date(),
+  ...over,
+});
+
+const ACCEPTED = "(accepted — no constraint rejected the row)";
+
+/**
+ * Insert and report the constraint that rejected it, or ACCEPTED if it went in.
+ *
+ * Drizzle wraps the driver error, so the postgres.js `constraint_name` is on the
+ * cause rather than the thrown error; fall back to the whole message so a
+ * failure is still legible if that ever changes.
+ */
+async function violation(row: RunRow): Promise<string> {
+  try {
+    await db.insert(acpRuns).values(row);
+    await rawSql`DELETE FROM acp_runs WHERE id = ${row.id}`;
+    return ACCEPTED;
+  } catch (err) {
+    const cause = (err as { cause?: { constraint_name?: string } })?.cause;
+    return String(
+      (err as { constraint_name?: string })?.constraint_name ?? cause?.constraint_name ?? err,
+    );
+  }
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  const now = new Date();
+  await rawSql`DELETE FROM acp_runs WHERE station_id = ${STATION_ID}`;
+  await rawSql`DELETE FROM acp_sessions WHERE station_id = ${STATION_ID}`;
+  await db.insert(acpSessions).values({
+    id: SESSION_ID,
+    stationId: STATION_ID,
+    userId: USER_ID,
+    mode: "full-auto",
+    status: "idle",
+    lastSeq: 0,
+    createdAt: now,
+    lastEventAt: now,
+  });
+});
+
+afterAll(async () => {
+  await rawSql`DELETE FROM acp_runs WHERE station_id = ${STATION_ID}`;
+  await rawSql`DELETE FROM acp_sessions WHERE station_id = ${STATION_ID}`;
+});
+
+describe("acp_runs — AgentPod's own id space, enforced by the database", () => {
+  test("no row anywhere carries the old `run_` prefix", async () => {
+    // The evidence behind "no data migration is needed". Nothing in apps/hub/src
+    // inserts into acp_runs and no such statement exists at any commit, so the
+    // table has never held a row — which is what made the rename free. If this
+    // ever fails, the constraints below could not have been added without one.
+    const [{ count }] = await rawSql<
+      { count: string }[]
+    >`SELECT count(*)::text AS count FROM acp_runs WHERE id LIKE 'run\\_%'`;
+    expect(count).toBe("0");
+  });
+
+  test("accepts an attempt id", async () => {
+    expect(await violation(runRow({}))).toBe(ACCEPTED);
+  });
+
+  test("refuses a kaambaan work run id as its own primary key", async () => {
+    // The collision itself. Reverting the prefix to `run_` makes this insert
+    // succeed, and this test fail.
+    expect(await violation(runRow({ id: KAAMBAAN_RUN_ID }))).toContain(
+      "acp_runs_id_is_agentpod_attempt",
+    );
+  });
+
+  test("refuses the old prefix even on a locally-shaped id", async () => {
+    // Not just kaambaan's minted shape: the prefix itself is what is gone.
+    expect(await violation(runRow({ id: `run_${OWN_ID.slice("attempt_".length)}` }))).toContain(
+      "acp_runs_id_is_agentpod_attempt",
+    );
+  });
+
+  test("keeps a dispatched run's two ids in their own spaces", async () => {
+    expect(
+      await violation(
+        runRow({ externalRunId: KAAMBAAN_RUN_ID, externalSource: "kaambaan" }),
+      ),
+    ).toBe(ACCEPTED);
+  });
+
+  test("refuses one of its own attempt ids as an external run id", async () => {
+    expect(
+      await violation(
+        runRow({
+          externalRunId: "attempt_3d4e5f60-7182-4a4b-8c56-51b6c7e8f0a2",
+          externalSource: "kaambaan",
+        }),
+      ),
+    ).toContain("acp_runs_external_is_not_agentpod");
+  });
+
+  test("refuses an external run id with no source, and a source with no id", async () => {
+    // #307 made these a paired presence in the contract; the storage layer is
+    // where a future writer that bypasses the contract still gets caught.
+    expect(await violation(runRow({ externalRunId: KAAMBAAN_RUN_ID }))).toContain(
+      "acp_runs_external_pair",
+    );
+    expect(await violation(runRow({ externalSource: "kaambaan" }))).toContain(
+      "acp_runs_external_pair",
+    );
+  });
+
+  test("leaves a local run with no board attached alone", async () => {
+    expect(await violation(runRow({ externalRunId: null, externalSource: null }))).toBe(ACCEPTED);
+  });
+});

--- a/fixtures/ecosystem-identity/README.md
+++ b/fixtures/ecosystem-identity/README.md
@@ -17,7 +17,7 @@ repo boundary instead of a language boundary.
 
 | File | What it pins |
 |---|---|
-| `id_grammar.json` | What each repo mints and validates for every entity id, plus the full prefix registry and the collisions in it. |
+| `id_grammar.json` | What each repo mints and validates for every entity id, plus the full prefix registry and the collisions in it — open (`knownConflicts`) and settled (`resolvedConflicts`). |
 | `run_join_key.json` | The run join key: *kaambaan mints the work run; AgentPod executes it; no competing run id for dispatched work.* |
 
 Both are plain JSON and depend on no type from any repo. That is deliberate — a corpus that
@@ -36,7 +36,7 @@ bare `z.string()` cannot catch and the one most likely to reach production.
 
 ## How AgentPod consumes it
 
-`packages/contract/src/ids.ts` holds the validators; `packages/contract/tests/ecosystem-identity.test.ts`
+`packages/contract/src/ids.ts` holds the validators; `packages/contract/src/ecosystem-identity.test.ts`
 drives them from these files. It runs under the `contract` CI job with everything else:
 
 ```bash
@@ -44,7 +44,27 @@ cd packages/contract && bun test
 ```
 
 The test fails if a corpus entity has no validator mapped to it, so adding an entity here
-cannot silently go untested.
+cannot silently go untested. It also shows every validator every *other* entity's canonical
+minted id and requires all of them to be rejected — the general form of the `run_` collision
+below, so a new one fails without anyone remembering to write a test for it.
+
+## Resolving a collision
+
+`prefixRegistry.knownConflicts` is for prefixes two owners genuinely both claim. It is not a
+parking space: an entry there means the corpus can prove a name is ambiguous and cannot prove
+which system a value came from.
+
+When a collision is settled, the entry moves to `resolvedConflicts`, which records who gave
+the claim up and what they moved to. The move is checked, not taken on trust — a resolved
+prefix must have exactly one owner left in `claims`, so declaring a conflict resolved while
+still claiming the prefix fails the suite.
+
+`run` is the worked example. kaambaan mints `run_<16 hex>` for a work run and has production
+data; AgentPod had reserved the same prefix for `acp_runs.id` in a schema comment that sat six
+lines above another comment promising it never minted a rival id. AgentPod moved to `attempt_`
+on 2026-08-14 — it is the executor, not the minter, and had never written an `acp_runs` row.
+The kaambaan-side change is nil: the corpus asks kaambaan to keep minting exactly what it
+already mints.
 
 ## How kaambaan (or any peer) consumes it
 

--- a/fixtures/ecosystem-identity/id_grammar.json
+++ b/fixtures/ecosystem-identity/id_grammar.json
@@ -109,7 +109,7 @@
       "grammarSource": "kaambaan packages/contract/src/ids.ts:21 — idSchema('run')",
       "mintedAs": "^run_[0-9a-f]{16}$",
       "mintSource": "kaambaan apps/api/src/ids.ts:2 newId(), called at apps/api/src/board/board-do.ts:1253 (claim → INSERT INTO runs)",
-      "note": "The join key. Kaambaan mints the work run; AgentPod executes it and must never mint a rival id for the same attempt. See run_join_key.json — and see `knownConflicts` below, because AgentPod has reserved the same `run_` prefix for its own primary key.",
+      "note": "The join key. Kaambaan mints the work run; AgentPod executes it and must never mint a rival id for the same attempt. See run_join_key.json. AgentPod used to reserve this same prefix for its own acp_runs primary key; it gave the claim up on 2026-08-14 and moved to `attempt_` — see `resolvedConflicts` below and the `agentpod.acpRun` entity.",
       "accept": [
         { "value": "run_e074a2160c4b4f28", "mint": true, "note": "canonical claim result" },
         { "value": "run_Aa0Bb1", "mint": false, "note": "kaambaan's own test suite asserts this parses (packages/contract/test/ids.test.ts:8). AgentPod must not be stricter than the minter's contract about an id it did not mint." }
@@ -117,6 +117,7 @@
       "reject": [
         { "value": "task_e074a2160c4b4f28", "reason": "other-entity" },
         { "value": "card_3d4e5f6071829304", "reason": "other-entity" },
+        { "value": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90", "reason": "other-entity", "note": "an AgentPod acp_runs id — one attempt at executing a work run, not the work run. This pair used to be indistinguishable; keeping it in both reject lists is what stops the collision returning." },
         { "value": "run_", "reason": "prefix-only" },
         { "value": "run_abc", "reason": "too-short" },
         { "value": "run_e074a216-0c4b", "reason": "wrong-alphabet" },
@@ -227,7 +228,34 @@
       "reject": [
         { "value": "acp_3d4e5f60", "reason": "other-entity", "note": "`acp_<8 hex>` is a DIFFERENT id: the node-agent's process-local ACP session id (apps/node-agent/internal/acp/manager.go:40-46, 32 bits of entropy, collision-retried in-process). The hub's `acps_<uuid>` doubles as the node-side instance discriminator (acp-sessions.ts:688-691), so both prefixes are live in the same subsystem and differ by one character." },
         { "value": "run_e074a2160c4b4f28", "reason": "other-entity", "note": "a kaambaan run id" },
+        { "value": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90", "reason": "other-entity", "note": "an AgentPod acp_runs id. Same family and same subsystem — acp_runs.session_id is a FK to acp_sessions.id — so these two travel together and must not be interchangeable." },
         { "value": "acps_", "reason": "prefix-only" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.acpRun",
+      "owner": "agentpod",
+      "prefix": "attempt",
+      "grammar": "^attempt_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "grammarSource": "agentpod packages/contract/src/ids.ts — AcpRunId. Also enforced in the database: acp_runs carries a CHECK constraint (`acp_runs_id_is_agentpod_attempt`) added by migration 0035.",
+      "mintedAs": "^attempt_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "mintSource": "NONE — nothing in apps/hub/src inserts into acp_runs yet, and no such statement has existed at any commit. The grammar is reserved and enforced ahead of its first writer, which is the only moment the rename was free.",
+      "note": "WAS `run_`, colliding head-on with kaambaan's work run — the schema file carried the comment `\"run_\" + uuid-ish` two lines above `We never mint a rival id` and contradicted itself. AgentPod moved because AgentPod is the executor: kaambaan mints work runs and has live production data, while acp_runs has no writer and no rows. `attempt` also names the thing correctly — a run here is a PROMPT-TURN, opening when a prompt is submitted and closing when the agent yields, while kaambaan's work run is a claimed card that takes as many prompt-turns as the work takes. One work run is executed as a series of attempts; the two never counted 1:1 and were never the same entity, whatever the shared prefix implied. Hyphenated-UUID family, matching its sibling acps_ in the same subsystem; `acpr_` was rejected as one character from `acps_`, which the acp_/acps_ near-miss below already shows is a trap.",
+      "accept": [
+        { "value": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90", "mint": true }
+      ],
+      "reject": [
+        { "value": "run_e074a2160c4b4f28", "reason": "other-entity", "note": "THE COLLISION. A kaambaan work run id. Before 2026-08-14 this shape was AgentPod's own primary key too, and the two were indistinguishable strings; this is the case that fails if the `run_` prefix is ever restored." },
+        { "value": "run_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90", "reason": "wrong-prefix", "note": "the exact old AgentPod grammar — the old prefix with the current suffix. Rejecting only kaambaan's minted shape would let a hub keep the contested prefix as long as it spelled the suffix differently." },
+        { "value": "attempt_9f1c2ab04d7e4b3a8c880d6e2f7c1b90", "reason": "wrong-alphabet", "note": "hyphens stripped — the shape node_/rt_ use. Both spellings would name the same UUID; only one is minted." },
+        { "value": "attempt_9F1C2AB0-4D7E-4B3A-8C88-0D6E2F7C1B90", "reason": "wrong-alphabet", "note": "uppercase" },
+        { "value": "attempt_9f1c2ab0-4d7e-4b3a-8c88", "reason": "too-short" },
+        { "value": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2", "reason": "other-entity", "note": "the ACP session this run belongs to — acp_runs.session_id references it, so both ids are in hand at every call site that will ever write a run" },
+        { "value": "attempts_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90", "reason": "prefix-not-anchored" },
+        { "value": "attempt_", "reason": "prefix-only" },
+        { "value": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90\n", "reason": "trailing-newline" },
         { "value": "", "reason": "empty" }
       ]
     },
@@ -281,14 +309,18 @@
       { "prefix": "acp", "owner": "agentpod", "entity": "nodeLocalAcpSession", "status": "minted-never-declared", "note": "node-agent only — `acp_<8 hex>`, apps/node-agent/internal/acp/manager.go:40-46. One character away from the hub's `acps_`, and the hub's id is passed to the node as the instance discriminator, so both live in the same subsystem." },
       { "prefix": "audit", "owner": "agentpod", "entity": "auditEntry", "status": "minted-never-declared", "note": "apps/hub/src/services/audit.ts:94 — `audit_${crypto.randomUUID()}`, hyphenated-UUID family" },
       { "prefix": "enr", "owner": "agentpod", "entity": "enrollmentTokenSecret", "status": "credential" },
-      { "prefix": "chg", "owner": "agentpod", "entity": "change", "status": "reserved-never-minted", "note": "only appears as a test literal in packages/contract/src/run.test.ts:76; Change is a reserved schema with no writer" },
-      { "prefix": "run", "owner": "agentpod", "entity": "acpRun", "status": "reserved-never-minted", "note": "COLLISION — see knownConflicts" }
+      { "prefix": "chg", "owner": "agentpod", "entity": "change", "status": "reserved-never-minted", "note": "only appears as a test literal in packages/contract/src/run.test.ts; Change is a reserved schema with no writer" },
+      { "prefix": "attempt", "owner": "agentpod", "entity": "acpRun", "status": "reserved-never-minted", "note": "acp_runs.id. Reserved but validated and CHECK-constrained ahead of its first writer — see the agentpod.acpRun entity, and resolvedConflicts for the `run_` prefix it replaced." }
     ],
-    "knownConflicts": [
+    "knownConflicts": [],
+    "resolvedConflicts": [
       {
         "prefix": "run",
-        "claimedBy": ["kaambaan", "agentpod"],
-        "detail": "kaambaan mints `run_<16 hex>` for a work run (apps/api/src/board/board-do.ts:1253). AgentPod reserves the SAME prefix for acp_runs.id — apps/hub/src/db/schema/acp.ts:69 carries the comment `\"run_\" + uuid-ish` directly above a primary key whose neighbouring column comment reads `We never mint a rival id`. Nothing mints an AgentPod run id yet, so nothing is broken today; the moment something does, a `run_…` value is ambiguous about which system it came from, and the acp_runs_external_idx reverse join (schema/acp.ts:88) becomes unsafe to reason about. Resolving this is a decision for both repos, not a fix this corpus can make. Recorded so it cannot be forgotten."
+        "wasClaimedBy": ["kaambaan", "agentpod"],
+        "nowClaimedBy": "kaambaan",
+        "resolvedAt": "2026-08-14",
+        "resolution": "AgentPod's acp_runs.id moved to `attempt_<uuid>`.",
+        "detail": "kaambaan mints `run_<16 hex>` for a work run (apps/api/src/board/board-do.ts:1253) and has live production data. AgentPod had reserved the SAME prefix for acp_runs.id — the schema file carried the comment `\"run_\" + uuid-ish` six lines above `We never mint a rival id` and so contradicted itself — but AgentPod is the executor, not the minter: no statement inserting into acp_runs exists at any commit in this repository, so no row anywhere carries the old prefix and the rename cost nothing. It stops being free the moment the bridge writes its first run, which is why it happened now. `attempt` is not a synonym for `run`: an AgentPod run is a prompt-turn and a kaambaan work run is a claimed card, so one work run is executed as a series of attempts and the shapes now say so. Recorded here, and asserted, so the collision cannot return unnoticed."
       }
     ]
   },
@@ -296,8 +328,8 @@
   "openDisagreements": [
     "Principal shape: kaambaan `usr_<16 hex>`; AgentPod a bare unprefixed UUID. No mapping exists in either repo.",
     "Token length: kaambaan takes 16 hex from a UUID, AgentPod takes 20. Same source, different slice, no reason recorded in either.",
-    "Alphabet: AgentPod has TWO families — `<prefix>_<20 hex>` (node, rt, etk) and `<prefix>_<hyphenated UUID>` (station, acps, audit). kaambaan's declared alphabet is base62 with no hyphen, so it would reject every id in AgentPod's second family.",
+    "Alphabet: AgentPod has TWO families — `<prefix>_<20 hex>` (node, rt, etk) and `<prefix>_<hyphenated UUID>` (station, acps, attempt, audit). kaambaan's declared alphabet is base62 with no hyphen, so it would reject every id in AgentPod's second family.",
     "Tenancy: kaambaan pins every principal to exactly one tenant at the storage layer; AgentPod has no tenant concept at all, so no AgentPod id carries tenancy. Out of scope here, flagged because it is the largest remaining modelling decision (see docs/strategy/2026-08-13-ecosystem-identity-decisions.md).",
-    "Prefix `run` is claimed by both repos — see prefixRegistry.knownConflicts."
+    "RESOLVED 2026-08-14 — prefix `run` was claimed by both repos; AgentPod moved acp_runs.id to `attempt_` and kaambaan keeps `run_`. See prefixRegistry.resolvedConflicts."
   ]
 }

--- a/fixtures/ecosystem-identity/run_join_key.json
+++ b/fixtures/ecosystem-identity/run_join_key.json
@@ -1,41 +1,47 @@
 {
   "corpus": "ecosystem-identity/run-join-key",
-  "version": 1,
+  "version": 2,
   "authoredAt": "2026-08-13",
+  "revisedAt": "2026-08-14",
 
   "invariant": "Kaambaan mints the work run; AgentPod executes it; there is no competing run id for dispatched work.",
 
   "enforcement": {
-    "status": "carried-in-schema-only",
-    "summary": "AgentPod has already reserved the field, in both the database and the contract, with comments naming kaambaan explicitly. Nothing writes it, nothing reads it, and no API accepts it. The invariant is a design intent with a place to live, not a behaviour.",
+    "status": "id-spaces-disjoint-no-write-path",
+    "summary": "Half of this is now executable rather than commented. AgentPod's own attempt id lives under `attempt_`, kaambaan's work run under `run_`, and the two grammars reject each other — asserted in the contract, in the shared corpus, and by CHECK constraints on the table itself. What is still missing is a write path: nothing inserts into acp_runs, nothing reads it, and no API accepts an external run id.",
     "whatExists": [
-      "agentpod apps/hub/src/db/schema/acp.ts:75-76 — `external_run_id` and `external_source` columns on `acp_runs`, really in the database via migration 0028_outgoing_magneto.sql, with `acp_runs_external_idx` on external_run_id (:88) for the reverse join from the board's side.",
-      "agentpod packages/contract/src/run.ts:60-63 — `Run.externalRunId` and `Run.externalSource`, both optional.",
-      "agentpod packages/contract/src/run.ts:18-27 — `RunState` is A2A's TaskState verbatim, chosen so no translation table to kaambaan's state machine is needed."
+      "agentpod apps/hub/src/db/schema/acp.ts — `acp_runs.id` is `attempt_<uuid>`, disjoint from kaambaan's `run_`, with a CHECK constraint (`acp_runs_id_is_agentpod_attempt`) so the database refuses a rival id rather than a comment asking it not to.",
+      "agentpod apps/hub/src/db/schema/acp.ts — `external_run_id` and `external_source` on `acp_runs`, really in the database via migration 0028_outgoing_magneto.sql, with `acp_runs_external_idx` on external_run_id for the reverse join from the board's side, plus CHECK constraints for paired presence (`acp_runs_external_pair`) and for an external id never coming from AgentPod's own space (`acp_runs_external_is_not_agentpod`).",
+      "agentpod packages/contract/src/ids.ts — `AcpRunId` (`^attempt_<uuid>$`) and `KaambaanRunId` (`^run_[A-Za-z0-9]{6,}$`), each rejecting the other's minted ids.",
+      "agentpod packages/contract/src/run.ts — `Run.id` is validated as an `AcpRunId`, `Run.externalRunId`/`externalSource` are optional and paired, and an `externalRunId` from AgentPod's own space is refused.",
+      "agentpod packages/contract/src/run.ts — `RunState` is A2A's TaskState verbatim, chosen so no translation table to kaambaan's state machine is needed."
     ],
     "whatDoesNot": [
-      "Nothing inserts into `acp_runs`. Grepping apps/hub for `acpRuns` outside the schema file finds only a unit test asserting column shape. `acp_sessions` by contrast is live (acp-sessions.ts:641 mints `acps_<uuid>`); there is no equivalent line for runs, so AgentPod does not currently mint a run id at all.",
-      "No route accepts an external run id. `POST /api/stations/:id/acp/sessions` takes `{mode}` and nothing else (apps/hub/src/routes/station-acp.ts:112).",
+      "Nothing inserts into `acp_runs`. Grepping apps/hub for `acpRuns` outside the schema file finds only tests. `acp_sessions` by contrast is live (acp-sessions.ts mints `acps_<uuid>`); there is no equivalent mint site for runs, so AgentPod does not currently mint an attempt id at all — the grammar is reserved and enforced ahead of its first writer.",
+      "No route accepts an external run id. `POST /api/stations/:id/acp/sessions` takes `{mode}` and nothing else (apps/hub/src/routes/station-acp.ts).",
       "The ACP wire carries no run or correlation id: neither AcpClientMsg nor AcpServerMsg in packages/contract/src/acp-session.ts has one. The session id is the only identity on the wire.",
-      "The bridge spike holds kaambaan's runId (apps/bridge/spike/src/kaambaan.ts:14-20, and every call is POST /v1/boards/{board}/runs/{runId}/{action}) but never sends it to AgentPod. The kaambaan-run → AgentPod-session correlation exists as a console.log line at apps/bridge/spike/src/bridge.ts:30-31 and nowhere else. The only identity that does flow is the reverse direction and unstructured: the station and ACP session ids are written into kaambaan as free text in an activity body and as a handoff JSON blob (bridge.ts:79-93).",
+      "The bridge spike holds kaambaan's runId (apps/bridge/spike/src/kaambaan.ts, and every call is POST /v1/boards/{board}/runs/{runId}/{action}) but never sends it to AgentPod. The kaambaan-run → AgentPod-session correlation exists as a console.log line at apps/bridge/spike/src/bridge.ts and nowhere else.",
       "kaambaan has no notion of AgentPod at all — zero occurrences of the string in its source or docs — so the dispatch path this invariant governs does not exist on either side yet."
     ],
     "consequence": "Every case below is an INTENDED shape, validated against AgentPod's `Run` schema, not an observed wire capture. When the write path lands, these fixtures are what it must satisfy. Until then they hold the shape still."
   },
 
-  "openConflict": {
+  "resolvedConflict": {
     "prefix": "run",
-    "detail": "AgentPod reserves the same `run_` prefix kaambaan mints with. apps/hub/src/db/schema/acp.ts:69 comments its primary key `\"run_\" + uuid-ish`, two lines above the comment `We never mint a rival id`. Nothing mints it yet, so nothing is broken; the day something does, a bare `run_…` value no longer says which system produced it, and the reverse join through acp_runs_external_idx stops being self-describing. Resolving this needs a decision in both repos. Recorded, not fixed.",
-    "alsoRecordedIn": "id_grammar.json → prefixRegistry.knownConflicts"
+    "wasClaimedBy": ["kaambaan", "agentpod"],
+    "nowClaimedBy": "kaambaan",
+    "resolvedAt": "2026-08-14",
+    "detail": "AgentPod used to reserve the same `run_` prefix kaambaan mints with: apps/hub/src/db/schema/acp.ts commented its primary key `\"run_\" + uuid-ish` two lines above the comment `We never mint a rival id`, so the file contradicted itself and the two ids were indistinguishable strings. AgentPod moved, because AgentPod is the executor rather than the minter: kaambaan mints work runs and has live production data, while nothing in apps/hub/src ever inserted into acp_runs (no such statement exists in the repository's history) so no AgentPod row anywhere carries the old prefix. `acp_runs.id` is now `attempt_<uuid>`, which also names the right thing — a run here is a prompt-turn while kaambaan's is a claimed card, so one work run is executed as a series of attempts and the two are not the same entity at all.",
+    "alsoRecordedIn": "id_grammar.json → prefixRegistry.resolvedConflicts"
   },
 
   "cases": [
     {
       "name": "dispatched_run",
       "mustParse": true,
-      "why": "The whole point: a run that came from a kaambaan claim carries the board's id and says who minted it. AgentPod's own `id` is a separate, local key — it does not, and must not, restate kaambaan's.",
+      "why": "The whole point: a run that came from a kaambaan claim carries the board's id and says who minted it. AgentPod's own `id` is a separate, local key in a different id space — it does not, and now cannot, restate kaambaan's.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalRunId": "run_e074a2160c4b4f28",
@@ -43,16 +49,15 @@
         "state": "working",
         "startSeq": 4,
         "endSeq": null,
-        "startedAt": "2026-08-13T10:00:00.000Z",
-        "endedAt": null
+        "startedAt": "2026-08-13T10:00:00.000Z"
       }
     },
     {
       "name": "local_run_no_board_attached",
       "mustParse": true,
-      "why": "The console must keep working with no board attached at all, which is why the external pair is optional rather than required (run.ts:48-54). A regression that made externalRunId mandatory would break every hand-driven Chat session in the fleet.",
+      "why": "The console must keep working with no board attached at all, which is why the external pair is optional rather than required. A regression that made externalRunId mandatory would break every hand-driven Chat session in the fleet.",
       "value": {
-        "id": "run_3d4e5f60718293a4b5c6",
+        "id": "attempt_3d4e5f60-7182-4a4b-8c56-51b6c7e8f0a2",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "state": "submitted",
@@ -63,9 +68,9 @@
     {
       "name": "dispatched_run_from_another_orchestrator",
       "mustParse": true,
-      "why": "`externalSource` is deliberately open so AgentPod is not kaambaan-only. A validator that hard-codes the literal \"kaambaan\" would make the field a boolean with extra steps and lock the hub to one board.",
+      "why": "`externalSource` is deliberately open so AgentPod is not kaambaan-only, and an external id therefore has no single grammar — a validator that hard-coded kaambaan's would lock the hub to one board. The one thing an external id may not be is one of AgentPod's own.",
       "value": {
-        "id": "run_7b2e9a103c5d4e8fb012",
+        "id": "attempt_7b2e9a10-3c5d-4e8f-b012-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalRunId": "wf-2026-08-13-0042",
@@ -80,7 +85,7 @@
       "mustParse": true,
       "why": "Closing a run must fill both the sequence and the timestamp. A run is a prompt-turn, so endSeq is the seq of the event that closed it — a permission request mid-attempt does not close it.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalRunId": "run_e074a2160c4b4f28",
@@ -94,11 +99,54 @@
     },
 
     {
+      "name": "own_id_is_a_kaambaan_work_run_id",
+      "mustParse": false,
+      "why": "THE COLLISION CASE. AgentPod's primary key used to be spelled `run_…`, exactly like kaambaan's work run, so a row could restate the board's id as its own and nothing could tell the two apart. `id` is now AgentPod's own id space and a kaambaan-shaped run id must not parse there. Reverting the prefix to `run_` makes this case pass when it must fail.",
+      "value": {
+        "id": "run_e074a2160c4b4f28",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "run_e074a2160c4b4f28",
+        "externalSource": "kaambaan",
+        "state": "working",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "own_id_in_the_old_prefix_even_when_locally_minted",
+      "mustParse": false,
+      "why": "The subtler half: a `run_`-prefixed id that is not kaambaan's either. The old grammar was `run_` + a uuid-ish suffix; a hub still minting that shape has not moved id spaces, it has only avoided a literal clash. The prefix itself is what must be gone.",
+      "value": {
+        "id": "run_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "state": "working",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
+      "name": "external_run_id_from_agentpods_own_space",
+      "mustParse": false,
+      "why": "The mirror of 'we never mint a rival id'. An `attempt_…` arriving as an external run id is either AgentPod's own key copied into the wrong column or a dispatch loop; in neither case is it a board's identifier, and joining on it through acp_runs_external_idx would point back at this hub.",
+      "value": {
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
+        "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
+        "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
+        "externalRunId": "attempt_3d4e5f60-7182-4a4b-8c56-51b6c7e8f0a2",
+        "externalSource": "kaambaan",
+        "state": "working",
+        "startSeq": 4,
+        "startedAt": "2026-08-13T10:00:00.000Z"
+      }
+    },
+    {
       "name": "external_run_id_without_a_source",
       "mustParse": false,
-      "why": "An external run id that does not say who minted it is unattributable, and — because both repos claim the `run_` prefix — indistinguishable from AgentPod's own key. The reverse join through acp_runs_external_idx would return a row that cannot be traced to a board. The two fields are one fact and must arrive together.",
+      "why": "An external run id that does not say who minted it is unattributable. Disjoint prefixes establish that the value is not AgentPod's own, but `externalSource` is deliberately open, so the shape alone cannot say WHICH orchestrator it belongs to and the reverse join through acp_runs_external_idx would return a row that cannot be traced to a board. The two fields are one fact and must arrive together.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalRunId": "run_e074a2160c4b4f28",
@@ -112,7 +160,7 @@
       "mustParse": false,
       "why": "The mirror image: naming an orchestrator with no id from it records an origin nothing can be joined back to.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalSource": "kaambaan",
@@ -126,7 +174,7 @@
       "mustParse": false,
       "why": "An empty string is not 'no external run'; absent is. Accepting it writes a falsy value into an indexed column that then joins to nothing.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalRunId": "",
@@ -141,7 +189,7 @@
       "mustParse": false,
       "why": "RunState is A2A's vocabulary verbatim so the board needs no translation table. `errored` was the earlier in-house proposal and must not parse; kaambaan spells `canceled` with one l for the same reason.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "externalRunId": "run_e074a2160c4b4f28",
@@ -156,7 +204,7 @@
       "mustParse": false,
       "why": "The spelling trap. A2A and kaambaan both use one l; a hub that accepted both would produce runs the board cannot classify.",
       "value": {
-        "id": "run_9f1c2ab04d7e6b3a5c88",
+        "id": "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
         "sessionId": "acps_e074a216-0c4b-4f28-9d3a-51b6c7e8f0a2",
         "stationId": "station_4a1482de-9c3f-4b17-8a55-0d6e2f7c1b90",
         "state": "cancelled",
@@ -172,7 +220,7 @@
     "terminal": ["completed", "rejected", "failed", "canceled"],
     "interrupted": ["input-required", "auth-required"],
     "sources": [
-      "agentpod packages/contract/src/run.ts:18-31",
+      "agentpod packages/contract/src/run.ts — RunState, TERMINAL_RUN_STATES, INTERRUPTED_RUN_STATES",
       "kaambaan packages/contract/src/primitives.ts:7-21 — `TaskState`, verified identical member-for-member and order-for-order on 2026-08-13"
     ]
   }

--- a/packages/contract/src/ecosystem-identity.test.ts
+++ b/packages/contract/src/ecosystem-identity.test.ts
@@ -33,6 +33,7 @@ import {
   EnrollmentTokenId,
   StationId,
   AcpSessionId,
+  AcpRunId,
   UserId,
 } from "./ids";
 import { Run, RunState, TERMINAL_RUN_STATES, INTERRUPTED_RUN_STATES } from "./run";
@@ -60,6 +61,12 @@ type IdGrammar = {
   prefixRegistry: {
     claims: Array<{ prefix: string; owner: string; entity: string; status: string }>;
     knownConflicts: Array<{ prefix: string; claimedBy: string[] }>;
+    resolvedConflicts: Array<{
+      prefix: string;
+      wasClaimedBy: string[];
+      nowClaimedBy: string;
+      resolution: string;
+    }>;
   };
 };
 
@@ -88,6 +95,7 @@ const VALIDATORS: Record<string, ZodType> = {
   "agentpod.enrollmentToken": EnrollmentTokenId,
   "agentpod.station": StationId,
   "agentpod.acpSession": AcpSessionId,
+  "agentpod.acpRun": AcpRunId,
   "agentpod.user": UserId,
 };
 
@@ -157,29 +165,87 @@ describe("ecosystem identity corpus — id grammar", () => {
 });
 
 describe("ecosystem identity corpus — prefix registry", () => {
-  test("no prefix is claimed by two owners except the recorded conflicts", () => {
+  const contestedPrefixes = (): string[] => {
     const byPrefix = new Map<string, Set<string>>();
     for (const c of grammar.prefixRegistry.claims) {
       byPrefix.set(c.prefix, (byPrefix.get(c.prefix) ?? new Set()).add(c.owner));
     }
-    const contested = [...byPrefix.entries()]
+    return [...byPrefix.entries()]
       .filter(([, owners]) => owners.size > 1)
       .map(([prefix]) => prefix)
       .sort();
+  };
+
+  test("no prefix is claimed by two owners except the recorded conflicts", () => {
     const known = grammar.prefixRegistry.knownConflicts.map((c) => c.prefix).sort();
 
-    // A NEW collision must fail here. `run` is already recorded: kaambaan mints
-    // it, and AgentPod reserves it for acp_runs.id in a schema comment two lines
-    // above "We never mint a rival id". Nothing mints AgentPod's yet, so nothing
-    // is broken — but the day one does, a bare `run_…` stops saying which system
-    // produced it.
-    expect(contested).toEqual(known);
+    // A NEW collision must fail here, and `knownConflicts` is now empty — so any
+    // second owner appearing against any prefix fails this test outright. This
+    // is the guard that catches `run_` coming back: re-pointing acp_runs.id at
+    // `run` means re-adding an agentpod claim on a prefix kaambaan already owns.
+    expect(contestedPrefixes()).toEqual(known);
   });
 
-  test("`run` is a known, unresolved conflict rather than a resolved one", () => {
-    const conflict = grammar.prefixRegistry.knownConflicts.find((c) => c.prefix === "run");
-    expect(conflict?.claimedBy.sort()).toEqual(["agentpod", "kaambaan"]);
+  test("`run` is resolved: kaambaan alone claims it", () => {
+    // Was a knownConflict. AgentPod's acp_runs.id moved to `attempt_` — an id
+    // space kaambaan does not claim — so the prefix has exactly one owner again.
+    expect(grammar.prefixRegistry.knownConflicts.map((c) => c.prefix)).not.toContain("run");
+
+    const owners = grammar.prefixRegistry.claims
+      .filter((c) => c.prefix === "run")
+      .map((c) => c.owner);
+    expect(owners).toEqual(["kaambaan"]);
   });
+
+  test("a resolved conflict is resolved in the claims, not merely declared resolved", () => {
+    // Moving an entry from knownConflicts to resolvedConflicts without actually
+    // giving up the claim would be exactly the kind of paper fix this corpus is
+    // meant to catch. Every resolved prefix must now have one owner, and that
+    // owner must be the one the resolution names.
+    for (const r of grammar.prefixRegistry.resolvedConflicts) {
+      const owners = [
+        ...new Set(
+          grammar.prefixRegistry.claims.filter((c) => c.prefix === r.prefix).map((c) => c.owner),
+        ),
+      ];
+      expect(owners, `${r.prefix} must have exactly one owner after resolution`).toEqual([
+        r.nowClaimedBy,
+      ]);
+      expect(contestedPrefixes()).not.toContain(r.prefix);
+    }
+  });
+
+  test("AgentPod's acp run prefix collides with nothing either repo claims", () => {
+    const acpRun = grammar.entities.find((e) => e.entity === "agentpod.acpRun")!;
+    const others = grammar.prefixRegistry.claims.filter(
+      (c) => c.prefix === acpRun.prefix && c.entity !== "acpRun",
+    );
+    expect(others).toEqual([]);
+  });
+});
+
+describe("ecosystem identity corpus — id spaces are mutually exclusive", () => {
+  // The general form of the `run_` collision. A comment saying "we never mint a
+  // rival id" did not prevent it; this does: every validator is shown every
+  // other entity's canonical minted id and must reject all of them. A new
+  // collision between any two entities fails here without anyone remembering to
+  // write a test for it.
+  for (const entity of grammar.entities) {
+    const schema = VALIDATORS[entity.entity];
+    if (!schema) continue;
+
+    test(`${entity.entity} rejects every other entity's minted id`, () => {
+      const foreign = grammar.entities
+        .filter((e) => e.entity !== entity.entity)
+        .flatMap((e) => e.accept.filter((c) => c.mint).map((c) => ({ entity: e.entity, ...c })));
+
+      const wronglyAccepted = foreign.filter((c) => schema.safeParse(c.value).success);
+      expect(
+        wronglyAccepted.map((c) => `${c.entity}:${c.value}`),
+        `${entity.entity}'s validator accepts an id minted for another entity`,
+      ).toEqual([]);
+    });
+  }
 });
 
 // ─── run_join_key.json ───────────────────────────────────────────────────────
@@ -195,13 +261,15 @@ type RunJoinKey = {
 const joinKey = readCorpus<RunJoinKey>("run_join_key.json");
 
 describe("ecosystem identity corpus — run join key", () => {
-  test("records that nothing enforces the invariant yet", () => {
-    // Honest bookkeeping. `acp_runs.external_run_id` and `Run.externalRunId`
-    // exist and are indexed, but nothing inserts into acp_runs, no route accepts
-    // an external run id, and the bridge spike correlates a kaambaan run to an
-    // AgentPod session in a console.log line and nowhere else. When a write path
-    // lands, this string changes and this test is the reminder to change it.
-    expect(joinKey.enforcement.status).toBe("carried-in-schema-only");
+  test("records how far enforcement has actually got", () => {
+    // Honest bookkeeping. Half the invariant is now executable: the two id
+    // spaces are disjoint, `Run.id` is validated against AgentPod's, and
+    // acp_runs carries CHECK constraints saying the same thing in the database.
+    // The other half is still absent — nothing inserts into acp_runs, no route
+    // accepts an external run id, and the bridge spike correlates a kaambaan run
+    // to an AgentPod session in a console.log line and nowhere else. When a
+    // write path lands, this string changes and this test is the reminder.
+    expect(joinKey.enforcement.status).toBe("id-spaces-disjoint-no-write-path");
   });
 
   for (const c of joinKey.cases) {
@@ -223,6 +291,20 @@ describe("ecosystem identity corpus — run join key", () => {
     expect(parsed.externalRunId).toBe("run_e074a2160c4b4f28");
     expect(parsed.externalSource).toBe("kaambaan");
     expect(parsed.id).not.toBe(parsed.externalRunId);
+  });
+
+  test("the two ids on a dispatched run are told apart by shape, not by column", () => {
+    // What replaces the comment. Before the rename both fields held `run_…` and
+    // only the column name said which system a value came from; a row read out
+    // of context was ambiguous. Now each id parses under exactly one grammar.
+    const dispatched = joinKey.cases.find((c) => c.name === "dispatched_run")!;
+    const parsed = Run.parse(dispatched.value);
+
+    expect(AcpRunId.safeParse(parsed.id).success).toBe(true);
+    expect(KaambaanRunId.safeParse(parsed.id).success).toBe(false);
+
+    expect(KaambaanRunId.safeParse(parsed.externalRunId).success).toBe(true);
+    expect(AcpRunId.safeParse(parsed.externalRunId).success).toBe(false);
   });
 
   test("kaambaan's run id in the fixture is valid by kaambaan's own grammar", () => {

--- a/packages/contract/src/ids.ts
+++ b/packages/contract/src/ids.ts
@@ -47,8 +47,13 @@ export const KaambaanUserId = kaambaanId("usr");
 export const KaambaanMembershipId = kaambaanId("mbr");
 export const KaambaanAgentId = kaambaanId("agt");
 /**
- * The run join key. kaambaan mints the work run; AgentPod executes it and never
- * mints a rival id for the same attempt (see `Run.externalRunId` in ./run.ts).
+ * The run join key, and `run_` belongs to it alone.
+ *
+ * kaambaan mints the work run; AgentPod executes it and never mints a rival id
+ * for the same attempt (see `Run.externalRunId` in ./run.ts). AgentPod used to
+ * reserve this same prefix for `acp_runs.id`, which made the two id spaces
+ * indistinguishable strings; AgentPod's own key is now `AcpRunId` below, and
+ * the corpus asserts that neither grammar accepts the other's ids.
  */
 export const KaambaanRunId = kaambaanId("run");
 
@@ -98,6 +103,37 @@ export const EnrollmentTokenId = truncatedUuidId("etk");
 export const StationId = uuidSuffixedId("station");
 export const AcpSessionId = uuidSuffixedId("acps");
 export const AuditEntryId = uuidSuffixedId("audit");
+
+/**
+ * `acp_runs.id` — one **attempt** on a station, and deliberately not `run_`.
+ *
+ * The prefix was `run_`, colliding head-on with the id kaambaan mints for a work
+ * run: the schema file declared `"run_" + uuid-ish` six lines above the comment
+ * "We never mint a rival id", and a `run_…` in an AgentPod row could not be told
+ * from a kaambaan one without reading a second column. AgentPod moved rather
+ * than kaambaan because AgentPod is the executor: kaambaan mints these ids and
+ * has live production data, while nothing here has ever inserted an `acp_runs`
+ * row at any commit, so the rename cost nothing — and would stop being free the
+ * moment the bridge writes its first run.
+ *
+ * `attempt` is not a euphemism for `run`. A run here is a **prompt-turn** — it
+ * opens when a prompt is submitted and closes when the agent yields — while
+ * kaambaan's work run is a claimed card, which takes as many prompt-turns as the
+ * work takes. One work run is therefore executed as a series of attempts, and
+ * the counts never matched: the two were never the same entity, whatever the
+ * shared prefix implied.
+ *
+ * Hyphenated-UUID family, matching its sibling `acps_` in the same subsystem
+ * (`acp_runs.session_id` is a FK to `acp_sessions.id`). `acpr_` was considered
+ * and rejected: one character from `acps_`, and the live `acp_`/`acps_` near-miss
+ * between the node-agent and the hub is already trap enough.
+ *
+ * Unlike the grammars above, this one **is** applied — to `Run.id` in ./run.ts.
+ * The retrofit caveat in this module's header is about rejecting rows that
+ * already exist; there are none, which is exactly what makes adoption safe here
+ * and not yet safe for `NodeSummary.id` and friends.
+ */
+export const AcpRunId = uuidSuffixedId("attempt");
 
 /**
  * AgentPod's principal id: a bare UUID with no prefix at all.

--- a/packages/contract/src/run.test.ts
+++ b/packages/contract/src/run.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { RunState, TERMINAL_RUN_STATES, isRunTerminal, Run, Change } from "./run";
+import { AcpRunId, KaambaanRunId } from "./ids";
 
 describe("RunState — A2A vocabulary, adopted verbatim", () => {
   test("is exactly the A2A task state set", () => {
@@ -39,13 +40,42 @@ describe("RunState — A2A vocabulary, adopted verbatim", () => {
 
 describe("Run — a station attempt", () => {
   const base = {
-    id: "run_01J2",
+    id: "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
     sessionId: "acps_abc",
     stationId: "station_xyz",
     state: "working" as const,
     startSeq: 4,
     startedAt: "2026-08-11T10:00:00.000Z",
   };
+
+  test("mints its own id under `attempt_`, an id space kaambaan does not claim", () => {
+    // The rename. `run_` belonged to kaambaan's work run and AgentPod reserved
+    // the same prefix for this primary key, so the two were indistinguishable
+    // strings. An AgentPod row's own key is now `attempt_<uuid>` and a kaambaan
+    // run id cannot be one.
+    expect(Run.parse(base).id).toBe("attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90");
+    expect(Run.safeParse({ ...base, id: "run_e074a2160c4b4f28" }).success).toBe(false);
+  });
+
+  test("the two id spaces are mutually exclusive, in both directions", () => {
+    // Told apart by shape, not by which column they happen to sit in.
+    expect(AcpRunId.safeParse("run_e074a2160c4b4f28").success).toBe(false);
+    expect(
+      KaambaanRunId.safeParse("attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90").success,
+    ).toBe(false);
+  });
+
+  test("refuses to record one of its own attempt ids as an external run id", () => {
+    // The mirror of "we never mint a rival id": an external id from AgentPod's
+    // own space is either a bug or a loop, and either way it is not a board's.
+    expect(
+      Run.safeParse({
+        ...base,
+        externalRunId: "attempt_3d4e5f60-7182-4a4b-8c56-51b6c7e8f0a2",
+        externalSource: "kaambaan",
+      }).success,
+    ).toBe(false);
+  });
 
   test("accepts a local attempt with no external run id", () => {
     // The console must keep working with no board attached at all.
@@ -62,10 +92,10 @@ describe("Run — a station attempt", () => {
 
   test("rejects an external run id with no source, and a source with no id", () => {
     // Regression: both fields were independently optional, so a run could record
-    // kaambaan's id without saying it was kaambaan's. Because both repos claim
-    // the `run_` prefix, an unattributed `run_…` is indistinguishable from
-    // AgentPod's own key, and the acp_runs_external_idx reverse join returns a
-    // row that cannot be traced to a board.
+    // kaambaan's id without saying it was kaambaan's. Disjoint prefixes now say
+    // the id is not AgentPod's, but not which of several possible orchestrators
+    // it belongs to — `externalSource` is open (§7), so the reverse join through
+    // acp_runs_external_idx still needs the source to reach the right board.
     expect(Run.safeParse({ ...base, externalRunId: "run_e074a2160c4b4f28" }).success).toBe(false);
     expect(Run.safeParse({ ...base, externalSource: "kaambaan" }).success).toBe(false);
   });
@@ -107,8 +137,22 @@ describe("Change — the thing that lands", () => {
   test("accumulates many runs — runIds is a list, not a single run", () => {
     // A change outlives the run that produced it: first attempt, revision after
     // review, CI fix.
-    const c = Change.parse({ ...base, runIds: ["run_a", "run_b", "run_c"] });
+    const c = Change.parse({
+      ...base,
+      runIds: [
+        "attempt_9f1c2ab0-4d7e-4b3a-8c88-0d6e2f7c1b90",
+        "attempt_3d4e5f60-7182-4a4b-8c56-51b6c7e8f0a2",
+        "attempt_7b2e9a10-3c5d-4e8f-b012-0d6e2f7c1b90",
+      ],
+    });
     expect(c.runIds).toHaveLength(3);
+  });
+
+  test("runIds holds AgentPod attempts, never a board's work run", () => {
+    // A change is assembled from attempts that ran here. A `run_…` in this list
+    // would be a kaambaan work run standing in for the attempts that produced
+    // the commit — the same conflation the prefix split exists to prevent.
+    expect(Change.safeParse({ ...base, runIds: ["run_e074a2160c4b4f28"] }).success).toBe(false);
   });
 
   test("defaults to an empty run list rather than requiring one", () => {

--- a/packages/contract/src/run.ts
+++ b/packages/contract/src/run.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { AcpRunId } from "./ids";
+
 // ─── Run state ───────────────────────────────────────────────────────────────
 
 /**
@@ -52,16 +54,26 @@ export const isRunInterrupted = (s: RunState): boolean =>
  * with no board attached at all, which is why it is optional rather than
  * required.
  *
+ * `id` is AgentPod's own key and lives in a **different id space** — `attempt_`,
+ * not `run_` — so which system minted a value is legible from the value itself
+ * rather than from the column it happens to sit in. Both directions are refused
+ * below: a kaambaan work run id cannot be this row's `id` (`AcpRunId` rejects
+ * it), and one of AgentPod's own attempt ids cannot be an `externalRunId`. That
+ * is the invariant §3 states, made executable — the comment that used to say
+ * "we never mint a rival id" sat six lines under a schema comment declaring the
+ * rival id, and did not prevent it.
+ *
  * The two external fields are **one fact and arrive together**, enforced below.
- * An `externalRunId` with no source is unattributable — and because both repos
- * currently claim the `run_` prefix (kaambaan mints it; `acp_runs.id` reserves
- * it in a schema comment), a bare `run_…` does not say which system produced it.
- * The reverse join the board needs, `acp_runs_external_idx`, would then return a
- * row that cannot be traced back to a board. A source with no id is the mirror
- * image: an origin nothing can be joined to.
+ * An `externalRunId` with no source is unattributable: disjoint prefixes say the
+ * id is not AgentPod's, but `externalSource` is deliberately open (§7), so shape
+ * alone cannot say *which* orchestrator it belongs to, and the reverse join the
+ * board needs, `acp_runs_external_idx`, would return a row that cannot be traced
+ * back to a board. A source with no id is the mirror image: an origin nothing
+ * can be joined to.
  */
 const Run_ = z.object({
-  id: z.string().min(1),
+  /** AgentPod's own key for this attempt — `attempt_<uuid>`, never kaambaan's `run_`. */
+  id: AcpRunId,
   sessionId: z.string().min(1),
   stationId: z.string().min(1),
 
@@ -88,7 +100,15 @@ export const Run = Run_.refine(
       "externalRunId and externalSource must both be present or both absent — an external run id with no source cannot be joined back to the orchestrator that minted it",
     path: ["externalSource"],
   },
-);
+).refine((r) => r.externalRunId === undefined || !AcpRunId.safeParse(r.externalRunId).success, {
+  // An `attempt_…` arriving as an external id is either AgentPod's own key
+  // copied into the wrong column or a dispatch loop. Either way it is not a
+  // board's identifier, and the reverse join through acp_runs_external_idx
+  // would point back at this hub.
+  message:
+    "externalRunId must not be one of AgentPod's own attempt ids — an external run belongs to the orchestrator that minted it",
+  path: ["externalRunId"],
+});
 export type Run = z.infer<typeof Run>;
 
 // ─── Change ──────────────────────────────────────────────────────────────────
@@ -118,14 +138,17 @@ export type ChangeStatus = z.infer<typeof ChangeStatus>;
  * another's (§7).
  *
  * `runIds` is a list because a change outlives the run that produced it — a
- * first attempt, a revision after review, a CI fix.
+ * first attempt, a revision after review, a CI fix. They are AgentPod attempt
+ * ids, never a board's work run: the work run is upstream of all of them, and
+ * substituting it here is the same conflation the `run_`/`attempt_` split
+ * exists to prevent.
  */
 export const Change = z.object({
   id: z.string().min(1),
   stationId: z.string().min(1),
 
   /** Every attempt that contributed. Runs are immutable; the change is not. */
-  runIds: z.array(z.string().min(1)).default([]),
+  runIds: z.array(AcpRunId).default([]),
 
   /** The commit this change is built against. */
   baseRef: z.string().min(1),


### PR DESCRIPTION
## The collision

Both products minted `run_`:

- **kaambaan** mints `run_<16 hex>` for a work run, and has live production data.
- **AgentPod** reserved `run_` for `acp_runs.id`. `apps/hub/src/db/schema/acp.ts:69` declared the primary key as `"run_" + uuid-ish`; six lines below, line 74 said **"We never mint a rival id"**. The file minted one in the same breath.

Two *indistinguishable strings*. A `run_…` read out of an AgentPod row could not be told from a board's without a second column, which is precisely what the suite invariant forbids — *kaambaan mints the work run; AgentPod executes it; no competing run ID for dispatched work.*

## The prefix: `attempt_<uuid>`

It is obviously AgentPod's and obviously not a work run, and the word is load-bearing rather than decorative:

> An AgentPod run is a **prompt-turn** — it opens when a prompt is submitted and closes when the agent yields (a permission request does not close it). kaambaan's work run is a **claimed card**, which takes as many prompt-turns as the work takes.

One work run is executed as a *series* of attempts. The two never counted 1:1, so they were never the same entity, whatever the shared prefix implied — the new shapes say so out loud.

Family and near-miss checks:

- Hyphenated-UUID family, matching its sibling `acps_` in the same subsystem (`acp_runs.session_id` is a FK to `acp_sessions.id`).
- **`acpr_` was considered and rejected**: one character from `acps_`, and the corpus already records the live `acp_`/`acps_` near-miss between the node-agent and the hub. Adding a third neighbour to that cluster trades one trap for another.
- `attempt` is claimed by neither repo — asserted, not assumed.

## Why AgentPod moves, and the migration conclusion

**No data migration is needed.** Established from the code rather than taken on trust:

| Question | Evidence |
|---|---|
| Does any code insert into `acp_runs`? | No. `grep -rn "acpRuns" apps/` outside the schema file finds only tests. |
| Did it ever, at any commit? | No. `git log -S "insert(acpRuns"` is empty across all history; `git log -S "acpRuns" -- apps/hub/src` returns exactly one commit — the one that added the table. |
| Could a row exist anyway? | The table was created six days ago by `0028_outgoing_magneto.sql` and has never had a writer in any shipped version. |

So no environment can hold an `acp_runs` row, let alone one carrying the old prefix. That is what made this free today — and what stops being free the moment the bridge writes its first run, which is the next thing being built. AgentPod is the executor, not the minter; kaambaan mints these ids and has live data, so AgentPod is the side that moves.

The test suite now asserts the zero-row claim rather than leaving it in a PR description (`no row anywhere carries the old "run_" prefix`), so if it is ever false, it fails loudly instead of being silently carried forward.

## What enforces the invariant now, beyond a comment

A comment saying "we never mint a rival id" sat six lines under the rival id and did not prevent it. Three layers replace it:

**1. Contract** — `AcpRunId` (`^attempt_<uuid>$`) in `packages/contract/src/ids.ts`, applied to `Run.id` and `Change.runIds`, plus a refine refusing an `attempt_…` as an `externalRunId` (the mirror direction: an external id from AgentPod's own space is a bug or a dispatch loop, never a board's identifier).

Adoption is safe here and still not safe for `NodeSummary.id` and friends — for exactly the reason the rename was free. The retrofit caveat in `ids.ts` is about rejecting rows that already exist; there are none.

**2. Database** — migration `0035_acp_runs_id_space.sql` adds three CHECK constraints, so a future writer that bypasses the contract still cannot bypass the table:

| Constraint | Prevents |
|---|---|
| `acp_runs_id_is_agentpod_attempt` | an orchestrator's work run standing in as this hub's primary key |
| `acp_runs_external_is_not_agentpod` | one of our own ids recorded as somebody else's |
| `acp_runs_external_pair` | #307's paired presence, at the storage layer |

`tests/integration/acp-runs-id-space.test.ts` exercises all three against real Postgres rather than drizzle's in-memory table config — a check declared in TypeScript but never migrated would pass a config assertion and enforce nothing.

**3. Corpus** (`fixtures/ecosystem-identity/`) — recorded as resolved, not weakened:

- `run` moves from `knownConflicts` to a new `resolvedConflicts`, and **the move is checked rather than trusted**: a resolved prefix must have exactly one owner left in `claims`. Declaring a conflict resolved while still claiming the prefix fails the suite.
- `knownConflicts` is now empty, which makes the pre-existing "no prefix has two owners" guard absolute — any new collision fails outright.
- New entity `agentpod.acpRun`, whose reject list carries both the kaambaan minted shape *and* the exact old AgentPod grammar (`run_<uuid>`), so sneaking the contested prefix back with a different suffix also fails.
- New test: **every validator is shown every other entity's canonical minted id and must reject all of them.** That is the general form of this bug — the next collision between any two entities fails without anyone remembering to write a test for it.
- `enforcement.status` moves from `carried-in-schema-only` to `id-spaces-disjoint-no-write-path`. Honest bookkeeping: the id spaces are now enforced, the write path still does not exist.

Nothing in kaambaan changes — the corpus asks it to keep minting exactly what it already mints.

## Mutation results

| Mutation | Result |
|---|---|
| Revert the prefix — `AcpRunId = uuidSuffixedId("run")` | **15 contract tests fail**, including the corpus-driven `agentpod.acpRun > rejects every id the corpus says it must` and `rejects: own_id_in_the_old_prefix_even_when_locally_minted`. The corpus catches it. |
| Accept a kaambaan-shaped id where AgentPod's own is required — `id: z.union([AcpRunId, KaambaanRunId])` | **2 tests fail**: `rejects: own_id_is_a_kaambaan_work_run_id` and ``mints its own id under `attempt_` ``. The failure prints the corpus's own explanation of why the case exists. |

At the DB layer the same was observed as a before/after: every constraint test reported `(accepted — no constraint rejected the row)` before 0035, and the constraint name after.

## Verification

- `cd packages/contract && bun test` — **197 pass, 0 fail**
- `cd apps/hub && DATABASE_URL=… bun test` — **849 pass, 0 fail** (841 before, +8 new integration tests)
- `bun run typecheck` in `apps/hub` — **exactly 15 errors**, the known-red pre-existing set; none added. Contract typecheck unchanged at its 4 pre-existing `rootDir` errors.

TDD throughout: the contract tests failed first on a missing `AcpRunId` export, and the integration tests failed first because every insert was accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
