### PR TITLE
feat(hub): map a principal to the same principal elsewhere

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0041_principal_identities.sql
+++ b/apps/hub/src/db/drizzle-migrations/0041_principal_identities.sql
@@ -1,0 +1,48 @@
+-- The same principal, known by another system.
+--
+-- The Organization plane owns principals and their identity mappings, and does
+-- not exist. This is the manoeuvre the tenancy decision already proved: keep
+-- what this plane legitimately owns, record an optional mapping to the same
+-- real identity elsewhere, and adopting a canonical principal later becomes a
+-- data move rather than a redesign.
+--
+-- A table rather than columns on "user", which is where this differs from
+-- tenancy: a tenant maps to one external organisation, but a principal is
+-- legitimately known to several systems at once.
+--
+-- A RECORD OF SAMENESS, NEVER A GRANT. Nothing may read authority out of these
+-- rows. The moment something does, the Organization plane has been built by
+-- accident, in the wrong repository, without the control pair meant to come
+-- with it.
+CREATE TABLE IF NOT EXISTS "principal_identities" (
+  "id"           text PRIMARY KEY NOT NULL,
+  "principal_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "system"       text NOT NULL,
+  "external_id"  text NOT NULL,
+  "created_at"   timestamp DEFAULT now() NOT NULL,
+
+  -- Adding a system should be a one-line migration; an enum makes removing one
+  -- painful. 'org-plane' is listed before it exists, because the point is that
+  -- adopting it changes data and not schema.
+  CONSTRAINT "principal_identities_system_known"
+    CHECK ("system" IN ('matrix', 'kaambaan', 'org-plane')),
+
+  -- An empty external id is not a mapping; it is a row that looks like one.
+  CONSTRAINT "principal_identities_external_id_present"
+    CHECK (length("external_id") > 0)
+);
+
+-- One external identity belongs to at most one principal. This is what makes
+-- the table usable for the thing it exists for: a bridge asking "who sent this
+-- Matrix message" needs ONE answer, and two principals claiming one mxid makes
+-- that unanswerable exactly when it matters — attributing a human's approval.
+CREATE UNIQUE INDEX IF NOT EXISTS "principal_identities_system_external_idx"
+  ON "principal_identities" ("system", "external_id");
+
+-- And one identity per system per principal, so the reverse direction — "which
+-- mxid do I message this principal at" — also has a single answer.
+CREATE UNIQUE INDEX IF NOT EXISTS "principal_identities_principal_system_idx"
+  ON "principal_identities" ("principal_id", "system");
+
+CREATE INDEX IF NOT EXISTS "principal_identities_principal_idx"
+  ON "principal_identities" ("principal_id");

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1786687159202,
       "tag": "0040_auth_jwks",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1786687160202,
