### PR TITLE
docs: preserve the verified kaambaan surface the spike measured

### DIFF
--- a/docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-findings.md
@@ -174,7 +174,7 @@ Its `AgentActivity` exposes only `{type, body, action, ephemeral, signal}` — n
 
 ### Four kaambaan doc-versus-code drifts
 
-Recorded in full in `apps/bridge/spike/findings/verified-surface.md`: no `requestInput` verb exists (post an `elicitation` activity instead); a `response` activity does not advance a card despite doc 04 §4 saying so; there is no card-read endpoint (the board snapshot is the only read surface); and `pnpm dev:setup` with tenant `tnt_dev` is a prerequisite that fails with an opaque `D1_ERROR` otherwise.
+Recorded in full in `docs/superpowers/specs/2026-08-11-kaambaan-verified-surface.md`: no `requestInput` verb exists (post an `elicitation` activity instead); a `response` activity does not advance a card despite doc 04 §4 saying so; there is no card-read endpoint (the board snapshot is the only read surface); and `pnpm dev:setup` with tenant `tnt_dev` is a prerequisite that fails with an opaque `D1_ERROR` otherwise.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-11-kaambaan-verified-surface.md
+++ b/docs/superpowers/specs/2026-08-11-kaambaan-verified-surface.md
@@ -1,0 +1,68 @@
+> **Preserved 2026-08-14 from `apps/bridge/spike/findings/verified-surface.md`**, which was
+> deleted with the spike in #310. The raw captures went with it; this distilled record did
+> not, because two documents cite it as the evidence for four kaambaan doc-vs-code drifts —
+> and a spec pointing at a file that no longer exists is how measured findings quietly become
+> folklore.
+>
+> **What has changed since it was written.** "There is no card-read endpoint" is **fixed**:
+> kaambaan PR #33 added `GET /v1/boards/:boardId/runs/:runId`, returning the claim response
+> re-readably, which is what removed the bridge's dev-header dependency. The `tnt_dev` setup
+> requirement still holds for local work. The elicitation and `response`-activity findings
+> still hold, and the missing elicitation return path remains open.
+>
+> Everything below is unedited.
+
+# Verified kaambaan surface (2026-08-11, kaambaan @ `573a9ba`, local `wrangler dev`)
+
+Everything here was observed against a running instance, not read from docs. It corrects
+four things the design and plan assumed.
+
+## Setup requires `tnt_dev` / `usr_dev`
+
+`apps/api/scripts/seed-dev.sql` seeds exactly one tenant (`tnt_dev`), one user (`usr_dev`)
+and their membership. Any other `X-Tenant-Id` fails the catalog foreign key with an opaque
+`500 D1_ERROR: FOREIGN KEY constraint failed`, with nothing naming the tenant. `pnpm
+dev:setup` (D1 migrations + seed) is a prerequisite for `pnpm dev` — the plan omitted it.
+
+## There is no card-read endpoint
+
+| Path | Method | Result |
+|---|---|---|
+| `GET /v1/boards/{board}/cards` | GET | `405 method not allowed` |
+| `GET /v1/boards/{board}/cards/{card}` | GET | `405 method not allowed` |
+| `GET /v1/boards/{board}` | GET | `200` — the whole snapshot |
+
+The board snapshot is the only read surface: `{boardId, tenantId, name, stages, cards, gates,
+references, usage, github}`. Each card carries `{id, title, spec, ownerUserId,
+currentStageKey, state, delegateAgentId, priority, contextId, createdAt, updatedAt, costUsd,
+overBudget, attemptCount}`.
+
+This is better than what the plan guessed at: `attemptCount` is exactly the RQ4 signal (a
+reclaim should increment it), and `costUsd` is per-card metering for RQ5.
+
+`POST /v1/boards/{board}/cards` returns `{card: {…}}` — the id is at `card.id`, not `cardId`.
+
+## A `response` activity does not advance the card
+
+Observed across one full run:
+
+```
+claim     → state=working    stage=work  attempts=1
+thought   → state=working    stage=work  attempts=1
+response  → state=working    stage=work  attempts=1
+complete  → state=submitted  stage=done  attempts=1
+```
+
+Doc 04 §4's activity table says `response` "drives state to `completed`". It did not move
+the card. `complete` advanced it to the next stage, where it sits as `submitted` awaiting
+that stage's human owner — which is correct pipeline behaviour.
+
+**Consequence for the bridge:** posting a terminal `response` activity is not sufficient.
+`complete` must be called explicitly. (Caveat on precision: the snapshot exposes *card*
+state; doc 04 describes *task* state. These may diverge, and the spike only observed the
+card. Either way the operational rule holds.)
+
+## Claim returns a lease epoch starting at 1
+
+`{claimed: true, runId, leaseEpoch: 1, card, stage, handoff}` — `leaseEpoch` must be echoed
+on every subsequent run call (`heartbeat`, `activities`, `complete`, `fail`).


### PR DESCRIPTION
#310 deleted `apps/bridge/spike/` as intended — the spike declared itself throwaway and said Horizon 2 should rewrite or delete it. The raw captures (event dumps, timings, transcripts) deserved to go with it.

`findings/verified-surface.md` did not. It is the only **measured** record of kaambaan's real surface — observed against a running instance, not read from docs — and `docs/superpowers/specs/2026-08-11-kaambaan-bridge-spike-findings.md` cites it as the evidence behind four doc-vs-code drifts. After the deletion that citation pointed at nothing.

That matters more than usual in this repo: today alone, five strategy claims turned out to have been written from documentation rather than code. A spec whose evidence file has been deleted is how a measured finding quietly becomes folklore again.

## What this does

- Restores the file verbatim under `docs/superpowers/specs/2026-08-11-kaambaan-verified-surface.md`.
- Adds a header recording **what has changed since it was written**, rather than presenting a nine-day-old measurement as current:
  - *"There is no card-read endpoint"* is **fixed** — kaambaan #33 added `GET /v1/boards/:boardId/runs/:runId`, which is exactly what let the bridge drop its `X-Tenant-Id: tnt_dev` dependency.
  - The `tnt_dev` local-setup requirement still holds.
  - The `response`-activity and elicitation findings still hold, and the missing elicitation return path remains open.
- Repoints the findings spec at the preserved copy.

The historical plan document still references the deleted `findings/` directory. That is left alone deliberately — it is a record of what the spike was asked to produce, not a live pointer.