### PR TITLE
feat(hub): grants over HTTP, so the control is inspectable

### DIFF
--- a/apps/hub/src/routes/admin-grants.ts
+++ b/apps/hub/src/routes/admin-grants.ts
@@ -1,0 +1,107 @@
+/**
+ * Grants, over HTTP.
+ *
+ * Without this the control pair is operable only by someone with a database
+ * client, which is not a control an organisation can actually use — and an
+ * authorization system nobody can inspect is one people route around.
+ *
+ * Admin-guarded, like everything else under `/api/admin`. Deliberately: the
+ * second half of the pair is *who may grant an agent its reach*, and an endpoint
+ * that let any principal edit grants would be the exact hole that half exists to
+ * close. Until `mayGrantReach` is itself enforced somewhere, admin is the
+ * stand-in, and it is a narrower one.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createLogger } from "../utils/logger";
+import { getGrant, setGrant, deleteGrant, listGrants, NO_GRANT } from "../services/grants";
+
+const log = createLogger("admin-grants");
+
+/**
+ * The planes a grant may name.
+ *
+ * An explicit list, not a shape. The obvious implementation — "anything before a
+ * colon is a namespace" — accepts `hermes:*`, which is precisely the retired
+ * `CONTROL_PAIR_GRANTS` format this is meant to stop: `hermes` looks exactly
+ * like a plane name. It would store happily, match nothing anywhere, and read as
+ * a working grant, which is the worst of the three outcomes.
+ *
+ * `org-plane` is here before it exists, for the same reason it is in the
+ * identity systems: adopting it should be a data move.
+ *
+ * Note the asymmetry with the reader, and that it is deliberate. A READER
+ * ignores a namespace it does not recognise, because a claim is read by more
+ * planes over time. A WRITER refuses one, because this is where a human types a
+ * value and a typo should come back as an error rather than as silence.
+ */
+const KNOWN_PLANES = ["agentpod", "kaambaan", "org-plane"] as const;
+
+const grantValue = z
+  .string()
+  .min(3)
+  .refine(
+    (v) => KNOWN_PLANES.some((p) => v.startsWith(`${p}:`) && v.length > p.length + 1),
+    `a grant value must name a known plane: ${KNOWN_PLANES.map((p) => `${p}:…`).join(", ")}`
+  );
+
+const grantBody = z.object({
+  mayDispatch: z.array(grantValue),
+  mayGrantReach: z.boolean(),
+});
+
+export const adminGrantsRouter = new Hono()
+  /** Every grant. The answer to "who may dispatch what", which nothing else answers. */
+  .get("/", async (c) => {
+    return c.json({ grants: await listGrants() });
+  })
+
+  /**
+   * One principal's grant.
+   *
+   * A principal with no row returns `granted: false` and an empty grant rather
+   * than 404: "this person has no permissions" is a real, useful answer, and a
+   * 404 would make a console show an error where it should show a blank slate.
+   */
+  .get("/:principalId", async (c) => {
+    const principalId = c.req.param("principalId");
+    const grant = await getGrant(principalId);
+    return c.json({ principalId, granted: grant !== null, grant: grant ?? NO_GRANT });
+  })
+
+  /** Set a principal's grant. Whole-object, not a patch — see below. */
+  .put("/:principalId", zValidator("json", grantBody), async (c) => {
+    const principalId = c.req.param("principalId");
+    const body = c.req.valid("json");
+
+    // Whole-object on purpose. A PATCH that merged arrays would make removing a
+    // permission harder than adding one, and an authorization surface should
+    // never be easier to widen than to narrow.
+    await setGrant(principalId, body);
+
+    log.info("grant updated", {
+      principalId,
+      mayDispatch: body.mayDispatch,
+      mayGrantReach: body.mayGrantReach,
+      by: c.get("user")?.id,
+    });
+
+    return c.json({ principalId, grant: body });
+  })
+
+  /**
+   * Remove a principal's grant entirely.
+   *
+   * Not the same as setting an empty one, and both are useful: an empty grant
+   * says "considered, and permitted nothing", while no grant says "never
+   * considered". Under enforcement they behave identically — which is the point
+   * — but they read differently to whoever comes next.
+   */
+  .delete("/:principalId", async (c) => {
+    const principalId = c.req.param("principalId");
+    await deleteGrant(principalId);
+    log.info("grant removed", { principalId, by: c.get("user")?.id });
+    return c.body(null, 204);
+  });

--- a/apps/hub/src/routes/admin.ts
+++ b/apps/hub/src/routes/admin.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { adminMiddleware, getRequestContext } from "../auth/admin-middleware";
 import { authMiddleware } from "../auth/middleware";
 import { createLogger } from "../utils/logger";