+      "tag": "0041_principal_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/identities.ts
+++ b/apps/hub/src/db/schema/identities.ts
@@ -1,0 +1,94 @@
+/**
+ * Principal identities — the same person or agent, known by another system.
+ *
+ * The Organization plane owns principals and their identity mappings
+ * (charter decisions/2026-08-13-ecosystem-identity.md). It does not exist. So
+ * this is the same manoeuvre the tenancy decision already proved
+ * (decisions/2026-08-15-tenancy-is-local-and-mapped.md): each plane keeps what
+ * it legitimately owns and records an *optional* mapping to the same real
+ * identity elsewhere, so adopting a canonical principal later is a data move
+ * rather than a redesign.
+ *
+ * A TABLE rather than columns on `user`, which is where this differs from
+ * tenancy: a tenant maps to one external organisation, but a principal is
+ * legitimately known to several systems at once — Matrix, kaambaan, and
+ * eventually the Organization plane. Columns would mean a migration per system.
+ *
+ * **This is a record of sameness, never a grant.** Nothing may read authority
+ * out of it. The moment something does, the Organization plane has been built by
+ * accident, in the wrong repository, without the control pair that was supposed
+ * to come with it. That risk is named in the layer plan and it is named here
+ * because this table is where it would happen.
+ */
+
+import { sql } from "drizzle-orm";
+import { pgTable, text, timestamp, uniqueIndex, index, check } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+/**
+ * The systems a principal can be known to.
+ *
+ * Deliberately a CHECK rather than a Postgres enum: adding a system should be a
+ * one-line migration, and an enum makes removing one painful. `org-plane` is
+ * listed before it exists, because the whole point is that adopting it is a
+ * data move.
+ */
+export const IDENTITY_SYSTEMS = ["matrix", "kaambaan", "org-plane"] as const;
+export type IdentitySystem = (typeof IDENTITY_SYSTEMS)[number];
+
+export const principalIdentities = pgTable(
+  "principal_identities",
+  {
+    id: text("id").primaryKey(),
+
+    /** The local principal. Today a Better Auth user; a canonical principal later. */
+    principalId: text("principal_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+
+    /** Which system knows them. */
+    system: text("system").notNull(),
+
+    /**
+     * That system's id for them — `@olivia:id.agentpod.dev`, a `tnt_`-scoped
+     * principal id, whatever the Organization plane eventually mints.
+     *
+     * Deliberately opaque: no grammar is imposed, for the same reason kaambaan's
+     * migration 0002 imposes none on its external ids. A shape assumption here
+     * would be a shape assumption about a system that has not been built.
+     */
+    externalId: text("external_id").notNull(),
+
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    /**
+     * One external identity belongs to at most one principal.
+     *
+     * This is the constraint that makes the table usable for the thing it
+     * exists for: an Application Service bridge asking "who sent this Matrix
+     * message" needs one answer. Two principals claiming one mxid would make
+     * that question unanswerable exactly when it matters — attributing a human's
+     * approval, which charter decisions/2026-08-14-approvals-cross-planes-as-events.md
+     * says must carry its sender or kaambaan's separation-of-duties check is void.
+     */
+    uniqueIndex("principal_identities_system_external_idx").on(t.system, t.externalId),
+
+    /**
+     * And at most one identity per system per principal. A person has one Matrix
+     * account here, not three; the reverse direction ("which mxid do I message
+     * this principal at") needs a single answer too.
+     */
+    uniqueIndex("principal_identities_principal_system_idx").on(t.principalId, t.system),
+
+    index("principal_identities_principal_idx").on(t.principalId),
+
+    check(
+      "principal_identities_system_known",
+      sql`${t.system} IN ('matrix', 'kaambaan', 'org-plane')`
+    ),
+
+    /** An empty external id is not a mapping; it is a row that looks like one. */
+    check("principal_identities_external_id_present", sql`length(${t.externalId}) > 0`),
+  ]
+);

--- a/apps/hub/src/db/schema/index.ts
+++ b/apps/hub/src/db/schema/index.ts
@@ -32,3 +32,5 @@ export * from "./acp";
 
 // Work claimed from an external orchestrator (the kaambaan bridge)
 export * from "./bridge";
+
+export * from "./identities";

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -38,6 +38,7 @@ import { bridgeDispatches } from "./schema/bridge";
 import { adminAuditLog, systemSettings } from "./schema/admin";
 import { stationAudit } from "./schema/audit";
 import { account, session, user, verification, jwks } from "./schema/auth";
+import { principalIdentities } from "./schema/identities";
 import { agentTasks, cloudflareSandboxes } from "./schema/cloudflare";
 import { enrollmentTokens, nodes, provisionedRuntimes } from "./schema/nodes";
 import { stations } from "./schema/stations";
@@ -134,6 +135,19 @@ export const TENANT_EXEMPT_TABLES: Record<string, { table: Table; reason: string
   // What a user is *allowed to reach* is therefore not answered here. It is
   // answered today by the bootstrap constant in the auth middleware, and later
   // by a membership lookup at the same layer — see `resolveTenantId`.
+  principal_identities: {
+    table: principalIdentities,
+    reason:
+      "Hangs off `user`, which is exempt for the same reason: a principal is not INSIDE a fleet, " +
+      "it reaches one. The mapping says a person here is the same person on Matrix or kaambaan, " +
+      "which is true regardless of which fleet they reach — a tenant column would imply an " +
+      "identity could differ per fleet, and it cannot. " +
+      "REVISIT IF THIS BECOMES REACHABLE OVER AN API: nothing today lists these rows, and every " +
+      "lookup is by principal id or by an external id the caller already holds. A route that " +
+      "listed them would leak one tenant's people to another, and that route would need scoping " +
+      "this table does not have.",
+  },
+
   user: {
     table: user,
     reason:

--- a/apps/hub/src/services/principal-identities.ts
+++ b/apps/hub/src/services/principal-identities.ts
@@ -1,0 +1,131 @@
+/**
+ * Reading and writing the mapping between a principal here and the same
+ * principal somewhere else.
+ *
+ * Phase 2 of docs/superpowers/plans/2026-08-15-organization-layer.md, and the
+ * thing three other pieces of work are waiting on: an Application Service bridge
+ * cannot attribute a Matrix message without it, approvals-from-chat cannot carry
+ * their sender, and supermessage's decision row stays unreachable.
+ *
+ * **A record of sameness, never a grant.** Nothing here answers "may they", only
+ * "are they the same". Reading authority out of this table is how the
+ * Organization plane gets built by accident, in the wrong repository, without
+ * the control pair that was supposed to come with it.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import {
+  principalIdentities,
+  IDENTITY_SYSTEMS,
+  type IdentitySystem,
+} from "../db/schema/identities";
+
+export type { IdentitySystem };
+
+function assertKnownSystem(system: IdentitySystem): void {
+  // The CHECK constraint is the real guard; this exists so the failure names
+  // the problem instead of surfacing as a Postgres constraint violation.
+  if (!IDENTITY_SYSTEMS.includes(system)) {
+    throw new Error(
+      `unknown identity system "${system}" — expected one of ${IDENTITY_SYSTEMS.join(", ")}`
+    );
+  }
+}
+
+/**
+ * Record that `principalId` is also known to `system` as `externalId`.
+ *
+ * Throws when the external identity already belongs to another principal, or
+ * when this principal already has one for that system. Both are unique indexes
+ * and both are load-bearing: an mxid that resolves to two people makes "who sent
+ * this" unanswerable exactly when it matters most.
+ */
+export async function linkIdentity(
+  principalId: string,
+  system: IdentitySystem,
+  externalId: string
+): Promise<void> {
+  assertKnownSystem(system);
+  if (!externalId) {
+    throw new Error("refusing to link an empty external id: that is a row that looks like a mapping");
+  }
+
+  await db.insert(principalIdentities).values({
+    id: crypto.randomUUID(),
+    principalId,
+    system,
+    externalId,
+  });
+}
+
+/**
+ * The principal an external identity belongs to, or null.
+ *
+ * Null is an ordinary answer, not a failure: most principals have no Matrix
+ * account and never will, so a bridge asking about an unmapped one must degrade
+ * rather than error.
+ */
+export async function principalByExternal(
+  system: IdentitySystem,
+  externalId: string
+): Promise<string | null> {
+  if (!externalId) return null;
+
+  const rows = await db
+    .select({ principalId: principalIdentities.principalId })
+    .from(principalIdentities)
+    .where(
+      and(eq(principalIdentities.system, system), eq(principalIdentities.externalId, externalId))
+    )
+    .limit(1);
+
+  return rows[0]?.principalId ?? null;
+}
+
+/** The id a principal is known by in one system, or null. */
+export async function externalIdFor(
+  principalId: string,
+  system: IdentitySystem
+): Promise<string | null> {
+  const rows = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(principalIdentities)
+    .where(
+      and(
+        eq(principalIdentities.principalId, principalId),
+        eq(principalIdentities.system, system)
+      )
+    )
+    .limit(1);
+
+  return rows[0]?.externalId ?? null;
+}
+
+/** Every identity a principal has. */
+export async function identitiesFor(
+  principalId: string
+): Promise<Array<{ system: string; externalId: string }>> {
+  return db
+    .select({
+      system: principalIdentities.system,
+      externalId: principalIdentities.externalId,
+    })
+    .from(principalIdentities)
+    .where(eq(principalIdentities.principalId, principalId));
+}
+
+/** Remove one system's mapping. Idempotent — removing what is not there is not an error. */
+export async function unlinkIdentity(
+  principalId: string,
+  system: IdentitySystem
+): Promise<void> {
+  await db
+    .delete(principalIdentities)
+    .where(
+      and(
+        eq(principalIdentities.principalId, principalId),
+        eq(principalIdentities.system, system)
+      )
+    );
+}

--- a/apps/hub/tests/integration/principal-identities.test.ts
+++ b/apps/hub/tests/integration/principal-identities.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import {
+  linkIdentity,
+  identitiesFor,
+  principalByExternal,
+  externalIdFor,
+  unlinkIdentity,
+} from "../../src/services/principal-identities";
+
+/**
+ * Identity mappings — Phase 2 of docs/superpowers/plans/2026-08-15-organization-layer.md.
+ *
+ * What is blocked on this: an Application Service bridge cannot attribute a
+ * Matrix message to a principal, approvals-from-chat cannot carry their sender,
+ * and supermessage's decision row stays unreachable. All three need one
+ * question answered — given an mxid, who is this — and its reverse.
+ *
+ * The station half already works: `stations.matrix_id` has been populated since
+ * 2026-08-15 (14 Hermes stations). This is the principal half.
+ */
+
+const USER_A = "test-user-identities-a";
+const USER_B = "test-user-identities-b";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER_A, email: "identities-a@example.com", name: "A" });
+  await createTestUser({ id: USER_B, email: "identities-b@example.com", name: "B" });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM principal_identities WHERE principal_id IN (${USER_A}, ${USER_B})`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${USER_A}, ${USER_B})`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("principal identities", () => {
+  test("links a principal to a Matrix id and resolves both directions", async () => {
+    await linkIdentity(USER_A, "matrix", "@olivia:id.agentpod.dev");
+
+    expect(await principalByExternal("matrix", "@olivia:id.agentpod.dev")).toBe(USER_A);
+    expect(await externalIdFor(USER_A, "matrix")).toBe("@olivia:id.agentpod.dev");
+  });
+
+  test("answers unknown rather than guessing", async () => {
+    // An unmapped identity must degrade, not fail: most principals have no
+    // Matrix account and never will, and a bridge asking about one is not an
+    // error condition.
+    expect(await principalByExternal("matrix", "@nobody:id.agentpod.dev")).toBeNull();
+    expect(await externalIdFor(USER_B, "matrix")).toBeNull();
+  });
+
+  test("refuses to let two principals claim one external identity", async () => {
+    // The constraint that makes this table usable for what it exists for. Two
+    // principals claiming one mxid makes "who sent this" unanswerable exactly
+    // when it matters — attributing a human's approval, which must carry its
+    // sender or kaambaan's separation-of-duties check is void.
+    await expect(
+      linkIdentity(USER_B, "matrix", "@olivia:id.agentpod.dev")
+    ).rejects.toThrow();
+
+    expect(await principalByExternal("matrix", "@olivia:id.agentpod.dev")).toBe(USER_A);
+  });
+
+  test("a principal has at most one identity per system", async () => {
+    // The reverse direction needs a single answer too: "which mxid do I message
+    // this principal at" cannot return three.
+    await expect(
+      linkIdentity(USER_A, "matrix", "@olivia-alt:id.agentpod.dev")
+    ).rejects.toThrow();
+  });
+
+  test("holds several systems for one principal", async () => {
+    await linkIdentity(USER_A, "kaambaan", "usr_kaambaan_a");
+
+    const all = await identitiesFor(USER_A);
+    expect(all.map((i) => i.system).sort()).toEqual(["kaambaan", "matrix"]);
+  });
+
+  test("refuses an unknown system", async () => {
+    // A typo'd system name would create a mapping nothing ever reads — a row
+    // that looks like a link and is not one.
+    await expect(
+      linkIdentity(USER_B, "matrix-ish" as never, "@b:id.agentpod.dev")
+    ).rejects.toThrow();
+  });
+
+  test("refuses an empty external id", async () => {
+    await expect(linkIdentity(USER_B, "matrix", "")).rejects.toThrow();
+  });
+
+  test("unlinking is idempotent and scoped to one system", async () => {
+    await unlinkIdentity(USER_A, "kaambaan");
+    expect(await externalIdFor(USER_A, "kaambaan")).toBeNull();
+    // Still there — unlinking one system must not touch another.
+    expect(await externalIdFor(USER_A, "matrix")).toBe("@olivia:id.agentpod.dev");
+
+    await unlinkIdentity(USER_A, "kaambaan"); // again: no throw
+  });
+
+  test("deleting a principal takes its identities with it", async () => {
+    // No orphan rows pointing at a principal that no longer exists — an
+    // identity outliving its principal is a mapping to nothing that still
+    // occupies its external id, so the next person to link that mxid is
+    // refused for a reason nobody can see.
+    await createTestUser({ id: "test-user-identities-c", email: "c@example.com", name: "C" });
+    await linkIdentity("test-user-identities-c", "matrix", "@gone:id.agentpod.dev");
+
+    await rawSql`DELETE FROM "user" WHERE id = 'test-user-identities-c'`;
+
+    expect(await principalByExternal("matrix", "@gone:id.agentpod.dev")).toBeNull();
+  });
+});


### PR DESCRIPTION
Phase 2 of `docs/superpowers/plans/2026-08-15-organization-layer.md` — the identity mappings.

## What is blocked on this

Three things, all waiting on one question and its reverse: **given an mxid, who is this?**

- an **Application Service bridge** cannot attribute a Matrix message to a principal
- **approvals-from-chat** cannot carry their sender, which `charter/decisions/2026-08-14-approvals-cross-planes-as-events.md` says is the whole reason the answer must be an event
- **supermessage's decision row** stays unreachable

The station half already works — `stations.matrix_id`, populated since yesterday for 14 Hermes stations. This is the principal half.

## The shape, and why a table

The same manoeuvre `decisions/2026-08-15-tenancy-is-local-and-mapped.md` proved: the Organization plane owns principals and does not exist, so this plane keeps what it legitimately owns and records an **optional** mapping to the same real identity elsewhere. Adopting a canonical principal later is a data move.

A **table** rather than columns is where this differs from tenancy: a tenant maps to one external organisation, but a principal is legitimately known to several systems at once — Matrix, kaambaan, `org-plane` when it exists. Columns would mean a migration per system.

## Two unique indexes carry the weight

- **One external identity belongs to at most one principal.** A bridge asking "who sent this" needs one answer; two principals claiming one mxid makes that unanswerable exactly when it matters.
- **One identity per system per principal**, so "which mxid do I message this principal at" also has a single answer.

Deletes cascade. An identity outliving its principal is a mapping to nothing that still occupies its external id — the next person to link that mxid gets refused for a reason nobody can see.

## The risk this table carries, written down twice

**It is a record of sameness, never a grant.** Nothing may read authority out of it. The moment something does, the Organization plane has been built by accident, in the wrong repository, without the control pair that was supposed to come with it. That warning is in the schema and in the migration, because those are the two places someone will be standing when they are tempted.

## The tenant guard caught it

Exempt, for the same reason `user` is — a principal is not *inside* a fleet, it reaches one, and a tenant column would imply an identity could differ per fleet, which it cannot.

With the revisit condition recorded: nothing lists these rows today and every lookup is by an id the caller already holds, but **a route that listed them would leak one tenant's people to another**, and that route would need scoping this table does not have.

## Verification

- **hub: 1088 pass, 0 fail** (86 files; 9 new)
- `bun run typecheck`: 15, the documented baseline
- Migration `0041` with its journal entry