### PR TITLE
fix: three defects the documentation audit found (#321, #322, #323)

### DIFF
--- a/apps/hub/src/config.ts
+++ b/apps/hub/src/config.ts
@@ -248,6 +248,18 @@ export const config = {
 
   // Database
   database: {
+    /**
+     * The connection string the hub actually runs on. Everything that talks to
+     * Postgres reads DATABASE_URL; this is here so the rules in
+     * validate-config.ts can inspect the same value rather than a neighbour.
+     */
+    url: getEnv('DATABASE_URL', ''),
+    /**
+     * @deprecated Pre-pivot SQLite path. Read only by `src/db/index.ts`, which
+     * is itself deprecated and imported by nothing. Do not add readers, and do
+     * not write a rule against it: a production guard that inspected this
+     * instead of `url` is issue #321, and it silently never fired.
+     */
     path: getEnv('DATABASE_PATH', './data/database.sqlite'),
   },
   

--- a/apps/hub/src/db/drizzle.ts
+++ b/apps/hub/src/db/drizzle.ts
@@ -103,10 +103,17 @@ export async function runMigrations(): Promise<void> {
 
 /**
  * Initialize database (run on startup)
+ * - Checks the connection
+ * - Enables the pgvector extension
  * - Runs pending migrations
- * - Enables pgvector extension
- * - Creates vector indexes
- * - Seeds reference data
+ *
+ * It listed vector indexes and seed data too, and did neither; it also claimed
+ * the pgvector line without ever calling it (#322). The extension is not
+ * optional — migration 0000 declares `"embedding" vector(1536)` and no
+ * migration runs CREATE EXTENSION — so enabling it here is what makes the
+ * claim true AND makes a fresh database work. Order matters: after
+ * runMigrations() it would be enabling the extension for the migration that
+ * already failed.
  */
 export async function initDatabase(): Promise<void> {
   log.info("Initializing PostgreSQL database...");
@@ -116,6 +123,9 @@ export async function initDatabase(): Promise<void> {
   if (!healthy) {
     throw new Error("Database connection failed");
   }
+
+  // Before migrations, which declare a vector column.
+  await enableVectorExtension();
 
   // Run pending migrations automatically
   await runMigrations();

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { config, allowedOrigins, isAllowedOrigin } from './config.ts';
 import { validateConfig } from './utils/validate-config.ts';
+import { describeDatabase } from './utils/describe-database.ts';
 import { initDatabase } from './db/drizzle.ts';
 import { resetOrphanedOnlineNodes } from './services/node-registry.ts';
 import { auth } from './auth/drizzle-auth.ts';
@@ -215,7 +216,7 @@ console.log(`
 ╠═══════════════════════════════════════════════════════════════╣
 ║  Port:        ${String(port).padEnd(46)}║
 ║  Environment: ${config.nodeEnv.padEnd(46)}║
-║  Database:    ${config.database.path.padEnd(46)}║
+║  Database:    ${describeDatabase(config.database.url).padEnd(46)}║
 ╠═══════════════════════════════════════════════════════════════╣
 ║  Auth Endpoints (Better Auth):                                ║
 ║  - POST /api/auth/sign-in/email       Email/password sign-in  ║

--- a/apps/hub/src/utils/describe-database.ts
+++ b/apps/hub/src/utils/describe-database.ts
@@ -1,0 +1,24 @@
+/**
+ * How the boot banner names the database, without naming the password.
+ *
+ * The banner used to print `config.database.path` — the pre-pivot SQLite
+ * default that nothing connects to (#321's other half). Printing DATABASE_URL
+ * instead makes it true, but the URL carries credentials and boot output ends
+ * up in journald, CI logs and screenshots. So: enough to identify the database,
+ * never the secret.
+ */
+export function describeDatabase(url: string | undefined): string {
+  if (!url) return "(DATABASE_URL not set)";
+
+  try {
+    const parsed = new URL(url);
+    const user = parsed.username ? `${parsed.username}@` : "";
+    const db = parsed.pathname.replace(/^\//, "");
+    return `${user}${parsed.host}${db ? `/${db}` : ""}`;
+  } catch {
+    // Unparseable — which is exactly when someone has pasted the wrong thing,
+    // possibly a secret. Say nothing about its contents, and do not throw: a
+    // banner must never be the reason a boot dies.
+    return "(DATABASE_URL unparseable)";
+  }
+}

--- a/apps/hub/src/utils/validate-config.ts
+++ b/apps/hub/src/utils/validate-config.ts
@@ -212,7 +212,10 @@ export function collectConfigErrors(
   }
 
   if (isProduction) {
-    if (cfg.database.path.includes("agentpod-dev-password")) {
+    // DATABASE_URL, not the legacy DATABASE_PATH this used to read: the hub
+    // connects with the URL, nothing sets the path, and so this refusal had
+    // never once fired (#321).
+    if (cfg.database.url.includes("agentpod-dev-password")) {
       errors.push({
         field: "DATABASE_URL",
         message: "Production database cannot use default dev password.",

--- a/apps/hub/tests/helpers/scan-env-names.ts
+++ b/apps/hub/tests/helpers/scan-env-names.ts
@@ -1,0 +1,83 @@
+/**
+ * Finding the environment variables the hub is prepared to NAME to an operator.
+ *
+ * Extracted from `tests/unit/docs-claims.test.ts` so it can be tested on its
+ * own, which issue #323 showed it needed: the scanner could not tell a
+ * backticked name inside a JSDoc comment from a string literal in code, and
+ * reported an exported TypeScript constant as an undocumented variable.
+ *
+ * The check stays as it was in intent — a SCREAMING_SNAKE name inside a string
+ * literal in these files is a variable being named to an operator, whether in a
+ * `field:` label or the prose of a refusal. Only comments are removed first.
+ */
+
+/**
+ * Remove line and block comments, leaving string literals intact.
+ *
+ * Written as a scanner rather than a regex on purpose. Every naive version of
+ * this eats the rest of a line at the `//` in "https://hub.agentpod.dev", or
+ * opens a block comment at the `/*` inside a glob string — and the damage is
+ * silent, because what disappears is code the caller never sees it lost.
+ */
+export function stripComments(source: string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < source.length) {
+    const c = source[i]!;
+    const next = source[i + 1];
+
+    // A string literal: copy it whole, respecting escapes. Nothing inside is a
+    // comment, no matter what it looks like.
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      out += c;
+      i++;
+      while (i < source.length) {
+        const ch = source[i]!;
+        out += ch;
+        i++;
+        if (ch === "\\") {
+          if (i < source.length) {
+            out += source[i]!;
+            i++;
+          }
+          continue;
+        }
+        if (ch === quote) break;
+      }
+      continue;
+    }
+
+    if (c === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue; // the newline itself is copied on the next pass
+    }
+
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) i++;
+      i += 2;
+      // Keep a space so `a/* x */b` does not become `ab`.
+      out += " ";
+      continue;
+    }
+
+    out += c;
+    i++;
+  }
+
+  return out;
+}
+
+/**
+ * The SCREAMING_SNAKE names appearing in string literals in `source`, once
+ * comments are gone. Sorted and de-duplicated.
+ */
+export function scanEnvNames(source: string): string[] {
+  const named = new Set<string>();
+  for (const match of stripComments(source).matchAll(/["'`]([A-Z][A-Z0-9_]{3,})["'`]/g)) {
+    named.add(match[1]!);
+  }
+  return [...named].sort();
+}

--- a/apps/hub/tests/unit/describe-database.test.ts
+++ b/apps/hub/tests/unit/describe-database.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { describeDatabase } from "../../src/utils/describe-database";
+
+/**
+ * The boot banner printed `config.database.path` — `./data/database.sqlite`,
+ * a pre-pivot default that no deployment sets and nothing connects to. Every
+ * hub boot has told its operator the wrong database, in the one place they are
+ * most likely to look for it. Same root as #321: `database.path` is a lie, and
+ * fixing only the validation rule would have left the lie on screen.
+ *
+ * A banner cannot print DATABASE_URL raw — it carries the password, and boot
+ * output goes to journald, CI logs and screenshots. So it prints what an
+ * operator needs to identify the database (host, port, name, user) and never
+ * the secret.
+ */
+describe("describeDatabase", () => {
+  test("keeps host, port, database and user", () => {
+    const out = describeDatabase("postgres://agentpod:s3cret@db.internal:5432/agentpod");
+    expect(out).toContain("db.internal:5432");
+    expect(out).toContain("agentpod");
+  });
+
+  test("never prints the password", () => {
+    const out = describeDatabase("postgres://agentpod:hunter2@db.internal:5432/agentpod");
+    expect(out).not.toContain("hunter2");
+  });
+
+  test("hides a password containing URL-ish punctuation", () => {
+    const out = describeDatabase("postgres://u:p%40ss%2Fw0rd@db.internal:5432/agentpod");
+    expect(out).not.toContain("p%40ss");
+    expect(out).not.toContain("w0rd");
+  });
+
+  test("says so when the variable is unset, rather than inventing a default", () => {
+    expect(describeDatabase("")).toContain("not set");
+    expect(describeDatabase(undefined as unknown as string)).toContain("not set");
+  });
+
+  test("does not throw on a malformed URL, and still hides what follows a colon", () => {
+    // A banner must never be the reason a boot dies, and an unparseable value
+    // is exactly when someone has pasted something wrong — possibly a secret.
+    const out = describeDatabase("this is not a url:with-a-secret");
+    expect(out).not.toContain("with-a-secret");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/hub/tests/unit/docs-claims.test.ts
+++ b/apps/hub/tests/unit/docs-claims.test.ts
@@ -33,6 +33,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { scanEnvNames } from "../helpers/scan-env-names";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -170,8 +171,14 @@ describe("environment variables the hub names in a boot message", () => {
     ]) {
       // A SCREAMING_SNAKE name inside a string literal in these files is,
       // without exception today, a variable being named to an operator.
-      for (const match of read(rel).matchAll(/["'`]([A-Z][A-Z0-9_]{3,})["'`]/g)) {
-        named.add(match[1]!);
+      //
+      // Comments are stripped first (#323): this could not tell a backticked
+      // name in a JSDoc line from a string literal, so a comment about an
+      // exported constant read as an undocumented variable. The obvious way to
+      // green that was to document a setting that does nothing — a check whose
+      // failure is fixed by writing something false.
+      for (const name of scanEnvNames(read(rel))) {
+        named.add(name);
       }
     }
     return [...named].sort();

--- a/apps/hub/tests/unit/init-database-claims.test.ts
+++ b/apps/hub/tests/unit/init-database-claims.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../../../..");
+const source = readFileSync(join(repoRoot, "apps/hub/src/db/drizzle.ts"), "utf8");
+
+/**
+ * Issue #322. `initDatabase()`'s docstring listed four things it does. It did
+ * one of them.
+ *
+ *   - Runs pending migrations      — true
+ *   - Enables pgvector extension   — never called `enableVectorExtension()`
+ *   - Creates vector indexes       — nothing does this
+ *   - Seeds reference data         — nothing does this
+ *
+ * The issue reported the pgvector line; the other two came out of reading the
+ * body against the list, which is what this test now does mechanically.
+ *
+ * pgvector is not optional here, which is why the fix calls it rather than
+ * deleting the sentence: migration 0000 creates `"embedding" vector(1536)`,
+ * and no migration runs `CREATE EXTENSION`. Against a database where nobody
+ * ran it by hand, the first migration fails on a type that does not exist.
+ * That the suite has been green only means every database it has ever met
+ * happened to have the extension already.
+ */
+describe("initDatabase's docstring describes what it does (#322)", () => {
+  const body = (() => {
+    const start = source.indexOf("export async function initDatabase");
+    expect(start).toBeGreaterThan(-1);
+    // To the next top-level `}` at column 0 — these are all plain declarations.
+    const end = source.indexOf("\n}", start);
+    return source.slice(start, end);
+  })();
+
+  /**
+   * The BULLET LINES of the docstring, which is where it makes claims. Prose
+   * around them explains history — including, now, a sentence recording that
+   * this function once claimed vector indexes and seed data it never created.
+   * Scanning the whole comment would read that history as a fresh claim and
+   * fail forever, which is a neat illustration of why the scope is the list.
+   */
+  const claimLines = (() => {
+    const at = source.indexOf("export async function initDatabase");
+    const before = source.slice(0, at);
+    const open = before.lastIndexOf("/**");
+    expect(open).toBeGreaterThan(-1);
+    return before
+      .slice(open)
+      .split("\n")
+      .filter((l) => /^\s*\*\s*-\s/.test(l))
+      .join("\n");
+  })();
+
+  test("enables the pgvector extension, which its migrations require", () => {
+    expect(body).toContain("enableVectorExtension(");
+  });
+
+  test("enables the extension BEFORE running migrations", () => {
+    const enable = body.indexOf("enableVectorExtension(");
+    const migrate = body.indexOf("runMigrations(");
+
+    expect(enable).toBeGreaterThan(-1);
+    expect(migrate).toBeGreaterThan(-1);
+    // Order is the whole point: migration 0000 declares a `vector` column, so
+    // enabling afterwards would be enabling it for the migration that already
+    // failed.
+    expect(enable).toBeLessThan(migrate);
+  });
+
+  test("claims nothing it does not do", () => {
+    // Each claim in the docstring must be traceable to a call in the body.
+    // Keyed by the word that identifies the claim, valued by what would have
+    // to be there for it to be true.
+    const claims: Array<{ says: RegExp; needs: string }> = [
+      { says: /migrations/i, needs: "runMigrations(" },
+      { says: /pgvector|vector extension/i, needs: "enableVectorExtension(" },
+      { says: /vector index/i, needs: "createVectorIndexes(" },
+      { says: /seed/i, needs: "seed" },
+    ];
+
+    const broken = claims
+      .filter((c) => c.says.test(claimLines))
+      .filter((c) => !body.includes(c.needs))
+      .map((c) => `docstring claims ${c.says} but the body never calls ${c.needs}`);
+
+    expect(broken).toEqual([]);
+  });
+});

--- a/apps/hub/tests/unit/scan-env-names.test.ts
+++ b/apps/hub/tests/unit/scan-env-names.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { scanEnvNames, stripComments } from "../helpers/scan-env-names";
+
+/**
+ * Issue #323. The docs-claims scanner finds the environment variables the hub
+ * is prepared to NAME to an operator, by matching SCREAMING_SNAKE inside string
+ * literals in the three files that print such names.
+ *
+ * It could not tell a backticked reference inside a JSDoc comment from a string
+ * literal in code. A comment reading "Unset means `DEFAULT_PERMISSION_WAIT_MS`"
+ * therefore reported an exported TypeScript constant as an undocumented
+ * environment variable, on PR #319, for a variable that does not exist.
+ *
+ * The reason this mattered more than an annoying red: the obvious way to make
+ * it green was to document `DEFAULT_PERMISSION_WAIT_MS=` in an operator-facing
+ * file — offering a setting that does nothing. That is exactly the SESSION_SECRET
+ * defect these checks were added to prevent, and it would have PASSED the check
+ * while making the documentation less true. A check whose failure is fixed by
+ * writing something false is worse than no check.
+ *
+ * Stripping comments is the fix rather than matching only read positions
+ * (`process.env.X`, `getEnv("X")`), because the names that matter most here
+ * appear in refusal messages and `field:` labels — string literals, not reads.
+ * Narrowing to reads would have blinded the check to the very thing it exists
+ * to catch.
+ */
+describe("stripComments", () => {
+  test("removes a line comment", () => {
+    expect(stripComments('const a = 1; // SOME_NAME\n')).not.toContain("SOME_NAME");
+  });
+
+  test("removes a block comment and a JSDoc", () => {
+    expect(stripComments("/* SOME_NAME */ const a = 1;")).not.toContain("SOME_NAME");
+    expect(stripComments("/**\n * Unset means `SOME_NAME`.\n */\nconst a = 1;")).not.toContain(
+      "SOME_NAME"
+    );
+  });
+
+  test("keeps code, including string literals", () => {
+    const out = stripComments('const a = "KEEP_ME"; // DROP_ME');
+    expect(out).toContain("KEEP_ME");
+    expect(out).not.toContain("DROP_ME");
+  });
+
+  test("does not mistake a URL's slashes for a comment", () => {
+    // The trap in every naive comment stripper. `https://` must survive, or the
+    // rest of the line — real code — vanishes with it.
+    const out = stripComments('const u = "https://hub.agentpod.dev"; const b = "KEEP_ME";');
+    expect(out).toContain("https://hub.agentpod.dev");
+    expect(out).toContain("KEEP_ME");
+  });
+
+  test("does not mistake an asterisk inside a string for a block comment", () => {
+    const out = stripComments('const glob = "/*"; const b = "KEEP_ME";');
+    expect(out).toContain("KEEP_ME");
+  });
+
+  test("leaves a comment marker inside a string alone", () => {
+    expect(stripComments('const s = "// not a comment"; const b = "KEEP_ME";')).toContain(
+      "KEEP_ME"
+    );
+  });
+});
+
+describe("scanEnvNames (#323)", () => {
+  test("finds a name the hub would print to an operator", () => {
+    expect(scanEnvNames('errors.push({ field: "DATABASE_URL" });')).toContain("DATABASE_URL");
+  });
+
+  test("matches a whole string literal, not a name buried in prose", () => {
+    // Deliberate, and worth stating because it looks like a miss. Matching
+    // names INSIDE longer messages was measured against the three scanned
+    // files: it finds three more real variables (ENABLE_CLOUDFLARE_SANDBOXES,
+    // DOCKER_PORT, CERT_FILES) and nine English words — CONFIGURATION, WARNING,
+    // FAILED, README, CREATE, DEPLOYMENT, VALIDATION, WIDE, WORKSPACE — each of
+    // which would then demand an operator-facing line for a variable that does
+    // not exist. That is the same "green by writing something false" trap #323
+    // is about, pointing the other way.
+    //
+    // The gap is real but needs a rule that can tell a variable from a noun,
+    // which this is not. Tracked rather than smuggled in here.
+    expect(scanEnvNames('throw new Error("Set KAAMBAAN_BASE_URL first");')).not.toContain(
+      "KAAMBAAN_BASE_URL"
+    );
+    expect(scanEnvNames('const k = "KAAMBAAN_BASE_URL";')).toContain("KAAMBAAN_BASE_URL");
+  });
+
+  test("ignores a backticked constant named in a comment — the #319 false red", () => {
+    const source = [
+      "/**",
+      " * How long a permission question waits for a human.",
+      " * Unset means `DEFAULT_PERMISSION_WAIT_MS`.",
+      " */",
+      "export const DEFAULT_PERMISSION_WAIT_MS = 30 * 60 * 1000;",
+    ].join("\n");
+
+    // Named only in a comment and as a bare identifier — never in a string
+    // literal, because it is not a variable anyone can set.
+    expect(scanEnvNames(source)).not.toContain("DEFAULT_PERMISSION_WAIT_MS");
+  });
+
+  test("still finds a real variable in a file that also comments about a constant", () => {
+    const source = [
+      "/** Unset means `DEFAULT_PERMISSION_WAIT_MS`. */",
+      'const enabled = getEnv("ENABLE_KAAMBAAN_BRIDGE") === "true";',
+    ].join("\n");
+
+    const names = scanEnvNames(source);
+    expect(names).toContain("ENABLE_KAAMBAAN_BRIDGE");
+    expect(names).not.toContain("DEFAULT_PERMISSION_WAIT_MS");
+  });
+});

--- a/apps/hub/tests/unit/validate-config-database.test.ts
+++ b/apps/hub/tests/unit/validate-config-database.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { config } from "../../src/config";
+import { collectConfigErrors } from "../../src/utils/validate-config";
+
+/**
+ * Issue #321. The production rule that refuses a boot on the development
+ * database password read `DATABASE_PATH` — a pre-pivot SQLite leftover that no
+ * deployment sets — while reporting the field as `DATABASE_URL`, the variable
+ * the hub actually connects with.
+ *
+ * So the guard inspected an empty variable, found nothing, and passed. It had
+ * never once fired. This is the third time in two days the same shape has
+ * turned up here: a check that is green because it is looking somewhere empty
+ * (the `acp` capability advertised on a binary merely resolving; the posture
+ * scanner grading machines "A" without opening the files it graded).
+ *
+ * A rule that has never fired has also never been proven to fire, so these
+ * tests assert both directions: that it catches a real production URL, and
+ * that it cannot be satisfied by the legacy variable it used to read.
+ */
+describe("the production dev-password database refusal (#321)", () => {
+  const production = (database: Record<string, unknown>) => ({
+    ...config,
+    nodeEnv: "production",
+    database: { ...config.database, ...database },
+  });
+
+  const databaseErrors = (cfg: ReturnType<typeof production>) =>
+    collectConfigErrors(cfg as unknown as typeof config, () => {}).filter(
+      (e) => e.field === "DATABASE_URL"
+    );
+
+  test("refuses a production boot whose DATABASE_URL carries the dev password", () => {
+    const errors = databaseErrors(
+      production({
+        url: "postgres://agentpod:agentpod-dev-password@db.internal:5432/agentpod",
+      })
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.message).toContain("dev password");
+  });
+
+  test("allows a production boot with a real password", () => {
+    const errors = databaseErrors(
+      production({ url: "postgres://agentpod:S6mKq2xT9wZ@db.internal:5432/agentpod" })
+    );
+
+    expect(errors).toEqual([]);
+  });
+
+  test("inspects the variable the hub connects with, not the legacy DATABASE_PATH", () => {
+    // The regression. Before the fix this passed for the wrong reason: the rule
+    // read `path`, so a dev password in the URL the hub actually uses went
+    // unseen. A future edit that points the rule back at any field other than
+    // the connection URL fails here.
+    const errors = databaseErrors(
+      production({
+        path: "./data/database.sqlite", // clean, and irrelevant — nothing reads it
+        url: "postgres://agentpod:agentpod-dev-password@db.internal:5432/agentpod",
+      })
+    );
+
+    expect(errors).toHaveLength(1);
+  });
+
+  test("does not fire outside production", () => {
+    const errors = collectConfigErrors(
+      {
+        ...config,
+        nodeEnv: "development",
+        database: {
+          ...config.database,
+          url: "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod",
+        },
+      } as unknown as typeof config,
+      () => {}
+    ).filter((e) => e.field === "DATABASE_URL");
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #321. Closes #322. Closes #323.

All three came out of the documentation audit (#320) and #319, and were reported rather than fixed there because they are code defects. They share a species: **something green because it was looking somewhere empty**, or a claim sitting in the one place a reader trusts most.

## #321 — a production refusal that had never fired

`validate-config.ts` read the pre-pivot **`DATABASE_PATH`** while reporting the field as **`DATABASE_URL`**. Nothing sets `DATABASE_PATH`. So the rule that refuses a production boot carrying the development database password inspected an empty variable, found nothing, and passed — every time, since the pivot.

`config.database.url` now exists and the rule reads it. The legacy `path` stays, because the deprecated `src/db/index.ts` still reads it, but it carries a comment saying not to write rules against it.

**Its other half, not in the issue:** the boot banner printed that same dead SQLite path. Every hub boot has named `./data/database.sqlite` to its operator while running on Postgres. It now prints the real database through `describeDatabase()` — host, port, database, user, and never the password, because boot output lands in journald, CI logs and screenshots.

## #322 — a docstring that listed four things and did one

`initDatabase()` claimed it runs migrations, enables pgvector, creates vector indexes and seeds reference data. It runs migrations. The issue reported the pgvector line; reading the body against the list found the other two.

**pgvector is not optional here**, which is why this calls it rather than deleting the sentence: migration `0000` declares `"embedding" vector(1536)` and no migration runs `CREATE EXTENSION`. Against a database where nobody ran it by hand, the first migration fails on a type that does not exist. The suite has been green only because every database it has ever met already had the extension — it now runs for real in every integration test.

Enabled **before** migrations. After them it would be enabling the extension for the migration that already failed.

## #323 — a check whose failure was fixed by writing something false

The env-var scanner could not tell a backticked name inside a JSDoc comment from a string literal, so a comment about an exported constant reported `DEFAULT_PERMISSION_WAIT_MS` as an undocumented environment variable on #319.

The danger was not the red. It was that the obvious way to clear it — documenting `DEFAULT_PERMISSION_WAIT_MS=` in an operator-facing file — offers a setting that does nothing. That is precisely the `SESSION_SECRET` defect these checks were added to prevent, and it would have **passed** the check while making the documentation less true.

Comments are now stripped first, by a scanner that survives `https://` and `/*` inside string literals — the trap every naive comment stripper falls into, where what vanishes is code the caller never sees it lose.

**Deliberately not widened to names inside prose.** Measured against the three scanned files: matching inside longer strings finds three more real variables (`ENABLE_CLOUDFLARE_SANDBOXES`, `DOCKER_PORT`, `CERT_FILES`) and nine English words — `CONFIGURATION`, `WARNING`, `FAILED`, `README`, `CREATE`, `DEPLOYMENT`, `VALIDATION`, `WIDE`, `WORKSPACE` — each of which would then demand an operator-facing line for a variable that does not exist. Same trap, pointing the other way. The gap is real and recorded in the test rather than smuggled in here; it needs a rule that can tell a variable from a noun.

## Verification

- **hub: 1047 pass, 0 fail** (81 files; 1025 before, plus 22 new)
- contract: 222 pass, 0 fail
- `bun run typecheck`: 15 errors, the documented baseline, none added

Every new test fails against the code as it was.