### PR TITLE
feat(bridge): make coalescing observable in production

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0039_bridge_dispatch_coalescing.sql
+++ b/apps/hub/src/db/drizzle-migrations/0039_bridge_dispatch_coalescing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "bridge_dispatches" ADD COLUMN "events_received" integer;--> statement-breakpoint
+ALTER TABLE "bridge_dispatches" ADD COLUMN "activities_posted" integer;

--- a/apps/hub/src/db/drizzle-migrations/meta/0039_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0039_snapshot.json
@@ -1,0 +1,2762 @@
+{
+  "id": "15ad5cf4-2102-475b-92b5-af8d9687afc1",
+  "prevId": "f04cef5a-f03b-4705-9f11-4364dac098b5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1786679565310,
       "tag": "0038_bridge_dispatch_released",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1786687158202,
+      "tag": "0039_bridge_dispatch_coalescing",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/bridge.ts
+++ b/apps/hub/src/db/schema/bridge.ts
@@ -82,6 +82,34 @@ export const bridgeDispatches = pgTable(
     /** The handoff produced by the work, held so a lost report can be replayed. */
     result: jsonb("result"),
 
+    /**
+     * **What coalescing actually did on this run**, as two numbers.
+     *
+     * Coalescing exists because one trivial prompt produced 57 ACP events from
+     * Codex and 1,051 from Hermes — an 18x spread that no fixed rate limit
+     * fits. But the first real card run through the bridge could be measured
+     * only on the way IN: 142 rows in `acp_events`, and no way whatsoever to
+     * learn how many activities went out. Coalescing could have been completely
+     * broken in production and nothing would have shown it.
+     *
+     * These live here rather than on `acp_runs` for the same reason the table
+     * exists: this is bookkeeping about a *claim*, and a hand-driven console
+     * session has no activities to post to anybody. They are two raw counts and
+     * not a ratio, because a ratio is `events_received / activities_posted` in
+     * whatever query asks — and storing a derived number is how you end up with
+     * a row whose parts disagree with its whole.
+     *
+     * **Nullable on purpose, and `0` is not `NULL`.** Null means *nobody
+     * counted*: a row written before this shipped, a claim handed straight back,
+     * a replay that started no harness. Zero means *counted, and the transcript
+     * projected to nothing* — a real and alarming state that a `NOT NULL
+     * DEFAULT 0` would make indistinguishable from every unmeasured row in the
+     * table. It also makes the migration safe against live rows by
+     * construction, which `ADD COLUMN … NOT NULL` is not.
+     */
+    eventsReceived: integer("events_received"),
+    activitiesPosted: integer("activities_posted"),
+
     startedAt: timestamp("started_at").notNull(),
     updatedAt: timestamp("updated_at").notNull(),
   },

--- a/apps/hub/src/services/bridge/dispatch.ts
+++ b/apps/hub/src/services/bridge/dispatch.ts
@@ -407,7 +407,11 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
     // had — including the one that threw. Reachable only from here, which is
     // also why a claim that never opened a session leaves both columns null
     // rather than claiming it counted zero of everything.
-    await summarise(deps, key, work, attemptId, counts, coalescer.unmapped());
+    //
+    // Swallowed whole: a throw in a `finally` REPLACES the value the try block
+    // returned, so an unlucky measurement could discard the `foreign-run` that
+    // is supposed to halt the loop. A note about the work never outranks it.
+    await summarise(deps, key, work, attemptId, counts, coalescer.unmapped()).catch(() => {});
   }
 }
 

--- a/apps/hub/src/services/bridge/dispatch.ts
+++ b/apps/hub/src/services/bridge/dispatch.ts
@@ -38,6 +38,16 @@
  *    "Never started" is exact: no ACP session was opened, so nothing can have
  *    touched the workspace and `release` is unambiguously safe. Once a session
  *    exists the answer changes — see `failStarted`.
+ *
+ * A fifth came from running a real card and then being unable to say what had
+ * happened. The hub could count what arrived — 142 rows in `acp_events`, 135 of
+ * them `agent-update` — and had no way at all to count what it posted out.
+ *
+ * 5. **A dispatch counts both ends of its own transcript.** Coalescing is the
+ *    reason 1,051 Hermes events do not become 1,051 HTTP POSTs, and until this
+ *    it could have been completely broken in production with nothing to show
+ *    it. Two integers on the ledger row and one log line per worked card — see
+ *    `summarise`, which is also where the bound on that lives.
  */
 
 import { CARD_PROMPT_VERSION, CardPrompt, renderCardPrompt, type AcpEvent, type AcpSessionMode } from "@agentpod/contract";
