### PR TITLE
feat(hub): given a Matrix id, answer who that is

### DIFF
--- a/apps/hub/src/services/matrix-identity.ts
+++ b/apps/hub/src/services/matrix-identity.ts
@@ -1,0 +1,100 @@
+/**
+ * Given a Matrix id, who is that?
+ *
+ * The question an Application Service bridge asks on every inbound event, and
+ * the last piece of Phase 2 in docs/superpowers/plans/2026-08-15-organization-layer.md.
+ *
+ * Both halves exist now and they live in different tables, for good reasons that
+ * this function has to reconcile:
+ *
+ *   - **agents** carry their mxid on `stations.matrix_id`, read off the host by
+ *     the node agent from a harness profile. AgentPod owns that fact because it
+ *     owns the station.
+ *   - **people** are mapped in `principal_identities`, because the Organization
+ *     plane owns principals and does not exist yet.
+ *
+ * The answer distinguishes them rather than merely saying "known", because
+ * everything downstream treats them differently: a human's approval must carry
+ * its sender or kaambaan's separation-of-duties check is void
+ * (charter decisions/2026-08-14-approvals-cross-planes-as-events.md), while an
+ * agent's message is work output. Collapsing the two here would throw that
+ * distinction away at the one point where keeping it is free.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { principalIdentities } from "../db/schema/identities";
+
+export type MatrixIdentity =
+  | { kind: "principal"; principalId: string }
+  | { kind: "station"; stationId: string; nodeId: string; harness: string }
+  /**
+   * The same mxid is claimed by a station AND a principal.
+   *
+   * Nothing prevents this: the two facts live in different tables with no
+   * constraint spanning them, and they arrive from different places — one read
+   * off a host, one written by an operator. Silently preferring either would
+   * attribute a human's approval to an agent, or an agent's output to a human.
+   * So the ambiguity is reported and the caller fails closed.
+   */
+  | { kind: "ambiguous"; stationId: string; principalId: string }
+  | null;
+
+/** `@localpart:domain`, checked only well enough to skip an obviously pointless query. */
+const MXID = /^@[^:]+:.+$/;
+
+export async function resolveMatrixId(mxid: string): Promise<MatrixIdentity> {
+  if (!mxid || !MXID.test(mxid)) return null;
+
+  const [stationRows, principalRows] = await Promise.all([
+    db
+      .select({
+        id: stations.id,
+        nodeId: stations.nodeId,
+        harness: stations.harness,
+      })
+      .from(stations)
+      .where(eq(stations.matrixId, mxid))
+      .limit(2),
+    db
+      .select({ principalId: principalIdentities.principalId })
+      .from(principalIdentities)
+      .where(
+        and(
+          eq(principalIdentities.system, "matrix"),
+          eq(principalIdentities.externalId, mxid)
+        )
+      )
+      .limit(2),
+  ]);
+
+  // Filtered to `system = 'matrix'` above, deliberately. An external id is
+  // opaque per system, so a kaambaan or org-plane id that happened to be shaped
+  // like an mxid must not answer "who is this Matrix sender" — it names the same
+  // person in a different namespace, which is not the same claim.
+  const station = stationRows[0];
+  const principal = principalRows[0];
+
+  if (station && principal) {
+    return { kind: "ambiguous", stationId: station.id, principalId: principal.principalId };
+  }
+
+  if (station) {
+    return {
+      kind: "station",
+      stationId: station.id,
+      nodeId: station.nodeId,
+      harness: station.harness,
+    };
+  }
+
+  if (principal) {
+    return { kind: "principal", principalId: principal.principalId };
+  }
+
+  // Most Matrix ids in a room belong to neither — other people's accounts, bots,
+  // the homeserver's own. Unknown is an ordinary answer, so a bridge can ignore
+  // an event instead of failing on it.
+  return null;
+}

