### PR TITLE
fix(bridge): don't claim work with nowhere to run it, and hand back a claim that never started

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0038_bridge_dispatch_released.sql
+++ b/apps/hub/src/db/drizzle-migrations/0038_bridge_dispatch_released.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "bridge_dispatches" DROP CONSTRAINT "bridge_dispatches_outcome";--> statement-breakpoint
+ALTER TABLE "bridge_dispatches" ADD CONSTRAINT "bridge_dispatches_outcome" CHECK ("bridge_dispatches"."outcome" IN ('working', 'produced', 'reported', 'released', 'abandoned'));

--- a/apps/hub/src/db/drizzle-migrations/meta/0038_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0038_snapshot.json
@@ -1,0 +1,2750 @@
+{
+  "id": "f04cef5a-f03b-4705-9f11-4364dac098b5",
+  "prevId": "3571eeca-52eb-488a-81ea-bc553de7f4b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1786675941921,
       "tag": "0037_bridge_dispatch_ledger",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1786679565310,
+      "tag": "0038_bridge_dispatch_released",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/bridge.ts
+++ b/apps/hub/src/db/schema/bridge.ts
@@ -32,8 +32,20 @@ import { pgTable, text, integer, timestamp, jsonb, primaryKey, index, check } fr
 import { acpRuns } from "./acp";
 import { tenants } from "./tenants";
 
-/** What the bridge knows about a dispatched run, in the order it learns it. */
-export const DISPATCH_OUTCOMES = ["working", "produced", "reported", "abandoned"] as const;
+/**
+ * What the bridge knows about a dispatched run, in the order it learns it.
+ *
+ * `released` is its own outcome rather than a flavour of `abandoned` because the
+ * two answer different questions for whoever reads the row next. `released`
+ * means **no session was ever opened**: the claim was handed straight back to
+ * the board, unpenalised, and nothing can have touched the workspace.
+ * `abandoned` means the run stopped after it had started — a lost lease, a
+ * foreign run, or a harness that died mid-turn — and the workspace may hold
+ * partial work. `acp_run_id` cannot carry that distinction on its own: it is
+ * written on the first ACP event, so a session that opened and failed before
+ * emitting one leaves it null too.
+ */
+export const DISPATCH_OUTCOMES = ["working", "produced", "reported", "released", "abandoned"] as const;
 export type DispatchOutcome = (typeof DISPATCH_OUTCOMES)[number];
 
 export const bridgeDispatches = pgTable(
@@ -88,7 +100,7 @@ export const bridgeDispatches = pgTable(
     check("bridge_dispatches_external_is_not_agentpod", sql`${t.externalRunId} NOT LIKE 'attempt\\_%'`),
     check(
       "bridge_dispatches_outcome",
-      sql`${t.outcome} IN ('working', 'produced', 'reported', 'abandoned')`,
+      sql`${t.outcome} IN ('working', 'produced', 'reported', 'released', 'abandoned')`,
     ),
   ],
 );

--- a/apps/hub/src/services/acp-sessions.test.ts
+++ b/apps/hub/src/services/acp-sessions.test.ts
@@ -72,6 +72,7 @@ import {
   endSession,
   subscribe,
   reconcileOnBoot,
+  stationReadiness,
   closeOrphanedProcesses,
   clampSessionLimit,
   deriveSessionTitle,
@@ -1934,6 +1935,56 @@ test(
 
       fake.close();
       await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      server.stop(true);
+    }
+  },
+  30_000
+);
+
+// ─── Readiness: can a session be opened on this station at all? ──────────────
+//
+// The bridge asks this BEFORE it claims work from a board. It exists because a
+// hub restart put a claim loop in front of node-agents that had not reconnected
+// yet: the claim succeeded, the session open threw "Node is offline.", and the
+// card sat held by a run that never ran. The probe must be exactly as strict as
+// createSession's fail-fast gates and no stricter — a healthy station that reads
+// as not-ready claims nothing at all, which is the same outage with no logs.
+test(
+  "stationReadiness answers the same three gates createSession fails fast on",
+  async () => {
+    const { server, nodeId, fake, station } = await setupRig(
+      "acpsess-readiness-host",
+      { stationKey: "acp-readiness-station" }
+    );
+    try {
+      // A healthy, online, acp-capable station: ready, with nothing to explain.
+      expect(await stationReadiness(TEST_USER, station.id)).toEqual({
+        ready: true,
+      });
+
+      expect(await stationReadiness(TEST_USER, "stn_nope")).toEqual({
+        ready: false,
+        reason: "Station not found.",
+      });
+      // Another user's station is not visible, so it is not ready either.
+      expect(await stationReadiness(OTHER_USER, station.id)).toEqual({
+        ready: false,
+        reason: "Station not found.",
+      });
+
+      fake.close();
+      await waitForNodeUnregistered(nodeId);
+      expect(await stationReadiness(TEST_USER, station.id)).toEqual({
+        ready: false,
+        reason: "Node is offline.",
+      });
+
+      // And the gate is load-bearing: the open it stands in front of throws the
+      // same sentence.
+      await expect(
+        createSession({ stationId: station.id, userId: TEST_USER, mode: "ask" })
+      ).rejects.toThrow("Node is offline.");
     } finally {
       server.stop(true);
     }

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -597,6 +597,41 @@ function withStationOpenLock<T>(
   return run;
 }
 
+/** Whether a session could be opened here right now, and if not, why not. */
+export interface StationReadiness {
+  ready: boolean;
+  /** The sentence `createSession` would have thrown. Absent when ready. */
+  reason?: string;
+}
+
+/**
+ * Can a session be opened on this station at all?
+ *
+ * The same three gates `createSession` fails fast on, asked without opening
+ * anything — for callers that want to know *before* they take on an obligation
+ * they would then have to unwind. The kaambaan bridge is the first: it claims a
+ * card from a board and a claim it cannot execute strands that card until the
+ * board's 15-minute reclaim, so it asks here first.
+ *
+ * Deliberately no stricter than the open it stands in front of. A probe that
+ * refused a station `createSession` would have accepted turns every start into
+ * an outage with no error anywhere — the caller simply never acts.
+ */
+export async function stationReadiness(
+  userId: string,
+  stationId: string
+): Promise<StationReadiness> {
+  const station = await getStation(userId, stationId);
+  if (!station) return { ready: false, reason: "Station not found." };
+  if (!gateCapability(station, "acp")) {
+    return { ready: false, reason: "This station does not support agent sessions." };
+  }
+  if (!connectionManager.isOnline(station.nodeId)) {
+    return { ready: false, reason: "Node is offline." };
+  }
+  return { ready: true };
+}
+
 export async function createSession(
   input: CreateSessionInput
 ): Promise<AcpSessionRow> {
@@ -604,14 +639,8 @@ export async function createSession(
 
   // Fail fast on the obvious gates before queueing (openSession re-checks them
   // under the lock, where the answers are current).
-  const station = await getStation(userId, stationId);
-  if (!station) throw new Error("Station not found.");
-  if (!gateCapability(station, "acp")) {
-    throw new Error("This station does not support agent sessions.");
-  }
-  if (!connectionManager.isOnline(station.nodeId)) {
-    throw new Error("Node is offline.");
-  }
+  const readiness = await stationReadiness(userId, stationId);
+  if (!readiness.ready) throw new Error(readiness.reason);
 
   return withStationOpenLock(stationId, () => openSession(input));
 }

--- a/apps/hub/src/services/bridge/dispatch.ts
+++ b/apps/hub/src/services/bridge/dispatch.ts
@@ -25,6 +25,19 @@
  *    a run that finished and never reported comes back. The work is not
  *    idempotent — it edited a workspace — but the *report* is, so a recorded
  *    handoff is replayed onto the new run and the harness is not started.
+ *
+ * A fourth was measured on the live hub, on the bridge's very first cycle: it
+ * claimed a card two seconds after a restart, before the node-agents had
+ * reconnected, and the session open threw "Node is offline.". The card sat in
+ * `working` with a delegate assigned, held by a run that would never do
+ * anything, until the board's 15-minute reclaim. Two rules came out of it:
+ *
+ * 4. **Nothing is claimed until the station can run it**, so the window is not
+ *    entered in the first place; and **a claim that never started is handed
+ *    back**, so the window that remains costs seconds instead of 15 minutes.
+ *    "Never started" is exact: no ACP session was opened, so nothing can have
+ *    touched the workspace and `release` is unambiguously safe. Once a session
+ *    exists the answer changes — see `failStarted`.
  */
 
 import { CARD_PROMPT_VERSION, CardPrompt, renderCardPrompt, type AcpEvent, type AcpSessionMode } from "@agentpod/contract";
@@ -36,6 +49,7 @@ import {
   endAttempt,
   findUnreportedOutput,
   markAbandoned,
+  markReleased,
   markReported,
   openDispatch,
   recordProduced,
@@ -50,6 +64,11 @@ import {
  * a station — the same seam `acp-agent.ts` already uses for Doors.
  */
 export interface AcpPort {
+  /**
+   * Could a session be opened on this station right now? Asked BEFORE a claim,
+   * because a claim the bridge cannot execute strands a card on the board.
+   */
+  stationReady(input: { stationId: string; userId: string }): Promise<{ ready: boolean; reason?: string }>;
   createSession(input: { stationId: string; userId: string; mode: AcpSessionMode }): Promise<{ id: string }>;
   promptSession(userId: string, sessionId: string, text: string): Promise<void>;
   subscribe(sessionId: string, fn: (e: AcpEvent) => void): () => void;
@@ -70,6 +89,10 @@ export interface DispatchDeps {
 export type DispatchStatus =
   /** Nothing to claim (or the board is over budget, or we are at capacity). */
   | "idle"
+  /** The station cannot run work, so NOTHING was claimed. No card was touched. */
+  | "not-ready"
+  /** Claimed, never started, handed straight back. The card is claimable again. */
+  | "released"
   /** A prior run's output was reported; the harness was not started. */
   | "replayed"
   /** Worked and reported. */
@@ -112,6 +135,18 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
   const { client, acp, agent, tenantId, source } = deps;
   const log = deps.log ?? (() => {});
 
+  // ─── requirement 4a: do not claim work there is nowhere to run ─────────────
+  // The board hands out a card on a claim; the hub cannot un-hand it for 15
+  // minutes except by asking. Checking first is what removes the race entirely,
+  // including the restart case that produced it — the bridge starts with the
+  // hub, the node-agents dial back in seconds later.
+  const readiness = await acp.stationReady({ stationId: agent.stationId, userId: agent.hubUserId });
+  if (!readiness.ready) {
+    const reason = readiness.reason ?? "the station cannot run work right now";
+    log("not claiming: the station is not ready", { station: agent.stationId, reason });
+    return { status: "not-ready", reason };
+  }
+
   const work = await client.claim({ maxConcurrency: agent.maxConcurrency, profileKey: agent.profileKey });
   // A bare "not claimed" covers an empty queue, an over-budget board and an
   // agent at its concurrency cap alike. kaambaan does not say which.
@@ -125,211 +160,356 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
     externalRunId: work.runId,
   };
 
-  await openDispatch({ ...key, agentKey: agent.key, stationId: agent.stationId, leaseEpoch: work.leaseEpoch });
-
-  // ─── requirement 3: check for prior output BEFORE starting work ────────────
-  const prior = await findUnreportedOutput(key);
-  if (prior) {
-    log("replaying a prior run's output", { card: work.card.id, priorRun: prior.externalRunId });
-    try {
-      await client.complete(work, prior.result ?? undefined);
-    } catch (err) {
-      return await abort(deps, key, work, null, err);
-    }
-    await markReported(key);
-    await markReported({ ...key, externalRunId: prior.externalRunId });
-    return { status: "replayed", externalRunId: work.runId };
-  }
-
-  // ─── the prompt contract ───────────────────────────────────────────────────
+  // ─── claimed, and nothing has run yet ──────────────────────────────────────
+  // Everything from here to the session opening happens on a card this bridge
+  // holds and has not begun. A throw anywhere in it used to escape to the loop,
+  // which logged and backed off — leaving the card `working` with a delegate
+  // assigned and a run that would never do anything. It is handed back instead.
   let text: string;
+  let session: { id: string };
   try {
-    text = renderCardPrompt(await assemblePrompt(deps, work));
-  } catch (err) {
-    await client.release(work).catch(() => {});
-    await markAbandoned(key, `could not assemble the prompt: ${String(err)}`);
-    return { status: "failed", externalRunId: work.runId, reason: String(err) };
-  }
+    await openDispatch({ ...key, agentKey: agent.key, stationId: agent.stationId, leaseEpoch: work.leaseEpoch });
 
-  // ─── the session ───────────────────────────────────────────────────────────
-  const session = await acp.createSession({ stationId: agent.stationId, userId: agent.hubUserId, mode: agent.mode });
+    // ─── requirement 3: check for prior output BEFORE starting work ──────────
+    const prior = await findUnreportedOutput(key);
+    if (prior) return await replay(deps, key, work, prior);
+
+    // ─── the prompt contract ────────────────────────────────────────────────
+    text = renderCardPrompt(await assemblePrompt(deps, work));
+
+    // ─── the session ────────────────────────────────────────────────────────
+    session = await acp.createSession({ stationId: agent.stationId, userId: agent.hubUserId, mode: agent.mode });
+  } catch (err) {
+    return await handBack(deps, key, work, err);
+  }
 
   const coalescer = new ActivityCoalescer();
   let attemptId: string | null = null;
   let lastSeq = 0;
   const said: string[] = [];
-
-  let settle: (end: TurnEnd) => void = () => {};
-  const turn = new Promise<TurnEnd>((resolve) => {
-    let done = false;
-    settle = (end) => {
-      if (done) return;
-      done = true;
-      resolve(end);
-    };
-  });
-
-  /**
-   * A lost lease learned late still ends the run.
-   *
-   * Posts are queued, so a 409 can surface *after* the harness has already
-   * yielded and the turn has settled as "yielded". Latching it here rather than
-   * relying on the race means the outcome does not depend on whether the board
-   * answered before or after the last event arrived — and the alternative is a
-   * `complete` sent on a card somebody else now holds.
-   */
-  let abortCause: "lease-superseded" | "foreign-run" | null = null;
-
-  // Posts are serialized so activities reach the board in transcript order —
-  // the same reason acp-sessions chains its own writes.
-  let chain: Promise<void> = Promise.resolve();
-  const queue = (fn: () => Promise<void>): void => {
-    chain = chain.then(fn).catch((err) => {
-      if (isLeaseSuperseded(err)) {
-        abortCause ??= "lease-superseded";
-        return settle({ kind: "lease-superseded" });
-      }
-      if (isForeignRun(err)) {
-        abortCause ??= "foreign-run";
-        return settle({ kind: "foreign-run" });
-      }
-      // Anything else is transient: a dropped activity is not worth ending a
-      // run over, and the board's own ordering is by its `seq`, not ours.
-      log("activity post failed", { error: String(err) });
-    });
-  };
-
-  const post = (activities: BoardActivity[]): void => {
-    for (const a of activities) {
-      if (a.type === "response" && a.body) said.push(a.body);
-      queue(async () => {
-        await client.activity(work, a);
-      });
-    }
-  };
-
-  const unsubscribe = acp.subscribe(session.id, (event) => {
-    lastSeq = Math.max(lastSeq, event.seq);
-
-    if (attemptId === null && !attemptStarted) {
-      attemptStarted = true;
-      // The run join, written as soon as the attempt has a first seq.
-      queue(async () => {
-        attemptId = await startAttempt({
-          ...key,
-          sessionId: session.id,
-          stationId: agent.stationId,
-          startSeq: event.seq,
-        });
-      });
-    }
-
-    if (event.type === "permission-request") {
-      post(coalescer.push(event));
-      return settle({ kind: "permission-required" });
-    }
-
-    if (event.type === "state") {
-      const status = (event.payload as { status?: string } | null)?.status;
-      if (status === "idle") return settle({ kind: "yielded" });
-      if (status === "ended") {
-        const reason = String((event.payload as { reason?: string } | null)?.reason ?? "session ended");
-        return settle({ kind: "session-ended", reason });
-      }
-      return;
-    }
-
-    post(coalescer.push(event));
-  });
-  let attemptStarted = false;
-
-  const beat = setInterval(() => {
-    queue(async () => {
-      await client.heartbeat(work);
-    });
-  }, deps.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
-
+  // Hoisted so the failure exit below can tear them down: a throw here must not
+  // leave a live subscription and a heartbeat still beating for a run that is
+  // over. Both are idempotent, so the happy path's own cleanup still stands.
+  let unsubscribe: () => void = () => {};
+  let beat: ReturnType<typeof setInterval> | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
-  const timeout = new Promise<TurnEnd>((resolve) => {
-    timer = setTimeout(() => resolve({ kind: "timeout" }), deps.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS);
-  });
 
-  let end: TurnEnd;
+  // ─── a session exists from here on ─────────────────────────────────────────
+  // Which changes the answer to "what should happen if this fails": the harness
+  // may already have edited the workspace, so the claim is NOT handed back. See
+  // `failStarted`.
   try {
-    await acp.promptSession(agent.hubUserId, session.id, text);
-    end = await Promise.race([turn, timeout]);
+    let settle: (end: TurnEnd) => void = () => {};
+    const turn = new Promise<TurnEnd>((resolve) => {
+      let done = false;
+      settle = (end) => {
+        if (done) return;
+        done = true;
+        resolve(end);
+      };
+    });
+
+    /**
+     * A lost lease learned late still ends the run.
+     *
+     * Posts are queued, so a 409 can surface *after* the harness has already
+     * yielded and the turn has settled as "yielded". Latching it here rather than
+     * relying on the race means the outcome does not depend on whether the board
+     * answered before or after the last event arrived — and the alternative is a
+     * `complete` sent on a card somebody else now holds.
+     */
+    let abortCause: "lease-superseded" | "foreign-run" | null = null;
+
+    // Posts are serialized so activities reach the board in transcript order —
+    // the same reason acp-sessions chains its own writes.
+    let chain: Promise<void> = Promise.resolve();
+    const queue = (fn: () => Promise<void>): void => {
+      chain = chain.then(fn).catch((err) => {
+        if (isLeaseSuperseded(err)) {
+          abortCause ??= "lease-superseded";
+          return settle({ kind: "lease-superseded" });
+        }
+        if (isForeignRun(err)) {
+          abortCause ??= "foreign-run";
+          return settle({ kind: "foreign-run" });
+        }
+        // Anything else is transient: a dropped activity is not worth ending a
+        // run over, and the board's own ordering is by its `seq`, not ours.
+        log("activity post failed", { error: String(err) });
+      });
+    };
+
+    const post = (activities: BoardActivity[]): void => {
+      for (const a of activities) {
+        if (a.type === "response" && a.body) said.push(a.body);
+        queue(async () => {
+          await client.activity(work, a);
+        });
+      }
+    };
+
+    unsubscribe = acp.subscribe(session.id, (event) => {
+      lastSeq = Math.max(lastSeq, event.seq);
+
+      if (attemptId === null && !attemptStarted) {
+        attemptStarted = true;
+        // The run join, written as soon as the attempt has a first seq.
+        queue(async () => {
+          attemptId = await startAttempt({
+            ...key,
+            sessionId: session.id,
+            stationId: agent.stationId,
+            startSeq: event.seq,
+          });
+        });
+      }
+
+      if (event.type === "permission-request") {
+        post(coalescer.push(event));
+        return settle({ kind: "permission-required" });
+      }
+
+      if (event.type === "state") {
+        const status = (event.payload as { status?: string } | null)?.status;
+        if (status === "idle") return settle({ kind: "yielded" });
+        if (status === "ended") {
+          const reason = String((event.payload as { reason?: string } | null)?.reason ?? "session ended");
+          return settle({ kind: "session-ended", reason });
+        }
+        return;
+      }
+
+      post(coalescer.push(event));
+    });
+    let attemptStarted = false;
+
+    beat = setInterval(() => {
+      queue(async () => {
+        await client.heartbeat(work);
+      });
+    }, deps.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
+
+    const timeout = new Promise<TurnEnd>((resolve) => {
+      timer = setTimeout(() => resolve({ kind: "timeout" }), deps.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS);
+    });
+
+    let end: TurnEnd;
+    try {
+      await acp.promptSession(agent.hubUserId, session.id, text);
+      end = await Promise.race([turn, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      if (beat) clearInterval(beat);
+    }
+
+    await chain;
+    post(coalescer.flush());
+    await chain;
+    unsubscribe();
+
+    // ─── requirement 2: the lease is gone, so the harness must stop ────────────
+    // `abortCause` is checked before `end`, because a queued post can answer 409
+    // after the harness has yielded — and a yield is not permission to report.
+    const aborted = abortCause ?? (end.kind === "lease-superseded" || end.kind === "foreign-run" ? end.kind : null);
+    if (aborted) {
+      return await abort(deps, key, work, attemptId, aborted, session.id);
+    }
+
+    if (end.kind === "permission-required") {
+      // RQ2: an elicitation is a dead end — kaambaan's input-required → working
+      // transition exists and nothing invokes it. Park the card for a human
+      // rather than hold the harness until the reclaim.
+      await acp.endSession(agent.hubUserId, session.id, "A permission request has no return path through the board.").catch(() => {});
+      if (attemptId) await endAttempt(attemptId, "input-required", lastSeq);
+      const reason = "the agent asked for permission, which the board cannot answer";
+      await client.block(work, reason).catch(() => {});
+      await afterTheBoardWasTold(deps, "the card was blocked", () => markAbandoned(key, reason));
+      return { status: "blocked", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason };
+    }
+
+    const contextPeak = coalescer.contextPeak();
+    const handoff = {
+      summary: said.join("").slice(0, SUMMARY_LIMIT) || null,
+      station: agent.stationId,
+      session: session.id,
+      attempt: attemptId,
+      // Context occupancy, not cost: no harness reports tokens or money over ACP.
+      ...(contextPeak ? { contextPeak } : {}),
+    };
+
+    // Written BEFORE the board is told. A bridge that dies between these two
+    // leaves a recoverable fact instead of a card that will be worked twice.
+    await recordProduced(key, handoff);
+    if (attemptId) await endAttempt(attemptId, end.kind === "yielded" ? "completed" : "failed", lastSeq);
+    await acp.endSession(agent.hubUserId, session.id, "The board's card is complete.").catch(() => {});
+
+    if (end.kind === "timeout" || end.kind === "session-ended") {
+      const reason = end.kind === "timeout" ? "the turn exceeded its time limit" : end.reason;
+      try {
+        await client.fail(work, reason);
+        await markAbandoned(key, reason);
+        return { status: "failed", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason };
+      } catch (err) {
+        return await abort(deps, key, work, attemptId, err);
+      }
+    }
+
+    try {
+      await client.complete(work, handoff);
+    } catch (err) {
+      if (isLeaseSuperseded(err) || isForeignRun(err)) {
+        return await abort(deps, key, work, attemptId, err);
+      }
+      // The work is done and recorded; the board just did not hear. The next
+      // claim of this card replays it — which is the whole point of writing the
+      // output down first.
+      log("the board could not be told; the output is recorded for replay", { run: work.runId, error: String(err) });
+      return { status: "unreported", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason: String(err) };
+    }
+
+    await afterTheBoardWasTold(deps, "the card was completed", () => markReported(key));
+    return { status: "reported", externalRunId: work.runId, attemptId: attemptId ?? undefined };
+  } catch (err) {
+    return await failStarted(deps, key, work, attemptId, lastSeq, session.id, err);
   } finally {
     if (timer) clearTimeout(timer);
-    clearInterval(beat);
+    if (beat) clearInterval(beat);
+    unsubscribe();
   }
+}
 
-  await chain;
-  post(coalescer.flush());
-  await chain;
-  unsubscribe();
+/**
+ * Report a prior run's recorded output onto the run holding the card now.
+ *
+ * The harness is not started: the work is not idempotent, but the report is.
+ * A refusal here is handled by the caller's hand-back — nothing ran on THIS
+ * run, and the prior row keeps its `produced` outcome, so the next claim of the
+ * card finds it again.
+ */
+async function replay(
+  deps: DispatchDeps,
+  key: DispatchKey,
+  work: ClaimedWork,
+  prior: { externalRunId: string; result: unknown },
+): Promise<DispatchResult> {
+  (deps.log ?? (() => {}))("replaying a prior run's output", {
+    card: key.externalCardId,
+    priorRun: prior.externalRunId,
+  });
+  await deps.client.complete(work, prior.result ?? undefined);
+  await afterTheBoardWasTold(deps, "the replay was reported", async () => {
+    await markReported(key);
+    await markReported({ ...key, externalRunId: prior.externalRunId });
+  });
+  return { status: "replayed", externalRunId: work.runId };
+}
 
-  // ─── requirement 2: the lease is gone, so the harness must stop ────────────
-  // `abortCause` is checked before `end`, because a queued post can answer 409
-  // after the harness has yielded — and a yield is not permission to report.
-  const aborted = abortCause ?? (end.kind === "lease-superseded" || end.kind === "foreign-run" ? end.kind : null);
-  if (aborted) {
-    return await abort(deps, key, work, attemptId, aborted, session.id);
-  }
-
-  if (end.kind === "permission-required") {
-    // RQ2: an elicitation is a dead end — kaambaan's input-required → working
-    // transition exists and nothing invokes it. Park the card for a human
-    // rather than hold the harness until the reclaim.
-    await acp.endSession(agent.hubUserId, session.id, "A permission request has no return path through the board.").catch(() => {});
-    if (attemptId) await endAttempt(attemptId, "input-required", lastSeq);
-    const reason = "the agent asked for permission, which the board cannot answer";
-    await client.block(work, reason).catch(() => {});
-    await markAbandoned(key, reason);
-    return { status: "blocked", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason };
-  }
-
-  const contextPeak = coalescer.contextPeak();
-  const handoff = {
-    summary: said.join("").slice(0, SUMMARY_LIMIT) || null,
-    station: agent.stationId,
-    session: session.id,
-    attempt: attemptId,
-    // Context occupancy, not cost: no harness reports tokens or money over ACP.
-    ...(contextPeak ? { contextPeak } : {}),
-  };
-
-  // Written BEFORE the board is told. A bridge that dies between these two
-  // leaves a recoverable fact instead of a card that will be worked twice.
-  await recordProduced(key, handoff);
-  if (attemptId) await endAttempt(attemptId, end.kind === "yielded" ? "completed" : "failed", lastSeq);
-  await acp.endSession(agent.hubUserId, session.id, "The board's card is complete.").catch(() => {});
-
-  if (end.kind === "timeout" || end.kind === "session-ended") {
-    const reason = end.kind === "timeout" ? "the turn exceeded its time limit" : end.reason;
-    try {
-      await client.fail(work, reason);
-      await markAbandoned(key, reason);
-      return { status: "failed", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason };
-    } catch (err) {
-      return await abort(deps, key, work, attemptId, err);
-    }
-  }
-
+/**
+ * A ledger write that happens AFTER the board has been told, and must not throw
+ * into the failure exits.
+ *
+ * Those exits send a verb — `release` before a session, `fail` after one — and
+ * a verb sent on top of a `complete` is a write to a run the board has already
+ * ended. The card's state is the board's; this row is our note about it, and a
+ * lost note is not a reason to contradict the board.
+ */
+async function afterTheBoardWasTold(
+  deps: DispatchDeps,
+  what: string,
+  write: () => Promise<void>,
+): Promise<void> {
   try {
-    await client.complete(work, handoff);
+    await write();
   } catch (err) {
-    if (isLeaseSuperseded(err) || isForeignRun(err)) {
-      return await abort(deps, key, work, attemptId, err);
-    }
-    // The work is done and recorded; the board just did not hear. The next
-    // claim of this card replays it — which is the whole point of writing the
-    // output down first.
-    log("the board could not be told; the output is recorded for replay", { run: work.runId, error: String(err) });
-    return { status: "unreported", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason: String(err) };
+    (deps.log ?? (() => {}))("the board was told, but the ledger could not be updated", {
+      what,
+      error: String(err),
+    });
+  }
+}
+
+/**
+ * Give the claim back: this run never started.
+ *
+ * Safe precisely because no session was opened — no harness process exists, no
+ * command ran, no file changed — so the card returns to the queue exactly as it
+ * left it. kaambaan's `release` is the unpenalised verb for that (board-do.ts:
+ * card back to `submitted`, delegate cleared, no failure count), and the card is
+ * claimable in seconds instead of after the 15-minute heartbeat reclaim.
+ *
+ * A run whose lease is already gone is NOT released: a 409/409-class refusal
+ * means the board has moved on, and `release` would be one more write to a card
+ * that is now someone else's.
+ */
+async function handBack(
+  deps: DispatchDeps,
+  key: DispatchKey,
+  work: ClaimedWork,
+  cause: unknown,
+): Promise<DispatchResult> {
+  const log = deps.log ?? (() => {});
+  if (isLeaseSuperseded(cause) || isForeignRun(cause)) {
+    return await abort(deps, key, work, null, cause);
   }
 
-  await markReported(key);
-  return { status: "reported", externalRunId: work.runId, attemptId: attemptId ?? undefined };
+  const reason = `no session was opened, so the claim was handed back: ${String(cause)}`;
+  try {
+    await deps.client.release(work);
+  } catch (err) {
+    // The board keeps the card until its own reclaim — the outcome this fix
+    // exists to avoid, reached only when the board itself cannot be reached.
+    log("the claim could not be handed back", { run: work.runId, error: String(err) });
+    await markAbandoned(key, `${reason} — but the release was refused: ${String(err)}`).catch(() => {});
+    return { status: "failed", externalRunId: work.runId, reason };
+  }
+
+  log("claimed with nothing to run it; the card was handed back", { run: work.runId, error: String(cause) });
+  await markReleased(key, reason).catch(() => {});
+  return { status: "released", externalRunId: work.runId, reason };
+}
+
+/**
+ * A session had already opened, and then something failed.
+ *
+ * **Not released.** The harness may have edited the workspace before the wire
+ * dropped, and kaambaan's reclaim is at-least-once: a `release` puts the card
+ * straight back in the queue, unpenalised, for a claimer with no way to learn
+ * that part of the work was already done. `fail` re-queues it too — but carries
+ * the reason and increments the card's failure count, so a station that keeps
+ * dying trips kaambaan's circuit breaker into `input-required` for a human
+ * (board-do.ts `endAttempt`) rather than looping forever. `block` would put a
+ * transient node blip in front of a human every time; letting the lease lapse
+ * costs 15 minutes and tells the board nothing at all.
+ *
+ * The ACP session is ended first, for the same reason a superseded lease ends
+ * it: kaambaan fences its own state, and nothing else fences the machine.
+ */
+async function failStarted(
+  deps: DispatchDeps,
+  key: DispatchKey,
+  work: ClaimedWork,
+  attemptId: string | null,
+  lastSeq: number,
+  sessionId: string,
+  cause: unknown,
+): Promise<DispatchResult> {
+  const log = deps.log ?? (() => {});
+  if (isLeaseSuperseded(cause) || isForeignRun(cause)) {
+    return await abort(deps, key, work, attemptId, cause, sessionId);
+  }
+
+  const reason =
+    `a session had started and then failed, so the workspace may hold partial work: ${String(cause)}`;
+  log("the run failed after its session had started", { run: work.runId, error: String(cause) });
+
+  await deps.acp.endSession(deps.agent.hubUserId, sessionId, reason).catch(() => {});
+  await deps.client.fail(work, reason).catch((err) => {
+    log("the board could not be told the run failed", { run: work.runId, error: String(err) });
+  });
+  if (attemptId) await endAttempt(attemptId, "failed", lastSeq || null);
+  await markAbandoned(key, reason);
+
+  return { status: "failed", externalRunId: work.runId, attemptId: attemptId ?? undefined, reason };
 }
 
 /**

--- a/apps/hub/src/services/bridge/ledger.ts
+++ b/apps/hub/src/services/bridge/ledger.ts
@@ -158,6 +158,19 @@ export async function markReported(key: DispatchKey): Promise<void> {
 }
 
 /**
+ * The claim was handed back to the board before any session opened.
+ *
+ * Its own outcome, not a flavour of `abandoned`: this row says the workspace
+ * cannot have been touched, which is the fact that makes handing the card
+ * straight back safe. `acp_run_id` cannot say it — that column is written on the
+ * first ACP event, so a session that opened and died before emitting one leaves
+ * it null as well.
+ */
+export async function markReleased(key: DispatchKey, reason: string): Promise<void> {
+  await setOutcome(key, "released", reason);
+}
+
+/**
  * No report will be made for this run — the lease was superseded, or the run
  * turned out to be another agent's. Deliberately NOT `produced`: replaying a
  * half-finished handoff onto whoever holds the card now would report work this

--- a/apps/hub/src/services/bridge/loop.test.ts
+++ b/apps/hub/src/services/bridge/loop.test.ts
@@ -104,6 +104,66 @@ describe("a run that belonged to another agent halts the loop", () => {
   });
 });
 
+describe("a station that is down does not become a claim storm", () => {
+  test("a station that is not ready backs off — it does not poll every 5s", async () => {
+    const s = scripted({ status: "not-ready", reason: "Node is offline." });
+    const slept: number[] = [];
+    const loop = startAgentLoop({
+      run: s.run,
+      pollMs: 5_000,
+      backoffMs: 30_000,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    while (s.calls.length < 2) await Promise.resolve();
+    await loop.stop();
+
+    expect(slept[0]).toBe(30_000);
+    expect(slept[0]).not.toBe(5_000);
+  });
+
+  test("a claim handed straight back backs off too — claim/release/claim is not a fix", async () => {
+    // The card is back on the board the moment we release it, so an immediate
+    // re-claim would take it again, fail again and churn the board.
+    const s = scripted(
+      { status: "released", externalRunId: "run_1" },
+      { status: "released", externalRunId: "run_2" },
+    );
+    const slept: number[] = [];
+    const loop = startAgentLoop({
+      run: s.run,
+      pollMs: 5_000,
+      backoffMs: 30_000,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    while (s.calls.length < 2) await Promise.resolve();
+    await loop.stop();
+
+    expect(slept.slice(0, 2)).toEqual([30_000, 30_000]);
+  });
+
+  test("a reported run claims again immediately — the backoff is for faults only", async () => {
+    const s = scripted({ status: "reported", externalRunId: "run_1" });
+    const slept: number[] = [];
+    const loop = startAgentLoop({
+      run: s.run,
+      pollMs: 5_000,
+      backoffMs: 30_000,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    while (s.calls.length < 2) await Promise.resolve();
+    await loop.stop();
+
+    // Nothing after the reported cycle; the next cycle idles and polls.
+    expect(slept).not.toContain(30_000);
+  });
+});
+
 describe("off by default", () => {
   test("an unconfigured hub starts no bridge and touches nothing", async () => {
     delete process.env[BRIDGE_ENV_FLAG];

--- a/apps/hub/src/services/bridge/loop.ts
+++ b/apps/hub/src/services/bridge/loop.ts
@@ -85,6 +85,21 @@ export function startAgentLoop(opts: AgentLoopOptions): LoopHandle {
 
       if (result.status === "idle") {
         await sleep(opts.pollMs ?? DEFAULT_POLL_MS, controller.signal);
+        continue;
+      }
+
+      // **The anti-storm rule.** Both of these mean the work could not start,
+      // and both leave the card claimable — so the next cycle would claim it
+      // straight back. At the poll interval that is a claim/release every five
+      // seconds for as long as the station is down: a stuck card traded for a
+      // busy one and a board full of churn. They wait out the error backoff
+      // instead, which is also long enough for a node-agent to reconnect.
+      if (result.status === "not-ready" || result.status === "released") {
+        log(result.status === "not-ready" ? "the station is not ready; backing off" : "the claim was handed back; backing off", {
+          run: result.externalRunId,
+          reason: result.reason,
+        });
+        await sleep(opts.backoffMs ?? DEFAULT_BACKOFF_MS, controller.signal);
       }
     }
   })();
@@ -100,6 +115,7 @@ export function startAgentLoop(opts: AgentLoopOptions): LoopHandle {
 
 /** The hub's real ACP machinery, behind the port a dispatch talks to. */
 const hubAcpPort: AcpPort = {
+  stationReady: ({ stationId, userId }) => acpSessions.stationReadiness(userId, stationId),
   createSession: (input) => acpSessions.createSession(input),
   promptSession: (userId, sessionId, text) => acpSessions.promptSession(userId, sessionId, text),
   subscribe: (sessionId, fn) => acpSessions.subscribe(sessionId, fn),

--- a/apps/hub/tests/integration/bridge-dispatch.test.ts
+++ b/apps/hub/tests/integration/bridge-dispatch.test.ts
@@ -85,16 +85,31 @@ const chunk = (text: string): AcpEvent =>
 
 const idle = (): AcpEvent => ev("state", { status: "idle" });
 
+interface FakeAcpOpts {
+  /** What the readiness probe answers. Ready unless a test says otherwise. */
+  ready?: { ready: boolean; reason?: string };
+  /** Fail the session open — a node that went offline between the two. */
+  failCreate?: string;
+  /** Fail the first prompt — a session that opened and then lost its wire. */
+  failPrompt?: string;
+}
+
 /** An ACP port that scripts a turn instead of talking to a station. */
-function fakeAcp(script: () => AcpEvent[]) {
+function fakeAcp(script: () => AcpEvent[], opts: FakeAcpOpts = {}) {
   const subs = new Set<(e: AcpEvent) => void>();
-  const state = { created: 0, prompts: [] as string[], ended: [] as string[] };
+  const state = { created: 0, readyChecks: 0, prompts: [] as string[], ended: [] as string[] };
   const port: AcpPort = {
+    async stationReady() {
+      state.readyChecks++;
+      return opts.ready ?? { ready: true };
+    },
     async createSession() {
+      if (opts.failCreate) throw new Error(opts.failCreate);
       state.created++;
       return { id: SESSION_ID };
     },
     async promptSession(_u, _s, text) {
+      if (opts.failPrompt) throw new Error(opts.failPrompt);
       state.prompts.push(text);
       // Events arrive after the prompt returns, as they do from a real station.
       queueMicrotask(() => {
@@ -388,6 +403,121 @@ describe("at-least-once — a finished-but-unreported run comes back", () => {
 
     expect(await dispatchOutcome(key("run_a1b2c3d4e5f60718"))).toMatchObject({ outcome: "reported" });
     expect(await dispatchOutcome(key())).toMatchObject({ outcome: "reported" });
+  });
+});
+
+describe("a station with nowhere to run the work is never claimed", () => {
+  // The live failure: the bridge's first cycle ran ~2s after a hub restart,
+  // before the node-agents had reconnected. It claimed a card, could not open a
+  // session, and left the card held by a run that never did anything.
+  test("no claim is made at all", async () => {
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [], { ready: { ready: false, reason: "Node is offline." } });
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(result.status).toBe("not-ready");
+    expect(result.reason).toContain("Node is offline.");
+    // Not "claimed and released" — never claimed. The board saw no request at all.
+    expect(board.calls).toHaveLength(0);
+    expect(acp.state.created).toBe(0);
+    expect(await dispatchOutcome(key())).toBeNull();
+  });
+
+  test("a ready station still claims — the check gates the race, not the work", async () => {
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [chunk("Reindexed 412 documents."), idle()]);
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(acp.state.readyChecks).toBe(1);
+    expect(result.status).toBe("reported");
+  });
+});
+
+describe("a claim that never started is handed straight back", () => {
+  test("the session open failing releases the run, and the ledger says nothing ran", async () => {
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [], { failCreate: "Node is offline." });
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(result.status).toBe("released");
+    // Released, not failed and not left to the 15-minute reclaim: no session
+    // opened, so nothing can have touched the workspace.
+    expect(board.verbs()).toContain("release");
+    expect(board.verbs()).not.toContain("fail");
+    expect(board.verbs()).not.toContain("block");
+
+    const outcome = await dispatchOutcome(key());
+    expect(outcome!.outcome).toBe("released");
+    expect(outcome!.reason!.toLowerCase()).toContain("no session");
+    expect(await db.select().from(acpRuns).where(eq(acpRuns.stationId, STATION_ID))).toHaveLength(0);
+  });
+
+  test("a prompt that cannot be assembled releases the same way", async () => {
+    const board = fakeBoard((path) => {
+      if (path.endsWith("/claims")) return { status: 200, body: claimBody };
+      if (path.endsWith(`/runs/${RUN_ID}`)) return { status: 500, body: "boom" };
+      return { status: 200, body: { ok: true } };
+    });
+    const acp = fakeAcp(() => []);
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(result.status).toBe("released");
+    expect(board.verbs()).toContain("release");
+    expect(acp.state.created).toBe(0);
+    expect((await dispatchOutcome(key()))!.outcome).toBe("released");
+  });
+
+  test("a run we no longer hold is not released — a 409 is not ours to hand back", async () => {
+    const board = fakeBoard((path) => {
+      if (path.endsWith("/claims")) return { status: 200, body: claimBody };
+      if (path.endsWith(`/runs/${RUN_ID}`)) return { status: 409, body: boardError("STALE_LEASE") };
+      return { status: 200, body: { ok: true } };
+    });
+    const acp = fakeAcp(() => []);
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(result.status).toBe("lease-superseded");
+    expect(board.verbs()).not.toContain("release");
+    expect((await dispatchOutcome(key()))!.outcome).toBe("abandoned");
+  });
+});
+
+describe("a failure after the session started is not released", () => {
+  // Releasing here would hand a card whose workspace may already be half-edited
+  // to the next claimer, with nothing recording that. kaambaan's `fail` re-queues
+  // it with a reason and a failure count, and the circuit breaker parks it for a
+  // human if it keeps happening.
+  test("the board is told it failed, and the reason says a session had started", async () => {
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [], { failPrompt: "the wire dropped" });
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(result.status).toBe("failed");
+    expect(board.verbs()).toContain("fail");
+    expect(board.verbs()).not.toContain("release");
+
+    const failCall = board.calls.find((c) => c.path.endsWith("/fail"))!;
+    expect(String((failCall.body as { reason: string }).reason).toLowerCase()).toContain("session had started");
+
+    const outcome = await dispatchOutcome(key());
+    expect(outcome!.outcome).toBe("abandoned");
+    expect(outcome!.outcome).not.toBe("released");
+    expect(outcome!.reason!.toLowerCase()).toContain("session had started");
+  });
+
+  test("the harness is stopped — nothing else fences the machine", async () => {
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [], { failPrompt: "the wire dropped" });
+
+    await runOnce(deps(board.client, acp.port));
+
+    expect(acp.state.ended).toHaveLength(1);
   });
 });
 

--- a/docs/superpowers/specs/2026-08-14-kaambaan-bridge.md
+++ b/docs/superpowers/specs/2026-08-14-kaambaan-bridge.md
@@ -224,4 +224,21 @@ state.
 - **Reading the join back.** `acp_runs_external_idx` exists for the reverse
   lookup and nothing queries it. A board still cannot ask AgentPod what
   executed one of its runs.
-- **Live verification.** Nothing here has been run against a real board.
+- **Live verification.** First real run: 2026-08-14, 03:40 UTC. The happy path
+  worked (claim → session → activities → `complete`, 40s) and so did recovery
+  after a hand-release. The first cycle did not: it ran ~2s after a hub restart,
+  before the node-agents had reconnected, claimed a card and then threw "Node is
+  offline." opening the session — leaving `run_12e6594bf8de4b37` in `working`
+  with `acp_run_id` empty, holding the board's only claimable card until the
+  15-minute reclaim.
+
+  Two rules came out of it, and they are now the fourth entry in `dispatch.ts`'s
+  header: **nothing is claimed until the station is ready** (`stationReadiness`,
+  asked before `claim`), and **a claim that never started is handed back**
+  (`release`, the unpenalised verb — safe precisely because no session opened).
+  A failure *after* a session opened is NOT released: the workspace may hold
+  partial work, so it gets `fail`, which re-queues the card with the reason and
+  a failure count that trips kaambaan's circuit breaker if it keeps happening.
+  The ledger tells the two apart with `released` vs `abandoned`; `acp_run_id`
+  cannot, because it is written on the first ACP event. Both results wait out
+  the loop's error backoff, or claim/release becomes its own storm.


### PR DESCRIPTION
The bridge's first real cycle claimed a card it had nowhere to run. It ran ~2s after a hub restart, before the node-agents had reconnected, `claim` succeeded, and `createSession` threw `Node is offline.`. The throw escaped to the loop, which logged and backed off — correctly — and the card stayed `working` with a delegate assigned, held by a run that would never do anything, until kaambaan's 15-minute reclaim. The row is still in production and says it plainly: `acp_run_id` empty, `outcome` `working`, `updated_at` equal to `started_at`.

The loop's catch-and-backoff is not touched. It behaved correctly; the absence of further log lines was correct too, because the stranded run held the only claimable card.

## What is released, and when

**Released:** any failure between the claim succeeding and the ACP session opening — the ledger write, the prior-output lookup, the run-context read, prompt assembly, and the session open itself. All of it now sits in one region in `runOnce`, and a throw anywhere in it calls kaambaan's `release`: card back to `submitted`, delegate cleared, **no failure count** (`board-do.ts:1565`). Claimable again in seconds instead of 15 minutes.

This is safe *because* no session opened. No harness process exists, no command ran, no file changed, so the card goes back exactly as it left.

**Not released:** a run whose lease is already gone. A 409 `STALE_LEASE` or 403 `NOT_RUN_OWNER` means the board has moved on, and `release` would be one more write to a card that is now someone else's — the same rule the existing abort path follows.

## What happens when a session had already started

`fail`, with a reason that says so. Not `release`, not silently.

The harness may have edited the workspace before the wire dropped, and kaambaan's reclaim is at-least-once — a `release` would put a half-done card straight back in the queue, unpenalised, for a claimer with no way to learn that part of the work was already done.

`fail` re-queues it too, but carries the reason and increments the card's `failure_count`; at `CIRCUIT_BREAKER_LIMIT` `endAttempt` parks the card in `input-required` for a human instead of re-offering it (`board-do.ts:1639`). So a station that keeps dying stops on its own. `block` was rejected because it puts a transient node blip in front of a human every single time; letting the lease lapse was rejected because it costs 15 minutes and tells the board nothing.

`failStarted` also ends the ACP session first — kaambaan fences its own data, and nothing else fences the machine.

## Telling the two apart afterwards

`acp_run_id` cannot do it: it is written on the first ACP event, so a session that opened and died before emitting one leaves it null exactly like a claim that never opened one. So the ledger gets a fifth outcome (migration `0038_bridge_dispatch_released`):

| | never started | started and died |
|---|---|---|
| `bridge_dispatches.outcome` | `released` | `abandoned` |
| `reason` | "no session was opened, so the claim was handed back: …" | "a session had started and then failed, so the workspace may hold partial work: …" |
| verb sent to kaambaan | `release` (unpenalised) | `fail` (reason + failure count) |
| `DispatchResult.status` | `released` | `failed` |

## How the race is removed, not just recovered from

`runOnce` asks `stationReadiness` **before** it claims — station visible to this user, `acp` capable, node online, which are exactly `createSession`'s fail-fast gates. Not ready → `{status: "not-ready"}` and no request to the board at all. The restart case that produced this can no longer reach a claim.

`createSession` now asks the same function, so there is one definition of "ready" and the probe cannot drift stricter than the open it stands in front of. That direction matters: a probe that refuses a station `createSession` would have accepted turns every start into an outage with no error anywhere — the bridge would simply claim nothing, forever, silently.

## How this avoids a claim storm

Releasing a card puts it straight back on the board, so an unchanged loop would re-claim it 5 seconds later, fail again and release again — a stuck card traded for a busy one and a board full of churn. Both "could not start" results now wait out the **error backoff (30s)** rather than the poll interval:

- `not-ready` — nothing was claimed; the loop just waits, which is also roughly how long a node-agent needs to dial back in.
- `released` — claimed, never started, handed back.

And the two compose: after one release, the next cycle's readiness check refuses before claiming, so a sustained outage costs *one* claim/release pair and then silence. Everything else keeps its timing — a reported run claims again immediately, an idle claim polls at 5s.

Also fixed while in here: a throw after the session opened used to leak the event subscription and the heartbeat interval (both are now torn down in a `finally`), and ledger writes that happen *after* the board has been told are quarantined behind `afterTheBoardWasTold` — a verb sent on top of a `complete` is a write to a run the board has already ended.

## Tests

TDD, RED first (10 failing tests before any implementation). New coverage:

- station not ready → **no claim is made at all**: `board.calls` is empty, no session, no ledger row.
- a ready station still claims (the anti-over-strictness assertion).
- session open fails → `release` sent, `fail`/`block` not sent, ledger `released`, no `acp_runs` row.
- prompt assembly fails → same hand-back.
- a 409 during the pre-session region → `lease-superseded`, **no** `release`.
- prompt fails after the session opened → `fail` sent with "session had started" in the reason, `release` not sent, ledger `abandoned`, ACP session ended.
- loop: `not-ready` and `released` sleep 30s not 5s; a repeated `released` sleeps 30s every time; a `reported` run never sleeps the backoff.
- `stationReadiness` against a real rig (gateway + fake node + adopted station): `{ready: true}` while healthy, `Station not found.` for a missing station and for another user's, `Node is offline.` after the node drops — and `createSession` throws the same sentence.

## Mutation results — both directions, all four killed

| Mutation | Result |
|---|---|
| **Remove the release** (`handBack` no longer calls `client.release`) | **2 fail** — "the session open failing releases the run…", "a prompt that cannot be assembled releases the same way" |
| **Release unconditionally**, including after a session started (`failStarted` releases too) | **1 fail** — "the board is told it failed, and the reason says a session had started" (`board.verbs()` contains `release`) |
| **Remove the readiness check** (`if (false && !readiness.ready)`) | **2 fail** — "no claim is made at all" (the board is claimed against, and the run then stalls to the turn timeout) |
| **Make readiness too strict** (a healthy station reads not-ready) | **23 fail** in `acp-sessions.test.ts`, including "stationReadiness answers the same three gates createSession fails fast on" — the shared definition means over-strictness cannot hide |

## Green

- `cd packages/contract && bun test` → 222 pass, 0 fail
- `cd apps/hub && DATABASE_URL=… bun test` → **966 pass, 0 fail**, 74 files
- `bun run typecheck` → 15 errors, the known pre-existing set, none added

Not deployed, not run against kaambaan.dev, no changes to the kaambaan repo. The stranded production row was released by hand before this work started; nothing here touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
