### PR TITLE
fix(bridge): a control-pair denial is permanent, and says so on the board

### DIFF
--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -47,7 +47,7 @@ import type {
 } from "@agentpod/contract";
 import { db } from "../db/drizzle";
 import { resolveTenantForUser } from "../auth/tenant";
-import { mayDispatch } from "./control-pair";
+import { mayDispatch, ControlPairDenied } from "./control-pair";
 import { acpSessions, acpEvents } from "../db/schema/acp";
 import { stations } from "../db/schema/stations";
 import { createLogger } from "../utils/logger";
@@ -658,9 +658,7 @@ export async function createSession(
       stationKey: station.stationKey,
       stationId,
     });
-    throw new Error(
-      "You do not have permission to dispatch this agent."
-    );
+    throw new ControlPairDenied(userId, station.stationKey);
   }
 
   // Fail fast on the obvious gates before queueing (openSession re-checks them

--- a/apps/hub/src/services/bridge/dispatch.ts
+++ b/apps/hub/src/services/bridge/dispatch.ts
@@ -68,6 +68,7 @@
 import { CARD_PROMPT_VERSION, CardPrompt, renderCardPrompt, type AcpEvent, type AcpSessionMode } from "@agentpod/contract";
 
 import { ActivityCoalescer, type BoardActivity } from "./coalesce";
