### PR TITLE
feat: give AgentPod a real isolation boundary (local tenant, `fleet_` id space)

### DIFF
--- a/apps/hub/src/auth/middleware.ts
+++ b/apps/hub/src/auth/middleware.ts
@@ -11,6 +11,7 @@ import { createMiddleware } from "hono/factory";
 import type { Context, Next } from "hono";
 import { timingSafeEqual } from "crypto";
 import { auth, type Session, type User } from "./drizzle-auth";
+import { BOOTSTRAP_TENANT_ID } from "./tenant";
 import { config } from "../config";
 import { createLogger } from "../utils/logger";
 
@@ -41,6 +42,16 @@ export interface AuthUser {
   name?: string;
   image?: string;
   authType: "better_auth" | "api_key";
+  /**
+   * The isolation boundary this caller acts in.
+   *
+   * Resolved here, at the same layer that resolves `config.defaultUserId` for
+   * the service-auth caller — which is plain configuration and never was a
+   * membership lookup either. One tenant exists today, so every authenticated
+   * caller gets it; when the Organization plane arrives this becomes a
+   * membership lookup and nothing below this layer changes. See ./tenant.ts.
+   */
+  tenantId: string;
 }
 
 /**
@@ -73,6 +84,7 @@ export const sessionMiddleware = createMiddleware(async (c: Context, next: Next)
         name: session.user.name,
         image: session.user.image ?? undefined,
         authType: "better_auth",
+        tenantId: BOOTSTRAP_TENANT_ID,
       });
       c.set("session", session.session);
       c.set("betterAuthUser", session.user);
@@ -82,6 +94,7 @@ export const sessionMiddleware = createMiddleware(async (c: Context, next: Next)
       c.set("user", {
         id: "anonymous",
         authType: "api_key",
+        tenantId: BOOTSTRAP_TENANT_ID,
       });
       c.set("session", null);
       c.set("betterAuthUser", null);
@@ -91,6 +104,7 @@ export const sessionMiddleware = createMiddleware(async (c: Context, next: Next)
     c.set("user", {
       id: "anonymous",
       authType: "api_key",
+      tenantId: BOOTSTRAP_TENANT_ID,
     });
     c.set("session", null);
     c.set("betterAuthUser", null);
@@ -126,6 +140,7 @@ export const authMiddleware = createMiddleware(async (c: Context, next: Next) =>
         name: session.user.name,
         image: session.user.image ?? undefined,
         authType: "better_auth",
+        tenantId: BOOTSTRAP_TENANT_ID,
       });
       c.set("session", session.session);
       c.set("betterAuthUser", session.user);
@@ -151,6 +166,7 @@ export const authMiddleware = createMiddleware(async (c: Context, next: Next) =>
       c.set("user", {
         id: config.defaultUserId,
         authType: "api_key",
+        tenantId: BOOTSTRAP_TENANT_ID,
       });
       c.set("session", null);
       c.set("betterAuthUser", null);
@@ -170,6 +186,7 @@ export const authMiddleware = createMiddleware(async (c: Context, next: Next) =>
           name: session.user.name,
           image: session.user.image ?? undefined,
           authType: "better_auth",
+          tenantId: BOOTSTRAP_TENANT_ID,
         });
         c.set("session", session.session);
         c.set("betterAuthUser", session.user);
@@ -219,6 +236,7 @@ export const optionalAuthMiddleware = createMiddleware(async (c: Context, next: 
         name: session.user.name,
         image: session.user.image ?? undefined,
         authType: "better_auth",
+        tenantId: BOOTSTRAP_TENANT_ID,
       });
       c.set("session", session.session);
       c.set("betterAuthUser", session.user);
@@ -238,6 +256,7 @@ export const optionalAuthMiddleware = createMiddleware(async (c: Context, next: 
       c.set("user", {
         id: config.defaultUserId,
         authType: "api_key",
+        tenantId: BOOTSTRAP_TENANT_ID,
       });
       c.set("session", null);
       c.set("betterAuthUser", null);

--- a/apps/hub/src/auth/tenant.ts
+++ b/apps/hub/src/auth/tenant.ts
@@ -1,0 +1,57 @@
+/**
+ * How a request finds its tenant.
+ *
+ * **Today: one tenant, and every principal reaches it.** That is not a
+ * placeholder pretending to be a lookup — it is the honest answer while exactly
+ * one tenant exists, and it is deliberately written as a *resolution function*
+ * rather than as a default sprinkled across call sites. A default is something a
+ * caller forgets; a function is something a caller asks.
+ *
+ * **Where it extends.** This sits at the same layer that already resolves
+ * `config.defaultUserId` for the service-auth caller (`auth/middleware.ts`,
+ * `config.ts:248`) — which is plain configuration and never was a membership
+ * lookup either. When the Organization plane exists, `resolveTenantForUser`
+ * becomes the membership lookup and every call site below is already asking the
+ * right question, so the change is confined to this file.
+ *
+ * **What this deliberately is not.** It is not membership, roles, invites or a
+ * tenant switcher: the Organization plane owns those (ecosystem decision 4, and
+ * the reason MT-1 (#145) was reshaped). AgentPod scopes its own rows and
+ * consumes principals; it does not model who may reach what.
+ *
+ * Note the asymmetry with child rows. A station's tenant is its node's and an
+ * acp_event's is its session's — those are *derived from the parent*, not from
+ * the request, and the composite foreign keys in migration 0036 enforce it. A
+ * request cannot assert a tenant that contradicts a row's parent, which is why
+ * only root rows consult this module at all.
+ */
+
+import type { Context } from "hono";
+
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
+
+export { BOOTSTRAP_TENANT_ID };
+
+/**
+ * The tenant a principal acts in.
+ *
+ * Async from the start, because the thing it becomes — a membership lookup — is,
+ * and a signature change later would touch every caller for no reason.
+ */
+export async function resolveTenantForUser(_userId: string): Promise<string> {
+  // One tenant exists (created by migration 0036) and every principal reaches
+  // it. When a second becomes possible this is a membership query, and a
+  // principal belonging to no tenant must fail closed rather than fall back
+  // here — which is a change to this function and to nothing else.
+  return BOOTSTRAP_TENANT_ID;
+}
+
+/**
+ * The tenant of the caller on this request, from the auth middleware.
+ *
+ * Falls back to resolving from the principal for the handful of routes that run
+ * without the middleware having populated the context.
+ */
+export function resolveTenantId(c: Context): string {
+  return c.get("user")?.tenantId ?? BOOTSTRAP_TENANT_ID;
+}