@@ -52,8 +62,10 @@ import {
   markReleased,
   markReported,
   openDispatch,
+  recordCoalescing,
   recordProduced,
   startAttempt,
+  type CoalescingCounts,
   type DispatchKey,
 } from "./ledger";
 
@@ -187,6 +199,14 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
   let attemptId: string | null = null;
   let lastSeq = 0;
   const said: string[] = [];
+  /**
+   * Requirement 5's two numbers (see the header). Counted here rather than
+   * inside the coalescer because the pair only means anything together, and one
+   * of them — what left for the board — is this function's business, not the
+   * projection's. Both are plain integers held for the length of one dispatch;
+   * nothing accumulates per event.
+   */
+  const counts: CoalescingCounts = { eventsReceived: 0, activitiesPosted: 0 };
   // Hoisted so the failure exit below can tear them down: a throw here must not
   // leave a live subscription and a heartbeat still beating for a run that is
   // over. Both are idempotent, so the happy path's own cleanup still stands.
@@ -242,6 +262,11 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
     const post = (activities: BoardActivity[]): void => {
       for (const a of activities) {
         if (a.type === "response" && a.body) said.push(a.body);
+        // Counted where the activity is sent, not where the board acknowledges
+        // it: this number answers "how much did the transcript collapse to",
+        // and a 502 on the wire is a delivery question. The queue logs those
+        // separately, and coalescing is what bounds how many there can be.
+        counts.activitiesPosted++;
         queue(async () => {
           await client.activity(work, a);
         });
@@ -250,6 +275,9 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
 
     unsubscribe = acp.subscribe(session.id, (event) => {
       lastSeq = Math.max(lastSeq, event.seq);
+      // Every event, before any branch drops one — this is the number an
+      // operator can cross-check against `SELECT count(*) FROM acp_events`.
+      counts.eventsReceived++;
 
       if (attemptId === null && !attemptStarted) {
         attemptStarted = true;
@@ -375,7 +403,70 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
     if (timer) clearTimeout(timer);
     if (beat) clearInterval(beat);
     unsubscribe();
+    // In the `finally`, so the summary is written once for every exit a session
+    // had — including the one that threw. Reachable only from here, which is
+    // also why a claim that never opened a session leaves both columns null
+    // rather than claiming it counted zero of everything.
+    await summarise(deps, key, work, attemptId, counts, coalescer.unmapped());
   }
+}
+
+/**
+ * The whole observability surface for one dispatch: two integers on its ledger
+ * row, and one line in the hub log.
+ *
+ * **One line, at the end.** Not one per event — that is precisely the volume
+ * coalescing exists to prevent, and issue #231 is a live example of a per-cycle
+ * log line making `apn logs` unusable at 83% of total volume. Not one per claim
+ * cycle either: the bridge polls every five seconds forever, and a cycle that
+ * claimed nothing has nothing to say. One line per card actually worked, which
+ * is minutes of harness time apiece.
+ *
+ * **Counts and ids, no payloads.** The bridge deliberately never logs its
+ * token; card content, prompts and harness output are treated the same. What
+ * appears here is arithmetic and identifiers that are already in the ledger.
+ * `unmapped` is the exception that proves it — event *kind* names, a closed set
+ * of ACP vocabulary, and the reason a surprising zero is legible instead of
+ * merely alarming.
+ *
+ * A failure to record this must never change the run's outcome: the work is
+ * real and the count is a note about it.
+ */
+async function summarise(
+  deps: DispatchDeps,
+  key: DispatchKey,
+  work: ClaimedWork,
+  attemptId: string | null,
+  counts: CoalescingCounts,
+  unmapped: string[],
+): Promise<void> {
+  const log = deps.log ?? (() => {});
+  try {
+    await recordCoalescing(key, counts);
+  } catch (err) {
+    log("the coalescing summary could not be recorded", { run: work.runId, error: String(err) });
+  }
+
+  log("coalesced the transcript", {
+    run: work.runId,
+    card: key.externalCardId,
+    station: deps.agent.stationId,
+    attempt: attemptId,
+    events: counts.eventsReceived,
+    activities: counts.activitiesPosted,
+    // The number the 18x spread made necessary: how many events collapsed into
+    // each activity. Null when nothing was posted — a ratio over zero is not a
+    // large number, it is an absent one, and rounding it to Infinity in a log
+    // reads as a bug rather than as the finding it is.
+    eventsPerActivity: eventsPerActivity(counts),
+    ...(unmapped.length ? { unmapped } : {}),
+  });
+}
+
+/** Events per activity, to one decimal place. Null when nothing was posted. */
+function eventsPerActivity(counts: CoalescingCounts): number | null {
+  if (counts.activitiesPosted === 0) return null;
+  return Math.round((counts.eventsReceived / counts.activitiesPosted) * 10) / 10;
 }
 
 /**

--- a/apps/hub/src/services/bridge/ledger.ts
+++ b/apps/hub/src/services/bridge/ledger.ts
@@ -170,6 +170,33 @@ export async function markReleased(key: DispatchKey, reason: string): Promise<vo
   await setOutcome(key, "released", reason);
 }
 
+/** What the transcript weighed, and what the board was sent. */
+export interface CoalescingCounts {
+  /** Every ACP event this dispatch observed — the `acp_events` number. */
+  eventsReceived: number;
+  /** Every activity it posted to the board. The coalescer's output volume. */
+  activitiesPosted: number;
+}
+
+/**
+ * Write the run's coalescing summary: one row, two numbers, no payloads.
+ *
+ * A separate write from the outcome, and it touches only these two columns, so
+ * it can run on **every** exit a session had — reported, unreported, blocked,
+ * abandoned — without any of them having to remember to carry it, and without
+ * a measurement ever overwriting the fact of how the run ended.
+ *
+ * `updated_at` is deliberately left alone: it is the ordering key
+ * `findUnreportedOutput` reads to pick the most recent produced output, and a
+ * bookkeeping write is not news about the work.
+ */
+export async function recordCoalescing(key: DispatchKey, counts: CoalescingCounts): Promise<void> {
+  await db
+    .update(bridgeDispatches)
+    .set({ eventsReceived: counts.eventsReceived, activitiesPosted: counts.activitiesPosted })
+    .where(scope(key));
+}
+
 /**
  * No report will be made for this run — the lease was superseded, or the run
  * turned out to be another agent's. Deliberately NOT `produced`: replaying a

--- a/apps/hub/tests/integration/bridge-dispatch.test.ts
+++ b/apps/hub/tests/integration/bridge-dispatch.test.ts
@@ -25,6 +25,7 @@ import { eq } from "drizzle-orm";
 
 import { db, rawSql } from "../../src/db/drizzle";
 import { acpRuns, acpSessions } from "../../src/db/schema/acp";
+import { bridgeDispatches } from "../../src/db/schema/bridge";
 import { BOOTSTRAP_TENANT_ID } from "../../src/db/schema/tenants";
 import type { BridgeAgentConfig } from "../../src/services/bridge/config";
 import { runOnce, type AcpPort } from "../../src/services/bridge/dispatch";
@@ -84,6 +85,13 @@ const chunk = (text: string): AcpEvent =>
   ev("agent-update", { sessionUpdate: "agent_message_chunk", content: { type: "text", text } });
 
 const idle = (): AcpEvent => ev("state", { status: "idle" });
+
+/** A durable event: one in, exactly one activity out. The 1:1 shape. */
+const toolCall = (title: string): AcpEvent =>
+  ev("agent-update", { sessionUpdate: "tool_call", title, rawInput: { path: "./data" } });
+
+/** A kind with no board representation at all: N in, zero activities out. */
+const droppedKind = (): AcpEvent => ev("agent-update", { sessionUpdate: "available_commands_update" });
 
 interface FakeAcpOpts {
   /** What the readiness probe answers. Ready unless a test says otherwise. */
@@ -162,7 +170,11 @@ const key = (externalRunId = RUN_ID) => ({
   externalRunId,
 });
 
-const deps = (client: KaambaanClient, acp: AcpPort) => ({
+const deps = (
+  client: KaambaanClient,
+  acp: AcpPort,
+  log?: (message: string, meta?: Record<string, unknown>) => void,
+) => ({
   client,
   acp,
   agent,
@@ -171,6 +183,7 @@ const deps = (client: KaambaanClient, acp: AcpPort) => ({
   // Long enough never to fire inside a test; the turn ends on an idle event.
   heartbeatMs: 60_000,
   turnTimeoutMs: 5_000,
+  log,
 });
 
 beforeAll(async () => {
@@ -536,5 +549,179 @@ describe("a permission request has nowhere to go", () => {
     expect(result.status).toBe("blocked");
     expect(board.verbs()).toContain("block");
     expect(acp.state.ended).toHaveLength(1);
+  });
+});
+
+/**
+ * The bridge ran a real card on a real harness and the hub could count the
+ * events *arriving* — 142 rows in `acp_events`, 135 of them `agent-update` —
+ * but had no way at all to count the activities it posted *out*. Coalescing
+ * could have been completely broken and nothing would have shown it: its unit
+ * tests passed, and that is not the same as knowing.
+ *
+ * These tests are what stop the number becoming decorative. Every one of them
+ * ties the count written to the ledger to something independently observed —
+ * the activities the fake board actually received — so a counter that reports
+ * a constant, and a counter that reports the event count, both fail here.
+ */
+describe("coalescing is countable from the hub alone", () => {
+  const counts = async (externalRunId = RUN_ID) => {
+    const [row] = await db
+      .select({
+        eventsReceived: bridgeDispatches.eventsReceived,
+        activitiesPosted: bridgeDispatches.activitiesPosted,
+      })
+      .from(bridgeDispatches)
+      .where(eq(bridgeDispatches.externalRunId, externalRunId));
+    return row!;
+  };
+
+  const activityCalls = (board: ReturnType<typeof fakeBoard>) =>
+    board.calls.filter((c) => c.path.endsWith("/activities")).length;
+
+  test("a chunk storm is recorded as many events in and few activities out", async () => {
+    // The Hermes shape in miniature: 1,051 events for one trivial prompt. If
+    // coalescing works, one ledger row says so; if it has silently become 1:1,
+    // this is the row that shows it.
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [...Array.from({ length: 300 }, (_, i) => chunk(`${i} `)), idle()]);
+
+    await runOnce(deps(board.client, acp.port));
+
+    const row = await counts();
+    // 300 chunks plus the `state: idle` that ended the turn — every event the
+    // dispatch saw, which is what `acp_events` counts too.
+    expect(row.eventsReceived).toBe(301);
+    // Tied to what the board actually received, not to an internal opinion.
+    expect(row.activitiesPosted).toBe(activityCalls(board));
+    expect(row.activitiesPosted).toBeLessThan(10);
+    expect(row.activitiesPosted).toBeGreaterThan(0);
+  });
+
+  test("a 1:1 transcript is recorded as 1:1 — the ratio is not assumed", async () => {
+    // The counter must report what happened, not what coalescing is supposed
+    // to achieve. Five durable events project to five activities, and a
+    // counter hard-wired to look impressive gets this wrong.
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [
+      toolCall("read a"),
+      toolCall("read b"),
+      toolCall("read c"),
+      toolCall("read d"),
+      toolCall("read e"),
+      idle(),
+    ]);
+
+    await runOnce(deps(board.client, acp.port));
+
+    const row = await counts();
+    expect(row.eventsReceived).toBe(6);
+    expect(row.activitiesPosted).toBe(5);
+    expect(row.activitiesPosted).toBe(activityCalls(board));
+  });
+
+  test("a flush that produced nothing is recorded as zero, not as missing", async () => {
+    // Worth seeing on its own: a run whose whole transcript projected to
+    // nothing looks identical to a healthy quiet run unless zero is written
+    // down as zero.
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [droppedKind(), droppedKind(), droppedKind(), idle()]);
+
+    await runOnce(deps(board.client, acp.port));
+
+    const row = await counts();
+    expect(row.eventsReceived).toBe(4);
+    expect(row.activitiesPosted).toBe(0);
+    expect(row.activitiesPosted).not.toBeNull();
+    expect(activityCalls(board)).toBe(0);
+  });
+
+  test("a run that never opened a session is not measured, and says so", async () => {
+    // Null is not zero. A replay starts no harness, so there is no transcript
+    // to have coalesced — and recording 0/0 for it would drop a fake data
+    // point into every ratio an operator computes.
+    await openDispatch({ ...key("run_a1b2c3d4e5f60718"), agentKey: "codex-mac", stationId: STATION_ID, leaseEpoch: 1 });
+    await recordProduced(key("run_a1b2c3d4e5f60718"), { summary: "wrote three files" });
+
+    const board = fakeBoard(happyBoard);
+    const result = await runOnce(deps(board.client, fakeAcp(() => [chunk("never runs"), idle()]).port));
+
+    expect(result.status).toBe("replayed");
+    const row = await counts();
+    expect(row.eventsReceived).toBeNull();
+    expect(row.activitiesPosted).toBeNull();
+  });
+
+  test("the counts survive a run that ended badly", async () => {
+    // A lost lease is where an operator most wants the number: it says how far
+    // the run got before the board took the card away.
+    const board = fakeBoard((path) => {
+      if (path.endsWith("/claims")) return { status: 200, body: claimBody };
+      if (path.endsWith(`/runs/${RUN_ID}`)) return { status: 200, body: contextBody };
+      if (path.endsWith("/activities")) return { status: 409, body: boardError("STALE_LEASE") };
+      return { status: 200, body: { ok: true } };
+    });
+    const acp = fakeAcp(() => [toolCall("read a"), chunk("thinking"), idle()]);
+
+    const result = await runOnce(deps(board.client, acp.port));
+
+    expect(result.status).toBe("lease-superseded");
+    const row = await counts();
+    expect(row.eventsReceived).toBeGreaterThan(0);
+    expect(row.activitiesPosted).toBeGreaterThan(0);
+  });
+});
+
+describe("the one log line a dispatch is allowed to spend on this", () => {
+  const lines: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+  const capture = (message: string, meta?: Record<string, unknown>) => lines.push({ message, meta });
+  const summaries = () => lines.filter((l) => l.message.includes("coalesced"));
+
+  beforeEach(() => {
+    lines.length = 0;
+  });
+
+  test("one line per dispatch carries the counts and the ratio", async () => {
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [...Array.from({ length: 200 }, () => chunk("x")), idle()]);
+
+    await runOnce(deps(board.client, acp.port, capture));
+
+    // ONE. Not one per event — that is the volume problem coalescing exists to
+    // solve, and issue #231 is a live example of a per-cycle line making
+    // `apn logs` unusable.
+    expect(summaries()).toHaveLength(1);
+    const meta = summaries()[0]!.meta!;
+    expect(meta.events).toBe(201);
+    expect(meta.activities).toBe(1);
+    expect(meta.eventsPerActivity).toBe(201);
+    expect(meta.run).toBe(RUN_ID);
+  });
+
+  test("nothing that ran through the coalescer appears in the line", async () => {
+    // The bridge deliberately never logs its token; work content is treated
+    // the same way. Counts and ids, not payloads.
+    const board = fakeBoard(happyBoard);
+    const acp = fakeAcp(() => [chunk("the secret contents of the workspace"), toolCall("Delete ./data"), idle()]);
+
+    await runOnce(deps(board.client, acp.port, capture));
+
+    const line = JSON.stringify(summaries()[0]);
+    expect(line).not.toContain("the secret contents of the workspace");
+    expect(line).not.toContain("Delete ./data");
+    // Nor the card's own spec, its title, or the agent's credential.
+    expect(line).not.toContain("Reindex everything under ./data.");
+    expect(line).not.toContain("Rebuild the index");
+    expect(line).not.toContain(TOKEN);
+  });
+
+  test("a cycle that claimed nothing spends no line at all", async () => {
+    // The loop polls every 5 seconds forever. A summary on an idle cycle is
+    // 17,000 lines a day saying nothing happened.
+    const board = fakeBoard(() => ({ status: 200, body: { claimed: false } }));
+
+    await runOnce(deps(board.client, fakeAcp(() => []).port, capture));
+
+    expect(summaries()).toHaveLength(0);
   });
 });

--- a/apps/hub/tests/integration/bridge-dispatch.test.ts
+++ b/apps/hub/tests/integration/bridge-dispatch.test.ts
@@ -715,6 +715,27 @@ describe("the one log line a dispatch is allowed to spend on this", () => {
     expect(line).not.toContain(TOKEN);
   });
 
+  test("a summary that cannot be written does not change what the run returned", async () => {
+    // It is emitted from a `finally`, and a throw there REPLACES the returned
+    // value — so a broken logger could swallow the `foreign-run` that is meant
+    // to halt the loop. The measurement never outranks the work.
+    const board = fakeBoard((path) => {
+      if (path.endsWith("/claims")) return { status: 200, body: claimBody };
+      if (path.endsWith(`/runs/${RUN_ID}`)) return { status: 200, body: contextBody };
+      if (path.endsWith("/activities")) return { status: 403, body: boardError("NOT_RUN_OWNER") };
+      return { status: 200, body: { ok: true } };
+    });
+    const acp = fakeAcp(() => [chunk("working"), idle()]);
+
+    const result = await runOnce(
+      deps(board.client, acp.port, () => {
+        throw new Error("the log sink is gone");
+      }),
+    );
+
+    expect(result.status).toBe("foreign-run");
+  });
+
   test("a cycle that claimed nothing spends no line at all", async () => {
     // The loop polls every 5 seconds forever. A summary on an idle cycle is
     // 17,000 lines a day saying nothing happened.

--- a/apps/hub/tests/integration/bridge-ledger.test.ts
+++ b/apps/hub/tests/integration/bridge-ledger.test.ts
@@ -34,6 +34,7 @@ import {
   markAbandoned,
   markReported,
   openDispatch,
+  recordCoalescing,
   recordProduced,
   startAttempt,
   endAttempt,
@@ -216,5 +217,125 @@ describe("the ledger — at-least-once reclaim", () => {
     await open();
     const [row] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID));
     expect(row!.tenantId).toBe(BOOTSTRAP_TENANT_ID);
+  });
+});
+
+describe("the coalescing summary — one row per dispatch, not one per event", () => {
+  test("a claim starts unmeasured, and unmeasured is not zero", async () => {
+    // The distinction the whole column pair rests on: a run that produced no
+    // activities and a run nobody counted must not read the same.
+    await open();
+    const [row] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID));
+    expect(row!.eventsReceived).toBeNull();
+    expect(row!.activitiesPosted).toBeNull();
+  });
+
+  test("the counts are written where the ratio can be computed from them", async () => {
+    await open();
+    await recordCoalescing(key(), { eventsReceived: 1051, activitiesPosted: 7 });
+
+    const [row] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID));
+    expect(row!.eventsReceived).toBe(1051);
+    expect(row!.activitiesPosted).toBe(7);
+  });
+
+  test("zero activities is stored as zero", async () => {
+    await open();
+    await recordCoalescing(key(), { eventsReceived: 12, activitiesPosted: 0 });
+
+    const [row] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID));
+    expect(row!.activitiesPosted).toBe(0);
+    expect(row!.activitiesPosted).not.toBeNull();
+  });
+
+  test("the write does not disturb the outcome it lands next to", async () => {
+    // It runs on every exit a session had, including the failures — and a
+    // measurement that overwrote `abandoned` with `working` would make the
+    // ledger lie about something that matters far more than a count.
+    await open();
+    await markAbandoned(key(), "the lease was superseded");
+    await recordCoalescing(key(), { eventsReceived: 40, activitiesPosted: 2 });
+
+    const [row] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID));
+    expect(row!.outcome).toBe("abandoned");
+    expect(row!.reason).toBe("the lease was superseded");
+    expect(row!.eventsReceived).toBe(40);
+  });
+
+  test("the counts are scoped to one run, and one tenant", async () => {
+    await open(RUN_ID);
+    await open(RUN_ID_2);
+    await recordCoalescing(key(RUN_ID), { eventsReceived: 9, activitiesPosted: 1 });
+
+    const [other] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID_2));
+    expect(other!.eventsReceived).toBeNull();
+
+    await recordCoalescing({ ...key(RUN_ID), tenantId: "fleet_ffffffffffffffffffff" }, {
+      eventsReceived: 999,
+      activitiesPosted: 999,
+    });
+    const [mine] = await db.select().from(bridgeDispatches).where(eq(bridgeDispatches.externalRunId, RUN_ID));
+    expect(mine!.eventsReceived).toBe(9);
+  });
+});
+
+/**
+ * A migration tested only on an empty database has not been tested.
+ *
+ * `bridge_dispatches` holds live rows in production, and Drizzle's own first
+ * instinct for a new column is `ADD COLUMN … NOT NULL`, which fails outright
+ * against a table that already has any. This replays the shipped SQL — read
+ * from the file that will actually run, not a copy of it — against a table
+ * with a row in it, inside a transaction that rolls back so the suite's schema
+ * is exactly as it found it.
+ */
+describe("migration 0039, against a table that already has rows", () => {
+  class Rollback extends Error {}
+
+  test("an existing row survives and reads as not-measured", async () => {
+    const path = new URL(
+      "../../src/db/drizzle-migrations/0039_bridge_dispatch_coalescing.sql",
+      import.meta.url,
+    ).pathname;
+    const sql = await Bun.file(path).text();
+    const statements = sql
+      .split("--> statement-breakpoint")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    expect(statements.length).toBeGreaterThan(0);
+
+    let observed: { events_received: number | null; activities_posted: number | null } | undefined;
+    try {
+      await rawSql.begin(async (tx) => {
+        // Rewind to the pre-migration shape, then put a row in it — the state
+        // production is in, which an empty test database never reproduces.
+        await tx`ALTER TABLE bridge_dispatches DROP COLUMN events_received, DROP COLUMN activities_posted`;
+        await tx`
+          INSERT INTO bridge_dispatches
+            (external_source, external_run_id, tenant_id, board_id, external_card_id,
+             agent_key, station_id, lease_epoch, outcome, started_at, updated_at)
+          VALUES
+            ('kaambaan', ${RUN_ID_2}, ${BOOTSTRAP_TENANT_ID}, ${BOARD_ID}, ${CARD_ID},
+             'codex-mac', ${STATION_ID}, 1, 'reported', now(), now())
+        `;
+
+        for (const statement of statements) await tx.unsafe(statement);
+
+        const rows = await tx<Array<{ events_received: number | null; activities_posted: number | null }>>`
+          SELECT events_received, activities_posted
+          FROM bridge_dispatches WHERE external_run_id = ${RUN_ID_2}
+        `;
+        observed = rows[0];
+        throw new Rollback();
+      });
+    } catch (err) {
+      if (!(err instanceof Rollback)) throw err;
+    }
+
+    // The row is still there — the migration did not need to be told what a
+    // dispatch from before it was counted had counted.
+    expect(observed).toBeDefined();
+    expect(observed!.events_received).toBeNull();
+    expect(observed!.activities_posted).toBeNull();
   });
 });

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -696,6 +696,26 @@ Hermes stations that have a Matrix identity configured display the **Matrix ID**
 **A Fly runtime is `stopped` but still billing:**
 - Also expected. A stopped Fly machine still bills its rootfs, and the volume bills for as long as the **app** exists. Only **Destroy** ends the charge. `flyctl apps list` shows what is still there.
 
