### PR TITLE
feat: roll the fleet from the hub, and stop depending on a redirect (#295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Fleet/facilities console for agent runtimes. Three tiers:
 
-- `apps/node-agent` — Go daemon on each host; detects harnesses (hermes, openclaw, claude-code, codex, opencode, pi — `cmd/agentpod-node/registry.go` is the list), dials the hub over WSS, serves station capabilities (health/logs/fs/terminal/lifecycle/cleanup/acp/changeset), self-updates from GitHub releases.
+- `apps/node-agent` — Go daemon on each host; detects harnesses (hermes, openclaw, claude-code, codex, opencode, pi — `cmd/agentpod-node/registry.go` is the list), dials the hub over WSS, serves station capabilities (health/logs/fs/terminal/lifecycle/cleanup/acp/changeset), and updates itself from GitHub releases **when asked to** — there is no timer on the node. The trigger is `apn update` on the host, or the hub: one node from the console, or the whole fleet via `POST /api/nodes/update-all`. Nodes do not drift forward on their own, so after a release the fleet stays where it is until someone rolls it (issue #295).
 - `apps/hub` — Bun + Hono + Drizzle/Postgres backend; node gateway, broker, station registry, Better Auth. See `apps/hub/CLAUDE.md`.
 - `apps/console` — SvelteKit with `adapter-static` (Svelte 5 runes, vite, bits-ui, Tailwind); a client-routed SPA deployed to Cloudflare Pages. It IS SvelteKit — `pnpm check` runs `svelte-kit sync`.
 - `packages/contract` — zod schemas shared by hub ↔ agent ↔ console. Change here first when a frame/API shape changes.

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -68,6 +68,32 @@ export const listNodes = () => http<NodeSummary[]>("/api/nodes");
  * `force` re-applies the current release — the escape hatch for a node whose
  * binary is corrupt but whose reported version is current.
  */
+/**
+ * Update the whole fleet, one node at a time, from the hub (issue #295).
+ *
+ * Always resolves on a reachable hub: the response carries a row per node,
+ * including the ones it declined to touch and why. A node that failed is a row
+ * with `outcome: "failed"`, not a thrown error — one unreachable machine must
+ * not read as "the rollout failed".
+ */
+export const updateAllNodes = (opts?: { force?: boolean; only?: string[] }) =>
+  http<{
+    ok: boolean;
+    summary: Record<string, number>;
+    results: Array<{
+      nodeId: string;
+      name: string;
+      outcome: "updated" | "no-op" | "skipped" | "failed";
+      tag?: string;
+      reason?: string;
+      error?: string;
+    }>;
+  }>("/api/nodes/update-all", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ force: opts?.force ?? false, ...(opts?.only ? { only: opts.only } : {}) }),
+  });
+
 export const updateNode = (id: string, opts?: { force?: boolean }) =>
   http<{
     ok: boolean;

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte
@@ -3,7 +3,7 @@
   import { startPolling } from "$lib/utils/poll";
   import { page } from "$app/state";
   import { replaceState } from "$app/navigation";
-  import { listNodes, createEnrollmentToken, listRuntimes, listRuntimeProviders, updateNode, getFleet, type DriverManifest } from "$lib/api/client";
+  import { listNodes, createEnrollmentToken, listRuntimes, listRuntimeProviders, updateNode, updateAllNodes, getFleet, type DriverManifest } from "$lib/api/client";
   import { toast } from "svelte-sonner";
   import type { NodeSummary, ProvisionedRuntime, FleetAgent } from "@agentpod/contract";
   import * as Table from "$lib/components/ui/table";
@@ -17,6 +17,7 @@
   import EnrollmentCommand from "./EnrollmentCommand.svelte";
   import { Metric } from "$lib/components/ui/metric";
   import PlusIcon from "@lucide/svelte/icons/plus";
+  import ArrowUpCircleIcon from "@lucide/svelte/icons/arrow-up-circle";
   import Loader2Icon from "@lucide/svelte/icons/loader-2";
   import NewRuntimeDialog from "./NewRuntimeDialog.svelte";
   import ConnectBanner from "./connect-banner.svelte";
@@ -214,6 +215,60 @@
   let copied = $state(false);
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
+
+  // ─── Fleet rollout (#295) ───────────────────────────────────────────────────
+
+  /**
+   * Nodes the hub can see are behind. Drives both the button's presence and its
+   * count, so an operator is never offered an action with nothing to do.
+   */
+  const nodesBehind = $derived(nodes.filter((n) => n.updateAvailable));
+
+  let isRollingOut = $state(false);
+
+  /**
+   * Roll the fleet. The hub goes one node at a time and always answers with a
+   * row per node, so this reports what actually happened rather than "sent" —
+   * a rollout claiming success while machines stayed on the old binary is the
+   * exact defect #296 fixed on the single-node path.
+   */
+  async function handleUpdateAll() {
+    isRollingOut = true;
+    try {
+      const result = await updateAllNodes();
+      const { updated = 0, failed = 0, skipped = 0 } = result.summary ?? {};
+
+      if (failed > 0) {
+        const names = result.results
+          .filter((r) => r.outcome === "failed")
+          .map((r) => r.name)
+          .join(", ");
+        toast.error(`${failed} node${failed === 1 ? "" : "s"} didn’t update`, {
+          description: `${names}. ${updated} updated, ${skipped} skipped.`,
+        });
+      } else if (updated > 0) {
+        toast.success(`Updating ${updated} node${updated === 1 ? "" : "s"}`, {
+          description:
+            "Each will blip offline and come back on the new version. Skipped: " +
+            `${skipped}.`,
+        });
+      } else {
+        toast.success("Nothing to update", {
+          description: "Every reachable node is already on the latest release.",
+        });
+      }
+
+      // The updated nodes restart; the next refresh reflects their new version.
+      await loadData();
+    } catch (e) {
+      toast.error("Couldn’t roll out the update", {
+        description: e instanceof Error ? e.message : "The hub didn’t respond.",
+      });
+    } finally {
+      isRollingOut = false;
+    }
+  }
+
   function handleCopyEnrollCmd() {
     const cmd = enrollmentCommand(resolvedHubUrl(), lastToken ?? "");
     navigator.clipboard.writeText(cmd).then(() => {
@@ -231,6 +286,19 @@
   {#snippet actions()}
     <div class="flex flex-col items-end gap-1.5">
       <div class="flex gap-2 flex-wrap justify-end">
+        <!--
+          Only offered when there is drift to clear (#295). Nodes never update
+          themselves — there is no timer anywhere — so after a release the fleet
+          sits where it is until someone rolls it. This is that someone's button.
+        -->
+        {#if nodesBehind.length > 0}
+          <Button onclick={handleUpdateAll} disabled={isRollingOut} variant="outline">
+            <ArrowUpCircleIcon class="h-4 w-4 mr-2" />
+            {isRollingOut
+              ? "Updating fleet…"
+              : `Update ${nodesBehind.length} node${nodesBehind.length === 1 ? "" : "s"}`}
+          </Button>
+        {/if}
         <Button onclick={() => (showNewRuntimeDialog = true)} variant="outline">
           <PlusIcon class="h-4 w-4 mr-2" />
           New runtime

--- a/apps/console/src/lib/components/fleet/NodesOverview.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/NodesOverview.svelte.test.ts
@@ -413,3 +413,91 @@ test("?action= the same value re-appearing WITHOUT an intervening action-less st
   expect(api.createEnrollmentToken).toHaveBeenCalledOnce();
   expect(nav.replaceState).toHaveBeenCalledTimes(1);
 });
+
+// ─── Fleet rollout button (#295) ───────────────────────────────────────────────
+//
+// Nodes never update themselves — there is no timer anywhere in the agent or
+// the hub — so after a release the fleet stays where it is until somebody rolls
+// it. These cover the button that does the rolling, and specifically that it
+// tells the truth afterwards: a rollout reporting success while machines sat on
+// the old binary is the defect issue #296 fixed on the single-node path.
+
+const behindNode = {
+  ...mockNodes[0],
+  id: "node_behind",
+  name: "molt-bot",
+  hostname: "molt-bot.example.com",
+  agentVersion: "v0.1.22",
+  latestVersion: "v0.1.26",
+  updateAvailable: true,
+};
+
+test("offers no fleet-update button when nothing is behind", async () => {
+  vi.spyOn(api, "listNodes").mockResolvedValue(mockNodes);
+
+  const { queryByRole } = render(NodesOverview);
+
+  await waitFor(() => {
+    expect(queryByRole("button", { name: /update \d+ node/i })).toBeNull();
+  });
+});
+
+test("offers to update exactly the nodes that are behind", async () => {
+  vi.spyOn(api, "listNodes").mockResolvedValue([behindNode, mockNodes[1]!]);
+
+  const { getByRole } = render(NodesOverview);
+
+  await waitFor(() => {
+    expect(getByRole("button", { name: /update 1 node/i })).toBeTruthy();
+  });
+});
+
+test("rolling out calls the hub once and reports what happened", async () => {
+  vi.spyOn(api, "listNodes").mockResolvedValue([behindNode]);
+  const updateAll = vi.spyOn(api, "updateAllNodes").mockResolvedValue({
+    ok: true,
+    summary: { updated: 1, "no-op": 0, skipped: 2, failed: 0 },
+    results: [
+      { nodeId: "node_behind", name: "molt-bot", outcome: "updated", tag: "v0.1.26" },
+    ],
+  });
+
+  const { getByRole } = render(NodesOverview);
+  const button = await waitFor(() => getByRole("button", { name: /update 1 node/i }));
+
+  await fireEvent.click(button);
+  await tick();
+
+  await waitFor(() => expect(updateAll).toHaveBeenCalledTimes(1));
+
+  const { toast } = await import("svelte-sonner");
+  expect(toast.success).toHaveBeenCalled();
+});
+
+test("a node that failed is reported as a failure, never as success", async () => {
+  vi.spyOn(api, "listNodes").mockResolvedValue([behindNode]);
+  vi.spyOn(api, "updateAllNodes").mockResolvedValue({
+    ok: true,
+    summary: { updated: 0, "no-op": 0, skipped: 0, failed: 1 },
+    results: [
+      {
+        nodeId: "node_behind",
+        name: "molt-bot",
+        outcome: "failed",
+        error: "checksum mismatch",
+      },
+    ],
+  });
+
+  const { getByRole } = render(NodesOverview);
+  const button = await waitFor(() => getByRole("button", { name: /update 1 node/i }));
+
+  await fireEvent.click(button);
+  await tick();
+
+  const { toast } = await import("svelte-sonner");
+  // The hub answered 200 — the request succeeded and the update did not. An
+  // operator must not read that as a fleet that moved.
+  await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  expect(toast.success).not.toHaveBeenCalled();
+});

--- a/apps/hub/src/routes/nodes.ts
+++ b/apps/hub/src/routes/nodes.ts
@@ -3,6 +3,12 @@ import { zValidator } from "@hono/zod-validator";
 import { EnrollRequest } from "@agentpod/contract";
 import { enrollNode, verifyNodeCredential } from "../services/enrollment";
 import { listNodes } from "../services/node-registry";
+import {
+  executeRollout,
+  planRollout,
+  summarise,
+  type RolloutNode,
+} from "../services/rollout";
 import { request as brokerRequest } from "../services/broker";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -66,8 +72,13 @@ async function readForce(c: {
  * An optional `deps.request` override replaces the real broker so tests can
  * assert the RPC call without needing a live WebSocket connection.
  */
-export function createNodeRoutes(deps?: { request?: RequestFn }) {
+export function createNodeRoutes(deps?: {
+  request?: RequestFn;
+  /** Replaces the database-backed node list so the rollout is unit-testable. */
+  listNodesFn?: (userId: string) => Promise<RolloutNode[]>;
+}) {
   const _request: RequestFn = deps?.request ?? brokerRequest;
+  const _listNodes = deps?.listNodesFn ?? (listNodes as (u: string) => Promise<RolloutNode[]>);
 
   return (
     new Hono()
@@ -75,6 +86,41 @@ export function createNodeRoutes(deps?: { request?: RequestFn }) {
        * GET /api/nodes → list nodes belonging to the current user.
        */
       .get("/", async (c) => c.json(await listNodes(c.get("user").id)))
+      /**
+       * POST /api/nodes/update-all  [body {"force"?:bool, "only"?:string[]}]
+       *
+       * Update the fleet, one node at a time, in name order (issue #295).
+       *
+       * Registered before `/:id/update` for readability only — the two cannot
+       * collide, one is a single segment and the other is two.
+       *
+       * Always 200 with a row per node, including the ones it chose not to
+       * touch. A rollout that reported only its successes would be the same
+       * defect as the single-node route's old envelope: an operator reading
+       * "ok" while machines sat on the old binary. `failed` here means a node
+       * was asked and did not update; `skipped` means it was never asked, and
+       * says why.
+       */
+      .post("/update-all", async (c) => {
+        const body = (await c.req.json().catch(() => null)) as {
+          force?: unknown;
+          only?: unknown;
+        } | null;
+        const force = body?.force === true;
+        const only = Array.isArray(body?.only)
+          ? (body.only as unknown[]).filter((x): x is string => typeof x === "string")
+          : undefined;
+
+        const nodes = await _listNodes(c.get("user").id);
+        const plan = planRollout(nodes, { force, only });
+        const results = await executeRollout(plan, { request: _request, force });
+
+        return c.json({
+          ok: true as const,
+          summary: summarise(results),
+          results,
+        });
+      })
       /**
        * POST /api/nodes/:id/update  [?force=1  |  body {"force":true}]
        *

--- a/apps/hub/src/services/agent-version.ts
+++ b/apps/hub/src/services/agent-version.ts
@@ -22,6 +22,17 @@ export interface GetLatestVersionOptions {
 
 // ─── Module-level cache ───────────────────────────────────────────────────────
 
+/**
+ * The repository releases are published to.
+ *
+ * Named the pre-transfer owner until 2026-08-14 and worked only through
+ * GitHub's redirect for a moved repository — which is not a contract. The node
+ * agent holds the same constant in `internal/selfupdate`; both must name the
+ * repository that actually publishes releases, or a fleet update depends on a
+ * redirection nobody controls (issue #295).
+ */
+const RELEASE_REPO = "SuperJackfruitLabs/agentpod";
+
 let _cache: { value: string | null; at: number } = { value: null, at: 0 };
 
 const TTL_MS = 3_600_000; // 1 hour
@@ -56,7 +67,7 @@ export async function getLatestAgentVersion(
 
   try {
     const res = await fetchFn(
-      `${baseUrl}/repos/rakeshgangwar/agentpod/releases/latest`,
+      `${baseUrl}/repos/${RELEASE_REPO}/releases/latest`,
       { headers: { Accept: "application/vnd.github.v3+json" } }
     );
     const data = (await res.json()) as { tag_name?: string };

--- a/apps/hub/src/services/rollout.ts
+++ b/apps/hub/src/services/rollout.ts
@@ -1,0 +1,202 @@
+/**
+ * rollout — updating the fleet from the hub, in an order an operator can read.
+ *
+ * Issue #295: nothing ever asked a node to update. Self-update worked and was
+ * never invoked — no ticker in the agent, no scheduler in the hub, no check on
+ * connect — so the fleet stayed on whatever version it was installed with while
+ * the docs read as if updates were automatic.
+ *
+ * This is the hub-driven answer rather than an agent-side timer. The hub
+ * already knows every node's version and the latest tag, so it can go in a
+ * deliberate order; an unattended binary swap plus service restart on nodes
+ * running live agent sessions is the version of this feature most likely to
+ * bite at the worst possible moment.
+ *
+ * Split into a pure planner and an executor on purpose. Which node gets touched
+ * and why one did not is the part an operator has to trust, and it should be
+ * arguable without a database, a network, or a fleet.
+ */
+
+/** What the planner needs to know about a node. A subset of NodeSummary. */
+export interface RolloutNode {
+  id: string;
+  name: string;
+  status: string;
+  agentVersion: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+}
+
+export interface PlanItem {
+  nodeId: string;
+  name: string;
+  action: "update" | "skip";
+  /** Why it is being skipped. Present only for `skip`. */
+  reason?: string;
+}
+
+export interface PlanOptions {
+  /**
+   * Update nodes that are already current. Does NOT override "offline" or
+   * "no latest release" — neither is a policy choice, they are absences of a
+   * thing the update needs.
+   */
+  force?: boolean;
+  /** Restrict the rollout to these node ids. */
+  only?: string[];
+}
+
+/**
+ * Decide what the rollout will do to each node, and why.
+ *
+ * Ordered by name so two runs over the same fleet read the same way, and so an
+ * operator watching can tell where it has got to.
+ */
+export function planRollout(nodes: RolloutNode[], opts: PlanOptions): PlanItem[] {
+  const only = opts.only ? new Set(opts.only) : null;
+
+  return nodes
+    .filter((n) => (only ? only.has(n.id) : true))
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((n): PlanItem => {
+      const skip = (reason: string): PlanItem => ({
+        nodeId: n.id,
+        name: n.name,
+        action: "skip",
+        reason,
+      });
+
+      // No target. Updating a fleet towards an unknown version is worse than
+      // doing nothing, and `force` cannot conjure a release that GitHub did not
+      // answer with.
+      if (n.latestVersion == null) {
+        return skip("the latest release could not be resolved");
+      }
+
+      // Not a policy choice: a node that is not connected cannot be sent an
+      // RPC. Calling this a failure would make every rollout report failures
+      // for machines that are merely switched off.
+      if (n.status !== "online") return skip(`the node is ${n.status || "offline"}`);
+
+      if (opts.force) return { nodeId: n.id, name: n.name, action: "update" };
+
+      if (n.agentVersion == null) {
+        return skip("the node's version is unknown; use force to update anyway");
+      }
+
+      if (!n.updateAvailable) return skip(`already current (${n.agentVersion})`);
+
+      return { nodeId: n.id, name: n.name, action: "update" };
+    });
+}
+
+/** What a node answers inside the broker envelope's `data` for "update". */
+interface UpdateResult {
+  ok?: boolean;
+  updating?: boolean;
+  tag?: string;
+  currentVersion?: string;
+  reason?: string;
+  error?: string;
+}
+
+type BrokerResponse = { ok: boolean; data?: unknown; error?: string };
+export type RequestFn = (
+  nodeId: string,
+  verb: string,
+  payload: unknown
+) => Promise<BrokerResponse>;
+
+export interface RolloutResult {
+  nodeId: string;
+  name: string;
+  /**
+   * - `updated` — the node accepted and began the swap
+   * - `no-op`   — the node answered but had nothing to do
+   * - `skipped` — never attempted; see `reason`
+   * - `failed`  — attempted and did not happen; see `error`
+   */
+  outcome: "updated" | "no-op" | "skipped" | "failed";
+  tag?: string;
+  reason?: string;
+  error?: string;
+}
+
+export interface ExecuteOptions {
+  request: RequestFn;
+  force?: boolean;
+  /** Called as each node resolves, for progress logging. */
+  onResult?: (result: RolloutResult) => void;
+}
+
+/**
+ * Run the plan, one node at a time.
+ *
+ * Sequential deliberately. Restarting every node at once is how an update
+ * becomes an outage, and the whole reason to drive this from the hub rather
+ * than from a timer on each host is that the hub can take them in turn.
+ *
+ * One node failing never stops the rollout or throws: the caller gets a row per
+ * node, because "which ones worked" is the only useful answer here.
+ */
+export async function executeRollout(
+  plan: PlanItem[],
+  opts: ExecuteOptions
+): Promise<RolloutResult[]> {
+  const results: RolloutResult[] = [];
+
+  for (const item of plan) {
+    const result = await runOne(item, opts);
+    results.push(result);
+    opts.onResult?.(result);
+  }
+
+  return results;
+}
+
+async function runOne(item: PlanItem, opts: ExecuteOptions): Promise<RolloutResult> {
+  const base = { nodeId: item.nodeId, name: item.name };
+
+  if (item.action === "skip") {
+    return { ...base, outcome: "skipped", reason: item.reason };
+  }
+
+  let response: BrokerResponse;
+  try {
+    response = await opts.request(item.nodeId, "update", { force: opts.force ?? false });
+  } catch (error) {
+    // A throw here is one node's socket, not the rollout's problem.
+    return {
+      ...base,
+      outcome: "failed",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  // The RPC never reached the node, or the node rejected the frame.
+  if (!response.ok) {
+    return { ...base, outcome: "failed", error: response.error ?? "update failed" };
+  }
+
+  // The round-trip succeeded but the update did not — a 404 on the release, a
+  // checksum that did not match. Reporting that as success is the same lie the
+  // single-node route refuses to tell: the node is still on the old binary.
+  const data = (response.data ?? {}) as UpdateResult;
+  if (data.ok === false) {
+    return { ...base, outcome: "failed", error: data.error ?? "update failed" };
+  }
+
+  if (data.updating === false) {
+    return { ...base, outcome: "no-op", reason: data.reason, tag: data.tag };
+  }
+
+  return { ...base, outcome: "updated", tag: data.tag };
+}
+
+/** A one-line summary for logs and the API response. */
+export function summarise(results: RolloutResult[]): Record<string, number> {
+  const counts: Record<string, number> = { updated: 0, "no-op": 0, skipped: 0, failed: 0 };
+  for (const r of results) counts[r.outcome] = (counts[r.outcome] ?? 0) + 1;
+  return counts;
+}

--- a/apps/hub/tests/unit/nodes-update-all-route.test.ts
+++ b/apps/hub/tests/unit/nodes-update-all-route.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createNodeRoutes } from "../../src/routes/nodes";
+import type { RolloutNode } from "../../src/services/rollout";
+
+/**
+ * POST /api/nodes/update-all — the fleet rollout of issue #295.
+ *
+ * The route itself is thin; what these assert is that it wires the planner to
+ * the broker faithfully and reports every node, including the ones it declined
+ * to touch. A rollout that answered only about its successes would repeat the
+ * defect issue #296 fixed on the single-node route: an operator reading "ok"
+ * while machines sat on the old binary.
+ */
+
+const fleet: RolloutNode[] = [
+  {
+    id: "n_behind",
+    name: "molt-bot",
+    status: "online",
+    agentVersion: "v0.1.22",
+    latestVersion: "v0.1.26",
+    updateAvailable: true,
+  },
+  {
+    id: "n_current",
+    name: "superchotu",
+    status: "online",
+    agentVersion: "v0.1.26",
+    latestVersion: "v0.1.26",
+    updateAvailable: false,
+  },
+  {
+    id: "n_offline",
+    name: "cloudchamber",
+    status: "offline",
+    agentVersion: "v0.1.22",
+    latestVersion: "v0.1.26",
+    updateAvailable: true,
+  },
+];
+
+/** Mounts the routes behind a stub that supplies the authenticated user. */
+function appWith(request: Parameters<typeof createNodeRoutes>[0]["request"]) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("user", { id: "user_1" });
+    await next();
+  });
+  app.route(
+    "/api/nodes",
+    createNodeRoutes({ request, listNodesFn: async () => fleet })
+  );
+  return app;
+}
+
+const post = (app: Hono, body?: unknown) =>
+  app.request("/api/nodes/update-all", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+describe("POST /api/nodes/update-all (#295)", () => {
+  test("updates only the node that is behind, and says why the others were left", async () => {
+    const asked: string[] = [];
+    const app = appWith(async (nodeId) => {
+      asked.push(nodeId);
+      return { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } };
+    });
+
+    const res = await post(app);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      summary: Record<string, number>;
+      results: Array<{ nodeId: string; outcome: string; reason?: string }>;
+    };
+
+    expect(asked).toEqual(["n_behind"]);
+    expect(body.summary).toMatchObject({ updated: 1, skipped: 2, failed: 0 });
+
+    // Every node is accounted for, not just the one that moved.
+    expect(body.results).toHaveLength(3);
+    const offline = body.results.find((r) => r.nodeId === "n_offline")!;
+    expect(offline.outcome).toBe("skipped");
+    expect(offline.reason).toContain("offline");
+    const current = body.results.find((r) => r.nodeId === "n_current")!;
+    expect(current.reason).toContain("current");
+  });
+
+  test("reports results in name order, so a long rollout reads in sequence", async () => {
+    const app = appWith(async () => ({
+      ok: true,
+      data: { ok: true, updating: true, tag: "v0.1.26" },
+    }));
+    const body = (await (await post(app)).json()) as {
+      results: Array<{ name: string }>;
+    };
+    expect(body.results.map((r) => r.name)).toEqual([
+      "cloudchamber",
+      "molt-bot",
+      "superchotu",
+    ]);
+  });
+
+  test("force re-applies to a current node but still leaves the offline one", async () => {
+    const asked: string[] = [];
+    const app = appWith(async (nodeId) => {
+      asked.push(nodeId);
+      return { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } };
+    });
+
+    await post(app, { force: true });
+    expect(asked.sort()).toEqual(["n_behind", "n_current"]);
+  });
+
+  test("`only` restricts the rollout to the named nodes", async () => {
+    const asked: string[] = [];
+    const app = appWith(async (nodeId) => {
+      asked.push(nodeId);
+      return { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } };
+    });
+
+    const body = (await (await post(app, { only: ["n_behind"] })).json()) as {
+      results: unknown[];
+    };
+    expect(asked).toEqual(["n_behind"]);
+    expect(body.results).toHaveLength(1);
+  });
+
+  test("one node failing is a failed row, not a failed request", async () => {
+    const app = appWith(async () => ({ ok: false, error: "node offline" }));
+
+    const res = await post(app, { force: true });
+    // 200: the rollout ran. The rows carry what happened to each node.
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      summary: Record<string, number>;
+      results: Array<{ outcome: string; error?: string }>;
+    };
+    expect(body.summary.failed).toBe(2);
+    expect(body.results.find((r) => r.outcome === "failed")!.error).toContain("offline");
+  });
+
+  test("an absent body is a plain rollout, not a 400", async () => {
+    const app = appWith(async () => ({
+      ok: true,
+      data: { ok: true, updating: true, tag: "v0.1.26" },
+    }));
+    const res = await app.request("/api/nodes/update-all", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hub/tests/unit/rollout.test.ts
+++ b/apps/hub/tests/unit/rollout.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { executeRollout, planRollout, type RolloutNode } from "../../src/services/rollout";
+
+/**
+ * Issue #295. Nothing ever asked the fleet to update: no ticker in the agent,
+ * no scheduler in the hub, no check on connect. Self-update had exactly two
+ * triggers, both a human — `apn update` on the host, or one console button per
+ * node. So the fleet sat on whatever version it was installed with, and on
+ * 2026-08-13 that was three releases behind while the docs read as if updates
+ * were automatic.
+ *
+ * The chosen answer is a hub-driven rollout rather than an agent-side timer:
+ * the hub already knows every node's version and the latest tag, and an
+ * unattended binary swap plus service restart across nodes running live agent
+ * sessions is the option most likely to bite at the worst moment. The hub
+ * decides, on an operator's command, in an order they can read afterwards.
+ *
+ * The planner is pure so these rules can be argued with directly — which node
+ * is touched, and why one was not, is the part an operator has to trust.
+ */
+
+const node = (over: Partial<RolloutNode> = {}): RolloutNode => ({
+  id: "node_1",
+  name: "alpha",
+  status: "online",
+  agentVersion: "v0.1.22",
+  latestVersion: "v0.1.26",
+  updateAvailable: true,
+  ...over,
+});
+
+describe("planRollout", () => {
+  test("updates an online node that is behind", () => {
+    const plan = planRollout([node()], {});
+    expect(plan).toHaveLength(1);
+    expect(plan[0]!.action).toBe("update");
+  });
+
+  test("skips an offline node, and says so rather than failing it", () => {
+    // A node that is not connected cannot be updated, and calling that a
+    // failure would make every rollout report failures for machines that are
+    // simply switched off. cloudchamber has been offline since 2026-08-13.
+    const plan = planRollout([node({ status: "offline" })], {});
+    expect(plan[0]!.action).toBe("skip");
+    expect(plan[0]!.reason).toContain("offline");
+  });
+
+  test("skips a node already on the latest version", () => {
+    const plan = planRollout(
+      [node({ agentVersion: "v0.1.26", updateAvailable: false })],
+      {}
+    );
+    expect(plan[0]!.action).toBe("skip");
+    expect(plan[0]!.reason).toContain("current");
+  });
+
+  test("skips a node whose version is unknown, instead of guessing", () => {
+    const plan = planRollout(
+      [node({ agentVersion: null, updateAvailable: false })],
+      {}
+    );
+    expect(plan[0]!.action).toBe("skip");
+    expect(plan[0]!.reason).toContain("unknown");
+  });
+
+  test("skips everything when the latest release could not be resolved", () => {
+    // getLatestAgentVersion returns null on a cold start with GitHub
+    // unreachable. Updating the fleet towards an unknown target is worse than
+    // doing nothing, and `force` must not override THIS — there is no target.
+    const plan = planRollout(
+      [node({ latestVersion: null, updateAvailable: false })],
+      { force: true }
+    );
+    expect(plan[0]!.action).toBe("skip");
+    expect(plan[0]!.reason).toContain("latest release");
+  });
+
+  test("force updates a node that is already current, but still not an offline one", () => {
+    const plan = planRollout(
+      [
+        node({ id: "a", name: "alpha", agentVersion: "v0.1.26", updateAvailable: false }),
+        node({ id: "b", name: "bravo", status: "offline" }),
+      ],
+      { force: true }
+    );
+    expect(plan.find((p) => p.nodeId === "a")!.action).toBe("update");
+    expect(plan.find((p) => p.nodeId === "b")!.action).toBe("skip");
+  });
+
+  test("restricts to the named nodes when `only` is given", () => {
+    const plan = planRollout(
+      [node({ id: "a", name: "alpha" }), node({ id: "b", name: "bravo" })],
+      { only: ["b"] }
+    );
+    expect(plan.map((p) => p.nodeId)).toEqual(["b"]);
+  });
+
+  test("orders by name, so a rollout is reproducible and readable", () => {
+    const plan = planRollout(
+      [node({ id: "c", name: "charlie" }), node({ id: "a", name: "alpha" }), node({ id: "b", name: "bravo" })],
+      {}
+    );
+    expect(plan.map((p) => p.name)).toEqual(["alpha", "bravo", "charlie"]);
+  });
+});
+
+describe("executeRollout", () => {
+  const updatePlan = (ids: string[]) =>
+    ids.map((id) => ({ nodeId: id, name: id, action: "update" as const }));
+
+  test("updates one node at a time by default", async () => {
+    // The point of a throttle. Restarting every node in a fleet at once is how
+    // an update becomes an outage; the hub has the whole picture precisely so
+    // it can go in order.
+    let inFlight = 0;
+    let peak = 0;
+
+    await executeRollout(updatePlan(["a", "b", "c"]), {
+      request: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } };
+      },
+    });
+
+    expect(peak).toBe(1);
+  });
+
+  test("keeps going after one node fails, and reports which", async () => {
+    const results = await executeRollout(updatePlan(["a", "b", "c"]), {
+      request: async (nodeId) =>
+        nodeId === "b"
+          ? { ok: false, error: "node offline" }
+          : { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } },
+    });
+
+    expect(results.map((r) => r.outcome)).toEqual(["updated", "failed", "updated"]);
+    expect(results[1]!.error).toContain("offline");
+  });
+
+  test("treats a round-trip that succeeded with a failed update as a failure", async () => {
+    // The download 404'd or the checksum did not match. Reporting that as
+    // success is the same class of lie the single-node route refuses to tell —
+    // a silently failed update leaves the node on the old binary.
+    const results = await executeRollout(updatePlan(["a"]), {
+      request: async () => ({
+        ok: true,
+        data: { ok: false, error: "checksum mismatch" },
+      }),
+    });
+
+    expect(results[0]!.outcome).toBe("failed");
+    expect(results[0]!.error).toContain("checksum");
+  });
+
+  test("records a node that answered but had nothing to do", async () => {
+    const results = await executeRollout(updatePlan(["a"]), {
+      request: async () => ({
+        ok: true,
+        data: { ok: true, updating: false, reason: "already on v0.1.26" },
+      }),
+    });
+
+    expect(results[0]!.outcome).toBe("no-op");
+    expect(results[0]!.reason).toContain("already");
+  });
+
+  test("carries skipped nodes through to the result, unattempted", async () => {
+    let calls = 0;
+    const results = await executeRollout(
+      [
+        { nodeId: "a", name: "alpha", action: "update" },
+        { nodeId: "b", name: "bravo", action: "skip", reason: "offline" },
+      ],
+      {
+        request: async () => {
+          calls++;
+          return { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } };
+        },
+      }
+    );
+
+    expect(calls).toBe(1);
+    expect(results.find((r) => r.nodeId === "b")!.outcome).toBe("skipped");
+    expect(results.find((r) => r.nodeId === "b")!.reason).toBe("offline");
+  });
+
+  test("an exception from the broker is a failed node, not a failed rollout", async () => {
+    const results = await executeRollout(updatePlan(["a", "b"]), {
+      request: async (nodeId) => {
+        if (nodeId === "a") throw new Error("socket exploded");
+        return { ok: true, data: { ok: true, updating: true, tag: "v0.1.26" } };
+      },
+    });
+
+    expect(results[0]!.outcome).toBe("failed");
+    expect(results[0]!.error).toContain("socket exploded");
+    expect(results[1]!.outcome).toBe("updated");
+  });
+});

--- a/apps/node-agent/internal/selfupdate/apply_noop_test.go
+++ b/apps/node-agent/internal/selfupdate/apply_noop_test.go
@@ -25,14 +25,14 @@ func countingUpdateServer(tag string, content []byte, hash string, downloads *in
 	asset := assetName(runtime.GOOS, runtime.GOARCH)
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/repos/rakeshgangwar/agentpod/releases/latest":
+		case "/repos/SuperJackfruitLabs/agentpod/releases/latest":
 			json.NewEncoder(w).Encode(struct {
 				TagName string `json:"tag_name"`
 			}{tag})
-		case fmt.Sprintf("/rakeshgangwar/agentpod/releases/download/%s/%s", tag, asset):
+		case fmt.Sprintf("/SuperJackfruitLabs/agentpod/releases/download/%s/%s", tag, asset):
 			*downloads++
 			w.Write(content)
-		case fmt.Sprintf("/rakeshgangwar/agentpod/releases/download/%s/SHA256SUMS", tag):
+		case fmt.Sprintf("/SuperJackfruitLabs/agentpod/releases/download/%s/SHA256SUMS", tag):
 			fmt.Fprintf(w, "%s  %s\n", hash, asset)
 		default:
 			http.NotFound(w, r)

--- a/apps/node-agent/internal/selfupdate/repo_test.go
+++ b/apps/node-agent/internal/selfupdate/repo_test.go
@@ -1,0 +1,45 @@
+package selfupdate
+
+import "strings"
+
+import "testing"
+
+// The repository every release URL is built from.
+//
+// AgentPod moved to the SuperJackfruitLabs organisation on 2026-08-14. Until
+// then all three of these URLs named `rakeshgangwar/agentpod`, and they kept
+// working only because GitHub redirects a transferred repository's requests.
+//
+// That is a thin thread to hang a fleet's self-update on. A redirect is not a
+// contract: it stops the day the old owner name is reclaimed by anyone, and
+// what breaks then is every node's ability to take a new binary — discovered,
+// as issue #295 found the last version drift, only by noticing the fleet is
+// months behind.
+//
+// One constant, asserted here, so a future move is a one-line change and a
+// failing test rather than a silent dependence on redirection.
+func TestReleaseURLsNameTheCurrentRepository(t *testing.T) {
+	if releaseRepo != "SuperJackfruitLabs/agentpod" {
+		t.Fatalf("releaseRepo = %q, want SuperJackfruitLabs/agentpod", releaseRepo)
+	}
+}
+
+func TestReleaseURLBuildersUseTheConstant(t *testing.T) {
+	// Guard the guard: a constant nothing reads would pass the test above while
+	// the URLs kept naming the old owner.
+	for _, tc := range []struct {
+		name string
+		got  string
+	}{
+		{"latest tag", latestTagURL("https://api.github.com")},
+		{"asset", assetDownloadURL("https://github.com", "v0.1.26", "agentpod-node-linux-amd64")},
+		{"checksums", checksumsURL("https://github.com", "v0.1.26")},
+	} {
+		if !strings.Contains(tc.got, releaseRepo) {
+			t.Errorf("%s URL %q does not contain %q", tc.name, tc.got, releaseRepo)
+		}
+		if strings.Contains(tc.got, "rakeshgangwar") {
+			t.Errorf("%s URL %q still names the pre-transfer owner", tc.name, tc.got)
+		}
+	}
+}

--- a/apps/node-agent/internal/selfupdate/selfupdate.go
+++ b/apps/node-agent/internal/selfupdate/selfupdate.go
@@ -74,7 +74,28 @@ func assetName(goos, goarch string) string {
 	return fmt.Sprintf("agentpod-node-%s-%s", goos, goarch)
 }
 
-// LatestTag fetches the latest GitHub release tag for agentpod/agentpod.
+// releaseRepo is the GitHub repository every release URL is built from.
+//
+// AgentPod moved to the SuperJackfruitLabs organisation on 2026-08-14. These
+// URLs named the old owner until then and worked only because GitHub redirects
+// a transferred repository — which is not a contract, and stops the day that
+// name is reclaimed. What breaks then is the fleet's ability to take a new
+// binary, discovered months later by noticing the drift (issue #295).
+const releaseRepo = "SuperJackfruitLabs/agentpod"
+
+func latestTagURL(apiBase string) string {
+	return apiBase + "/repos/" + releaseRepo + "/releases/latest"
+}
+
+func assetDownloadURL(dlBase, tag, asset string) string {
+	return fmt.Sprintf("%s/%s/releases/download/%s/%s", dlBase, releaseRepo, tag, asset)
+}
+
+func checksumsURL(dlBase, tag string) string {
+	return fmt.Sprintf("%s/%s/releases/download/%s/SHA256SUMS", dlBase, releaseRepo, tag)
+}
+
+// LatestTag fetches the latest GitHub release tag for the release repository.
 // apiBase defaults to "https://api.github.com" when empty.
 func LatestTag(ctx context.Context, client *http.Client, apiBase string) (string, error) {
 	if client == nil {
@@ -83,7 +104,7 @@ func LatestTag(ctx context.Context, client *http.Client, apiBase string) (string
 	if apiBase == "" {
 		apiBase = "https://api.github.com"
 	}
-	url := apiBase + "/repos/rakeshgangwar/agentpod/releases/latest"
+	url := latestTagURL(apiBase)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
@@ -134,7 +155,7 @@ func downloadAndVerify(ctx context.Context, client *http.Client, dlBase, tag, as
 	}
 
 	// Download the binary and compute its SHA-256 in one pass.
-	assetURL := fmt.Sprintf("%s/rakeshgangwar/agentpod/releases/download/%s/%s", dlBase, tag, asset)
+	assetURL := assetDownloadURL(dlBase, tag, asset)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
 	if err != nil {
 		cleanup()
@@ -163,7 +184,7 @@ func downloadAndVerify(ctx context.Context, client *http.Client, dlBase, tag, as
 	gotHex := hex.EncodeToString(h.Sum(nil))
 
 	// Download SHA256SUMS.
-	sumsURL := fmt.Sprintf("%s/rakeshgangwar/agentpod/releases/download/%s/SHA256SUMS", dlBase, tag)
+	sumsURL := checksumsURL(dlBase, tag)
 	req2, err := http.NewRequestWithContext(ctx, http.MethodGet, sumsURL, nil)
 	if err != nil {
 		os.Remove(tmpPath)

--- a/apps/node-agent/internal/selfupdate/selfupdate_test.go
+++ b/apps/node-agent/internal/selfupdate/selfupdate_test.go
@@ -71,7 +71,7 @@ func TestAssetName(t *testing.T) {
 
 func TestLatestTag(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/rakeshgangwar/agentpod/releases/latest" {
+		if r.URL.Path == "/repos/SuperJackfruitLabs/agentpod/releases/latest" {
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(`{"tag_name":"v0.1.2"}`))
 			return
@@ -119,8 +119,8 @@ func TestDownloadAndVerify(t *testing.T) {
 
 	// Server with correct SHA256SUMS
 	goodSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assetPath := "/rakeshgangwar/agentpod/releases/download/" + tag + "/" + asset
-		sumsPath := "/rakeshgangwar/agentpod/releases/download/" + tag + "/SHA256SUMS"
+		assetPath := "/SuperJackfruitLabs/agentpod/releases/download/" + tag + "/" + asset
+		sumsPath := "/SuperJackfruitLabs/agentpod/releases/download/" + tag + "/SHA256SUMS"
 		switch r.URL.Path {
 		case assetPath:
 			w.Write(content)
@@ -150,8 +150,8 @@ func TestDownloadAndVerify(t *testing.T) {
 	t.Run("mismatch_leaves_no_file", func(t *testing.T) {
 		// Server with wrong hash in SHA256SUMS
 		badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assetPath := "/rakeshgangwar/agentpod/releases/download/" + tag + "/" + asset
-			sumsPath := "/rakeshgangwar/agentpod/releases/download/" + tag + "/SHA256SUMS"
+			assetPath := "/SuperJackfruitLabs/agentpod/releases/download/" + tag + "/" + asset
+			sumsPath := "/SuperJackfruitLabs/agentpod/releases/download/" + tag + "/SHA256SUMS"
 			switch r.URL.Path {
 			case assetPath:
 				w.Write(content)
@@ -415,13 +415,13 @@ func makeUpdateServer(tag string, content []byte, hash string) *httptest.Server 
 	asset := assetName(runtime.GOOS, runtime.GOARCH)
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/repos/rakeshgangwar/agentpod/releases/latest":
+		case "/repos/SuperJackfruitLabs/agentpod/releases/latest":
 			json.NewEncoder(w).Encode(struct {
 				TagName string `json:"tag_name"`
 			}{tag})
-		case fmt.Sprintf("/rakeshgangwar/agentpod/releases/download/%s/%s", tag, asset):
+		case fmt.Sprintf("/SuperJackfruitLabs/agentpod/releases/download/%s/%s", tag, asset):
 			w.Write(content)
-		case fmt.Sprintf("/rakeshgangwar/agentpod/releases/download/%s/SHA256SUMS", tag):
+		case fmt.Sprintf("/SuperJackfruitLabs/agentpod/releases/download/%s/SHA256SUMS", tag):
 			fmt.Fprintf(w, "%s  %s\n", hash, asset)
 		default:
 			http.NotFound(w, r)

--- a/apps/node-agent/scripts/install.sh
+++ b/apps/node-agent/scripts/install.sh
@@ -2,11 +2,11 @@
 # install.sh — curl-based installer for the AgentPod node-agent.
 #
 # System-wide (needs root; installs a systemd service on Linux):
-#   curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/install.sh \
+#   curl -fsSL https://github.com/SuperJackfruitLabs/agentpod/releases/latest/download/install.sh \
 #     | sudo bash -s -- <HUB_URL> <TOKEN>
 #
 # Rootless (no sudo; installs into ~/.local/bin — for key-only hosts with no sudo password):
-#   curl -fsSL https://github.com/rakeshgangwar/agentpod/releases/latest/download/install.sh \
+#   curl -fsSL https://github.com/SuperJackfruitLabs/agentpod/releases/latest/download/install.sh \
 #     | bash -s -- --user <HUB_URL> <TOKEN>
 #
 #   HUB_URL   e.g. https://hub.agentpod.dev
@@ -52,7 +52,7 @@ TOKEN="${ARGS[1]:-}"
 # Release URL base (needed early: the re-exec helper below re-fetches this
 # script from here whenever $0 isn't a real file on disk).
 # ---------------------------------------------------------------------------
-REPO="rakeshgangwar/agentpod"
+REPO="SuperJackfruitLabs/agentpod"
 BASE_URL="https://github.com/${REPO}/releases"
 
 # ---------------------------------------------------------------------------

--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -55,7 +55,7 @@ RUN bun add -g opencode-ai@1.18.15
 
 # Installed at /agentpod-node so the fleet entrypoint works unmodified.
 RUN set -eux; \
-    base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
+    base="https://github.com/SuperJackfruitLabs/agentpod/releases/download/${AGENTPOD_VERSION}"; \
     curl -fsSL -o /agentpod-node "${base}/agentpod-node-linux-amd64"; \
     curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
     cp /agentpod-node /tmp/agentpod-node-linux-amd64; \

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -77,7 +77,7 @@ RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.84.1 \
 
 # Installed at /agentpod-node so the fleet entrypoint works unmodified.
 RUN set -eux; \
-    base="https://github.com/rakeshgangwar/agentpod/releases/download/${AGENTPOD_VERSION}"; \
+    base="https://github.com/SuperJackfruitLabs/agentpod/releases/download/${AGENTPOD_VERSION}"; \
     curl -fsSL -o /agentpod-node "${base}/agentpod-node-linux-amd64"; \
     curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
     cp /agentpod-node /tmp/agentpod-node-linux-amd64; \

--- a/fly/node-image/README.md
+++ b/fly/node-image/README.md
@@ -5,8 +5,8 @@ one harness, with its workspace anchored on a mounted Fly Volume.
 
 | Dockerfile | Harness | Published as | Hub variable |
 |---|---|---|---|
-| `Dockerfile` | OpenCode | `ghcr.io/rakeshgangwar/agentpod-node-opencode-fly` | `NODE_AGENT_FLY_OPENCODE_IMAGE` |
-| `Dockerfile.pi` | Pi | `ghcr.io/rakeshgangwar/agentpod-node-pi-fly` | `NODE_AGENT_FLY_PI_IMAGE` |
+| `Dockerfile` | OpenCode | `ghcr.io/superjackfruitlabs/agentpod-node-opencode-fly` | `NODE_AGENT_FLY_OPENCODE_IMAGE` |
+| `Dockerfile.pi` | Pi | `ghcr.io/superjackfruitlabs/agentpod-node-pi-fly` | `NODE_AGENT_FLY_PI_IMAGE` |
 
 There is no generic (harness-less) Fly image, so a **Generic** Fly runtime cannot
 work; the hub warns about it at boot naming `NODE_AGENT_FLY_IMAGE`.
@@ -63,11 +63,11 @@ By hand, with the build context at the **repository root**:
 ```bash
 docker buildx build --platform linux/amd64 \
   -f fly/node-image/Dockerfile \
-  -t ghcr.io/rakeshgangwar/agentpod-node-opencode-fly:v0.1.22 --push .
+  -t ghcr.io/superjackfruitlabs/agentpod-node-opencode-fly:v0.1.22 --push .
 
 docker buildx build --platform linux/amd64 \
   -f fly/node-image/Dockerfile.pi \
-  -t ghcr.io/rakeshgangwar/agentpod-node-pi-fly:v0.1.22 --push .
+  -t ghcr.io/superjackfruitlabs/agentpod-node-pi-fly:v0.1.22 --push .
 ```
 
 `--platform linux/amd64` is required: Fly Machines are amd64, and an arm64 image
@@ -121,8 +121,8 @@ precedes `v0.1.24`.
 the hub's env:
 
 ```
-NODE_AGENT_FLY_OPENCODE_IMAGE=ghcr.io/rakeshgangwar/agentpod-node-opencode-fly:v0.1.22
-NODE_AGENT_FLY_PI_IMAGE=ghcr.io/rakeshgangwar/agentpod-node-pi-fly:v0.1.22
+NODE_AGENT_FLY_OPENCODE_IMAGE=ghcr.io/superjackfruitlabs/agentpod-node-opencode-fly:v0.1.22
+NODE_AGENT_FLY_PI_IMAGE=ghcr.io/superjackfruitlabs/agentpod-node-pi-fly:v0.1.22
 ```
 
 The provider-scoped names are the safe choice on a hub that also runs Docker,

--- a/fly/node-image/test-version-pin.sh
+++ b/fly/node-image/test-version-pin.sh
@@ -65,7 +65,7 @@ write_dockerfile() {
   cat >"$TMP/$1" <<EOF
 FROM debian:trixie-slim
 ARG AGENTPOD_VERSION=$2
-RUN curl -fsSL -o /agentpod-node "https://github.com/rakeshgangwar/agentpod/releases/download/\${AGENTPOD_VERSION}/agentpod-node-linux-amd64"
+RUN curl -fsSL -o /agentpod-node "https://github.com/SuperJackfruitLabs/agentpod/releases/download/\${AGENTPOD_VERSION}/agentpod-node-linux-amd64"
 EOF
 }
 


### PR DESCRIPTION
Closes #295.

Nothing ever asked a node to update. Self-update worked perfectly and was never invoked — no ticker in the agent, no scheduler in the hub, no check on connect. So nodes sat on whatever version they were installed with, while the root `CLAUDE.md` described an agent that *"self-updates from GitHub releases"*, which reads as automatic.

**The fleet is current today only because a human updated it by hand.** That is the point rather than a mitigation: the drift returns after every release and nothing announces it.

## The choice

Hub-driven rollout, not an agent-side timer.

The hub already knows every node's version and the latest tag, so it can go in a deliberate order and report what happened. An unattended binary swap plus service restart, on nodes running live agent sessions, with no maintenance window, is the version of this feature most likely to bite at the worst possible moment.

## `POST /api/nodes/update-all`

One node at a time, in name order. Always `200` with **a row per node, including the ones it declined to touch and why**:

- `updated` — the node accepted and began the swap
- `no-op` — answered, nothing to do
- `skipped` — never asked; `reason` says why
- `failed` — asked, and it did not happen

A rollout that reported only its successes would repeat exactly the defect #296 fixed on the single-node route: an operator reading "ok" while machines sat on the old binary.

The **planner is pure and separate from the executor**, because which node gets touched — and why one did not — is the part an operator has to trust, and it should be arguable without a database, a network or a fleet. Rules worth stating:

- **Offline is a skip, not a failure.** Otherwise every rollout reports failures for machines that are merely switched off. `cloudchamber` has been offline since 2026-08-13.
- **No resolvable latest release skips everything**, and `force` cannot override it — there is no target to move towards.
- **`force`** re-applies to a current node, but still will not touch an offline one.

## Drift visibility already existed

The issue proposed surfacing version drift in the console. It was already there — `node-registry.ts` computes `updateAvailable` per node and `NodesOverview.svelte` renders `v0.1.22 → v0.1.26`. Left alone. What was missing was the ability to *act* on it fleet-wide, which is the button this adds, shown only when there is drift to clear.

## The redirect this was quietly resting on

Every runtime path to a release still named the pre-transfer owner: `selfupdate.go`'s three URLs, the hub's tag lookup, `install.sh`, and the Fly images. They worked only because GitHub redirects a transferred repository.

That is not a contract. It ends the day the old owner name is reclaimed by anyone, and what breaks then is every node's ability to take a new binary — discovered, like the drift in this issue, months later. Now one constant per side, with a test asserting the built URLs actually use it (a constant nothing reads would pass a weaker check).

Directly load-bearing for the release this precedes.

**The Go module path still says `rakeshgangwar`** — renaming it touches every import for no functional gain, and is not this change.

## Verification

- hub: **1067 pass, 0 fail** (83 files)
- console: **751 pass, 0 fail** (70 files)
- node-agent: `go test -race ./...` clean
- `bun run typecheck`: 15 errors, the documented baseline, none added

Two environment notes worth recording, neither caused by this branch:

1. **The console suite needs Node 20–22.** On Node 26 jsdom's environment does not initialise, `window` is undefined, and 132 tests across 11 files fail in a way that looks like broken code. CI pins Node 20, so it stays green. The repo has no `.nvmrc` and no `engines` field — filed separately.
2. `TestBuildRegistry_ThreadsClaudeCodeACPKeys` fails when `PATH` is empty — the known flake, #293.