### PR TITLE
fix(ci): GHCR refs must be lowercase, and the owner is not

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -218,7 +218,13 @@ jobs:
           # nobody reads), so the argument is only added when there is one.
           AGENT_VERSION: ${{ steps.agent.outputs.version }}
         run: |
-          ref="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
+          # GHCR refs must be lowercase; `github.repository_owner` is not — it is the
+          # account name verbatim, and this repository moved to an owner with capitals
+          # in it on 2026-08-14, which failed every build with "repository name must
+          # be lowercase". Lowercasing here rather than hardcoding keeps a fork or a
+          # future move working without another edit.
+          owner=$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          ref="ghcr.io/${owner}/${{ matrix.image }}"
           args=(
             --platform linux/amd64
             -f "${{ matrix.dockerfile }}"
@@ -243,7 +249,8 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: |
           set -eux
-          ref="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ inputs.tag }}"
+          owner=$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          ref="ghcr.io/${owner}/${{ matrix.image }}:${{ inputs.tag }}"
 
           # Every image: the node-agent binary is there and runs.
           agent_version_out="$(docker run --rm --entrypoint /agentpod-node "$ref" version)"


### PR DESCRIPTION
Found by running the publish workflow immediately after transferring this repository to `SuperJackfruitLabs`, rather than discovering it at the next release.

```
ERROR: failed to build: invalid tag "ghcr.io/SuperJackfruitLabs/agentpod-node-pi-fly:v0.1.26":
       repository name must be lowercase
```

All five images failed identically.

`github.repository_owner` is the account name verbatim. Under `rakeshgangwar` it was lowercase already, so the workflow was correct **by coincidence, not by construction** — it had never been exercised under an owner with capitals.

Lowercased at the point of use rather than hardcoded, so a fork or a future move keeps working without another edit. Both `Build and push` and `Verify what was published` use the same derivation.

Verified `printf 'SuperJackfruitLabs' | tr '[:upper:]' '[:lower:]'` → `superjackfruitlabs`, and the workflow YAML still parses.

Publishing after this merges will create packages under the new `ghcr.io/superjackfruitlabs/…` namespace. The hub currently pulls `ghcr.io/rakeshgangwar/…:v0.1.26`, which still exists and is unaffected — the two must be reconciled deliberately, including confirming the new packages are **public**, since Modal calls `images.fromRegistry()` with no credential and a private package fails at first pull rather than at publish.