### PR TITLE
feat(hub): the control pair — who may dispatch which agent

### DIFF
--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -47,6 +47,7 @@ import type {
 } from "@agentpod/contract";
 import { db } from "../db/drizzle";
 import { resolveTenantForUser } from "../auth/tenant";
+import { mayDispatch } from "./control-pair";
 import { acpSessions, acpEvents } from "../db/schema/acp";
 import { stations } from "../db/schema/stations";
 import { createLogger } from "../utils/logger";
@@ -636,6 +637,31 @@ export async function createSession(
   input: CreateSessionInput
 ): Promise<AcpSessionRow> {
   const { stationId, userId } = input;
+
+  // ── The control pair, first half: may this principal dispatch this agent? ──
+  //
+  // Decision 4 of charter decisions/2026-08-13-ecosystem-identity.md, enforced
+  // HERE because this is the one choke point both dispatch paths pass through:
+  // the console/API route and the kaambaan bridge. A check in kaambaan alone
+  // would cover board-driven work while provisioning straight at AgentPod — the
+  // most common path today — went unguarded, and "a control with a hole that
+  // shape is not a control".
+  //
+  // Unconfigured is off; configured is fail-closed. Before the readiness gates
+  // on purpose: whether a caller is ALLOWED to reach a station does not depend
+  // on whether that station happens to be online, and answering "node offline"
+  // to someone who was never permitted leaks which stations exist.
+  const station = await getStation(userId, stationId);
+  if (station && !mayDispatch(process.env.CONTROL_PAIR_GRANTS, userId, station.stationKey)) {
+    log.warn("dispatch refused by the control pair", {
+      principalId: userId,
+      stationKey: station.stationKey,
+      stationId,
+    });
+    throw new Error(
+      "You do not have permission to dispatch this agent."
+    );
+  }
 
   // Fail fast on the obvious gates before queueing (openSession re-checks them
   // under the lock, where the answers are current).

--- a/apps/hub/src/services/control-pair.ts
+++ b/apps/hub/src/services/control-pair.ts
@@ -1,0 +1,167 @@
+/**
+ * The control pair: who may dispatch which agent, and who may grant an agent
+ * its reach.
+ *
+ * Decision 4 of charter decisions/2026-08-13-ecosystem-identity.md. Because
+ * agents hold their own reach rather than authority delegated per run, these two
+ * checks carry the weight that delegation would otherwise have carried — and
+ * **both** are required. Dispatch control alone is decorative: anyone who can
+ * register an agent and grant it production credentials does not need permission
+ * to dispatch anything, because they build the agent they want.
+ *
+ * ## Where this is enforced, and why here
+ *
+ * At `acp.createSession`, which is the one choke point both paths pass through —
+ * the console/API route and the kaambaan bridge's dispatch. That matters: the
+ * decision is explicit that a check living only in kaambaan would cover
+ * board-driven work while the most common path today, provisioning straight at
+ * AgentPod, went unguarded. "A control with a hole that shape is not a control."
+ *
+ * ## Static configuration, in the shape of the eventual claim
+ *
+ * The Organization plane is authoritative for the grant and does not exist. The
+ * decision blesses an interim where the grant lives as static configuration in
+ * each plane **provided it is the same shape as the eventual claim**, so that
+ * adopting a real issuer is a data move rather than a redesign. The names here
+ * are the ones already reserved in
+ * `fixtures/ecosystem-identity/token_claims.json`: `mayDispatch`,
+ * `mayGrantReach`.
+ *
+ * ## Two postures, deliberately different
+ *
+ * **Unconfigured is off.** Introducing the first real authorization check in
+ * this suite must not be the same event as switching it on across a live fleet.
+ * An unset `CONTROL_PAIR_GRANTS` means the check does not run — the same posture
+ * `HUB_ISSUER` and the tenant external mapping take, and the reason a standalone
+ * hub keeps working.
+ *
+ * **Configured is fail-closed.** Once grants exist, a principal with no grant is
+ * refused. Absence is never permission; that is the decision's own wording and
+ * the whole point of the pair.
+ */
+
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("control-pair");
+
+/** One principal's grant, in the shape the eventual token claim will carry. */
+export interface Grant {
+  /**
+   * Station keys this principal may dispatch work to. Exact, or a single
+   * trailing `*` as a prefix wildcard within one segment — `hermes:*` reaches
+   * every Hermes station and no OpenClaw one.
+   */
+  mayDispatch: string[];
+  /** Whether this principal may grant an agent its reach. */
+  mayGrantReach: boolean;
+}
+
+export type Grants = Record<string, Grant>;
+
+/**
+ * Parse the configured grants, or throw.
+ *
+ * Throws rather than falling back, because half-understood authorization
+ * configuration is worse than none: it looks enforced and is not. A parse
+ * failure belongs in a boot refusal where somebody reads it.
+ */
+export function parseGrants(raw: string): Grants {
+  const parsed: unknown = JSON.parse(raw);
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("CONTROL_PAIR_GRANTS must be a JSON object keyed by principal id");
+  }
+
+  const grants: Grants = {};
+  for (const [principal, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw new Error(`CONTROL_PAIR_GRANTS["${principal}"] must be an object`);
+    }
+    const v = value as Record<string, unknown>;
+
+    if (!Array.isArray(v.mayDispatch) || v.mayDispatch.some((s) => typeof s !== "string")) {
+      throw new Error(
+        `CONTROL_PAIR_GRANTS["${principal}"].mayDispatch must be an array of station-key patterns`
+      );
+    }
+    if (typeof v.mayGrantReach !== "boolean") {
+      throw new Error(
+        `CONTROL_PAIR_GRANTS["${principal}"].mayGrantReach must be a boolean — both halves of the pair are required`
+      );
+    }
+
+    grants[principal] = {
+      mayDispatch: v.mayDispatch as string[],
+      mayGrantReach: v.mayGrantReach,
+    };
+  }
+  return grants;
+}
+
+/** Is the control enforced at all? False when nothing is configured. */
+export function isControlPairEnforced(raw: string | undefined): boolean {
+  return typeof raw === "string" && raw.trim() !== "";
+}
+
+/**
+ * Read the grants, or null when unenforced.
+ *
+ * A parse failure returns an EMPTY grant set rather than null, so a broken
+ * configuration denies everything instead of disabling the control. Losing the
+ * rules must never be the same thing as having none.
+ */
+function grantsOf(raw: string | undefined): Grants | null {
+  if (!isControlPairEnforced(raw)) return null;
+  try {
+    return parseGrants(raw as string);
+  } catch (e) {
+    log.error("CONTROL_PAIR_GRANTS could not be parsed — denying all dispatch", {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return {};
+  }
+}
+
+/** `hermes:*` matches `hermes:anything`, but never `openclaw:anything`. */
+function patternMatches(pattern: string, stationKey: string): boolean {
+  if (pattern === stationKey) return true;
+  if (!pattern.endsWith("*")) return false;
+
+  const prefix = pattern.slice(0, -1);
+  if (!stationKey.startsWith(prefix)) return false;
+
+  // A wildcard may not cross the segment separator it was written inside: a
+  // grant of `hermes:*` is about Hermes stations, and reading it as "anything
+  // beginning with hermes:" is the same until someone writes `her*`.
+  const rest = stationKey.slice(prefix.length);
+  return !prefix.includes(":") || !rest.includes(":");
+}
+
+/**
+ * May this principal dispatch work to this station?
+ *
+ * True when unenforced. When enforced, a principal with no grant is refused —
+ * absence is not permission.
+ */
+export function mayDispatch(
+  raw: string | undefined,
+  principalId: string,
+  stationKey: string
+): boolean {
+  const grants = grantsOf(raw);
+  if (grants === null) return true; // unenforced
+
+  const grant = grants[principalId];
+  if (!grant) return false;
+
+  // An empty list is a decision, and the decision is no. It is also what an
+  // operator writes to suspend someone without deleting their grant.
+  return grant.mayDispatch.some((p) => patternMatches(p, stationKey));
+}
+
+/** May this principal grant an agent its reach? Same two postures. */
+export function mayGrantReach(raw: string | undefined, principalId: string): boolean {
+  const grants = grantsOf(raw);
+  if (grants === null) return true; // unenforced
+  return grants[principalId]?.mayGrantReach === true;
+}

--- a/apps/hub/src/utils/validate-config.ts
+++ b/apps/hub/src/utils/validate-config.ts
@@ -226,6 +226,15 @@ export function collectConfigErrors(
       warn("⚠️  WARNING: TLS is disabled. Enable for production deployment!");
     }
 
+    // The control pair is opt-in, and an operator should not have to read the
+    // source to learn whether the first real authorization check in this suite
+    // is switched on. Silence here would be indistinguishable from enforcement.
+    if (!process.env.CONTROL_PAIR_GRANTS) {
+      warn(
+        "⚠️  WARNING: CONTROL_PAIR_GRANTS is not set — any principal may dispatch any agent."
+      );
+    }
+
     if (!hasMinimumEntropy(cfg.betterAuth.session.secret, 32)) {
       errors.push({
         field: "BETTER_AUTH_SECRET",

--- a/apps/hub/tests/integration/control-pair-dispatch.test.ts
+++ b/apps/hub/tests/integration/control-pair-dispatch.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { mintEnrollmentToken, enrollNode } from "../../src/services/enrollment";
+import { adoptStations, listAdopted } from "../../src/services/station-registry";
+import { createSession } from "../../src/services/acp-sessions";
+
+/**
+ * The control pair, enforced where dispatch actually happens.
+ *
+ * The unit tests cover the policy; this covers the thing that matters — that
+ * `createSession` consults it. A policy function nobody calls is the failure
+ * this repo has met before: an `acp` capability advertised because a binary
+ * resolved, a posture scanner grading machines it never opened.
+ *
+ * `createSession` is the one choke point BOTH dispatch paths pass through: the
+ * console/API route (`routes/station-acp.ts`) and the kaambaan bridge
+ * (`services/bridge/dispatch.ts`). Decision 4 of the ecosystem-identity decision
+ * is explicit that a check covering only board-driven work leaves the most
+ * common path — provisioning straight at AgentPod — unguarded, and "a control
+ * with a hole that shape is not a control".
+ */
+
+const USER = "test-user-controlpair";
+let nodeId = "";
+let stationKey = "";
+let stationId = "";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "controlpair@example.com", name: "CP" });
+
+  const { token } = await mintEnrollmentToken(USER);
+  const enrolled = await enrollNode(token, {
+    hostname: "controlpair-host",
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+  nodeId = enrolled.nodeId;
+
+  stationKey = "hermes:cp-agent";
+  await adoptStations(USER, nodeId, [stationKey], [
+    {
+      key: stationKey,
+      harness: "hermes",
+      kind: "leaf",
+      displayName: "CP Agent",
+      parentKey: null,
+      workspacePath: "/root/.hermes",
+      capabilities: ["health", "acp"],
+      adopted: false,
+    },
+  ]);
+  stationId = (await listAdopted(USER, nodeId)).find((s) => s.stationKey === stationKey)!.id;
+});
+
+afterEach(() => {
+  delete process.env.CONTROL_PAIR_GRANTS;
+});
+
+afterAll(async () => {
+  delete process.env.CONTROL_PAIR_GRANTS;
+  try {
+    await rawSql`DELETE FROM stations WHERE node_id = ${nodeId}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${nodeId}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("dispatch consults the control pair (#Phase 3)", () => {
+  test("refuses a principal with no grant, when grants are configured", async () => {
+    process.env.CONTROL_PAIR_GRANTS = JSON.stringify({
+      someone_else: { mayDispatch: ["hermes:*"], mayGrantReach: false },
+    });
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/permission/i);
+  });
+
+  test("refuses a grant that does not cover this station", async () => {
+    process.env.CONTROL_PAIR_GRANTS = JSON.stringify({
+      [USER]: { mayDispatch: ["hermes:some-other-agent"], mayGrantReach: false },
+    });
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/permission/i);
+  });
+
+  test("refuses BEFORE reporting on the station's readiness", async () => {
+    // Ordering is the assertion. This node is offline, so an unguarded call
+    // fails with "Node is offline." — a caller who was never permitted must not
+    // learn that, because the difference between "offline" and "no permission"
+    // tells them the station exists.
+    process.env.CONTROL_PAIR_GRANTS = JSON.stringify({
+      someone_else: { mayDispatch: ["hermes:*"], mayGrantReach: false },
+    });
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/permission/i);
+
+    // And with a grant, the SAME call gets past the control and fails on
+    // readiness instead — which is what proves the refusal above came from the
+    // control pair and not from the station being unreachable.
+    process.env.CONTROL_PAIR_GRANTS = JSON.stringify({
+      [USER]: { mayDispatch: ["hermes:*"], mayGrantReach: false },
+    });
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/offline|not ready|does not support/i);
+  });
+
+  test("is not enforced when nothing is configured", async () => {
+    // Unconfigured is off. The same call reaches the readiness gates, so a
+    // standalone hub with no grants anywhere keeps working exactly as before.
+    delete process.env.CONTROL_PAIR_GRANTS;
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/offline|not ready|does not support/i);
+  });
+
+  test("a broken configuration denies rather than disabling the control", async () => {
+    // Losing the rules must never be the same thing as having none.
+    process.env.CONTROL_PAIR_GRANTS = "{not json";
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/permission/i);
+  });
+});

--- a/apps/hub/tests/unit/control-pair.test.ts
+++ b/apps/hub/tests/unit/control-pair.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseGrants,
+  mayDispatch,
+  mayGrantReach,
+  isControlPairEnforced,
+} from "../../src/services/control-pair";
+
+/**
+ * The control pair — Phase 3 of the Organization layer plan, implementing
+ * Decision 4 of charter decisions/2026-08-13-ecosystem-identity.md.
+ *
+ * Two checks carry the weight that per-run delegation would otherwise have
+ * carried, because agents hold their own reach:
+ *
+ *   1. who may DISPATCH which agent
+ *   2. who may GRANT an agent its reach
+ *
+ * Both are required. Dispatch control alone is decorative: anyone who can
+ * register an agent and grant it production credentials does not need
+ * permission to dispatch anything — they build the agent they want.
+ *
+ * The grant lives as static configuration until an issuer can answer it, and
+ * deliberately in the SHAPE OF THE EVENTUAL CLAIM (`mayDispatch`,
+ * `mayGrantReach` — reserved in fixtures/ecosystem-identity/token_claims.json),
+ * so adopting a real issuer is a data move rather than a redesign.
+ */
+
+const GRANTS = JSON.stringify({
+  "user_alice": { mayDispatch: ["hermes:*"], mayGrantReach: true },
+  "user_bob": { mayDispatch: ["hermes:analyst-echo"], mayGrantReach: false },
+  "user_none": { mayDispatch: [], mayGrantReach: false },
+});
+
+describe("the control pair", () => {
+  test("is off when nothing is configured, and says so", () => {
+    // Introducing the first real authorization check in the suite must not be
+    // the same event as turning it on everywhere. Unconfigured means off — the
+    // same posture HUB_ISSUER and the tenant external mapping take — so a
+    // standalone hub keeps working and enabling the control is a deliberate act.
+    expect(isControlPairEnforced(undefined)).toBe(false);
+    expect(isControlPairEnforced("")).toBe(false);
+    expect(isControlPairEnforced(GRANTS)).toBe(true);
+  });
+
+  test("allows everything when unenforced, and nothing silently when enforced", () => {
+    // The two regimes, stated as one assertion so the difference cannot drift.
+    expect(mayDispatch(undefined, "user_alice", "hermes:analyst-echo")).toBe(true);
+    expect(mayDispatch(GRANTS, "user_nobody", "hermes:analyst-echo")).toBe(false);
+  });
+
+  test("fails closed for a principal with no grant at all", () => {
+    // Absence is not permission. The decision is explicit, and this is the case
+    // it is explicit about: a caller nobody has granted anything is refused,
+    // not waved through because there is no rule mentioning them.
+    expect(mayDispatch(GRANTS, "user_unknown", "hermes:analyst-echo")).toBe(false);
+    expect(mayGrantReach(GRANTS, "user_unknown")).toBe(false);
+  });
+
+  test("matches an exact station key", () => {
+    expect(mayDispatch(GRANTS, "user_bob", "hermes:analyst-echo")).toBe(true);
+    expect(mayDispatch(GRANTS, "user_bob", "hermes:coder-kai")).toBe(false);
+  });
+
+  test("matches a trailing wildcard, and only as a prefix", () => {
+    expect(mayDispatch(GRANTS, "user_alice", "hermes:anything")).toBe(true);
+    // `hermes:*` must not reach a different harness. A wildcard that matched
+    // across the separator would grant openclaw and codex too.
+    expect(mayDispatch(GRANTS, "user_alice", "openclaw:something")).toBe(false);
+  });
+
+  test("an empty grant list denies rather than permits", () => {
+    // `[]` is a decision, and the decision is no. Reading it as "unrestricted"
+    // is the classic inversion — it is also what an operator would write to
+    // suspend someone.
+    expect(mayDispatch(GRANTS, "user_none", "hermes:analyst-echo")).toBe(false);
+  });
+
+  test("carries the second half, which is not optional", () => {
+    expect(mayGrantReach(GRANTS, "user_alice")).toBe(true);
+    expect(mayGrantReach(GRANTS, "user_bob")).toBe(false);
+  });
+
+  test("refuses to parse a malformed grant rather than guessing at it", () => {
+    // Half-understood authorization configuration is worse than none: it looks
+    // enforced and is not. A parse failure must be loud at boot, not a quiet
+    // fallback to permit.
+    expect(() => parseGrants("{not json")).toThrow();
+    expect(() => parseGrants(JSON.stringify({ user_x: { mayDispatch: "hermes:*" } }))).toThrow();
+    expect(() => parseGrants(JSON.stringify({ user_x: { mayGrantReach: "yes" } }))).toThrow();
+    expect(() => parseGrants(JSON.stringify(["not", "an", "object"]))).toThrow();
+  });
+
+  test("an unparseable configuration denies everything rather than allowing it", () => {
+    // If the config cannot be read, the safe reading is that nobody is granted
+    // anything — never that everybody is.
+    expect(mayDispatch("{not json", "user_alice", "hermes:analyst-echo")).toBe(false);
+    expect(mayGrantReach("{not json", "user_alice")).toBe(false);
+  });
+});

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -361,6 +361,53 @@ hub box needs no `flyctl` install and no Fly login.
 > - **Which Fly images exist.** `agentpod-node-opencode-fly` (`fly/node-image/Dockerfile`) and `agentpod-node-pi-fly` (`fly/node-image/Dockerfile.pi`) — OpenCode and Pi. There is **no generic (harness-less) Fly image**, so a Fly runtime created with the **Generic** harness cannot work; the hub says so at boot with a `⚠️ WARNING` naming `NODE_AGENT_FLY_IMAGE`, and reports the same for any other harness whose resolved image is a local Docker tag. It is a report rather than a refusal precisely because of that gap: a fatal rule would make `ENABLE_FLY_PROVISIONING=true` unbootable no matter what you set, taking down a substrate that serves OpenCode and Pi perfectly well.
 > - **The images are published by CI, not by hand:** `.github/workflows/publish-images.yml` (manual dispatch — pick the image and the tag). It builds `linux/amd64` on an amd64 runner and then verifies the image it pushed: the `agentpod-node` binary runs, and the harness binary is resolvable from a *minimal service PATH*. Building by hand still works (`fly/node-image/README.md` has the `docker buildx … --push` line) and the same two things will not let you skip them: `--platform linux/amd64` (Fly Machines are amd64; an arm64 image built on an Apple laptop dies at boot with `exec format error`) and making the registry package **public** (Fly pulls anonymously). The tag in `NODE_AGENT_FLY_OPENCODE_IMAGE` / `NODE_AGENT_FLY_PI_IMAGE` is the record of which build the fleet is running.
 
+### Who may dispatch which agent — `CONTROL_PAIR_GRANTS`
+
+The first real authorization check in this suite, and it is **opt-in**. Unset
+means the check does not run and any principal may dispatch any agent; the hub
+says so at boot rather than leaving you to infer it:
+
+```
+⚠️  WARNING: CONTROL_PAIR_GRANTS is not set — any principal may dispatch any agent.
+```
+
+Set it to a JSON object keyed by principal id:
+
+```sh
+CONTROL_PAIR_GRANTS='{
+  "68jYD9VOCmXlPhIYGFOgoZVE6vDUVHPA": { "mayDispatch": ["hermes:*"], "mayGrantReach": true },
+  "usr_contractor":                   { "mayDispatch": ["hermes:analyst-echo"], "mayGrantReach": false }
+}'
+```
+
+| Field | Meaning |
+|---|---|
+| `mayDispatch` | Station keys this principal may start work on. Exact (`hermes:analyst-echo`) or one trailing `*` as a prefix (`hermes:*`). A wildcard does **not** cross the `:` it was written inside, so `hermes:*` never reaches an OpenClaw station. |
+| `mayGrantReach` | Whether this principal may grant an agent its reach. Both fields are required — a grant missing either is a configuration error and refuses to parse. |
+
+**Once it is set, it fails closed.** A principal with no entry is refused, and an
+empty `mayDispatch: []` denies rather than permits — that is what you write to
+suspend someone without deleting their grant.
+
+**A malformed value denies everything** rather than disabling the check. Losing
+the rules must never be the same thing as having none; the parse failure is
+logged at error level naming the variable.
+
+**Both halves are required and that is deliberate.** Dispatch control alone is
+decorative: anyone who can register an agent and grant it production credentials
+does not need permission to dispatch anything, because they build the agent they
+want (`charter` → `decisions/2026-08-13-ecosystem-identity.md`, Decision 4).
+
+**Why the shape looks like a token claim.** It is one. The Organization plane
+will answer this eventually, and the grant is written in the shape of the
+eventual claim — the names `mayDispatch` and `mayGrantReach` are already reserved
+in `fixtures/ecosystem-identity/token_claims.json` — so adopting a real issuer is
+a data move rather than a redesign.
+
+Enforced at `acp.createSession`, which is the one choke point both the console
+and the kaambaan bridge pass through. A check that lived only in the bridge would
+leave provisioning straight at this API unguarded.
+
 ### kaambaan bridge
 
 Off by default, and **nothing is inferred from a credential being present** — a `kbn_` token


### PR DESCRIPTION
Phase 3 of `docs/superpowers/plans/2026-08-15-organization-layer.md`, implementing **Decision 4** of `charter/decisions/2026-08-13-ecosystem-identity.md`.

**This is the first real authorization check in the suite.** Neither product enforced any before it.

## Where, and why there

At `acp.createSession` — the one choke point **both** dispatch paths pass through: the console/API route (`routes/station-acp.ts`) and the kaambaan bridge (`services/bridge/dispatch.ts`).

The decision is explicit about why that matters: a check living only in kaambaan would cover board-driven work while *provisioning straight at AgentPod* — the most common path today — went unguarded. *"A control with a hole that shape is not a control."*

**Checked before the readiness gates**, deliberately. Whether a caller may reach a station does not depend on whether that station is online, and answering *"Node is offline"* to someone who was never permitted tells them the station exists. A test asserts the ordering: grant permission, and the same call fails on readiness instead — which is what proves the earlier refusal came from the control and not from the node.

## Two postures, and the difference is the design

**Unconfigured is off.** Introducing the first authorization check in a live suite must not be the same event as switching it on everywhere. Unset `CONTROL_PAIR_GRANTS` means the check does not run — the posture `HUB_ISSUER` and the tenant external mapping already take, and the reason a standalone hub keeps working.

**Configured is fail-closed.** A principal with no grant is refused. `mayDispatch: []` **denies** rather than permits — `[]` is a decision, and the decision is no; it is also what an operator writes to suspend someone without deleting their grant.

**A malformed value denies everything** rather than disabling the check. Losing the rules must never be the same thing as having none.

## Both halves, required

A grant missing either field refuses to parse. Dispatch control alone is decorative: anyone who can register an agent and grant it production credentials does not need permission to dispatch anything — they build the agent they want.

## It is written as a claim, because it will be one

`mayDispatch` and `mayGrantReach` are already reserved in `fixtures/ecosystem-identity/token_claims.json`, with the consumer rule that absence never means permission. The static configuration uses those exact names, so adopting a real issuer is a **data move rather than a redesign** — which is precisely the interim the decision blesses.

## Operator-visible

The hub warns at boot when the check is off, because silence is indistinguishable from enforcement:

```
⚠️  WARNING: CONTROL_PAIR_GRANTS is not set — any principal may dispatch any agent.
```

Documented in `docs/DEPLOYMENT.md` with the wildcard semantics (`hermes:*` never crosses the `:` into OpenClaw), the fail-closed rules, and why both halves exist.

**Worth noting:** the docs-claims check did *not* force that documentation. The scanner matches whole string literals, and this is read as `process.env.CONTROL_PAIR_GRANTS` — invisible to it. A live instance of the gap recorded in #323.

## Verification

- **hub: 1108 pass, 0 fail** (89 files; 14 new across two files)
- `bun run typecheck`: 15, the documented baseline

**Not in this PR:** kaambaan's half (checking the claim before routing a claim), and reporting a denial as structured work activity. Both are named in the plan and neither belongs in the change that introduces the check.