### PR TITLE
docs: the pre-flight command mangled any value containing quotes

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -572,15 +572,37 @@ turns a restart into an outage:
 
 ```bash
 cd /opt/agentpod/apps/hub
-env $(grep -v '^#' /etc/agentpod/hub.env | grep -v '^$' | xargs) \
-  /root/.bun/bin/bun --env-file=/dev/null -e '
+python3 - <<'PY'
+import os, subprocess
+env = dict(os.environ)
+for line in open("/etc/agentpod/hub.env"):
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    k, v = line.split("=", 1)
+    env[k.strip()] = v          # literal, exactly as systemd EnvironmentFile does
+script = '''
   const { collectConfigErrors } = await import("./src/utils/validate-config.ts");
-  console.log(JSON.stringify(collectConfigErrors(undefined, () => {}).map(e => e.field)));'
+  console.log(JSON.stringify(collectConfigErrors(undefined, () => {}).map(e => e.field)));
+'''
+r = subprocess.run(["/root/.bun/bin/bun", "--env-file=/dev/null", "-e", script],
+                   env=env, capture_output=True, text=True)
+print(r.stdout.strip() or r.stderr.strip()[-500:])
+PY
 # [] means the hub will boot. Anything else names the variable to fix.
-# --env-file=/dev/null matters: without it bun would also load any .env in the
-# working directory, so you would be validating a different environment than
-# systemd passes.
 ```
+
+Two things about that snippet are load-bearing, and both were learned the hard way:
+
+- **`--env-file=/dev/null`.** Without it bun also loads any `.env` in the working
+  directory, so you would validate a different environment than systemd passes.
+- **Parse the file literally; do not pipe it through `xargs`.** The obvious form —
+  `env $(grep -v '^#' /etc/agentpod/hub.env | xargs) bun …` — was in this runbook
+  until 2026-08-14 and is **wrong**: `xargs` strips quotes, so any value containing
+  them arrives mangled. Enabling the kaambaan bridge, whose roster is a JSON array,
+  produced `KAAMBAAN_BRIDGE_AGENTS is not valid JSON` from a config file that was
+  perfectly valid — a pre-flight failing on a fault it invented, which is worse than
+  no pre-flight at all, because it sends you to debug the wrong thing.
 
 `() => {}` swallows the WARNINGS, and Fly's per-harness image gaps are warnings
 (see the Fly notes above). Pass `console.warn` instead of the empty function to


### PR DESCRIPTION
The config pre-flight this runbook gained in #277 is wrong, and I found out by using it.

```bash
env $(grep -v '^#' /etc/agentpod/hub.env | grep -v '^$' | xargs) bun … # WRONG
```

`xargs` strips quotes. Any value containing them reaches the child mangled.

## How it surfaced

Enabling the kaambaan bridge for its first live run. Its roster is a JSON array:

```
KAAMBAAN_BRIDGE_AGENTS=[{"key":"bridge-tester","boardId":"brd_…",…}]
```

Through `xargs` that becomes `[{key:bridge-tester,…}]`, and the pre-flight reported `KAAMBAAN_BRIDGE_AGENTS is not valid JSON` — from a config file that was perfectly valid. systemd's `EnvironmentFile` reads the value literally, so the hub would have started without complaint.

**A pre-flight that invents a fault is worse than none at all.** One that fails on a real problem sends you to the problem; one that fails on its own parsing sends you to debug a file that was never wrong. It cost a few minutes here only because the failure was implausible enough to make me suspect the harness.

## The fix

A literal `KEY=VALUE` parse that matches systemd's behaviour, with the two load-bearing details written down: the literal parse, and `--env-file=/dev/null` (from #275 — otherwise bun layers a stray `.env` on top and you validate an environment systemd will never pass).

Verified verbatim against the live hub's env file — prints `[]`, and correctly loads the bridge roster that the old form rejected.

No other copy of the broken form exists in the repo.