### PR TITLE
fix(hub): refresh a station's matrixId, not only its capabilities

### DIFF
--- a/apps/hub/src/services/station-registry.test.ts
+++ b/apps/hub/src/services/station-registry.test.ts
@@ -332,3 +332,91 @@ test("refresh survives a broker that throws", async () => {
   });
   expect(updated).toBe(0);
 });
+
+// ─── refreshAdoptedCapabilities: matrixId ─────────────────────────────────────
+//
+// The same bug as capabilities, one column over, and it survived the fix that
+// found it. `stations.matrix_id` was written ONLY by adoptStations, so a station
+// adopted before the mxid reader worked could never gain one. In production on
+// 2026-08-15 that was every station: 32 adopted, 0 with a matrix_id, while
+// `agentpod-node detect` on the same hosts reported
+// "@buddhimaan:id.agentpod.dev" correctly and the contract carried it with
+// tests. The node said it, the wire allowed it, and nothing wrote it down.
+//
+// It is on the critical path for the Matrix bridge: routing a room message to a
+// station requires knowing which identity belongs to which station.
+
+test("refresh writes a matrixId onto a station adopted without one", async () => {
+  await adoptStations(TEST_USER, testNodeId, ["refresh-mxid"], [
+    {
+      key: "refresh-mxid", harness: "hermes", kind: "leaf", displayName: "olivia",
+      parentKey: null, workspacePath: "/root/.hermes", capabilities: ["health"],
+      adopted: false,
+    },
+  ]);
+
+  await refreshAdoptedCapabilities(testNodeId, {
+    brokerRequest: detectReturning([
+      {
+        key: "refresh-mxid", harness: "hermes", kind: "leaf", displayName: "olivia",
+        parentKey: null, workspacePath: "/root/.hermes", capabilities: ["health"],
+        matrixId: "@onboarding-olivia:id.agentpod.dev",
+      },
+    ]),
+  });
+
+  const row = await getStation(TEST_USER, (await listAdopted(TEST_USER, testNodeId))
+    .find((r) => r.stationKey === "refresh-mxid")!.id);
+  expect(row!.matrixId).toBe("@onboarding-olivia:id.agentpod.dev");
+});
+
+test("refresh clears a matrixId the node no longer reports", async () => {
+  // An agent whose Matrix identity was removed must not keep a stale one: the
+  // bridge would route to an mxid nobody answers on.
+  await adoptStations(TEST_USER, testNodeId, ["refresh-mxid-gone"], [
+    {
+      key: "refresh-mxid-gone", harness: "hermes", kind: "leaf", displayName: "gone",
+      parentKey: null, workspacePath: null, capabilities: ["health"],
+      matrixId: "@stale:id.agentpod.dev", adopted: false,
+    },
+  ]);
+
+  await refreshAdoptedCapabilities(testNodeId, {
+    brokerRequest: detectReturning([
+      {
+        key: "refresh-mxid-gone", harness: "hermes", kind: "leaf", displayName: "gone",
+        parentKey: null, workspacePath: null, capabilities: ["health"], matrixId: null,
+      },
+    ]),
+  });
+
+  const row = await getStation(TEST_USER, (await listAdopted(TEST_USER, testNodeId))
+    .find((r) => r.stationKey === "refresh-mxid-gone")!.id);
+  expect(row!.matrixId).toBeNull();
+});
+
+test("refresh leaves matrixId alone for a harness that reports none", async () => {
+  // codex, opencode and pi have no Matrix identity at all — they are the
+  // stations a bridge would mint a virtual user FOR. Absent must read as null,
+  // never as an error.
+  await adoptStations(TEST_USER, testNodeId, ["refresh-mxid-absent"], [
+    {
+      key: "refresh-mxid-absent", harness: "codex", kind: "leaf", displayName: "codex",
+      parentKey: null, workspacePath: null, capabilities: ["health"], adopted: false,
+    },
+  ]);
+
+  const updated = await refreshAdoptedCapabilities(testNodeId, {
+    brokerRequest: detectReturning([
+      {
+        key: "refresh-mxid-absent", harness: "codex", kind: "leaf", displayName: "codex",
+        parentKey: null, workspacePath: null, capabilities: ["health"],
+      },
+    ]),
+  });
+
+  expect(updated).toBeGreaterThanOrEqual(1);
+  const row = await getStation(TEST_USER, (await listAdopted(TEST_USER, testNodeId))
+    .find((r) => r.stationKey === "refresh-mxid-absent")!.id);
+  expect(row!.matrixId).toBeNull();
+});

--- a/apps/hub/src/services/station-registry.ts
+++ b/apps/hub/src/services/station-registry.ts
@@ -221,6 +221,16 @@ export async function refreshAdoptedCapabilities(
           capabilities: s.capabilities as string[],
           displayName: s.displayName,
           workspacePath: s.workspacePath ?? null,
+          // The same defect as capabilities, one column over. `matrix_id` was
+          // written only at adoption, so a station adopted before the mxid
+          // reader worked could never gain one — in production that was every
+          // station: 32 adopted, 0 with an identity, while `detect` on the same
+          // hosts reported them correctly all along.
+          //
+          // `?? null` rather than a skip-if-absent: an agent whose Matrix
+          // identity was removed must lose it here too, or a bridge routes a
+          // room message to an mxid nobody answers on.
+          matrixId: s.matrixId ?? null,
         })
         .where(and(eq(stations.nodeId, nodeId), eq(stations.stationKey, s.key)));
       updated++;


### PR DESCRIPTION
Found while checking whether the fleet could support a Matrix bridge.

## The defect

`stations.matrix_id` is written **only** by `adoptStations`. The one ongoing refresh — `refreshAdoptedCapabilities`, which runs on every node connect — updates `capabilities`, `displayName` and `workspacePath`, and leaves `matrix_id` alone.

So a station adopted before the mxid reader worked can never gain an identity. In production right now that is **every station**:

```
   harness   | total | with_mxid
-------------+-------+-----------
 claude-code |     2 |         0
 codex       |     3 |         0
 hermes      |    14 |         0
 openclaw    |    10 |         0
 opencode    |     2 |         0
 pi          |     1 |         0
```

Meanwhile `agentpod-node detect` on molt-bot answers:

```json
{ "key": "hermes", "harness": "hermes", "matrixId": "@buddhimaan:id.agentpod.dev" }
```

The node reports it, `packages/contract` carries it with its own tests, the hub has a column for it — and nothing writes it down after adoption.

It is the **same defect this function exists to fix**, one column over. Its comment says "nothing else in the hub ever refreshes that column"; that was fixed for capabilities and not for this one.

## Why it is not cosmetic

Routing a Matrix room message to the right station requires knowing which identity belongs to which station. An empty column blocks the Application Service bridge before it starts — and the bridge is how any non-Matrix harness (codex, opencode, pi, claude-code) becomes reachable from a chat room at all.

## `?? null`, not skip-if-absent

An agent whose Matrix identity is removed must lose it here too. A stale mxid would have the bridge route to an account nobody answers on — a failure that looks exactly like the agent ignoring you.

## Tests

Three, matching the existing block's idiom:

- an identity arriving on a station adopted without one (fails before this change)
- an identity going away (fails before this change)
- a harness that never had one — codex, opencode and pi report none, and they are precisely the stations a bridge would mint a virtual user *for*, so absent must read as `null` and not as an error

**hub: 1070 pass, 0 fail.**