+import { adminGrantsRouter } from "./admin-grants";
 
 // Models
 import {
@@ -43,6 +44,11 @@ export const adminRouter = new Hono();
 // Apply auth middleware to all admin routes
 adminRouter.use("*", authMiddleware);
 adminRouter.use("*", adminMiddleware);
+
+// The control pair's grants, mounted inside the same guard. Without an HTTP
+// surface the control is operable only by someone with a database client, and
+// an authorization system nobody can inspect is one people route around.
+adminRouter.route("/grants", adminGrantsRouter);
 
 // =============================================================================
 // Validation Schemas

--- a/apps/hub/tests/integration/admin-grants-route.test.ts
+++ b/apps/hub/tests/integration/admin-grants-route.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { adminGrantsRouter } from "../../src/routes/admin-grants";
+import { getGrant, setGrant } from "../../src/services/grants";
+
+/**
+ * The grants HTTP surface.
+ *
+ * Mounted under `/api/admin` in production, behind the same auth + admin
+ * middleware as every other admin route; this exercises the router itself, so
+ * the guard is asserted where it is mounted rather than mocked here.
+ *
+ * What these cover is the part a database client cannot: that the surface a
+ * human types into refuses the values that would look like working grants and
+ * silently permit nothing.
+ */
+
+const SUBJECT = "test-user-admin-grants";
+
+/** The router, with a stub admin in context — the guard lives at the mount site. */
+function app() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: "test-admin", role: "admin" });
+    await next();
+  });
+  a.route("/grants", adminGrantsRouter);
+  return a;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: SUBJECT, email: "admin-grants@example.com", name: "Subject" });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${SUBJECT}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${SUBJECT}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("/api/admin/grants", () => {
+  test("reports a principal with no grant as a blank slate, not a 404", async () => {
+    // "This person has no permissions" is a real answer. A 404 would make a
+    // console show an error where it should show an empty form.
+    const res = await app().request(`/grants/${SUBJECT}`);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { granted: boolean; grant: { mayDispatch: string[] } };
+    expect(body.granted).toBe(false);
+    expect(body.grant.mayDispatch).toEqual([]);
+  });
+
+  test("sets and reads back a grant", async () => {
+    const res = await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+        mayGrantReach: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(await getGrant(SUBJECT)).toEqual({
+      mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+      mayGrantReach: true,
+    });
+  });
+
+  test("refuses an unnamespaced value instead of storing a grant that matches nothing", async () => {
+    // The retired `CONTROL_PAIR_GRANTS` format. A reader IGNORES a namespace it
+    // does not recognise; a WRITER must refuse a malformed one — otherwise this
+    // stores happily, matches nothing anywhere, and looks like a working grant,
+    // which is the worst of the three outcomes.
+    const res = await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mayDispatch: ["hermes:*"], mayGrantReach: false }),
+    });
+
+    expect(res.status).toBe(400);
+    // And the previous grant is untouched by a rejected write.
+    expect((await getGrant(SUBJECT))!.mayGrantReach).toBe(true);
+  });
+
+  test("refuses a grant missing half the pair", async () => {
+    const res = await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mayDispatch: ["agentpod:hermes:*"] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("replaces rather than merges, so narrowing is as easy as widening", async () => {
+    await setGrant(SUBJECT, {
+      mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+      mayGrantReach: true,
+    });
+
+    await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mayDispatch: ["agentpod:hermes:analyst-echo"], mayGrantReach: false }),
+    });
+
+    // A PATCH that merged arrays would make removing a permission harder than
+    // adding one, and an authorization surface must never be easier to widen
+    // than to narrow.
+    expect(await getGrant(SUBJECT)).toEqual({
+      mayDispatch: ["agentpod:hermes:analyst-echo"],
+      mayGrantReach: false,
+    });
+  });
+
+  test("lists every grant, which nothing else answers", async () => {
+    const res = await app().request("/grants");
+    const body = (await res.json()) as { grants: Array<{ principalId: string }> };
+    expect(body.grants.some((g) => g.principalId === SUBJECT)).toBe(true);
+  });
+
+  test("removing a grant is not the same as emptying it", async () => {
+    await app().request(`/grants/${SUBJECT}`, { method: "DELETE" });
+
+    // Both deny under enforcement — that is the point — but they read
+    // differently: empty says "considered, permitted nothing", absent says
+    // "never considered".
+    expect(await getGrant(SUBJECT)).toBeNull();
+
+    const res = await app().request(`/grants/${SUBJECT}`);
+    expect(((await res.json()) as { granted: boolean }).granted).toBe(false);
+  });
+});


### PR DESCRIPTION
Item 6 of `docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md`.

Without it the control pair is operable only by someone with a database client — and **an authorization system nobody can inspect is one people route around.**

`GET /api/admin/grants` · `GET|PUT|DELETE /api/admin/grants/:principalId`

## Admin-guarded, and that is the argument

The pair's second half is *who may grant an agent its reach*. An endpoint letting any principal edit grants would be **the exact hole that half exists to close**. Until `mayGrantReach` is itself enforced somewhere, admin is the stand-in — and it is the narrower one.

## Three deliberate choices

**PUT replaces, it does not merge.** A PATCH that merged arrays would make *removing* a permission harder than adding one, and an authorization surface must never be easier to widen than to narrow.

**No grant is a blank slate, not a 404.** "This person has no permissions" is a real answer; a 404 would make a console show an error where it should show an empty form.

**Removing a grant stays distinct from emptying one.** Both deny under enforcement — that is the point — but empty says *considered, permitted nothing* and absent says *never considered*, and those read differently to whoever comes next.

## The test caught a real hole

The obvious validation — "anything before a colon is a namespace" — **accepts `hermes:*`**, the retired `CONTROL_PAIR_GRANTS` format, because `hermes` looks exactly like a plane name. It would have stored happily, matched nothing anywhere, and read as a working grant: the worst of the three outcomes.

So the writer validates against an **explicit list of known planes** (`agentpod`, `kaambaan`, and `org-plane` before it exists, so adopting it is a data move).

**That asymmetry with the reader is intentional and documented:** a *reader* ignores a namespace it does not recognise, because a claim is read by more planes over time. A *writer* refuses one, because this is where a human types a value and a typo should come back as an error rather than as silence.

## Verification

- **hub: 1123 pass, 0 fail** (91 files; 7 new)
- `bun run typecheck`: 15, the documented baseline

## Next

The console view (same item), then retiring the interim, then production testing.