### PR TITLE
chore(fly): pin the node-agent to v0.1.27

### DIFF
--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.26
+ARG AGENTPOD_VERSION=v0.1.27
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.26
+ARG AGENTPOD_VERSION=v0.1.27
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
Opened by hand. `release-node-agent.yml` pushed this branch when v0.1.27 was released, then failed to open the PR:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

That is a consequence of the move to the `SuperJackfruitLabs` organisation on 2026-08-14 — the org denies Actions the ability to create pull requests, a setting that did not apply under the previous personal account. **The release itself succeeded**: all seven assets published and verified. Only this follow-up PR was blocked.

Fixing it properly is one org setting — Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests". Until then every release will push this branch and fail this job, and the failure looks like a broken release when it is not.

## What this changes

Both Fly Dockerfiles move `ARG AGENTPOD_VERSION` onto `v0.1.27`, so `fly/node-image/check-version-pin.sh` stops refusing a Fly publish. The images still download the released binary and verify it against this release's `SHA256SUMS` — unchanged.

Merge this before publishing the Fly images.