--- a/apps/hub/src/db/drizzle-migrations/0036_tenant_isolation_boundary.sql
+++ b/apps/hub/src/db/drizzle-migrations/0036_tenant_isolation_boundary.sql
@@ -1,0 +1,163 @@
+-- AgentPod's local isolation boundary.
+--
+-- Before this migration every row in the hub hung off a `user_id` and nothing
+-- above it. A `user_id` predicate is an ownership filter, not an isolation
+-- boundary: it answers "whose is this" and cannot answer "which organisation is
+-- this inside", because a user here belonged to no larger thing. This creates
+-- the larger thing and puts every row that belongs to one inside it.
+--
+-- The boundary is LOCAL on purpose. Neither AgentPod nor kaambaan owns the
+-- organisation — that belongs to an Organization plane that does not exist yet —
+-- and both products must keep running standalone, so each keeps its own tenant
+-- and records an optional external mapping to the same real organisation
+-- elsewhere. Hence `fleet_`, not kaambaan's `tnt_`; hence external_id and
+-- external_source, nullable and paired.
+--
+-- **This is a backfill migration, not a fresh-schema one.** The generated form
+-- of this change was `ALTER TABLE … ADD COLUMN "tenant_id" text NOT NULL`, which
+-- succeeds on an empty database and fails on every row the live hub holds. It
+-- also emitted the composite foreign keys before the unique indexes they
+-- reference, which fails even when empty. Both are rewritten below: add
+-- nullable, backfill, then constrain — and indexes before the keys that need
+-- them.
+
+-- ─── The boundary ────────────────────────────────────────────────────────────
+
+CREATE TABLE "tenants" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"external_id" text,
+	"external_source" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "tenants_id_is_agentpod_fleet" CHECK ("tenants"."id" LIKE 'fleet\_%'),
+	CONSTRAINT "tenants_external_is_not_agentpod" CHECK ("tenants"."external_id" IS NULL OR "tenants"."external_id" NOT LIKE 'fleet\_%'),
+	CONSTRAINT "tenants_external_pair" CHECK (("tenants"."external_id" IS NULL) = ("tenants"."external_source" IS NULL))
+);--> statement-breakpoint
+
+-- NULLs are distinct in a Postgres unique index, so this constrains only the
+-- tenants that ARE mapped: a given organisation maps to at most one AgentPod
+-- tenant, and any number of unmapped tenants coexist.
+CREATE UNIQUE INDEX "tenants_external_idx" ON "tenants" USING btree ("external_source","external_id");--> statement-breakpoint
+
+-- The bootstrap tenant. A deterministic literal rather than a minted id,
+-- because this migration runs independently on a fresh deploy and on the live
+-- hub and both must land on the SAME boundary without coordinating — a
+-- gen_random_uuid() here would give every environment a different tenant and
+-- make the eventual external mapping environment-specific for no reason.
+-- Mirrors BOOTSTRAP_TENANT_ID in src/db/schema/tenants.ts.
+--
+-- external_id/external_source stay NULL: nothing has linked this hub to a
+-- kaambaan tenant, and ecosystem decision 2 requires that link to be minted
+-- explicitly rather than inferred. Guessing it here is exactly the inference
+-- that decision forbids.
+INSERT INTO "tenants" ("id", "name") VALUES ('fleet_00000000000000000000', 'Default')
+	ON CONFLICT ("id") DO NOTHING;--> statement-breakpoint
+
+-- ─── Add nullable, so existing rows survive the statement ────────────────────
+
+ALTER TABLE "nodes" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "provisioned_runtimes" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "enrollment_tokens" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "stations" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "station_audit" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "acp_sessions" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "acp_events" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "acp_runs" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "agent_tasks" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+ALTER TABLE "cloudflare_sandboxes" ADD COLUMN "tenant_id" text;--> statement-breakpoint
+
+-- ─── Backfill ────────────────────────────────────────────────────────────────
+--
+-- Every existing row belongs to the one tenant that now exists. That is the
+-- honest statement of the live dataset: one operator, one fleet, no boundary to
+-- have crossed.
+--
+-- Parents take the constant. Children take THEIR PARENT'S tenant rather than the
+-- constant — the same value today, but it says the right thing, and it is what
+-- the composite foreign keys below check. Backfilling a child from a constant
+-- would satisfy those keys by luck rather than by construction.
+
+UPDATE "nodes" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "provisioned_runtimes" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "enrollment_tokens" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "station_audit" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "acp_sessions" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "agent_tasks" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "cloudflare_sandboxes" SET "tenant_id" = 'fleet_00000000000000000000' WHERE "tenant_id" IS NULL;--> statement-breakpoint
+
+-- Children, from their parents. Ordered after the parents above.
+UPDATE "stations" SET "tenant_id" = "nodes"."tenant_id"
+	FROM "nodes" WHERE "stations"."node_id" = "nodes"."id" AND "stations"."tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "acp_events" SET "tenant_id" = "acp_sessions"."tenant_id"
+	FROM "acp_sessions" WHERE "acp_events"."session_id" = "acp_sessions"."id" AND "acp_events"."tenant_id" IS NULL;--> statement-breakpoint
+UPDATE "acp_runs" SET "tenant_id" = "acp_sessions"."tenant_id"
+	FROM "acp_sessions" WHERE "acp_runs"."session_id" = "acp_sessions"."id" AND "acp_runs"."tenant_id" IS NULL;--> statement-breakpoint
+
+-- ─── Constrain ───────────────────────────────────────────────────────────────
+--
+-- SET NOT NULL is the assertion that the backfill above was complete: a row the
+-- UPDATEs missed fails the migration here rather than sitting unscoped in a
+-- table the guard believes is scoped. Deliberately no DEFAULT — a default would
+-- make a forgotten tenant on some future INSERT land silently in the bootstrap
+-- tenant, which is the per-query-discipline failure this whole change exists to
+-- replace.
+
+ALTER TABLE "nodes" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "provisioned_runtimes" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "enrollment_tokens" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "stations" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "station_audit" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "acp_sessions" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "acp_events" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "acp_runs" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent_tasks" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "cloudflare_sandboxes" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+
+-- ─── Composite targets, BEFORE the keys that reference them ──────────────────
+--
+-- The generated migration emitted these after the foreign keys below, which
+-- cannot work: a composite FK requires a unique constraint on the referenced
+-- pair to already exist.
+
+CREATE UNIQUE INDEX "nodes_id_tenant_idx" ON "nodes" USING btree ("id","tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "acp_sessions_id_tenant_idx" ON "acp_sessions" USING btree ("id","tenant_id");--> statement-breakpoint
+
+-- ─── Foreign keys ────────────────────────────────────────────────────────────
+--
+-- ON DELETE restrict on the tenant: deleting a tenant that still owns nodes must
+-- fail loudly rather than cascade a fleet away. Nothing deletes tenants today,
+-- and this is the posture to have before something does.
+
+ALTER TABLE "nodes" ADD CONSTRAINT "nodes_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "provisioned_runtimes" ADD CONSTRAINT "provisioned_runtimes_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "enrollment_tokens" ADD CONSTRAINT "enrollment_tokens_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stations" ADD CONSTRAINT "stations_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "station_audit" ADD CONSTRAINT "station_audit_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "acp_sessions" ADD CONSTRAINT "acp_sessions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "acp_events" ADD CONSTRAINT "acp_events_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "acp_runs" ADD CONSTRAINT "acp_runs_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent_tasks" ADD CONSTRAINT "agent_tasks_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cloudflare_sandboxes" ADD CONSTRAINT "cloudflare_sandboxes_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- A child's tenant is its parent's, copied — and a copied fact drifts unless
+-- something stops it. These make a station in one tenant on a node in another
+-- unrepresentable rather than merely unwritten, which is what lets the tenant
+-- live on the row instead of being reached through a join on every read.
+ALTER TABLE "stations" ADD CONSTRAINT "stations_node_tenant_fk" FOREIGN KEY ("node_id","tenant_id") REFERENCES "public"."nodes"("id","tenant_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "acp_events" ADD CONSTRAINT "acp_events_session_tenant_fk" FOREIGN KEY ("session_id","tenant_id") REFERENCES "public"."acp_sessions"("id","tenant_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "acp_runs" ADD CONSTRAINT "acp_runs_session_tenant_fk" FOREIGN KEY ("session_id","tenant_id") REFERENCES "public"."acp_sessions"("id","tenant_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- ─── Lookup indexes ──────────────────────────────────────────────────────────
+--
+-- Every scoped read now leads with tenant_id, so every scoped table needs one.
+
+CREATE INDEX "nodes_tenant_id_idx" ON "nodes" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "provisioned_runtimes_tenant_id_idx" ON "provisioned_runtimes" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "enrollment_tokens_tenant_id_idx" ON "enrollment_tokens" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "stations_tenant_id_idx" ON "stations" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "station_audit_tenant_id_idx" ON "station_audit" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "acp_sessions_tenant_id_idx" ON "acp_sessions" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "acp_events_tenant_id_idx" ON "acp_events" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "acp_runs_tenant_id_idx" ON "acp_runs" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "agent_tasks_tenant_id_idx" ON "agent_tasks" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "cloudflare_sandboxes_tenant_id_idx" ON "cloudflare_sandboxes" USING btree ("tenant_id");

--- a/apps/hub/src/db/drizzle-migrations/meta/0036_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0036_snapshot.json
@@ -1,0 +1,2545 @@
+{
+  "id": "9d61e481-b6c6-4ff3-912e-c2c2e22f3326",
+  "prevId": "a75d60ec-8ab4-4236-838e-da04e94729f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1786646893273,
       "tag": "0035_acp_runs_id_space",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1786650945434,
+      "tag": "0036_tenant_isolation_boundary",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/acp.ts
+++ b/apps/hub/src/db/schema/acp.ts
@@ -17,11 +17,15 @@ import {
   jsonb,
   primaryKey,
   index,
+  uniqueIndex,
+  foreignKey,
   check,
 } from "drizzle-orm/pg-core";
+import { tenants } from "./tenants";
 
 export const acpSessions = pgTable("acp_sessions", {
   id: text("id").primaryKey(),                                        // "acps_" + uuid-ish
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   // Deliberately NOT a FK to stations.id (no ON DELETE CASCADE), mirroring the
   // station_audit.stationKey precedent: transcripts must survive station
   // deletion. Destroying a throwaway runtime/station must not silently erase
@@ -42,10 +46,18 @@ export const acpSessions = pgTable("acp_sessions", {
   index("acp_sessions_station_id_idx").on(t.stationId),
   // Ordering index for the paginated per-station history list (newest first).
   index("acp_sessions_station_activity_idx").on(t.stationId, t.lastEventAt.desc()),
+  index("acp_sessions_tenant_id_idx").on(t.tenantId),
+  // Composite target for the two child tables below.
+  uniqueIndex("acp_sessions_id_tenant_idx").on(t.id, t.tenantId),
 ]);
 
 export const acpEvents = pgTable("acp_events", {
   sessionId: text("session_id").notNull().references(() => acpSessions.id, { onDelete: "cascade" }),
+  // A transcript belongs to the tenant its session does. Carried on the row
+  // rather than reached through the session, so that reading the largest table
+  // in the database does not require a join to be safe — and enforced as a
+  // composite FK below, so the copy cannot disagree with the original.
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   seq: integer("seq").notNull(),
   type: text("type").notNull(),
   payload: jsonb("payload").notNull(),
@@ -64,6 +76,12 @@ export const acpEvents = pgTable("acp_events", {
   // once ended and older than the retention window, and its events go with it.
   // That keeps a transcript whole, which a legal record has to be.
   index("acp_events_created_at_idx").on(t.createdAt),
+  index("acp_events_tenant_id_idx").on(t.tenantId),
+  foreignKey({
+    columns: [t.sessionId, t.tenantId],
+    foreignColumns: [acpSessions.id, acpSessions.tenantId],
+    name: "acp_events_session_tenant_fk",
+  }).onDelete("cascade"),
 ]);
 
 /**
@@ -86,6 +104,7 @@ export const acpEvents = pgTable("acp_events", {
  */
 export const acpRuns = pgTable("acp_runs", {
   id: text("id").primaryKey(),                                        // "attempt_" + uuid (AcpRunId)
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   sessionId: text("session_id").notNull().references(() => acpSessions.id, { onDelete: "cascade" }),
   stationId: text("station_id").notNull(),
 
@@ -106,6 +125,12 @@ export const acpRuns = pgTable("acp_runs", {
   index("acp_runs_station_started_idx").on(t.stationId, t.startedAt.desc()),
   // The join from the board's side: given kaambaan's runId, find what ran.
   index("acp_runs_external_idx").on(t.externalRunId),
+  index("acp_runs_tenant_id_idx").on(t.tenantId),
+  foreignKey({
+    columns: [t.sessionId, t.tenantId],
+    foreignColumns: [acpSessions.id, acpSessions.tenantId],
+    name: "acp_runs_session_tenant_fk",
+  }).onDelete("cascade"),
 
   // Our own key is ours. A `run_…` here would be an orchestrator's work run
   // standing in as this hub's primary key — the collision this table was born

--- a/apps/hub/src/db/schema/audit.ts
+++ b/apps/hub/src/db/schema/audit.ts
@@ -9,11 +9,13 @@
  */
 
 import { pgTable, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { tenants } from "./tenants";
 
 export const stationAudit = pgTable(
   "station_audit",
   {
     id:           text("id").primaryKey(),
+    tenantId:     text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
     userId:       text("user_id").notNull(),
     nodeId:       text("node_id").notNull(),
     stationKey:   text("station_key").notNull(),
@@ -28,5 +30,6 @@ export const stationAudit = pgTable(
     index("station_audit_station_key_idx").on(t.stationKey),
     index("station_audit_node_id_idx").on(t.nodeId),
     index("station_audit_created_at_idx").on(t.createdAt),
+    index("station_audit_tenant_id_idx").on(t.tenantId),
   ]
 );

--- a/apps/hub/src/db/schema/cloudflare.ts
+++ b/apps/hub/src/db/schema/cloudflare.ts
@@ -1,5 +1,6 @@
 import { pgTable, text, timestamp, index, pgEnum, jsonb } from "drizzle-orm/pg-core";
 import { user } from "./auth";
+import { tenants } from "./tenants";
 
 export const agentTaskStatusEnum = pgEnum("agent_task_status", [
   "pending",
@@ -26,6 +27,9 @@ export const agentTasks = pgTable(
   "agent_tasks",
   {
     id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "restrict" }),
     userId: text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
@@ -48,6 +52,7 @@ export const agentTasks = pgTable(
     index("agent_tasks_status_idx").on(table.status),
     index("agent_tasks_sandbox_id_idx").on(table.sandboxId),
     index("agent_tasks_created_at_idx").on(table.createdAt),
+    index("agent_tasks_tenant_id_idx").on(table.tenantId),
   ]
 );
 
@@ -55,6 +60,9 @@ export const cloudflareSandboxes = pgTable(
   "cloudflare_sandboxes",
   {
     id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "restrict" }),
     userId: text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
@@ -70,6 +78,7 @@ export const cloudflareSandboxes = pgTable(
   (table) => [
     index("cloudflare_sandboxes_user_id_idx").on(table.userId),
     index("cloudflare_sandboxes_status_idx").on(table.status),
+    index("cloudflare_sandboxes_tenant_id_idx").on(table.tenantId),
   ]
 );
 

--- a/apps/hub/src/db/schema/index.ts
+++ b/apps/hub/src/db/schema/index.ts
@@ -5,6 +5,10 @@
  * Each module defines tables for a specific domain.
  */
 
+// Tenants — the local isolation boundary every scoped table hangs off.
+// First, because everything below references it.
+export * from "./tenants";
+
 // Authentication (Better Auth tables)
 export * from "./auth";
 

--- a/apps/hub/src/db/schema/nodes.ts
+++ b/apps/hub/src/db/schema/nodes.ts
@@ -1,10 +1,12 @@
-import { pgTable, text, integer, timestamp, index, pgEnum, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, timestamp, index, uniqueIndex, pgEnum, jsonb } from "drizzle-orm/pg-core";
 import { user } from "./auth";
+import { tenants } from "./tenants";
 
 export const nodeStatusEnum = pgEnum("node_status", ["online", "offline"]);
 
 export const nodes = pgTable("nodes", {
   id: text("id").primaryKey(),
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
   hostname: text("hostname").notNull(),
@@ -19,12 +21,19 @@ export const nodes = pgTable("nodes", {
   status: nodeStatusEnum("status").notNull().default("offline"),
   lastSeenAt: timestamp("last_seen_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
-}, (t) => [index("nodes_user_id_idx").on(t.userId)]);
+}, (t) => [
+  index("nodes_user_id_idx").on(t.userId),
+  index("nodes_tenant_id_idx").on(t.tenantId),
+  // Composite target for the child FKs below: a station cannot claim a node in
+  // another tenant, because the pair it references has to exist.
+  uniqueIndex("nodes_id_tenant_idx").on(t.id, t.tenantId),
+]);
 
 export const runtimeStatusEnum = pgEnum("runtime_status", ["provisioning", "starting", "online", "stopping", "stopped", "asleep", "error", "destroyed"]);
 
 export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   id: text("id").primaryKey(),
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
   provider: text("provider").notNull(),
   externalId: text("external_id"),
@@ -54,14 +63,21 @@ export const provisionedRuntimes = pgTable("provisioned_runtimes", {
   externalStartedAt: timestamp("external_started_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
-}, (t) => [index("provisioned_runtimes_user_id_idx").on(t.userId)]);
+}, (t) => [
+  index("provisioned_runtimes_user_id_idx").on(t.userId),
+  index("provisioned_runtimes_tenant_id_idx").on(t.tenantId),
+]);
 
 export const enrollmentTokens = pgTable("enrollment_tokens", {
   id: text("id").primaryKey(),
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
   tokenHash: text("token_hash").notNull(),
   expiresAt: timestamp("expires_at").notNull(),
   usedAt: timestamp("used_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   provisionedRuntimeId: text("provisioned_runtime_id").references(() => provisionedRuntimes.id, { onDelete: "set null" }),
-}, (t) => [index("enrollment_tokens_user_id_idx").on(t.userId)]);
+}, (t) => [
+  index("enrollment_tokens_user_id_idx").on(t.userId),
+  index("enrollment_tokens_tenant_id_idx").on(t.tenantId),
+]);

--- a/apps/hub/src/db/schema/stations.ts
+++ b/apps/hub/src/db/schema/stations.ts
@@ -1,9 +1,11 @@
-import { pgTable, text, timestamp, index, uniqueIndex, jsonb, AnyPgColumn } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, index, uniqueIndex, jsonb, foreignKey, AnyPgColumn } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 import { nodes } from "./nodes";
+import { tenants } from "./tenants";
 
 export const stations = pgTable("stations", {
   id: text("id").primaryKey(),
+  tenantId: text("tenant_id").notNull().references(() => tenants.id, { onDelete: "restrict" }),
   userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
   nodeId: text("node_id").notNull().references(() => nodes.id, { onDelete: "cascade" }),
   harness: text("harness").notNull(),
@@ -20,4 +22,14 @@ export const stations = pgTable("stations", {
   uniqueIndex("stations_node_id_station_key_idx").on(t.nodeId, t.stationKey),
   index("stations_node_id_idx").on(t.nodeId),
   index("stations_user_id_idx").on(t.userId),
+  index("stations_tenant_id_idx").on(t.tenantId),
+  // A station's tenant is not an independent fact — it is its node's, copied.
+  // A copied fact drifts, so it is a composite FK rather than a convention: the
+  // (node_id, tenant_id) pair must exist in nodes, which makes a station in one
+  // tenant on a node in another unrepresentable rather than merely unwritten.
+  foreignKey({
+    columns: [t.nodeId, t.tenantId],
+    foreignColumns: [nodes.id, nodes.tenantId],
+    name: "stations_node_tenant_fk",
+  }).onDelete("cascade"),
 ]);

--- a/apps/hub/src/db/schema/tenants.ts
+++ b/apps/hub/src/db/schema/tenants.ts
@@ -1,0 +1,99 @@
+/**
+ * Tenant Schema — AgentPod's local isolation boundary.
+ *
+ * Before this table every row in the hub hung off a `user_id` and nothing above
+ * it: there was no boundary a row could be inside, so there was nothing for a
+ * query to be scoped *to*. A `user_id` predicate is an ownership filter, not an
+ * isolation boundary — it answers "whose is this", never "which organisation is
+ * this inside", and it cannot answer the second one because a user belongs to no
+ * larger thing here.
+ *
+ * **This tenant is local, and deliberately so.** Neither AgentPod nor kaambaan
+ * owns the organisation: Principal, Team, Role and authority belong to an
+ * Organization plane that does not exist yet
+ * (docs/strategy/2026-08-13-ecosystem-identity-decisions.md). Both products must
+ * keep running standalone in the meantime, so each keeps its own boundary and
+ * records an *optional* mapping to the same real organisation elsewhere — which
+ * is what `externalId` + `externalSource` below are for. kaambaan is taking the
+ * identical shape in parallel.
+ *
+ * Concretely that means AgentPod does **not** mint kaambaan's `tnt_`. Two
+ * products minting one prefix for rows in two different databases is exactly the
+ * `run_` collision undone in #308, and doing it deliberately would be worse than
+ * doing it by accident. AgentPod's tenant id space is `fleet_<20 hex>`; the
+ * reasoning is in packages/contract/src/ids.ts and pinned across both repos by
+ * fixtures/ecosystem-identity/id_grammar.json.
+ */
+
+import { sql } from "drizzle-orm";
+import { pgTable, text, timestamp, uniqueIndex, check } from "drizzle-orm/pg-core";
+
+/**
+ * The one tenant that exists, created by migration 0036.
+ *
+ * Deterministic rather than minted, and that is the requirement rather than a
+ * shortcut: the migration runs on a fresh deploy and on the live hub
+ * independently, and both must land on the same tenant id without coordinating.
+ * A `crypto.randomUUID()` in a migration would give every environment a
+ * different boundary and make the eventual external mapping environment-specific
+ * for no reason.
+ *
+ * All-zero so it is unmistakable in a log line as the tenant a migration
+ * created rather than one a person did. It is a legal `fleet_<20 hex>` id, so it
+ * satisfies the same validator and the same CHECK as any future tenant.
+ */
+export const BOOTSTRAP_TENANT_ID = "fleet_00000000000000000000";
+
+export const tenants = pgTable(
+  "tenants",
+  {
+    id: text("id").primaryKey(), // "fleet_" + 20 hex (TenantId)
+    name: text("name").notNull(),
+
+    // ── The optional external mapping ───────────────────────────────────────
+    //
+    // The id this tenant has in the system that actually owns the organisation,
+    // and which system that is — "kaambaan" today, "org-plane" when it exists.
+    // Null on a standalone deployment, which is the default and must stay
+    // workable: AgentPod cannot require a peer product to boot.
+    //
+    // Shape copied verbatim from acp_runs.externalRunId/externalSource rather
+    // than invented, including the paired-presence CHECK below. Same problem,
+    // same answer: a foreign id with no source cannot be resolved back to the
+    // system that minted it, and a source with no id names an origin nothing
+    // points at.
+    externalId: text("external_id"),
+    externalSource: text("external_source"),
+
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    // A given organisation maps to at most one AgentPod tenant. Without this,
+    // two tenants could both claim to be the same kaambaan tenant and the
+    // mapping would stop being a mapping. Partial by construction — NULLs are
+    // distinct in a Postgres unique index, so any number of unmapped tenants
+    // coexist.
+    uniqueIndex("tenants_external_idx").on(t.externalSource, t.externalId),
+
+    // Our own key is ours — the acp_runs precedent, for the same reason. A
+    // `tnt_…` here would be kaambaan's boundary standing in as this hub's
+    // primary key. Prefix-only, deliberately: the suffix family may change, the
+    // id space may not.
+    check("tenants_id_is_agentpod_fleet", sql`${t.id} LIKE 'fleet\\_%'`),
+    // The mirror: an external id may be any shape the owning system mints, but
+    // it may never be one of ours — a `fleet_…` external id would mean this hub
+    // pointing at itself and calling it an organisation elsewhere.
+    check(
+      "tenants_external_is_not_agentpod",
+      sql`${t.externalId} IS NULL OR ${t.externalId} NOT LIKE 'fleet\\_%'`,
+    ),
+    // One fact, two columns. Both present or both absent.
+    check(
+      "tenants_external_pair",
+      sql`(${t.externalId} IS NULL) = (${t.externalSource} IS NULL)`,
+    ),
+  ],
+);
+
+export type Tenant = typeof tenants.$inferSelect;
+export type InsertTenant = typeof tenants.$inferInsert;

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -1,0 +1,219 @@
+/**
+ * The tenant isolation guard.
+ *
+ * Isolation is a property of the data-access layer, not a filter every caller
+ * has to remember to add. The principle is kaambaan's — *"there is NO unscoped
+ * query builder"* — and it is the strongest thing in either codebase; the
+ * implementation is not, because kaambaan builds raw SQL strings for D1 and this
+ * is Drizzle over Postgres. What transfers is the shape: a tenant predicate that
+ * is built first, a table whitelist that refuses anything not registered, and a
+ * tenant that cannot be absent.
+ *
+ * Two entry points, because this codebase has both kinds of query:
+ *
+ * - `tenantScope(table, tenantId, ...extra)` returns the predicate, for the
+ *   selects that project specific columns or join (`listNodes` left-joins
+ *   provisioned_runtimes) and for updates and deletes. The predicate is the unit
+ *   that composes with what is already written.
+ * - `tenantScopedSelect(table, tenantId, ...extra)` returns a builder with the
+ *   predicate already bound, for the plain case.
+ *
+ * Neither can be constructed for an unregistered table or without a tenant, so
+ * the mistake this exists to prevent is a thrown error rather than a silent
+ * cross-tenant read.
+ *
+ * **What this does not claim.** Drizzle exposes `db.select()` directly and this
+ * module cannot take it away, so a determined caller can still write an unscoped
+ * query. What closes that gap is the guard in `tests/unit/tenant-scope.test.ts`,
+ * which enumerates the *schema* rather than the whitelist: a tenant-scoped table
+ * added without being classified fails on the commit that adds it.
+ */
+
+import { and, eq, getTableName, type SQL, type Table } from "drizzle-orm";
+import { TenantId } from "@agentpod/contract";
+
+import { db } from "./drizzle";
+import { acpEvents, acpRuns, acpSessions } from "./schema/acp";
+import { adminAuditLog, systemSettings } from "./schema/admin";
+import { stationAudit } from "./schema/audit";
+import { account, session, user, verification } from "./schema/auth";
+import { agentTasks, cloudflareSandboxes } from "./schema/cloudflare";
+import { enrollmentTokens, nodes, provisionedRuntimes } from "./schema/nodes";
+import { stations } from "./schema/stations";
+import { tenants } from "./schema/tenants";
+
+export { BOOTSTRAP_TENANT_ID } from "./schema/tenants";
+
+export class TenantIsolationError extends Error {
+  constructor(message = "a tenant scope is required to access tenant-scoped data") {
+    super(message);
+    this.name = "TenantIsolationError";
+  }
+}
+
+/**
+ * Narrow `tenantId` to a real AgentPod tenant id or throw.
+ *
+ * Stricter than kaambaan's equivalent, which only checks for a non-empty string.
+ * The extra check earns its place across the seam: `tnt_5f2b8c1a9d3e4076` is a
+ * perfectly well-formed *kaambaan* tenant naming a boundary in a different
+ * database, and once a bridge exists it is a value that can reach this function.
+ * A non-empty-string check would accept it and build a predicate that matches
+ * nothing — a query that returns zero rows and looks like an empty fleet rather
+ * than like a bug.
+ */
+export function assertTenantId(tenantId: unknown): asserts tenantId is string {
+  if (typeof tenantId !== "string" || tenantId.trim() === "") {
+    throw new TenantIsolationError("a non-empty tenantId is required");
+  }
+  if (!TenantId.safeParse(tenantId).success) {
+    throw new TenantIsolationError(
+      `"${tenantId}" is not an AgentPod tenant id (expected "fleet_<20 hex>")`,
+    );
+  }
+}
+
+/** A table registered as tenant-scoped: it has a `tenantId` column by construction. */
+export type TenantScopedTable = Table & { tenantId: Parameters<typeof eq>[0] };
+
+/**
+ * Tables whose rows belong to exactly one tenant.
+ *
+ * The membership rule is deliberately about the row, not about today's query
+ * paths: *does this row belong to one tenant?* That has an objective answer.
+ * The tempting alternative — "is it reachable only through an already-scoped
+ * parent?" — is a claim about the routes that happen to exist, and it stops
+ * being true the moment someone adds one. So `acp_events` is scoped even though
+ * it is only ever read through its session, and the copy is held honest by a
+ * composite FK rather than by the rule.
+ */
+export const TENANT_SCOPED_TABLES = {
+  nodes,
+  provisionedRuntimes,
+  enrollmentTokens,
+  stations,
+  stationAudit,
+  acpSessions,
+  acpEvents,
+  acpRuns,
+  agentTasks,
+  cloudflareSandboxes,
+} as const satisfies Record<string, TenantScopedTable>;
+
+/**
+ * Tables that deliberately belong to no tenant, and why.
+ *
+ * These need an argument, not an omission — an exemption without a reason is a
+ * todo — so the reason lives here and the guard test asserts every entry has
+ * one. Keyed by SQL table name so the guard can compare against the schema.
+ */
+export const TENANT_EXEMPT_TABLES: Record<string, { table: Table; reason: string }> = {
+  tenants: {
+    table: tenants,
+    reason:
+      "It IS the boundary. A tenant inside a tenant is the membership/hierarchy model the " +
+      "Organization plane owns, and building it here is what MT-1 (#145) was rewritten to avoid.",
+  },
+
+  // ── The Better Auth family ────────────────────────────────────────────────
+  //
+  // AgentPod declares these four tables but does not own them: Better Auth
+  // inserts, updates and deletes them through its own adapter, so a NOT NULL
+  // `tenant_id` here is a column AgentPod would have to populate on writes it
+  // does not make. Every such write is a signup, a login or a token refresh.
+  //
+  // The deeper reason is the strategy's, not convenience: principals belong to
+  // the Organization plane, which owns "Principal, Team, Role, objective,
+  // identity mappings, authority". Pinning a user to an AgentPod-local tenant
+  // models the org in the wrong plane and would have to be migrated out — the
+  // exact objection that reshaped MT-1. AgentPod scopes its own rows and
+  // consumes principals; it does not own them.
+  //
+  // What a user is *allowed to reach* is therefore not answered here. It is
+  // answered today by the bootstrap constant in the auth middleware, and later
+  // by a membership lookup at the same layer — see `resolveTenantId`.
+  user: {
+    table: user,
+    reason:
+      "Better Auth owns the lifecycle of this table; the Organization plane owns principals. " +
+      "A user is not inside an AgentPod fleet — it reaches one, which is a membership question " +
+      "and not this plane's to answer.",
+  },
+  session: {
+    table: session,
+    reason:
+      "Better Auth writes this on every login and refresh. Belongs to a user, and a user " +
+      "belongs to no AgentPod tenant.",
+  },
+  account: {
+    table: account,
+    reason:
+      "OAuth provider linkage, written by Better Auth. A GitHub identity is a property of a " +
+      "principal, not of a fleet.",
+  },
+  verification: {
+    table: verification,
+    reason:
+      "Email-verification and password-reset challenges, written by Better Auth and keyed by " +
+      "an email address that no tenant owns.",
+  },
+
+  // ── Instance-wide ─────────────────────────────────────────────────────────
+  system_settings: {
+    table: systemSettings,
+    reason:
+      "One key-value row per setting for the whole hub — whether signup is open, for instance. " +
+      "Per-tenant configuration would be a different table with a different primary key, not a " +
+      "column added to this one.",
+  },
+  admin_audit_log: {
+    table: adminAuditLog,
+    reason:
+      "Records instance-admin actions, which cross tenants by definition: banning a user or " +
+      "changing a role is not an act performed inside a fleet. Scoping it would either lose " +
+      "those rows or force them into a tenant that did not perform them. Per-tenant activity " +
+      "is station_audit, which IS scoped.",
+  },
+};
+
+/**
+ * The tenant predicate, always bound first.
+ *
+ * Ordering is kaambaan's invariant and it costs nothing to keep: the tenant is
+ * never one condition among several that a later edit might reorder away.
+ */
+export function tenantScope<T extends TenantScopedTable>(
+  table: T,
+  tenantId: string,
+  ...extra: (SQL | undefined)[]
+): SQL {
+  assertTenantId(tenantId);
+
+  const registered = Object.values(TENANT_SCOPED_TABLES) as readonly Table[];
+  if (!registered.includes(table as Table)) {
+    throw new TenantIsolationError(
+      `table "${getTableName(table as Table)}" is not registered as tenant-scoped`,
+    );
+  }
+
+  // `and()` with a single argument still returns a SQL node, so the non-null
+  // assertion is safe: the tenant predicate is always present.
+  return and(eq(table.tenantId, tenantId), ...extra)!;
+}
+
+/**
+ * A select that is structurally incapable of crossing tenants.
+ *
+ * For the plain case. Queries that project columns or join should compose
+ * `tenantScope()` into their own `.where()` instead — the predicate is the part
+ * that has to be right, and wrapping a builder that cannot express a join would
+ * only push those call sites back to a raw `db.select()`.
+ */
+export function tenantScopedSelect<T extends TenantScopedTable>(
+  table: T,
+  tenantId: string,
+  ...extra: (SQL | undefined)[]
+) {
+  const where = tenantScope(table, tenantId, ...extra);
+  return db.select().from(table as never).where(where);
+}

--- a/apps/hub/src/routes/activity-fleet.test.ts
+++ b/apps/hub/src/routes/activity-fleet.test.ts
@@ -18,6 +18,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
 import { Hono } from "hono";
 
 import { db, rawSql } from "../db/drizzle";
@@ -38,11 +39,12 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
       c.set("user", {
         id: "anonymous",
         authType: "api_key",
+        tenantId: "fleet_00000000000000000000",
       } satisfies AuthUser);
     }
     return next();
@@ -85,34 +87,40 @@ test(
 
     await db.insert(stationAudit).values([
       {
+        tenantId: BOOTSTRAP_TENANT_ID,
         id: "fleet-audit-a-older",
         userId: USER_A,
         nodeId: "node-a-test",
         stationKey: "station-a-test",
         verb: "fs.list",
-        paramsSummary: {},
+        paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
         result: "ok",
         error: null,
         createdAt: older,
       },
       {
+        tenantId: BOOTSTRAP_TENANT_ID,
         id: "fleet-audit-a-newer",
         userId: USER_A,
         nodeId: "node-a-test",
         stationKey: "station-a-test",
         verb: "fs.read",
-        paramsSummary: {},
+        paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
         result: "ok",
         error: null,
         createdAt: now,
       },
       {
+        tenantId: BOOTSTRAP_TENANT_ID,
         id: "fleet-audit-b-1",
         userId: USER_B,
         nodeId: "node-b-test",
         stationKey: "station-b-test",
         verb: "terminal.start",
-        paramsSummary: {},
+        paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
         result: "ok",
         error: null,
         createdAt: now,
@@ -163,23 +171,27 @@ test(
 
     await db.insert(stationAudit).values([
       {
+        tenantId: BOOTSTRAP_TENANT_ID,
         id: "fleet-audit-sep-a",
         userId: USER_A,
         nodeId: "node-a",
         stationKey: "key-a",
         verb: "fs.write",
-        paramsSummary: {},
+        paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
         result: "ok",
         error: null,
         createdAt: now,
       },
       {
+        tenantId: BOOTSTRAP_TENANT_ID,
         id: "fleet-audit-sep-b",
         userId: USER_B,
         nodeId: "node-b",
         stationKey: "key-b",
         verb: "terminal.start",
-        paramsSummary: {},
+        paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
         result: "ok",
         error: null,
         createdAt: now,

--- a/apps/hub/src/routes/cloudflare-webhook.ts
+++ b/apps/hub/src/routes/cloudflare-webhook.ts
@@ -3,6 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { createLogger } from "../utils/logger";
 import { db } from "../db/drizzle";
+import { resolveTenantForUser } from "../auth/tenant";
 import { cloudflareSandboxes } from "../db/schema/cloudflare";
 import { eq } from "drizzle-orm";
 
@@ -123,6 +124,7 @@ async function handleSandboxCreated(data: { sandboxId: string; userId?: string }
 
   if (existing.length === 0) {
     await db.insert(cloudflareSandboxes).values({
+      tenantId: await resolveTenantForUser(data.userId),
       id: data.sandboxId,
       userId: data.userId,
       status: "running",

--- a/apps/hub/src/routes/node-posture.test.ts
+++ b/apps/hub/src/routes/node-posture.test.ts
@@ -65,6 +65,7 @@ const testApp = new Hono()
     c.set("user", {
       id: userId && userId !== "anonymous" ? userId : "anonymous",
       authType: "api_key",
+        tenantId: "fleet_00000000000000000000",
     } satisfies AuthUser);
     return next();
   })

--- a/apps/hub/src/routes/runtime-callback.test.ts
+++ b/apps/hub/src/routes/runtime-callback.test.ts
@@ -50,8 +50,8 @@ afterAll(async () => {
 async function seedRuntime(): Promise<string> {
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
-    INSERT INTO provisioned_runtimes (id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${TEST_USER}, 'cloudflare', 'online', 'callback-test', 'small', 'none', now(), now())
+    INSERT INTO provisioned_runtimes (tenant_id, id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${TEST_USER}, 'cloudflare', 'online', 'callback-test', 'small', 'none', now(), now())
   `;
   return id;
 }

--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -30,6 +30,7 @@ process.env.ENABLE_MODAL_PROVISIONING = "true";
 process.env.PROVISIONING_HUB_URL = "https://hub.test";
 
 import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 
@@ -207,7 +208,7 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
       return next();
     }
     return c.json({ error: "Unauthorized", message: "Valid session or API key required" }, 401);
@@ -579,10 +580,12 @@ test("DELETE /api/runtimes/:id removes the provisioned node + its stations (no g
   // link the runtime to it (as the gateway's enrollNode would).
   const nodeId = "node_ghost_test_001";
   await db.insert(nodes).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id: nodeId, userId: TEST_USER, name: "ghost", hostname: "ghostbox",
     os: "linux", arch: "amd64", secretHash: "x",
   });
   await db.insert(stations).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id: "st_ghost_001", userId: TEST_USER, nodeId, harness: "opencode",
     stationKey: "opencode:ws", kind: "workspace", displayName: "/workspace",
   });
@@ -916,8 +919,8 @@ test("an asleep runtime is never swept into error", async () => {
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
     INSERT INTO provisioned_runtimes
-      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${TEST_USER}, 'cloudflare', 'ext-asleep', 'asleep', 'sleeper', 'small', 'none',
+      (tenant_id, id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${TEST_USER}, 'cloudflare', 'ext-asleep', 'asleep', 'sleeper', 'small', 'none',
             now() - interval '1 day', now() - interval '1 day')
   `;
 
@@ -1232,8 +1235,8 @@ test("an asleep runtime is never swept by the stop sweeper", async () => {
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
     INSERT INTO provisioned_runtimes
-      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${TEST_USER}, 'cloudflare', 'ext-asleep-stop', 'asleep', 'sleeper2', 'small', 'none',
+      (tenant_id, id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${TEST_USER}, 'cloudflare', 'ext-asleep-stop', 'asleep', 'sleeper2', 'small', 'none',
             now() - interval '1 day', now() - interval '1 day')
   `;
 
@@ -1264,8 +1267,8 @@ test("a runtime still being provisioned (no external id yet) is not swept", asyn
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
     INSERT INTO provisioned_runtimes
-      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${TEST_USER}, 'docker', NULL, 'provisioning', 'slow-pull', 'small', 'none',
+      (tenant_id, id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${TEST_USER}, 'docker', NULL, 'provisioning', 'slow-pull', 'small', 'none',
             now() - interval '1 day', now() - interval '1 day')
   `;
 
@@ -1341,8 +1344,8 @@ test("a row written without an instance start time keeps NULL — the column is 
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
     INSERT INTO provisioned_runtimes
-      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${TEST_USER}, 'docker', 'ext-legacy-row', 'online', 'legacy', 'small', 'none',
+      (tenant_id, id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${TEST_USER}, 'docker', 'ext-legacy-row', 'online', 'legacy', 'small', 'none',
             now() - interval '30 days', now() - interval '30 days')
   `;
 
@@ -1840,8 +1843,8 @@ test("skips a row with no instance clock instead of guessing its age", async () 
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
     INSERT INTO provisioned_runtimes
-      (id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${TEST_USER}, 'modal', 'vol-legacy#sb-legacy', 'online', 'legacy-modal', 'small', 'none',
+      (tenant_id, id, user_id, provider, external_id, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${TEST_USER}, 'modal', 'vol-legacy#sb-legacy', 'online', 'legacy-modal', 'small', 'none',
             now() - interval '30 days', now() - interval '30 days')
   `;
 

--- a/apps/hub/src/routes/station-acp.test.ts
+++ b/apps/hub/src/routes/station-acp.test.ts
@@ -68,9 +68,9 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })

--- a/apps/hub/src/routes/station-activity.test.ts
+++ b/apps/hub/src/routes/station-activity.test.ts
@@ -17,6 +17,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
 import { Hono } from "hono";
 
 import { db, rawSql } from "../db/drizzle";
@@ -47,9 +48,9 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })
@@ -187,23 +188,27 @@ test(
 
       await db.insert(stationAudit).values([
         {
+        tenantId: BOOTSTRAP_TENANT_ID,
           id: "audit_row_older",
           userId: TEST_USER,
           nodeId,
           stationKey: STATION_KEY,
           verb: "fs.list",
-          paramsSummary: {},
+          paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
           result: "ok",
           error: null,
           createdAt: older,
         },
         {
+        tenantId: BOOTSTRAP_TENANT_ID,
           id: "audit_row_newer",
           userId: TEST_USER,
           nodeId,
           stationKey: STATION_KEY,
           verb: "fs.read",
-          paramsSummary: {},
+          paramsSummary: {
+        tenantId: BOOTSTRAP_TENANT_ID,},
           result: "ok",
           error: null,
           createdAt: now,

--- a/apps/hub/src/routes/station-changeset.test.ts
+++ b/apps/hub/src/routes/station-changeset.test.ts
@@ -60,9 +60,9 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })

--- a/apps/hub/src/routes/station-cleanup.test.ts
+++ b/apps/hub/src/routes/station-cleanup.test.ts
@@ -46,9 +46,9 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })

--- a/apps/hub/src/routes/station-lifecycle.test.ts
+++ b/apps/hub/src/routes/station-lifecycle.test.ts
@@ -44,9 +44,9 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })

--- a/apps/hub/src/routes/station-terminal.test.ts
+++ b/apps/hub/src/routes/station-terminal.test.ts
@@ -46,10 +46,10 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
       // No header → anonymous; the terminal route rejects this with 1008.
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })

--- a/apps/hub/src/routes/station-writes.test.ts
+++ b/apps/hub/src/routes/station-writes.test.ts
@@ -47,9 +47,9 @@ const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id");
     if (userId && userId !== "anonymous") {
-      c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     } else {
-      c.set("user", { id: "anonymous", authType: "api_key" } satisfies AuthUser);
+      c.set("user", { id: "anonymous", authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     }
     return next();
   })

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -40,6 +40,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
 import { Hono } from "hono";
 import { asc, eq } from "drizzle-orm";
 import type { AcpEvent, DetectedStation } from "@agentpod/contract";
@@ -999,6 +1000,7 @@ test(
       ]);
       const staleId = `acps_${crypto.randomUUID()}`;
       await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
         id: staleId,
         stationId: station!.id,
         userId: TEST_USER,
@@ -1113,6 +1115,7 @@ test(
       // A stale row as if the hub crashed mid-session.
       const staleId = `acps_${crypto.randomUUID()}`;
       await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
         id: staleId,
         stationId: station.id,
         userId: TEST_USER,
@@ -1124,6 +1127,7 @@ test(
         lastEventAt: new Date(),
       });
       await db.insert(acpEvents).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
         sessionId: staleId,
         seq: 1,
         type: "state",
@@ -1135,6 +1139,7 @@ test(
       // concurrent sessions before the restart) — each must be closed by id.
       const staleId2 = `acps_${crypto.randomUUID()}`;
       await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
         id: staleId2,
         stationId: station.id,
         userId: TEST_USER,
@@ -1149,6 +1154,7 @@ test(
       // A stale row whose station is gone (transcript survives; no close possible).
       const orphanId = `acps_${crypto.randomUUID()}`;
       await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
         id: orphanId,
         stationId: "station_deleted_long_ago",
         userId: TEST_USER,
@@ -1569,6 +1575,7 @@ test(
         const id = `acps_${crypto.randomUUID()}`;
         orphanIds.push(id);
         await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
           id,
           stationId: station.id,
           userId: TEST_USER,
@@ -1583,6 +1590,7 @@ test(
       // … and a poisoned marker pointing at the process the LIVE session holds.
       const poisonedId = `acps_${crypto.randomUUID()}`;
       await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
         id: poisonedId,
         stationId: station.id,
         userId: TEST_USER,

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -46,6 +46,7 @@ import type {
   AcpSessionStatus,
 } from "@agentpod/contract";
 import { db } from "../db/drizzle";
+import { resolveTenantForUser } from "../auth/tenant";
 import { acpSessions, acpEvents } from "../db/schema/acp";
 import { stations } from "../db/schema/stations";
 import { createLogger } from "../utils/logger";
@@ -150,6 +151,8 @@ export interface CreateSessionInput {
 
 interface LiveSession {
   id: string;
+  /** The session's tenant, carried so every event write inherits it. */
+  tenantId: string;
   stationId: string;
   userId: string;
   nodeId: string;
@@ -341,6 +344,11 @@ function persistEvent(
   const done = enqueue(live, async () => {
     await db.insert(acpEvents).values({
       sessionId: live.id,
+      // The session's tenant, not a re-resolved one. acp_events carries a
+      // composite FK to (acp_sessions.id, tenant_id), so an event can only ever
+      // sit in its session's tenant — copying it from `live` is the copy the
+      // database checks.
+      tenantId: live.tenantId,
       seq,
       type,
       payload: payload as object,
@@ -640,8 +648,13 @@ async function openSession(input: CreateSessionInput): Promise<AcpSessionRow> {
 
   const id = `acps_${crypto.randomUUID()}`;
   const now = new Date();
+  // Resolved once, here, and carried on the live session: every event this
+  // session ever writes inherits it, so a transcript cannot end up split across
+  // tenants by a later re-resolution.
+  const tenantId = await resolveTenantForUser(userId);
   const live: LiveSession = {
     id,
+    tenantId,
     stationId,
     userId,
     nodeId,
@@ -673,6 +686,7 @@ async function openSession(input: CreateSessionInput): Promise<AcpSessionRow> {
     await boundedDb(
       db.insert(acpSessions).values({
         id,
+        tenantId: live.tenantId,
         stationId,
         userId,
         mode,
@@ -1034,8 +1048,17 @@ async function appendEndedState(sessionId: string, reason: string): Promise<void
   const seq = Number(agg?.maxSeq ?? 0) + 1;
   const createdAt = new Date();
   const payload = { status: "ended", reason };
+  // This session is not live, so its tenant is read back from the row rather
+  // than carried in memory. Same rule as persistEvent: the event's tenant is the
+  // session's, which the composite FK then checks.
+  const [sessionRow] = await db
+    .select({ tenantId: acpSessions.tenantId })
+    .from(acpSessions)
+    .where(eq(acpSessions.id, sessionId));
+  if (!sessionRow) return;
   await db.insert(acpEvents).values({
     sessionId,
+    tenantId: sessionRow.tenantId,
     seq,
     type: "state",
     payload,

--- a/apps/hub/src/services/audit.ts
+++ b/apps/hub/src/services/audit.ts
@@ -16,6 +16,7 @@
 
 import { eq } from "drizzle-orm";
 import type { Database } from "../db/drizzle";
+import { resolveTenantForUser } from "../auth/tenant";
 import { stationAudit } from "../db/schema/audit";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -96,6 +97,7 @@ export async function recordAudit(
 
   await db.insert(stationAudit).values({
     id,
+    tenantId: await resolveTenantForUser(args.userId),
     userId: args.userId,
     nodeId: args.nodeId,
     stationKey: args.stationKey,

--- a/apps/hub/src/services/enrollment.test.ts
+++ b/apps/hub/src/services/enrollment.test.ts
@@ -18,6 +18,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
 import { eq } from "drizzle-orm";
 import { db, rawSql } from "../db/drizzle";
 import { provisionedRuntimes } from "../db/schema/nodes";
@@ -91,6 +92,7 @@ test("linked path: mintEnrollmentToken({ provisionedRuntimeId }) → enrollNode 
   // Insert a provisioning runtime row (no nodeId yet)
   const runtimeId = `rt_test_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
   await db.insert(provisionedRuntimes).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id: runtimeId,
     userId: TEST_USER,
     provider: "docker",

--- a/apps/hub/src/services/enrollment.ts
+++ b/apps/hub/src/services/enrollment.ts
@@ -1,5 +1,6 @@
 import { and, eq, gt, isNull } from "drizzle-orm";
 import { db } from "../db/drizzle";
+import { resolveTenantForUser } from "../auth/tenant";
 import { nodes, enrollmentTokens, provisionedRuntimes } from "../db/schema/nodes";
 import type { HostInfo, EnrollResponse } from "@agentpod/contract";
 
@@ -56,6 +57,9 @@ export async function mintEnrollmentToken(
 
   await db.insert(enrollmentTokens).values({
     id: prefixedId("etk"),
+    // A root row: its tenant comes from the principal minting it. Everything
+    // enrolled with this token inherits the tenant from here.
+    tenantId: await resolveTenantForUser(userId),
     userId,
     tokenHash: await sha256(token),
     expiresAt,
@@ -189,6 +193,11 @@ export async function enrollNode(
 
   await db.insert(nodes).values({
     id: nodeId,
+    // The node inherits the TOKEN's tenant, not a freshly resolved one. The
+    // token is the authority that admitted this node to the fleet, so a node
+    // cannot land in a tenant other than the one whose token enrolled it —
+    // which stays true once tokens can be minted for more than one.
+    tenantId: row.tenantId,
     userId: row.userId,
     name: hostInfo.hostname,
     hostname: hostInfo.hostname,

--- a/apps/hub/src/services/node-registry.ts
+++ b/apps/hub/src/services/node-registry.ts
@@ -1,5 +1,7 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db/drizzle";
+import { tenantScope } from "../db/tenant-scope";
+import { resolveTenantForUser } from "../auth/tenant";
 import { nodes, provisionedRuntimes } from "../db/schema/nodes";
 import type { NodeSummary } from "@agentpod/contract";
 import { getLatestAgentVersion, isNewerVersion } from "./agent-version";
@@ -31,6 +33,12 @@ export function annotateWithVersion<
 }
 
 export async function listNodes(userId: string): Promise<NodeWithProvisioning[]> {
+  // Tenant first, owner second. `user_id` answers "whose is this"; it has never
+  // been able to answer "which fleet is this inside", and with one tenant the
+  // two happen to select the same rows — which is exactly why this has to be
+  // structural now rather than when a second tenant makes the gap visible.
+  const tenantId = await resolveTenantForUser(userId);
+
   // Left-join provisioned_runtimes on node_id so each node carries its
   // provisioned-runtime info (null if the node was attached manually).
   const rows = await db
@@ -51,7 +59,7 @@ export async function listNodes(userId: string): Promise<NodeWithProvisioning[]>
     })
     .from(nodes)
     .leftJoin(provisionedRuntimes, eq(provisionedRuntimes.nodeId, nodes.id))
-    .where(eq(nodes.userId, userId));
+    .where(tenantScope(nodes, tenantId, eq(nodes.userId, userId)));
 
   // Resolve latest version once for the whole batch.
   const latestVersion = await getLatestAgentVersion();

--- a/apps/hub/src/services/runtime-autoadopt.test.ts
+++ b/apps/hub/src/services/runtime-autoadopt.test.ts
@@ -25,6 +25,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
 import { db, rawSql } from "../db/drizzle";
 import { provisionedRuntimes } from "../db/schema/nodes";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
@@ -112,6 +113,7 @@ beforeAll(async () => {
   testNodeId = enrolledA.nodeId;
 
   await db.insert(provisionedRuntimes).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id: `runtime_autoadopt_opencode_${crypto.randomUUID().slice(0, 8)}`,
     userId: TEST_USER,
     provider: "docker",
@@ -132,6 +134,7 @@ beforeAll(async () => {
   noneNodeId = enrolledB.nodeId;
 
   await db.insert(provisionedRuntimes).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id: `runtime_autoadopt_none_${crypto.randomUUID().slice(0, 8)}`,
     userId: TEST_USER,
     provider: "docker",
@@ -273,6 +276,7 @@ test(
     const failNodeId = enrolledC.nodeId;
 
     await db.insert(provisionedRuntimes).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
       id: `runtime_autoadopt_fail_${crypto.randomUUID().slice(0, 8)}`,
       userId: TEST_USER,
       provider: "docker",

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -34,6 +34,7 @@
 
 import { and, eq, inArray, isNotNull, lt, ne } from "drizzle-orm";
 import { db } from "../db/drizzle";
+import { resolveTenantForUser } from "../auth/tenant";
 import { provisionedRuntimes, nodes } from "../db/schema/nodes";
 import { mintEnrollmentToken } from "./enrollment";
 import {
@@ -157,6 +158,7 @@ export async function createRuntime(
 
   await db.insert(provisionedRuntimes).values({
     id,
+    tenantId: await resolveTenantForUser(userId),
     userId,
     provider,
     status: "provisioning",

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -35,6 +35,7 @@
 import { and, eq, inArray, isNotNull, lt, ne } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { resolveTenantForUser } from "../auth/tenant";
+import { tenantScope } from "../db/tenant-scope";
 import { provisionedRuntimes, nodes } from "../db/schema/nodes";
 import { mintEnrollmentToken } from "./enrollment";
 import {
@@ -276,9 +277,11 @@ export async function listRuntimes(userId: string): Promise<ProvisionedRuntime[]
     .select()
     .from(provisionedRuntimes)
     .where(
-      and(
+      tenantScope(
+        provisionedRuntimes,
+        await resolveTenantForUser(userId),
         eq(provisionedRuntimes.userId, userId),
-        ne(provisionedRuntimes.status, "destroyed")
+        ne(provisionedRuntimes.status, "destroyed"),
       )
     );
 

--- a/apps/hub/src/services/station-registry.ts
+++ b/apps/hub/src/services/station-registry.ts
@@ -12,6 +12,8 @@ import { and, eq } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
+import { tenantScope } from "../db/tenant-scope";
+import { resolveTenantForUser } from "../auth/tenant";
 import { VERB_RESULTS } from "@agentpod/contract";
 import type { DetectedStation } from "@agentpod/contract";
 import * as broker from "./broker";
@@ -127,10 +129,13 @@ export async function listAdopted(
   userId: string,
   nodeId: string
 ): Promise<StationRow[]> {
+  const tenantId = await resolveTenantForUser(userId);
   return db
     .select()
     .from(stations)
-    .where(and(eq(stations.userId, userId), eq(stations.nodeId, nodeId)));
+    .where(
+      tenantScope(stations, tenantId, eq(stations.userId, userId), eq(stations.nodeId, nodeId)),
+    );
 }
 
 // ─── getStation ───────────────────────────────────────────────────────────────

--- a/apps/hub/src/services/station-registry.ts
+++ b/apps/hub/src/services/station-registry.ts
@@ -11,6 +11,7 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
+import { nodes } from "../db/schema/nodes";
 import { VERB_RESULTS } from "@agentpod/contract";
 import type { DetectedStation } from "@agentpod/contract";
 import * as broker from "./broker";
@@ -42,12 +43,25 @@ export async function adoptStations(
   const toAdopt = detected.filter((d) => keys.includes(d.key));
   if (toAdopt.length === 0) return [];
 
+  // A station's tenant is its node's, read from the node rather than resolved
+  // from the caller. The composite FK (stations.node_id, tenant_id) → nodes
+  // makes the alternative unrepresentable anyway: a request cannot adopt a
+  // station into a tenant its node is not in, so asking the node is the only
+  // answer that can succeed.
+  const [nodeRow] = await db
+    .select({ tenantId: nodes.tenantId })
+    .from(nodes)
+    .where(eq(nodes.id, nodeId));
+  if (!nodeRow) throw new Error(`cannot adopt stations on unknown node ${nodeId}`);
+  const tenantId = nodeRow.tenantId;
+
   // ── First pass: upsert all rows without parent links ─────────────────────
   for (const station of toAdopt) {
     await db
       .insert(stations)
       .values({
         id: `station_${crypto.randomUUID()}`,
+        tenantId,
         userId,
         nodeId,
         harness: station.harness,

--- a/apps/hub/tests/integration/acp-runs-id-space.test.ts
+++ b/apps/hub/tests/integration/acp-runs-id-space.test.ts
@@ -21,6 +21,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../../src/db/schema/tenants";
 
 import { db, rawSql } from "../../src/db/drizzle";
 import { acpSessions, acpRuns } from "../../src/db/schema/acp";
@@ -38,6 +39,10 @@ type RunRow = typeof acpRuns.$inferInsert;
 
 const runRow = (over: Partial<RunRow>): RunRow => ({
   id: OWN_ID,
+  // An attempt sits in its session's tenant — the composite FK added by
+  // migration 0036 means these must agree, and the session below is seeded into
+  // the same one.
+  tenantId: BOOTSTRAP_TENANT_ID,
   sessionId: SESSION_ID,
   stationId: STATION_ID,
   state: "working",
@@ -74,6 +79,7 @@ beforeAll(async () => {
   await rawSql`DELETE FROM acp_runs WHERE station_id = ${STATION_ID}`;
   await rawSql`DELETE FROM acp_sessions WHERE station_id = ${STATION_ID}`;
   await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id: SESSION_ID,
     stationId: STATION_ID,
     userId: USER_ID,

--- a/apps/hub/tests/integration/backfill-last-seq.test.ts
+++ b/apps/hub/tests/integration/backfill-last-seq.test.ts
@@ -26,6 +26,7 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
+import { BOOTSTRAP_TENANT_ID } from "../../src/db/schema/tenants";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -61,6 +62,7 @@ function loadBackfillSql(): string {
 async function insertSession(id: string, lastSeq: number): Promise<void> {
   const now = new Date();
   await db.insert(acpSessions).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     id,
     stationId: STATION_ID,
     userId: USER_ID,
@@ -77,6 +79,7 @@ async function insertSession(id: string, lastSeq: number): Promise<void> {
 
 async function insertEvent(sessionId: string, seq: number): Promise<void> {
   await db.insert(acpEvents).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
     sessionId,
     seq,
     type: "state",

--- a/apps/hub/tests/integration/enrollment.test.ts
+++ b/apps/hub/tests/integration/enrollment.test.ts
@@ -51,8 +51,8 @@ const HOST_INFO = { hostname: "identity-test", os: "linux", arch: "amd64", cpuCo
 async function seedRuntime(userId: string): Promise<string> {
   const id = `rt_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
   await rawSql`
-    INSERT INTO provisioned_runtimes (id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
-    VALUES (${id}, ${userId}, 'docker', 'provisioning', 'identity-test', 'small', 'none', now(), now())
+    INSERT INTO provisioned_runtimes (tenant_id, id, user_id, provider, status, name, resource_tier, harness, created_at, updated_at)
+    VALUES ('fleet_00000000000000000000', ${id}, ${userId}, 'docker', 'provisioning', 'identity-test', 'small', 'none', now(), now())
   `;
   return id;
 }

--- a/apps/hub/tests/integration/gateway-runtime-resume.test.ts
+++ b/apps/hub/tests/integration/gateway-runtime-resume.test.ts
@@ -86,8 +86,8 @@ async function enrolledNodeWithRuntime(
   const runtimeId = `rt-${creds.nodeId}`;
   await rawSql`
     INSERT INTO provisioned_runtimes
-      (id, user_id, provider, external_id, status, status_reason, node_id, name, harness)
-    VALUES (${runtimeId}, ${TEST_USER_ID}, 'fly', ${`fly-${creds.nodeId}`},
+      (tenant_id, id, user_id, provider, external_id, status, status_reason, node_id, name, harness)
+    VALUES ('fleet_00000000000000000000', ${runtimeId}, ${TEST_USER_ID}, 'fly', ${`fly-${creds.nodeId}`},
             ${status}::runtime_status, ${statusReason}, ${creds.nodeId}, ${hostname}, 'opencode')
   `;
   return { ...creds, runtimeId };

--- a/apps/hub/tests/integration/gateway.test.ts
+++ b/apps/hub/tests/integration/gateway.test.ts
@@ -368,8 +368,8 @@ async function enrollProvisionedNode(hostname: string) {
     hostname, os: "linux", arch: "amd64", cpuCount: 1,
   });
   await rawSql`
-    INSERT INTO provisioned_runtimes (id, user_id, provider, status, node_id, name, harness)
-    VALUES (${`rt-${creds.nodeId}`}, ${TEST_USER_ID}, 'docker', 'online',
+    INSERT INTO provisioned_runtimes (tenant_id, id, user_id, provider, status, node_id, name, harness)
+    VALUES ('fleet_00000000000000000000', ${`rt-${creds.nodeId}`}, ${TEST_USER_ID}, 'docker', 'online',
             ${creds.nodeId}, ${hostname}, 'opencode')
   `;
   return creds;

--- a/apps/hub/tests/integration/station-observe.test.ts
+++ b/apps/hub/tests/integration/station-observe.test.ts
@@ -96,7 +96,7 @@ const fakeFileContent = {
 const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id") ?? "anonymous";
-    c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+    c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     return next();
   })
   .route("/public/nodes", gatewayRoutes)

--- a/apps/hub/tests/integration/stations.test.ts
+++ b/apps/hub/tests/integration/stations.test.ts
@@ -94,7 +94,7 @@ const fakeDetected = [
 const testApp = new Hono()
   .use("/api/*", async (c, next) => {
     const userId = c.req.header("X-Test-User-Id") ?? "anonymous";
-    c.set("user", { id: userId, authType: "api_key" } satisfies AuthUser);
+    c.set("user", { id: userId, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
     return next();
   })
   .route("/public/nodes", gatewayRoutes)

--- a/apps/hub/tests/integration/tenant-isolation.test.ts
+++ b/apps/hub/tests/integration/tenant-isolation.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration Test: the tenant boundary, as it exists in Postgres.
+ *
+ * `tests/unit/tenant-scope.test.ts` pins the boundary's shape in TypeScript.
+ * This file exists because a column declared in a Drizzle schema and never
+ * migrated would pass every assertion there and isolate nothing — the same
+ * reason `acp-runs-id-space.test.ts` exercises its CHECKs against a real
+ * database rather than against drizzle's in-memory table config.
+ *
+ * Two halves:
+ *
+ * 1. **The database agrees with the whitelist.** Read from `information_schema`,
+ *    in both directions — every registered table really has the column, and
+ *    every table that has the column is really registered. The second direction
+ *    is the one that catches drift: a migration that adds `tenant_id` to a new
+ *    table fails here until someone decides what that table is.
+ *
+ * 2. **A scoped read really is scoped.** Two tenants, one user id, one query.
+ *    With one tenant in production this is the only place the isolation can
+ *    actually be observed, so it is the only place that can prove the predicate
+ *    does something — which makes it the test that fails if the scoping is
+ *    removed from `listNodes`.
+ *
+ * DATABASE_URL must point to the local Docker test-postgres on localhost:5434.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL || "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { getTableName } from "drizzle-orm";
+
+import { rawSql } from "../../src/db/drizzle";
+import { BOOTSTRAP_TENANT_ID, TENANT_SCOPED_TABLES } from "../../src/db/tenant-scope";
+import { listNodes } from "../../src/services/node-registry";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+
+const OTHER_TENANT = "fleet_11111111111111111111";
+const SHARED_USER = "tenant-isolation-user";
+const OWN_NODE = "node_1111111111111111aaaa";
+const FOREIGN_NODE = "node_2222222222222222bbbb";
+
+const scopedNames = Object.values(TENANT_SCOPED_TABLES).map((t) => getTableName(t)).sort();
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await rawSql`DELETE FROM nodes WHERE id IN (${OWN_NODE}, ${FOREIGN_NODE})`;
+  await rawSql`DELETE FROM tenants WHERE id = ${OTHER_TENANT}`;
+  await rawSql`DELETE FROM "user" WHERE id = ${SHARED_USER}`;
+  await rawSql`INSERT INTO "user" (id, name, email, email_verified)
+               VALUES (${SHARED_USER}, 'Shared', 'shared@tenant-isolation.test', true)`;
+  await rawSql`INSERT INTO tenants (id, name) VALUES (${OTHER_TENANT}, 'Other')`;
+
+  // The same user id, the same everything — except the tenant. This is the row
+  // that must not come back, and the ONLY thing that can keep it out is the
+  // tenant predicate: an owner filter matches it perfectly.
+  for (const [id, tenant] of [
+    [OWN_NODE, BOOTSTRAP_TENANT_ID],
+    [FOREIGN_NODE, OTHER_TENANT],
+  ] as const) {
+    await rawSql`
+      INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, secret_hash)
+      VALUES (${id}, ${tenant}, ${SHARED_USER}, ${id}, 'h', 'linux', 'arm64', 'x')`;
+  }
+});
+
+afterAll(async () => {
+  await rawSql`DELETE FROM nodes WHERE id IN (${OWN_NODE}, ${FOREIGN_NODE})`;
+  await rawSql`DELETE FROM tenants WHERE id = ${OTHER_TENANT}`;
+  await rawSql`DELETE FROM "user" WHERE id = ${SHARED_USER}`;
+});
+
+describe("the boundary reached the database", () => {
+  test("the bootstrap tenant exists with the deterministic id", async () => {
+    const rows = await rawSql`SELECT id FROM tenants WHERE id = ${BOOTSTRAP_TENANT_ID}`;
+    expect(rows.map((r) => r.id)).toEqual([BOOTSTRAP_TENANT_ID]);
+  });
+
+  test("every registered table really has a NOT NULL tenant_id", async () => {
+    const rows = await rawSql<{ table_name: string; is_nullable: string }[]>`
+      SELECT table_name, is_nullable FROM information_schema.columns
+      WHERE table_schema = 'public' AND column_name = 'tenant_id'`;
+    const byName = new Map(rows.map((r) => [r.table_name, r.is_nullable]));
+
+    const missing = scopedNames.filter((t) => !byName.has(t));
+    expect(missing).toEqual([]);
+
+    const nullable = scopedNames.filter((t) => byName.get(t) !== "NO");
+    expect(nullable).toEqual([]);
+  });
+
+  test("every table with a tenant_id is registered as tenant-scoped", async () => {
+    // The direction that catches drift. A migration adding `tenant_id` to a
+    // table nobody classified leaves a column the database enforces and no
+    // query uses — scoped in storage, unscoped in every read.
+    const rows = await rawSql<{ table_name: string }[]>`
+      SELECT table_name FROM information_schema.columns
+      WHERE table_schema = 'public' AND column_name = 'tenant_id' AND table_name <> 'tenants'`;
+    const unregistered = rows.map((r) => r.table_name).filter((t) => !scopedNames.includes(t)).sort();
+    expect(unregistered).toEqual([]);
+  });
+
+  test("every scoped table's tenant_id is a foreign key to tenants", async () => {
+    // NOT NULL alone would let a row name a tenant that does not exist.
+    const rows = await rawSql<{ table_name: string }[]>`
+      SELECT DISTINCT tc.table_name
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = 'public'
+        AND kcu.column_name = 'tenant_id' AND ccu.table_name = 'tenants'`;
+    const withFk = rows.map((r) => r.table_name);
+    expect(scopedNames.filter((t) => !withFk.includes(t))).toEqual([]);
+  });
+
+  test("no row anywhere sits outside a tenant that exists", async () => {
+    // The backfill's standing assertion, re-checked against whatever the suite
+    // has since written rather than only against the migration's own output.
+    for (const t of scopedNames) {
+      const [{ orphans }] = (await rawSql.unsafe(
+        `SELECT count(*)::text AS orphans FROM "${t}" s
+         WHERE NOT EXISTS (SELECT 1 FROM tenants x WHERE x.id = s.tenant_id)`,
+      )) as unknown as { orphans: string }[];
+      expect({ table: t, orphans }).toEqual({ table: t, orphans: "0" });
+    }
+  });
+});
+
+describe("a scoped read is scoped by tenant, not only by owner", () => {
+  test("listNodes returns the caller's tenant and not another's", async () => {
+    // THE MUTATION TARGET. Both nodes have the same user_id, so the owner
+    // predicate matches both; only the tenant predicate separates them. Delete
+    // the tenantScope() call from listNodes and this test fails — which is the
+    // whole claim that the scoping does something.
+    const ids = (await listNodes(SHARED_USER)).map((n) => n.id).sort();
+    expect(ids).toEqual([OWN_NODE]);
+  });
+
+  test("the foreign node really is there to be leaked", async () => {
+    // Guard the guard. If the fixture silently stopped inserting the other
+    // tenant's row, the test above would pass while proving nothing at all.
+    const rows = await rawSql`
+      SELECT id FROM nodes WHERE user_id = ${SHARED_USER} AND tenant_id = ${OTHER_TENANT}`;
+    expect(rows.map((r) => r.id)).toEqual([FOREIGN_NODE]);
+  });
+
+  test("both rows share an owner, so the owner filter cannot be what excluded one", async () => {
+    const rows = await rawSql`SELECT id FROM nodes WHERE user_id = ${SHARED_USER} ORDER BY id`;
+    expect(rows.map((r) => r.id)).toEqual([OWN_NODE, FOREIGN_NODE].sort());
+  });
+});

--- a/apps/hub/tests/unit/acp.schema.test.ts
+++ b/apps/hub/tests/unit/acp.schema.test.ts
@@ -53,8 +53,17 @@ test("acpSessions.stationId column is named station_id", () => {
 });
 
 test("acpSessions.stationId has NO foreign key (transcripts must survive station deletion)", () => {
+  // Asserts the property rather than a count. This used to read
+  // `foreignKeys.length === 0`, which meant the right thing only for as long as
+  // station_id was the sole candidate — adding the tenant FK broke it while the
+  // invariant it guards was untouched. Naming the column keeps it pointed at
+  // what actually matters: destroying a throwaway station must not cascade a
+  // transcript away.
   const config = getTableConfig(acpSessions);
-  expect(config.foreignKeys.length).toBe(0);
+  const stationFks = config.foreignKeys.filter((fk) =>
+    fk.reference().columns.some((c) => c.name === "station_id"),
+  );
+  expect(stationFks).toEqual([]);
 });
 
 test("acpSessions has an index on station_id", () => {
@@ -88,9 +97,26 @@ test("acpSessions has a (station_id, last_event_at desc) activity index", () => 
 
 test("acpEvents.sessionId still has a foreign key to acpSessions.id ON DELETE CASCADE", () => {
   const config = getTableConfig(acpEvents);
-  expect(config.foreignKeys.length).toBe(1);
-  const fk = config.foreignKeys[0];
-  expect(fk.onDelete).toBe("cascade");
+  const sessionFk = config.foreignKeys.find((fk) => {
+    const cols = fk.reference().columns.map((c) => c.name);
+    return cols.includes("session_id") && !cols.includes("tenant_id");
+  });
+  expect(sessionFk).toBeDefined();
+  expect(sessionFk!.onDelete).toBe("cascade");
+});
+
+test("acpEvents carries a composite FK pinning an event to its session's tenant", () => {
+  // The copied fact, held honest. acp_events.tenant_id duplicates
+  // acp_sessions.tenant_id so the largest table in the database can be read
+  // safely without a join; this is what stops the copy drifting from the
+  // original, and it cascades for the same reason the plain session FK does.
+  const config = getTableConfig(acpEvents);
+  const composite = config.foreignKeys.find((fk) => {
+    const cols = fk.reference().columns.map((c) => c.name).sort();
+    return cols.join() === ["session_id", "tenant_id"].join();
+  });
+  expect(composite).toBeDefined();
+  expect(composite!.onDelete).toBe("cascade");
 });
 
 test("acpEvents.sessionId column is named session_id", () => {

--- a/apps/hub/tests/unit/fleet-route.test.ts
+++ b/apps/hub/tests/unit/fleet-route.test.ts
@@ -70,6 +70,7 @@ function makeTestApp() {
       c.set("user", {
         id: TEST_USER_ID,
         authType: "api_key",
+        tenantId: "fleet_00000000000000000000",
       } satisfies AuthUser);
       return next();
     })
@@ -175,7 +176,7 @@ describe("GET /api/fleet/stats", () => {
     });
     const app = new Hono()
       .use("/api/fleet/*", async (c, next) => {
-        c.set("user", { id: TEST_USER_ID, authType: "api_key" } satisfies AuthUser);
+        c.set("user", { id: TEST_USER_ID, authType: "api_key" , tenantId: "fleet_00000000000000000000"} satisfies AuthUser);
         return next();
       })
       .route("/api/fleet", routes);

--- a/apps/hub/tests/unit/nodes-update-route.test.ts
+++ b/apps/hub/tests/unit/nodes-update-route.test.ts
@@ -52,6 +52,7 @@ function makeTestApp(mockRequest: RequestFn) {
       c.set("user", {
         id: TEST_USER_ID,
         authType: "api_key",
+        tenantId: "fleet_00000000000000000000",
       } satisfies AuthUser);
       return next();
     })

--- a/apps/hub/tests/unit/tenant-scope.test.ts
+++ b/apps/hub/tests/unit/tenant-scope.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { getTableName, is, Table } from "drizzle-orm";
+import { eq, getTableName, is, Table } from "drizzle-orm";
 
 import * as schema from "../../src/db/schema";
 import {
@@ -30,6 +30,7 @@ import {
   TENANT_SCOPED_TABLES,
   TenantIsolationError,
   tenantScope,
+  tenantScopedSelect,
 } from "../../src/db/tenant-scope";
 import { TenantId } from "@agentpod/contract";
 
@@ -155,15 +156,20 @@ describe("tenant guard — a scoped predicate cannot be built without a tenant",
     );
   });
 
-  test("binds tenant_id as the first predicate", () => {
-    // Ordering is the kaambaan invariant and it is cheap to keep: the tenant is
-    // never one condition among several that a later edit might drop.
-    const sql = tenantScope(schema.nodes, TENANT);
-    const rendered = JSON.stringify(sql);
-    expect(rendered).toContain("tenant_id");
-    expect(rendered.indexOf("tenant_id")).toBeLessThan(
-      rendered.indexOf("user_id") === -1 ? Infinity : rendered.indexOf("user_id"),
-    );
+  test("binds tenant_id as the first predicate, ahead of the caller's own", () => {
+    // Ordering is the kaambaan invariant and it costs nothing to keep: the
+    // tenant is never one condition among several that a later edit might
+    // reorder away. Rendered rather than inspected — what matters is the SQL
+    // that reaches Postgres, not the shape of the builder that produced it.
+    const { sql, params } = tenantScopedSelect(
+      schema.nodes,
+      TENANT,
+      eq(schema.nodes.userId, "some-user"),
+    ).toSQL();
+
+    expect(sql).toContain("tenant_id");
+    expect(sql.indexOf("tenant_id")).toBeLessThan(sql.indexOf("user_id"));
+    expect(params[0]).toBe(TENANT);
   });
 
   test("accepts a valid tenant on a registered table", () => {

--- a/apps/hub/tests/unit/tenant-scope.test.ts
+++ b/apps/hub/tests/unit/tenant-scope.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The tenant-isolation guard.
+ *
+ * AgentPod had no isolation boundary at all: every row hung off a `user_id` and
+ * nothing above it. This suite pins the boundary's *shape* — which tables carry
+ * a tenant, which deliberately do not, and that a scoped query cannot be built
+ * without a tenant.
+ *
+ * The important test here is `every table in the schema is classified`. A list
+ * someone has to remember to update is not a guard; #308 made that point for id
+ * collisions by showing every validator every other entity's minted id rather
+ * than enumerating the pairs that had gone wrong so far. The equivalent here is
+ * to enumerate the *schema* rather than the whitelist: adding a table without
+ * deciding whether it belongs to a tenant fails, and the decision is recorded in
+ * code with a reason rather than left to review.
+ *
+ * No database — this is the config-level half. That the columns and constraints
+ * actually reached Postgres is `tests/integration/tenant-isolation.test.ts`,
+ * because a column declared in TypeScript and never migrated would pass every
+ * assertion in this file and isolate nothing.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getTableName, is, Table } from "drizzle-orm";
+
+import * as schema from "../../src/db/schema";
+import {
+  BOOTSTRAP_TENANT_ID,
+  TENANT_EXEMPT_TABLES,
+  TENANT_SCOPED_TABLES,
+  TenantIsolationError,
+  tenantScope,
+} from "../../src/db/tenant-scope";
+import { TenantId } from "@agentpod/contract";
+
+/** Every Drizzle table the schema module exports, by SQL name. */
+const allSchemaTables = (): string[] =>
+  [...new Set(Object.values(schema).filter((v) => is(v, Table)).map((t) => getTableName(t as Table)))].sort();
+
+const scopedNames = (): string[] =>
+  Object.values(TENANT_SCOPED_TABLES).map((t) => getTableName(t)).sort();
+
+const exemptNames = (): string[] => Object.keys(TENANT_EXEMPT_TABLES).sort();
+
+describe("tenant guard — every table is a decision", () => {
+  test("every table in the schema is classified as scoped or exempt", () => {
+    // THE GUARD. Not a list of tables someone remembered: the schema itself is
+    // the source, so a new pgTable that belongs to a tenant and was never scoped
+    // fails here on the commit that adds it, with no test to remember to write.
+    const classified = new Set([...scopedNames(), ...exemptNames()]);
+    const unclassified = allSchemaTables().filter((t) => !classified.has(t));
+
+    expect(unclassified).toEqual([]);
+  });
+
+  test("no table is both scoped and exempt", () => {
+    const exempt = new Set(exemptNames());
+    expect(scopedNames().filter((t) => exempt.has(t))).toEqual([]);
+  });
+
+  test("nothing is classified that is not in the schema", () => {
+    // The mirror: a stale entry left behind by a dropped table would make the
+    // guard above pass while covering a table that no longer exists.
+    const known = new Set(allSchemaTables());
+    expect([...scopedNames(), ...exemptNames()].filter((t) => !known.has(t))).toEqual([]);
+  });
+
+  test("every scoped table actually carries a tenantId column", () => {
+    const missing = Object.entries(TENANT_SCOPED_TABLES)
+      .filter(([, t]) => !("tenantId" in t))
+      .map(([name]) => name);
+    expect(missing).toEqual([]);
+  });
+
+  test("no exempt table carries a tenantId column", () => {
+    // Catches the half-done change: a table given a tenant_id column but never
+    // added to the whitelist would be scoped in the database and unscoped in
+    // every query — the worst of both, and invisible without this.
+    const stray = Object.entries(TENANT_EXEMPT_TABLES)
+      .filter(([, e]) => "tenantId" in e.table)
+      .map(([name]) => name);
+    expect(stray).toEqual([]);
+  });
+
+  test("every exemption records why", () => {
+    // An exemption without a reason is a todo. These are the ones that need a
+    // real argument, so the argument has to be written down next to the entry.
+    for (const [name, entry] of Object.entries(TENANT_EXEMPT_TABLES)) {
+      expect(entry.reason.length, `${name} must record why it is not tenant-scoped`).toBeGreaterThan(
+        30,
+      );
+    }
+  });
+});
+
+describe("tenant guard — unscoped tables are legitimate, and stay refusable", () => {
+  // These are what fails if the guard is made unconditional — if "every table
+  // must be scoped" replaced the classification. Some tables genuinely belong to
+  // no tenant, and a guard that cannot say so would force a meaningless tenant
+  // onto them.
+  test("the Better Auth family is exempt, not forgotten", () => {
+    // AgentPod declares these tables but Better Auth owns their lifecycle: it
+    // inserts and deletes them through its own adapter, so a NOT NULL column
+    // AgentPod has to populate is a column Better Auth will not populate. The
+    // strategy also assigns principals to the Organization plane, so pinning a
+    // user to an AgentPod-local tenant would model the org in the wrong plane —
+    // exactly what MT-1 (#145) was rewritten to avoid.
+    for (const t of ["user", "session", "account", "verification"]) {
+      expect(TENANT_EXEMPT_TABLES[t], `${t} must be an explicit exemption`).toBeDefined();
+    }
+  });
+
+  test("instance-wide tables are exempt", () => {
+    // system_settings is one row per key for the whole hub (signup open/closed);
+    // admin_audit_log records instance-admin actions that cross tenants by
+    // definition — banning a user is not an act inside a fleet.
+    expect(TENANT_EXEMPT_TABLES["system_settings"]).toBeDefined();
+    expect(TENANT_EXEMPT_TABLES["admin_audit_log"]).toBeDefined();
+  });
+
+  test("the tenants table is exempt from itself", () => {
+    expect(TENANT_EXEMPT_TABLES["tenants"]).toBeDefined();
+  });
+
+  test("the exemption list is not empty", () => {
+    // Guard the guard: if exemptions were ever removed as a concept, the tests
+    // above would vanish with them and this one would not.
+    expect(exemptNames().length).toBeGreaterThan(0);
+  });
+});
+
+describe("tenant guard — a scoped predicate cannot be built without a tenant", () => {
+  const TENANT = BOOTSTRAP_TENANT_ID;
+
+  test("refuses a table that is not registered as tenant-scoped", () => {
+    // The kaambaan principle, transferred: the helper is not a convenience that
+    // also happens to filter. Asking it to scope `user` is a bug, and it says so
+    // rather than quietly building a predicate against a column that is absent.
+    expect(() => tenantScope(schema.user as never, TENANT)).toThrow(TenantIsolationError);
+    expect(() => tenantScope(schema.systemSettings as never, TENANT)).toThrow(/not registered/);
+  });
+
+  test("refuses an absent, empty or blank tenant", () => {
+    for (const bad of [undefined, null, "", "   "]) {
+      expect(() => tenantScope(schema.nodes, bad as never)).toThrow(TenantIsolationError);
+    }
+  });
+
+  test("refuses an id that is not an AgentPod tenant id", () => {
+    // `tnt_…` is kaambaan's tenant, for rows in a different database. A value
+    // that arrived across the seam must not silently become a predicate here.
+    expect(() => tenantScope(schema.nodes, "tnt_5f2b8c1a9d3e4076")).toThrow(TenantIsolationError);
+    expect(() => tenantScope(schema.nodes, "node_9f1c2ab04d7e6b3a5c88")).toThrow(
+      TenantIsolationError,
+    );
+  });
+
+  test("binds tenant_id as the first predicate", () => {
+    // Ordering is the kaambaan invariant and it is cheap to keep: the tenant is
+    // never one condition among several that a later edit might drop.
+    const sql = tenantScope(schema.nodes, TENANT);
+    const rendered = JSON.stringify(sql);
+    expect(rendered).toContain("tenant_id");
+    expect(rendered.indexOf("tenant_id")).toBeLessThan(
+      rendered.indexOf("user_id") === -1 ? Infinity : rendered.indexOf("user_id"),
+    );
+  });
+
+  test("accepts a valid tenant on a registered table", () => {
+    expect(() => tenantScope(schema.nodes, TENANT)).not.toThrow();
+    expect(() => tenantScope(schema.acpEvents, TENANT)).not.toThrow();
+  });
+});
+
+describe("the bootstrap tenant", () => {
+  test("is a valid AgentPod tenant id by the shared corpus grammar", () => {
+    // Same validator the ecosystem-identity corpus drives, so the hub and the
+    // cross-repo fixture cannot drift on what a tenant id looks like.
+    expect(TenantId.safeParse(BOOTSTRAP_TENANT_ID).success).toBe(true);
+  });
+
+  test("is deterministic, not minted", () => {
+    // A fresh deploy and the live hub must land on the SAME tenant id without
+    // coordinating — the migration creates this exact value on both.
+    expect(BOOTSTRAP_TENANT_ID).toBe("fleet_00000000000000000000");
+  });
+
+  test("is not kaambaan's tenant id space", () => {
+    expect(BOOTSTRAP_TENANT_ID.startsWith("tnt_")).toBe(false);
+  });
+});

--- a/fixtures/ecosystem-identity/id_grammar.json
+++ b/fixtures/ecosystem-identity/id_grammar.json
@@ -261,6 +261,39 @@
     },
 
     {
+      "entity": "agentpod.tenant",
+      "owner": "agentpod",
+      "prefix": "fleet",
+      "grammar": "^fleet_[0-9a-f]{20}$",
+      "grammarSource": "agentpod packages/contract/src/ids.ts — TenantId. Also enforced in the database: tenants carries a CHECK constraint (`tenants_id_is_agentpod_fleet`) added by migration 0036.",
+      "mintedAs": "^fleet_[0-9a-f]{20}$",
+      "mintSource": "agentpod apps/hub/src/db/schema/tenants.ts — BOOTSTRAP_TENANT_ID, a deterministic literal created by migration 0036. No random minter exists yet: exactly one tenant exists, and it must be the SAME id on a fresh deploy and on the live hub, which a random id cannot guarantee. When a second tenant becomes creatable the minter is prefixedId('fleet'), the helper already used for node/rt/etk.",
+      "note": "AgentPod's LOCAL isolation boundary. Deliberately NOT `tnt_`, which kaambaan mints: neither product owns the organisation — that belongs to an Organization plane that does not exist yet — so each keeps its own local tenant and records an optional external mapping (tenants.external_id + tenants.external_source) to the same real organisation elsewhere. Two products minting one prefix for rows in different databases is precisely the `run_` collision resolved on 2026-08-14, and doing it deliberately would be worse than doing it by accident.\n\nWhy `fleet` and not an abbreviation of `tenant`: `ten_`, `tn_` and `tnnt_` are all one glance from kaambaan's `tnt_` while meaning the identical thing in a different database — the `acp_`/`acps_` near-miss recorded below is already evidence that one character of distance is not distance. A prefix that differs from its table name is the norm in this repo, not an exception (`rt_`/provisioned_runtimes, `etk_`/enrollment_tokens, `acps_`/acp_sessions, `attempt_`/acp_runs), so the table keeps the suite's shared word — `tenants`, column `tenant_id`, which is what an Organization plane will map — while the id space says whose rows these are. `fleet` also names what an AgentPod tenant contains: the nodes, stations and runtimes of one fleet.\n\nWhy the 20-hex family and not the hyphenated-UUID family: this is the one AgentPod id DESIGNED to cross the repo seam — kaambaan's tenant row records it as its own external id, and the Organization plane will map it. kaambaan's declared alphabet is base62 with no separator (`^<prefix>_[A-Za-z0-9]{6,}$`), so every id in AgentPod's hyphenated family is rejected by the peer's own contract on arrival; the corpus already records that as a live disagreement for `station_`. `fleet_<20 hex>` satisfies both repos' grammars, so the mapping is exchangeable in both directions on the day it is written rather than after a migration.",
+      "accept": [
+        { "value": "fleet_00000000000000000000", "mint": true, "note": "THE BOOTSTRAP TENANT. All-zero on purpose: deterministic, so a fresh deploy and the live hub agree without coordinating, and unmistakable in a log line as the one tenant that was created by a migration rather than by a person." },
+        { "value": "fleet_9f1c2ab04d7e6b3a5c88", "mint": true, "note": "what prefixedId('fleet') will produce for the second tenant" }
+      ],
+      "reject": [
+        { "value": "tnt_5f2b8c1a9d3e4076", "reason": "other-entity", "note": "THE COLLISION THIS PREFIX EXISTS TO AVOID — a kaambaan tenant. Both name an isolation boundary, both are the natural join for the same real organisation, and they live in different databases; a shared prefix would make a value read out of context unattributable, which is the `run_` failure exactly." },
+        { "value": "tenant_00000000000000000000", "reason": "wrong-prefix", "note": "the spelled-out word" },
+        { "value": "ten_00000000000000000000", "reason": "wrong-prefix", "note": "an abbreviation of `tenant` one character from kaambaan's `tnt_`. Rejected here so a later hand cannot quietly re-introduce the near-miss the note above rules out." },
+        { "value": "fleet_9f1c2ab04d7e6b3a", "reason": "too-short", "note": "16 hex — kaambaan's length. AgentPod slices the same UUID source to 20; a kaambaan-shaped id must not pass as an AgentPod tenant." },
+        { "value": "fleet_9f1c2ab04d7e6b3a5c88a", "reason": "too-long", "note": "21 hex — catches a regex missing its trailing $" },
+        { "value": "fleet_9F1C2AB04D7E6B3A5C88", "reason": "wrong-alphabet", "note": "uppercase hex is never minted; accepting it means two spellings of one tenant can both exist as distinct primary keys, which is an isolation boundary with two names" },
+        { "value": "fleet_9f1c2ab0-4d7e-6b3a-5c88-000000000000", "reason": "wrong-alphabet", "note": "hyphenated UUID — AgentPod's OTHER family, and the one kaambaan's contract would reject on arrival. Choosing it here would have made the external mapping unusable in one direction." },
+        { "value": "node_9f1c2ab04d7e6b3a5c88", "reason": "other-entity", "note": "same family and same length — a node id and a tenant id are now one prefix apart in shape, so this case is what keeps them apart in a validator" },
+        { "value": "fleets_00000000000000000000", "reason": "prefix-not-anchored" },
+        { "value": "xfleet_00000000000000000000", "reason": "prefix-not-anchored" },
+        { "value": "fleet_", "reason": "prefix-only" },
+        { "value": "00000000000000000000", "reason": "no-prefix" },
+        { "value": "fleet00000000000000000000", "reason": "no-separator" },
+        { "value": "fleet_00000000000000000000\n", "reason": "trailing-newline" },
+        { "value": " fleet_00000000000000000000", "reason": "leading-whitespace" },
+        { "value": "", "reason": "empty" }
+      ]
+    },
+
+    {
       "entity": "agentpod.user",
       "owner": "agentpod",
       "prefix": null,
@@ -310,7 +343,8 @@
       { "prefix": "audit", "owner": "agentpod", "entity": "auditEntry", "status": "minted-never-declared", "note": "apps/hub/src/services/audit.ts:94 — `audit_${crypto.randomUUID()}`, hyphenated-UUID family" },
       { "prefix": "enr", "owner": "agentpod", "entity": "enrollmentTokenSecret", "status": "credential" },
       { "prefix": "chg", "owner": "agentpod", "entity": "change", "status": "reserved-never-minted", "note": "only appears as a test literal in packages/contract/src/run.test.ts; Change is a reserved schema with no writer" },
-      { "prefix": "attempt", "owner": "agentpod", "entity": "acpRun", "status": "reserved-never-minted", "note": "acp_runs.id. Reserved but validated and CHECK-constrained ahead of its first writer — see the agentpod.acpRun entity, and resolvedConflicts for the `run_` prefix it replaced." }
+      { "prefix": "attempt", "owner": "agentpod", "entity": "acpRun", "status": "reserved-never-minted", "note": "acp_runs.id. Reserved but validated and CHECK-constrained ahead of its first writer — see the agentpod.acpRun entity, and resolvedConflicts for the `run_` prefix it replaced." },
+      { "prefix": "fleet", "owner": "agentpod", "entity": "tenant", "status": "declared-and-minted", "note": "tenants.id — AgentPod's LOCAL isolation boundary, deliberately not kaambaan's `tnt_`. Exactly one value is minted today (the bootstrap tenant, created deterministically by migration 0036) and it is validated in the contract and CHECK-constrained in the database. See the agentpod.tenant entity for why the prefix is not an abbreviation of `tenant` and why it takes the 20-hex family rather than the hyphenated one." }
     ],
     "knownConflicts": [],
     "resolvedConflicts": [
@@ -329,7 +363,7 @@
     "Principal shape: kaambaan `usr_<16 hex>`; AgentPod a bare unprefixed UUID. No mapping exists in either repo.",
     "Token length: kaambaan takes 16 hex from a UUID, AgentPod takes 20. Same source, different slice, no reason recorded in either.",
     "Alphabet: AgentPod has TWO families — `<prefix>_<20 hex>` (node, rt, etk) and `<prefix>_<hyphenated UUID>` (station, acps, attempt, audit). kaambaan's declared alphabet is base62 with no hyphen, so it would reject every id in AgentPod's second family.",
-    "Tenancy: kaambaan pins every principal to exactly one tenant at the storage layer; AgentPod has no tenant concept at all, so no AgentPod id carries tenancy. Out of scope here, flagged because it is the largest remaining modelling decision (see docs/strategy/2026-08-13-ecosystem-identity-decisions.md).",
+    "Tenancy: both repos now scope their own rows structurally, and NEITHER owns the organisation — that belongs to an Organization plane that does not exist yet, so each keeps a LOCAL boundary (kaambaan `tnt_`, AgentPod `fleet_`) plus an optional external mapping to the same real organisation elsewhere. What is still open is the mapping itself: nothing has yet written an AgentPod tenants.external_id, no kaambaan tenant points back, and per ecosystem decision 2 that link must be minted explicitly rather than inferred from a matching name. Was 'AgentPod has no tenant concept at all'; that half is closed.",
     "RESOLVED 2026-08-14 — prefix `run` was claimed by both repos; AgentPod moved acp_runs.id to `attempt_` and kaambaan keeps `run_`. See prefixRegistry.resolvedConflicts."
   ]
 }

--- a/packages/contract/src/ecosystem-identity.test.ts
+++ b/packages/contract/src/ecosystem-identity.test.ts
@@ -28,6 +28,7 @@ import {
   KaambaanMembershipId,
   KaambaanAgentId,
   KaambaanRunId,
+  TenantId,
   NodeId,
   RuntimeId,
   EnrollmentTokenId,
@@ -90,6 +91,7 @@ const VALIDATORS: Record<string, ZodType> = {
 
   // AgentPod-owned. AgentPod is the only minter, so these are pinned to exactly
   // what the mint sites produce.
+  "agentpod.tenant": TenantId,
   "agentpod.node": NodeId,
   "agentpod.runtime": RuntimeId,
   "agentpod.enrollmentToken": EnrollmentTokenId,

--- a/packages/contract/src/ids.ts
+++ b/packages/contract/src/ids.ts
@@ -91,6 +91,42 @@ const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const uuidSuffixedId = (prefix: string) =>
   z.string().regex(new RegExp(`^${prefix}_${UUID}$`), `expected a "${prefix}_…" id`);
 
+/**
+ * AgentPod's **local** isolation boundary — `tenants.id`, and deliberately not `tnt_`.
+ *
+ * Neither AgentPod nor kaambaan owns the organisation. Principal, Team, Role and
+ * authority belong to an Organization plane that does not exist yet, and both
+ * products have to run standalone in the meantime, so each keeps a local tenant
+ * and records an *optional* external mapping — `tenants.external_id` +
+ * `tenants.external_source` — to the same real organisation elsewhere. Minting
+ * kaambaan's `tnt_` for rows in a different database would be the `run_`
+ * collision committed on purpose rather than by accident.
+ *
+ * **Why `fleet` rather than an abbreviation of `tenant`.** `ten_`, `tn_` and
+ * `tnnt_` all mean the identical thing as `tnt_` while sitting one glance away
+ * from it; the live `acp_`/`acps_` near-miss in this codebase is evidence enough
+ * that one character is not distance. A prefix that differs from its table name
+ * is the norm here, not an exception — `rt_`/provisioned_runtimes,
+ * `etk_`/enrollment_tokens, `acps_`/acp_sessions, `attempt_`/acp_runs — so the
+ * table keeps the suite's shared word (`tenants`, column `tenant_id`, which is
+ * what an Organization plane will eventually map) while the id space says whose
+ * rows these are. `fleet` also names what an AgentPod tenant holds: the nodes,
+ * stations and runtimes of one fleet.
+ *
+ * **Why the 20-hex family and not the hyphenated one.** This is the one AgentPod
+ * id designed from the start to cross the repo seam: kaambaan's tenant row will
+ * record it as an external id, and the Organization plane will map it. kaambaan's
+ * declared alphabet is base62 with no separator, so every id in AgentPod's
+ * hyphenated family — `station_`, `acps_`, `attempt_` — is rejected by the peer's
+ * own contract on arrival, which the corpus already records as a live
+ * disagreement. `fleet_<20 hex>` parses under both repos' grammars, so the
+ * mapping is exchangeable in both directions the day it is written.
+ *
+ * Enforced in the database too (migration 0036), for the same reason `acp_runs`
+ * is: a writer can bypass the contract but not the table.
+ */
+export const TenantId = truncatedUuidId("fleet");
+
 export const NodeId = truncatedUuidId("node");
 export const RuntimeId = truncatedUuidId("rt");
 /**


### PR DESCRIPTION
AgentPod had no isolation boundary. Every row hung off a `user_id` and nothing above it, so there was no thing a row could be *inside* and nothing for a query to be scoped *to*. This makes the boundary real: a local tenant table, a `tenant_id` on the rows that belong to one, an optional external mapping to the organisation elsewhere, structural scoping, and a guard that catches the class rather than a list someone must remember.

**No observable behaviour change.** One tenant exists; every request behaves identically. API-boundary enforcement comes later.

## The prefix and id family: `fleet_<20 lowercase hex>`

Registered in `fixtures/ecosystem-identity/id_grammar.json` with 16 negative cases. The corpus's generalized cross-rejection test — every validator is shown every other entity's minted id — proves it collides with nothing either repo claims, and `knownConflicts` stays `[]`.

**Not `tnt_`.** kaambaan mints that. Neither product owns the organisation: Principal, Team, Role and authority belong to an Organization plane that does not exist yet, and both products must keep running standalone. So each keeps a *local* boundary and records an *optional* external mapping to the same real organisation. Two products minting one prefix for rows in two different databases is the `run_` collision from #308 committed deliberately rather than by accident.

**Not an abbreviation of "tenant" either.** `ten_`, `tn_` and `tnnt_` all mean the identical thing as `tnt_` from one glance away, and the corpus already records the live `acp_`/`acps_` near-miss as evidence that one character is not distance. A prefix differing from its table name is the norm here, not an exception — `rt_`/provisioned_runtimes, `etk_`/enrollment_tokens, `acps_`/acp_sessions, `attempt_`/acp_runs — so the table keeps the suite's shared word (`tenants`, column `tenant_id`, which is what an Organization plane will map) while the id space says whose rows these are. `fleet` also names what an AgentPod tenant holds.

**Why the 20-hex family, not the hyphenated-UUID one.** AgentPod has both. This is the one AgentPod id *designed* to cross the repo seam — kaambaan's tenant row will record it as its own external id, and the Organization plane will map it. kaambaan's declared alphabet is base62 with no separator, so every id in AgentPod's hyphenated family is rejected by the peer's own contract on arrival; the corpus already logs that as a live disagreement for `station_`. `fleet_<20 hex>` parses under both repos' grammars, so the mapping is exchangeable in both directions the day it is written rather than after a migration.

The bootstrap tenant is `fleet_00000000000000000000` — a deterministic literal, not a minted id, because the migration runs independently on a fresh deploy and on the live hub and both must land on the same boundary without coordinating.

## The external mapping

`tenants.external_id` + `tenants.external_source`, shape copied from `acp_runs` rather than invented — including the paired-presence CHECK, plus the two mirrors that precedent also carries:

- `tenants_external_pair` — `(external_id IS NULL) = (external_source IS NULL)`. A foreign id with no source cannot be resolved back to the system that minted it; a source with no id names an origin nothing points at.
- `tenants_id_is_agentpod_fleet` — our own key is ours.
- `tenants_external_is_not_agentpod` — an external id may be any shape the owning system mints, but never one of ours.

A unique index on `(external_source, external_id)` means an organisation maps to at most one AgentPod tenant; NULLs being distinct in Postgres, any number of unmapped tenants coexist. The bootstrap tenant's mapping is left NULL: nothing has linked this hub to a kaambaan tenant, and ecosystem decision 2 requires that link to be *minted explicitly*, never inferred — guessing it in a migration is the exact inference that decision forbids.

## Which tables are scoped, and which deliberately are not

The prior recon listed 8 tables and flagged that its `pgTable(` grep may have missed some. It had: re-enumerating from the schema module found **17**, with `admin.ts` and `cloudflare.ts` contributing four the earlier pass missed. `tenants` itself is the seventeenth.

**Scoped (10):** `nodes`, `provisioned_runtimes`, `enrollment_tokens`, `stations`, `station_audit`, `acp_sessions`, `acp_events`, `acp_runs`, `agent_tasks`, `cloudflare_sandboxes`.

The membership rule is about the row, not about today's query paths: *does this row belong to exactly one tenant?* That has an objective answer. The tempting alternative — "is it reachable only through an already-scoped parent?" — is a claim about the routes that happen to exist and stops being true the moment someone adds one. So `acp_events` is scoped even though it is only ever read through its session.

**Not scoped (7), each with a written reason the guard asserts exists:**

- `user`, `session`, `account`, `verification` — **the Better Auth family.** AgentPod declares these tables but does not own them: Better Auth inserts, updates and deletes them through its own adapter, so a NOT NULL `tenant_id` here is a column AgentPod would have to populate on writes it does not make — every one of them a signup, a login or a token refresh. The deeper reason is the strategy's: principals belong to the Organization plane, which owns "Principal, Team, Role, objective, identity mappings, authority". A user is not *inside* an AgentPod fleet, it *reaches* one — a membership question this plane does not answer. Pinning a user to an AgentPod-local tenant would model the org in the wrong plane and have to be migrated out, which is the objection that reshaped MT-1 (#145). The Better Auth organization plugin is **not** installed, and no membership, role, invite or tenant switcher is added here.
- `system_settings` — one row per key for the whole hub (whether signup is open). Per-tenant configuration would be a different table with a different primary key, not a column on this one.
- `admin_audit_log` — records instance-admin actions that cross tenants by definition; banning a user is not an act performed inside a fleet. Its per-tenant counterpart, `station_audit`, **is** scoped.
- `tenants` — it *is* the boundary. A tenant inside a tenant is the hierarchy the Organization plane owns.

## How a request resolves its tenant today, and where that extends

`resolveTenantForUser()` (`src/auth/tenant.ts`) returns the bootstrap tenant for every principal. That is the honest answer while one tenant exists, and it is deliberately a *resolution function* rather than a default sprinkled across call sites — a default is something a caller forgets, a function is something a caller asks. It is `async` from the start because the thing it becomes is.

It sits at the same layer that already resolves `config.defaultUserId` for the service-auth caller (`config.ts:67` / `config.ts:248`) — also plain configuration, and never a membership lookup either. `AuthUser` gains `tenantId`, set wherever the middleware sets a principal. **When the Organization plane arrives, that one function becomes the membership lookup and every call site is already asking the right question.** A principal belonging to no tenant must then fail closed rather than fall back — a change to that function and nothing else.

**Child rows do not consult it at all.** A station's tenant is read from its node; an `acp_event`'s is carried on the live session; a node's is its *enrollment token's*, because the token is the authority that admitted it to the fleet. The composite FKs make this the only answer that can succeed — a request cannot adopt a station into a tenant its node is not in — so deriving from the parent is not a convention, it is the shape the database insists on.

## The migration on the live dataset

`0036_tenant_isolation_boundary.sql`. The generated form was wrong in two ways that only show on a database that is not empty or not brand new, and both are rewritten:

- `ADD COLUMN "tenant_id" text NOT NULL` succeeds on an empty database and fails on every row the live hub holds. Now add-nullable → backfill → `SET NOT NULL`, where the `SET NOT NULL` *is* the assertion that the backfill was complete: a missed row fails the migration rather than sitting unscoped in a table the guard believes is scoped.
- The composite foreign keys were emitted *before* the unique indexes they reference, which fails even against an empty database. Reordered.

**Deliberately no DEFAULT** on the column: a default would make a forgotten tenant on some future INSERT land silently in the bootstrap tenant, which is the per-query-discipline failure this change exists to replace.

Children are backfilled from their parents rather than from the constant — the same value today, but it says the right thing and it is what the composite FKs check; backfilling a child from a constant would satisfy those keys by luck.

**Rehearsed against real Postgres holding data**, not just an empty database: a scratch database replays all 36 prior migrations, a row is seeded in every one of the ten scoped tables, then 0036 is applied. All 24 assertions pass — every row backfilled, no column left nullable, exactly ten tables gained the column, the bootstrap tenant created unmapped and its insert idempotent, and every CHECK and FK *exercised* rather than read off the catalog (a `tnt_` id refused as our own key; both halves of the external pair; a station refused in a tenant its node is not in; a tenant still owning rows refused deletion).

On the live hub the effect is: one tenant row created, every existing row backfilled into it, nothing else observable.

## Mutation results, both directions

1. **Removed `tenantScope()` from `listNodes`**, back to a bare owner filter → `listNodes returns the caller's tenant and not another's` **FAILS**, returning 2 nodes instead of 1. The integration fixture seeds two nodes with the *same* `user_id` in different tenants, so the owner predicate matches both and only the tenant predicate separates them. The scoping is load-bearing.
2. **Made the guard unconditional** (emptied `TENANT_EXEMPT_TABLES`, so every table must be scoped) → **5 tests FAIL**, including `the Better Auth family is exempt, not forgotten`, `instance-wide tables are exempt` and `every table in the schema is classified`. A guard that cannot say a table legitimately belongs to no tenant is refused.

## The guard catches the class

`tests/unit/tenant-scope.test.ts` enumerates the **schema**, not the whitelist — the same move #308 made for id collisions by showing every validator every other entity's minted id instead of listing the pairs that had gone wrong. Every `pgTable` the schema exports must be classified as scoped or exempt, so a tenant-scoped table added without scoping fails on the commit that adds it, with no test to remember to write. Mirrors: no exempt table may carry a `tenant_id` column (catches the half-done change — scoped in storage, unscoped in every query), nothing may be classified that is not in the schema, and every exemption must carry a reason.

`tests/integration/tenant-isolation.test.ts` closes the gap a schema assertion cannot: it reads `information_schema` in both directions, because a column declared in TypeScript and never migrated would pass every unit assertion and isolate nothing.

Copied facts are enforced rather than trusted: `acp_events` and `acp_runs` carry composite FKs to `acp_sessions(id, tenant_id)`, and `stations` to `nodes(id, tenant_id)`. A child in one tenant on a parent in another is unrepresentable rather than merely unwritten — which is what lets the tenant live on the row instead of requiring a join on every read.

Two pre-existing schema assertions were **tightened, not relaxed**: `acpSessions.stationId has NO foreign key` and the `acp_events` cascade test both asserted a *count* of foreign keys as a proxy for a property, so adding a legitimate tenant FK broke them while the invariants they guard were untouched. They now name the column they mean.

## Verification

- `packages/contract`: **202 pass**, 0 fail (was 197).
- `apps/hub`: **876 pass**, 0 fail (was 849).
- `bun run typecheck`: **15 errors**, unchanged from the documented pre-existing baseline. None added — the two in files touched here (`AnyPgColumn` needing a type-only import, `z.record` arity) are both pre-existing and untouched.
- Migration rehearsed against real Postgres with data, as above.

Not deployed; the live hub was not touched; kaambaan was not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