--- a/apps/hub/tests/integration/resolve-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/resolve-matrix-identity.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { mintEnrollmentToken, enrollNode } from "../../src/services/enrollment";
+import { adoptStations, listAdopted } from "../../src/services/station-registry";
+import { linkIdentity } from "../../src/services/principal-identities";
+import { resolveMatrixId } from "../../src/services/matrix-identity";
+
+/**
+ * Given a Matrix id, who is that?
+ *
+ * The question an Application Service bridge asks on every inbound event, and
+ * the last piece of Phase 2 in the Organization layer plan. Both halves now
+ * exist: `stations.matrix_id` for agents (populated 2026-08-15) and
+ * `principal_identities` for people (#335).
+ *
+ * The answer has to distinguish them, because the two are treated differently
+ * everywhere downstream: a human's approval must carry its sender or kaambaan's
+ * separation-of-duties check is void, while an agent's message is work output.
+ * A resolver that said only "known" would have thrown that distinction away at
+ * the one point where it is cheap to keep.
+ */
+
+const USER = "test-user-mxresolve";
+const AGENT_MXID = "@onboarding-olivia:id.agentpod.dev";
+const CLASHER = "test-user-mxresolve-clash";
+let nodeId = "";
+let stationId = "";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "mxresolve@example.com", name: "MX" });
+
+  // Enrolled and adopted through the real services rather than hand-written
+  // INSERTs. A fixture that writes its own rows has to guess the schema, and a
+  // guess that is wrong fails as a column error five tests deep — which is
+  // exactly what the first version of this file did.
+  const { token } = await mintEnrollmentToken(USER);
+  const enrolled = await enrollNode(token, {
+    hostname: "mxresolve-host",
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+  nodeId = enrolled.nodeId;
+
+  await adoptStations(USER, nodeId, ["hermes:olivia"], [
+    {
+      key: "hermes:olivia",
+      harness: "hermes",
+      kind: "leaf",
+      displayName: "Olivia",
+      parentKey: null,
+      workspacePath: "/root/.hermes",
+      capabilities: ["health"],
+      matrixId: AGENT_MXID,
+      adopted: false,
+    },
+  ]);
+
+  stationId = (await listAdopted(USER, nodeId)).find((s) => s.stationKey === "hermes:olivia")!.id;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE node_id = ${nodeId}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${nodeId}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("resolveMatrixId", () => {
+  test("resolves an agent's mxid to its station", async () => {
+    const found = await resolveMatrixId(AGENT_MXID);
+
+    expect(found?.kind).toBe("station");
+    if (found?.kind !== "station") throw new Error("unreachable");
+    expect(found.stationId).toBe(stationId);
+    expect(found.harness).toBe("hermes");
+  });
+
+  test("resolves a person's mxid to their principal", async () => {
+    await linkIdentity(USER, "matrix", "@rakesh:id.agentpod.dev");
+
+    const found = await resolveMatrixId("@rakesh:id.agentpod.dev");
+    expect(found?.kind).toBe("principal");
+    if (found?.kind !== "principal") throw new Error("unreachable");
+    expect(found.principalId).toBe(USER);
+  });
+
+  test("answers null for an mxid nobody claims", async () => {
+    // Most Matrix ids in a room belong to neither: other people's accounts,
+    // bots, the server's own. Unknown is an ordinary answer and a bridge must
+    // be able to ignore an event rather than fail on it.
+    expect(await resolveMatrixId("@stranger:matrix.org")).toBeNull();
+  });
+
+  test("an id in another namespace does not answer for Matrix", async () => {
+    // External ids are opaque per system. A kaambaan id shaped like an mxid
+    // names the same person in a different namespace, which is not the same
+    // claim — and must not resolve a Matrix sender.
+    await linkIdentity(USER, "kaambaan", "@lookalike:id.agentpod.dev");
+
+    expect(await resolveMatrixId("@lookalike:id.agentpod.dev")).toBeNull();
+  });
+
+  test("refuses to choose when a station and a principal claim one mxid", async () => {
+    // Nothing prevents this: the two facts live in different tables with no
+    // constraint spanning them, and they arrive from different places — one read
+    // off a host by the node agent, one written by an operator. Silently
+    // preferring either would attribute a human's approval to an agent, or an
+    // agent's output to a human.
+    await createTestUser({ id: CLASHER, email: "clash@example.com", name: "Clash" });
+    await linkIdentity(CLASHER, "matrix", AGENT_MXID);
+
+    const found = await resolveMatrixId(AGENT_MXID);
+
+    // Deterministic: it must be ambiguous, not "whichever table was queried
+    // first". An earlier version of this test accepted either answer, which
+    // meant it could not fail for the reason it names.
+    expect(found?.kind).toBe("ambiguous");
+    if (found?.kind !== "ambiguous") throw new Error("unreachable");
+    expect(found.stationId).toBe(stationId);
+    expect(found.principalId).toBe(CLASHER);
+
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${CLASHER}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${CLASHER}`;
+
+    // And with the clash removed it resolves cleanly again.
+    expect((await resolveMatrixId(AGENT_MXID))?.kind).toBe("station");
+  });
+
+  test("an empty or malformed id is unknown, not an error", async () => {
+    expect(await resolveMatrixId("")).toBeNull();
+    expect(await resolveMatrixId("not-an-mxid")).toBeNull();
+  });
+});


### PR DESCRIPTION
The last piece of Phase 2 in `docs/superpowers/plans/2026-08-15-organization-layer.md`, on top of #335.

## The question

What an Application Service bridge asks on **every inbound event**: given a Matrix id, who is that?

Both halves exist now and live in different tables, for reasons this reconciles:

- **agents** carry their mxid on `stations.matrix_id`, read off the host by the node agent — AgentPod owns that because it owns the station
- **people** are mapped in `principal_identities` (#335), because the Organization plane owns principals and does not exist yet

## It distinguishes rather than merely recognising

A `station` and a `principal` are different answers, because everything downstream treats them differently: a human's approval **must carry its sender** or kaambaan's separation-of-duties check is void; an agent's message is work output. A resolver that said only "known" would discard that distinction at the one point where keeping it is free.

**`null` is an ordinary answer.** Most Matrix ids in a room belong to neither — other people's accounts, bots, the homeserver's own. A bridge must be able to ignore an event rather than fail on it.

**`ambiguous` when both claim one mxid.** Nothing prevents that: the two facts live in different tables with no constraint spanning them, and they arrive from different places — one read off a host, one written by an operator. Silently preferring either would attribute a human's approval to an agent, or an agent's output to a human.

## Two things fixed after review rather than shipped

**The principal lookup now filters `system = 'matrix'`.** External ids are opaque per system, so a kaambaan id shaped like an mxid names the same person in a *different namespace* — not the same claim. The first version queried on the id alone while carrying a comment asserting it didn't.

**The ambiguity test accepted `["station", "ambiguous"]`**, so it could not fail for the reason it named. It now builds a real clash with a second principal, requires exactly `ambiguous`, then removes the clash and requires a clean resolve again.

Also: the fixture stopped hand-writing rows. It invented a `nodes` column that doesn't exist and failed five tests deep with a column error — it now enrolls and adopts through the real services.

## Verification

- **hub: 1094 pass, 0 fail** (87 files; 6 new)
- `bun run typecheck`: 15, the documented baseline

**Phase 2 is complete after this**: a human's Matrix id resolves to a principal, an agent station resolves to one, and an unmapped id degrades. What's left before a bridge can be built is linking the identities we actually have.