+import { isControlPairDenied } from "../control-pair";
 import { DEFAULT_PERMISSION_WAIT_MS, type BridgeAgentConfig } from "./config";
 import { isAutoAnswered, selectedOptionId } from "./permission";
 import {
@@ -746,6 +747,46 @@ async function handBack(
   const log = deps.log ?? (() => {});
   if (isLeaseSuperseded(cause) || isForeignRun(cause)) {
     return await abort(deps, key, work, null, cause);
+  }
+
+  // A refusal by the control pair is PERMANENT, and handing the claim back
+  // would be a hot loop: the board reissues the card, the same agent claims it,
+  // the same principal is refused, forever — bounded only by a circuit breaker
+  // that a release may never trip.
+  //
+  // So it fails the card instead, and says why as structured work activity
+  // rather than as a stringified exception. charter
+  // decisions/2026-08-13-ecosystem-identity.md requires exactly that: "a denial
+  // must be reported back as structured work activity, never silently dropped."
+  // An operator reading the board should see that permission was missing, not
+  // that something went wrong.
+  if (isControlPairDenied(cause)) {
+    const reason = `dispatch refused: ${cause.principalId} may not dispatch ${cause.stationKey}`;
+    try {
+      await deps.client.activity(work, {
+        type: "error",
+        body: "This agent was not dispatched: the operator who queued it does not have permission to dispatch this station.",
+        action: "control-pair.denied",
+        parameter: { principalId: cause.principalId, stationKey: cause.stationKey },
+      });
+    } catch (err) {
+      // The board may be unreachable; the fail below still carries the reason.
+      log("the denial could not be posted as activity", { run: work.runId, error: String(err) });
+    }
+    try {
+      await deps.client.fail(work, reason);
+    } catch (err) {
+      log("the denial could not be failed onto the board", { run: work.runId, error: String(err) });
+      await markAbandoned(key, `${reason} — and the fail was refused: ${String(err)}`).catch(() => {});
+      return { status: "failed", externalRunId: work.runId, reason };
+    }
+    log("dispatch refused by the control pair", {
+      run: work.runId,
+      principalId: cause.principalId,
+      stationKey: cause.stationKey,
+    });
+    await markAbandoned(key, reason).catch(() => {});
+    return { status: "failed", externalRunId: work.runId, reason };
   }
 
   const reason = `no session was opened, so the claim was handed back: ${String(cause)}`;

--- a/apps/hub/src/services/control-pair.ts
+++ b/apps/hub/src/services/control-pair.ts
@@ -42,6 +42,32 @@
 
 import { createLogger } from "../utils/logger";
 
+/**
+ * A dispatch refused by the control pair.
+ *
+ * A distinct type because a denial is **permanent** and every other failure at
+ * that point is transient. Callers that retry — the kaambaan bridge hands a
+ * claim back and lets the board reissue it — must be able to tell the
+ * difference, or a refusal becomes a hot loop: claim, refuse, release, claim
+ * again, forever.
+ */
+export class ControlPairDenied extends Error {
+  readonly principalId: string;
+  readonly stationKey: string;
+
+  constructor(principalId: string, stationKey: string) {
+    super("You do not have permission to dispatch this agent.");
+    this.name = "ControlPairDenied";
+    this.principalId = principalId;
+    this.stationKey = stationKey;
+  }
+}
+
+/** Is this the control pair refusing, rather than something transient? */
+export function isControlPairDenied(e: unknown): e is ControlPairDenied {
+  return e instanceof ControlPairDenied || (e as { name?: string })?.name === "ControlPairDenied";
+}
+
 const log = createLogger("control-pair");
 
 /** One principal's grant, in the shape the eventual token claim will carry. */

--- a/apps/hub/tests/unit/bridge-control-pair-denial.test.ts
+++ b/apps/hub/tests/unit/bridge-control-pair-denial.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { ControlPairDenied, isControlPairDenied } from "../../src/services/control-pair";
+
+/**
+ * A control-pair refusal is permanent, and the bridge must treat it that way.
+ *
+ * The defect this guards against was introduced by the change that added the
+ * check (#337) and is invisible from the AgentPod side: `createSession` throws,
+ * the bridge's `handBack` releases the claim, the board reissues the card, the
+ * same agent claims it, the same principal is refused — a hot loop, bounded only
+ * by a circuit breaker that a release may never trip.
+ *
+ * Every other failure at that point IS transient (the node went offline, the
+ * station lost a capability), which is exactly why handing the claim back is the
+ * right default and why a denial has to be told apart from one.
+ */
+describe("a control-pair denial is distinguishable", () => {
+  test("is recognisable as itself", () => {
+    const denied = new ControlPairDenied("user_x", "hermes:agent");
+    expect(isControlPairDenied(denied)).toBe(true);
+    expect(denied.principalId).toBe("user_x");
+    expect(denied.stationKey).toBe("hermes:agent");
+  });
+
+  test("an ordinary failure is not mistaken for one", () => {
+    // The transient cases must keep taking the release path. Reading them as
+    // denials would fail cards permanently for a node that was briefly offline.
+    expect(isControlPairDenied(new Error("Node is offline."))).toBe(false);
+    expect(isControlPairDenied(new Error("Station not found."))).toBe(false);
+    expect(isControlPairDenied(null)).toBe(false);
+    expect(isControlPairDenied(undefined)).toBe(false);
+    expect(isControlPairDenied("You do not have permission to dispatch this agent.")).toBe(false);
+  });
+
+  test("survives crossing a boundary that loses the prototype", () => {
+    // Errors are re-thrown, wrapped and serialised on the way out of a service.
+    // Matching on the name as well as the instance means the check still holds
+    // when only the shape survives — a `instanceof`-only guard would silently
+    // start releasing again.
+    const shaped = { name: "ControlPairDenied", message: "…", principalId: "u", stationKey: "s" };
+    expect(isControlPairDenied(shaped)).toBe(true);
+  });
+
+  test("carries what the board needs to explain the refusal", () => {
+    // The denial is reported as structured activity, not a stringified
+    // exception: charter decisions/2026-08-13-ecosystem-identity.md requires a
+    // denial to come back as work activity and never be silently dropped. Both
+    // fields are what make that message specific rather than "something failed".
+    const denied = new ControlPairDenied("68jYD9VOCmXlPhIYGFOgoZVE6vDUVHPA", "hermes:analyst-echo");
+    expect(denied.principalId).toBeTruthy();
+    expect(denied.stationKey).toBeTruthy();
+    expect(denied.message).toMatch(/permission/i);
+  });
+});


### PR DESCRIPTION
Fixes a defect **introduced by #337** — the change that added the control pair — and completes the half of Phase 3 that #337 deferred.

## The loop

#337 makes `createSession` throw when a principal may not dispatch a station. On the bridge path that throw lands in `handBack`, which **releases the claim**. So:

```
board reissues the card → same agent claims it → same principal refused → released → …
```

A hot loop, bounded only by a circuit breaker that a release may never trip.

**The default is right; the exception is the problem.** Every *other* failure at that point genuinely is transient — the node went offline, the station lost a capability — which is exactly why handing the claim back is correct, and exactly why a **permanent** refusal has to be told apart from one.

## What changes

A control-pair refusal is now:

- **a distinct type** (`ControlPairDenied`) rather than a message to match on
- **failed, not released** — so the card stops being reissued
- **reported as structured work activity**, naming the principal and the station

That last one is the governing decision's own requirement, not a nicety: *"a denial must be reported back as structured work activity, never silently dropped."* An operator reading the board should see **permission was missing**, not that something went wrong.

```
type:      "error"
action:    "control-pair.denied"
parameter: { principalId, stationKey }
body:      "This agent was not dispatched: the operator who queued it does not
            have permission to dispatch this station."
```

## One deliberate detail

The type guard matches on **`name` as well as `instanceof`**. Errors get re-thrown, wrapped and serialised on the way out of a service, and an `instanceof`-only guard would silently start releasing again the first time only the shape survived — reintroducing this exact loop, quietly. There is a test named for that case.

## Verification

- **hub: 1112 pass, 0 fail** (90 files; 4 new)
- `bun run typecheck`: 15, the documented baseline

**Still open in Phase 3:** kaambaan's own check. Worth noting what the code showed: the claim route carries an *agent's* `kbn_` token and no human principal, so "kaambaan checks before routing a claim" does not map onto it directly. Enforcing there needs either a record of who queued a card, or the hub-JWT path extended to the human routes that dispatch. That is a design question, not an implementation gap, and it should be answered before it is built.