+**Is the kaambaan bridge's coalescing working, and by how much?**
+
+The bridge projects a harness's ACP transcript into board activities, and it must not do so 1:1 — one trivial prompt was measured at 57 events from Codex and 1,051 from Hermes, so a harness that streams token by token would otherwise fire a thousand POSTs at a board for one instruction. Every dispatch records both ends of its own transcript, so the question is answerable from the hub alone:
+
+```sql
+SELECT external_run_id, external_card_id, outcome,
+       events_received, activities_posted,
+       round(events_received::numeric / nullif(activities_posted, 0), 1) AS events_per_activity
+FROM bridge_dispatches
+WHERE events_received IS NOT NULL
+ORDER BY started_at DESC
+LIMIT 20;
+```
+
+- **`events_per_activity` near 1** on a chatty harness means coalescing is not happening — the board is being posted to once per chunk.
+- **`activities_posted = 0`** with a non-zero `events_received` means the whole transcript projected to nothing and the board saw silence. The hub log line for that run lists the event kinds that had no projection.
+- **Both columns `NULL`** is not zero: nobody counted. The run never opened a session (a claim handed straight back, or a replay of a prior run's recorded output), or it predates this being measured at all.
+
+The same two numbers appear once per worked card in the hub log — `journalctl -u agentpod-hub | grep 'coalesced the transcript'` — with the run, card, station and attempt ids. One line per card, never per event, and it carries no card content, prompt or harness output.
+
 **Hub startup fails with migration error:**
 - Confirm `DATABASE_URL` is correct and Postgres is running: `systemctl status postgresql`.
 - Run migrations manually: `cd /opt/agentpod/apps/hub && bun run db:migrate`.


### PR DESCRIPTION
The bridge ran a real card on a real harness. From the hub we could measure **142 ACP events (135 of them `agent-update`)** arriving from the harness, by counting rows in `acp_events`. We could **not** determine how many activities the bridge posted upstream: the hub did not log its outbound calls, and kaambaan's board snapshot exposes no activity count.

Coalescing exists because one trivial prompt produced 57 events from Codex and 1,051 from Hermes — an 18x spread that means no fixed rate limit fits. It could have been completely broken in production and nothing would have shown it. Its unit tests pass; that is not the same as knowing.

No behaviour change to coalescing. This is observability.

## What an operator can now see, and where

**Per dispatch, in the ledger.** Two integer columns on `bridge_dispatches`:

| column | meaning |
|---|---|
| `events_received` | every ACP event the dispatch observed — the same population `acp_events` counts, so the two are cross-checkable |
| `activities_posted` | every activity it sent to the board |

```sql
SELECT external_run_id, outcome, events_received, activities_posted,
       round(events_received::numeric / nullif(activities_posted, 0), 1) AS events_per_activity
FROM bridge_dispatches WHERE events_received IS NOT NULL
ORDER BY started_at DESC LIMIT 20;
```

`events_per_activity` near 1 on a chatty harness means coalescing is not happening. `activities_posted = 0` against a non-empty transcript means the board saw silence. Both are readable at a glance, historically, without the bridge having been running in a special mode when the interesting run happened.

**Per worked card, in the hub log.** One line — `coalesced the transcript` — carrying run, card, station and attempt ids, the two counts, the ratio, and the event *kinds* that had no projection (the last is what makes a surprising zero legible rather than merely alarming).

Documented in `docs/OPERATING.md` §8, with the query verified against Postgres.

## Why there and not somewhere else

**Both, and they answer different questions.** The ledger is the durable record: it survives log rotation, it is queryable across runs, and it answers the question retroactively — which is the actual failure here, since the run that raised the question had already finished. The log is what an operator reads without database access, at the moment it happens. The gap needed both.

**On `bridge_dispatches` and not `acp_runs`.** That split already exists and this falls on the same side of it: an `acp_runs` row is one prompt-turn on a station and exists for hand-driven console sessions with no board anywhere, which have no activities to post to anybody. This is bookkeeping about a *claim*.

**Two raw counts, not a stored ratio.** The ratio is a division in whatever query asks. Storing a derivative is how a row's parts come to disagree with its whole.

**Nullable, and `0` is not `NULL`.** Null means nobody counted — a row written before this shipped, a claim handed straight back, a replay that started no harness. Zero means counted, and the whole transcript projected to nothing. `NOT NULL DEFAULT 0` would collapse those into one value and would put a fake data point into every ratio an operator computes. It also makes the migration safe against live rows by construction.

**Written from the dispatch's `finally`**, so every exit a session had records the counts — reported, unreported, blocked, abandoned, and the one that threw — without seven exit paths each having to remember. A lost lease is exactly where the number is most wanted: it says how far the run got before the board took the card away.

## What was deliberately excluded, to stay bounded

- **Any per-event logging.** That reintroduces the volume problem coalescing exists to solve, and #231 in this repo is a live example of a per-cycle log line making `apn logs` unusable at 83% of volume.
- **A per-claim-cycle line.** The loop polls every five seconds forever; a summary on an idle cycle is ~17,000 lines a day saying nothing happened. There is a test for this.
- **Per-event-type breakdown columns.** `acp_events` already holds the types and can be grouped. Only the closed set of *unmapped kind names* rides in the log line, because it explains an anomalous count.
- **An HTTP surface.** The bridge has no routes today and this does not earn the first one.
- **Contract changes.** No frame or API shape moved.

Nothing that ran through the coalescer is logged. The bridge deliberately does not log its token; card content, prompts and harness output are treated the same. There is a test asserting the line contains neither the agent's output, nor a tool title, nor the card's spec, nor its title, nor the credential.

## Migration

`0039_bridge_dispatch_coalescing.sql` — two nullable `integer` columns. **Exercised against real Postgres with existing rows**, not an empty database: the test in `bridge-ledger.test.ts` rewinds the table to its pre-migration shape inside a transaction, inserts a dispatch row, replays the shipped `.sql` file (read from the file that will actually run, not a copy), asserts the row survives reading as not-measured, and rolls back.

## Mutation results

Both directions, as asked. Each mutation was applied to the real implementation and the suite run:

| mutation | result |
|---|---|
| **always report the coalesced number regardless of input** (`activitiesPosted: 1`) | **2 tests failed** — `a 1:1 transcript is recorded as 1:1` (expected 5, got 1) and `a flush that produced nothing is recorded as zero` (expected 0, got 1) |
| **count every event as an activity** (`activitiesPosted = eventsReceived`) | **4 tests failed** — the chunk storm, the 1:1 transcript, the zero flush, and the log line's ratio |

The counter cannot silently become decorative because every count test ties the number written to the ledger to something independently observed: the activities the fake board actually received. A constant fails the 1:1 case; the event count fails the chunk storm.

A third mutation guards the delivery mechanism: removing the `.catch()` on the `finally` call makes `a summary that cannot be written does not change what the run returned` fail. A throw in a `finally` replaces the value the try block returned, which would have let a broken log sink swallow the `foreign-run` that halts the agent loop.

## Green

- `cd packages/contract && bun test` — 222 pass, 0 fail
- `cd apps/hub && DATABASE_URL=… bun test` — **981 pass, 0 fail**, 74 files
- `bun run typecheck` — 15 errors, the known pre-existing count, none in bridge files

Not deployed, and the live hub was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
