### PR TITLE
fix(hub): a grant names a node, because station keys are not unique

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0043_node_name_unique.sql
+++ b/apps/hub/src/db/drizzle-migrations/0043_node_name_unique.sql
@@ -1,0 +1,20 @@
+-- A node name identifies one machine, because a grant now names one.
+--
+-- Names come straight from `hostname` and were never unique: two Fly machines,
+-- two laptops called `localhost`, two containers from one image. Harmless while
+-- a name was only a label. It stopped being harmless when
+-- `agentpod:<node>/<stationKey>` started deciding who may dispatch what — a
+-- permission written for a staging box would silently cover production.
+--
+-- This is the same shape of defect as station keys not being unique across
+-- nodes, which is what sent us looking: uniqueness assumed rather than checked.
+--
+-- Existing duplicates are renamed rather than rejected, so the constraint can
+-- land on a live fleet. The suffix matches what enrollment now mints, and
+-- `hostname` is untouched — the machine's own answer about itself stays true.
+UPDATE nodes SET name = name || '-' || substr(id, 6, 6)
+WHERE ctid NOT IN (
+  SELECT min(ctid) FROM nodes GROUP BY tenant_id, name
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "nodes_tenant_name_idx" ON "nodes" ("tenant_id", "name");

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1786687161202,
       "tag": "0042_principal_grants",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786687162202,
+      "tag": "0043_node_name_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -50,6 +50,7 @@ import { resolveTenantForUser } from "../auth/tenant";
 import { ControlPairDenied, isControlPairEnforced } from "./control-pair";
 import { getGrant, grantAllowsStation } from "./grants";
 import { acpSessions, acpEvents } from "../db/schema/acp";
+import { nodes } from "../db/schema/nodes";
 import { stations } from "../db/schema/stations";
 import { createLogger } from "../utils/logger";
 import { getStation } from "./station-registry";
@@ -653,13 +654,31 @@ export async function createSession(
   // on whether that station happens to be online, and answering "node offline"
   // to someone who was never permitted leaks which stations exist.
   const station = await getStation(userId, stationId);
-  if (station && isControlPairEnforced() && !grantAllowsStation(await getGrant(userId), station.stationKey)) {
-    log.warn("dispatch refused by the control pair", {
-      principalId: userId,
-      stationKey: station.stationKey,
-      stationId,
-    });
-    throw new ControlPairDenied(userId, station.stationKey);
+  if (station && isControlPairEnforced()) {
+    // The grant names a node as well as a station, because station keys repeat
+    // across nodes — `opencode:c52ddf65` exists on two of them in production.
+    const [node] = await db
+      .select({ name: nodes.name })
+      .from(nodes)
+      .where(eq(nodes.id, station.nodeId))
+      .limit(1);
+
+    const allowed =
+      node !== undefined &&
+      grantAllowsStation(await getGrant(userId), {
+        nodeName: node.name,
+        stationKey: station.stationKey,
+      });
+
+    if (!allowed) {
+      log.warn("dispatch refused by the control pair", {
+        principalId: userId,
+        node: node?.name,
+        stationKey: station.stationKey,
+        stationId,
+      });
+      throw new ControlPairDenied(userId, station.stationKey);
+    }
   }
 
   // Fail fast on the obvious gates before queueing (openSession re-checks them

--- a/apps/hub/src/services/enrollment.ts
+++ b/apps/hub/src/services/enrollment.ts
@@ -71,6 +71,45 @@ export async function mintEnrollmentToken(
   return { token, expiresAt };
 }
 
+
+/**
+ * A node name nothing else in the tenant is using.
+ *
+ * Names come straight from `hostname`, which is not unique in any meaningful
+ * sense — two Fly machines, two laptops called `localhost`, two containers from
+ * one image. That was harmless while a name was only a label. It stopped being
+ * harmless when a grant started naming one: `agentpod:molt-bot/hermes:*` has to
+ * identify ONE host, or a permission written for a staging box silently covers
+ * production.
+ *
+ * So a collision gets a numeric suffix — `molt-bot`, then `molt-bot-2` — chosen
+ * over a hash because the person reading a grant has to recognise the machine.
+ *
+ * The unique index is the real guarantee; this loop is what makes the common
+ * case produce a readable name rather than an error. A race that slips past it
+ * fails on the constraint, which is the correct outcome and not a silent one.
+ */
+async function uniqueNodeName(tenantId: string, hostname: string): Promise<string> {
+  const base = hostname.trim() === "" ? "node" : hostname.trim();
+
+  const taken = new Set(
+    (
+      await db
+        .select({ name: nodes.name })
+        .from(nodes)
+        .where(eq(nodes.tenantId, tenantId))
+    ).map((r) => r.name)
+  );
+
+  if (!taken.has(base)) return base;
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  // A thousand machines sharing one hostname is not a naming problem any more.
+  return `${base}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
 /**
  * Enroll a node using a valid enrollment token.
  *
@@ -199,7 +238,10 @@ export async function enrollNode(
     // which stays true once tokens can be minted for more than one.
     tenantId: row.tenantId,
     userId: row.userId,
-    name: hostInfo.hostname,
+    // Unique within the tenant, because a grant names a node by this
+    // (`agentpod:<node>/<stationKey>`) and an ambiguous name is an ambiguous
+    // permission. `hostname` below keeps the machine's own answer, unaltered.
+    name: await uniqueNodeName(row.tenantId, hostInfo.hostname),
     hostname: hostInfo.hostname,
     os: hostInfo.os,
     arch: hostInfo.arch,

--- a/apps/hub/src/services/grants.ts
+++ b/apps/hub/src/services/grants.ts
@@ -108,32 +108,78 @@ export async function listGrants(): Promise<Array<{ principalId: string } & Gran
 }
 
 /**
- * Does a namespaced pattern match a station key?
+ * What a grant value has to identify, and why a station key alone will not do.
  *
- * Only `agentpod:` patterns are considered. Anything else belongs to another
- * plane and is **ignored rather than denied** — refusing what we do not
- * understand would break this check the day a third plane appears, and a claim
- * is read by more planes over time, not fewer.
+ * Station keys are **not unique across the fleet**: uniqueness is
+ * `(node_id, station_key)`, and in production `opencode:c52ddf65` exists on two
+ * different nodes today. Matching on the key alone would mean a grant for an
+ * agent on a staging box silently authorising the identically-named agent in
+ * production — different host, different workspace, different credentials.
+ *
+ * So a value names a node and a station:
+ *
+ *     agentpod:<nodePattern>/<stationKeyPattern>
+ *
+ *     agentpod:*&#47;hermes:*                 every Hermes station, anywhere
+ *     agentpod:molt-bot/hermes:*          every Hermes station on molt-bot
+ *     agentpod:molt-bot/hermes:analyst-echo   exactly one
+ *
+ * `/` separates them because station keys already contain `:`.
+ *
+ * Node NAMES rather than ids, because a grant has to be readable by the person
+ * who writes it, and ids are opaque and change when a runtime is reprovisioned.
+ *
+ * That only works because names are now unique within a tenant, by construction:
+ * enrollment suffixes a collision (`molt-bot`, `molt-bot-2`) and migration 0043
+ * enforces it. Before that they were merely usually distinct — which is the same
+ * assumed-uniqueness that made station keys unsafe to grant on in the first
+ * place.
  */
-export function patternMatchesStation(pattern: string, stationKey: string): boolean {
-  if (!pattern.startsWith(AGENTPOD_NS)) return false; // another plane's business
-  const target = pattern.slice(AGENTPOD_NS.length);
+export interface StationRef {
+  /** The node's display name — unique within the tenant. */
+  nodeName: string;
+  stationKey: string;
+}
 
-  if (target === stationKey) return true;
-  if (!target.endsWith("*")) return false;
+/** `hermes:*` matches `hermes:x`, but never crosses the `:` it was written inside. */
+function segmentMatches(pattern: string, value: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern === value) return true;
+  if (!pattern.endsWith("*")) return false;
 
-  const prefix = target.slice(0, -1);
-  if (!stationKey.startsWith(prefix)) return false;
-
-  // A wildcard may not cross the separator it was written inside: `hermes:*` is
-  // about Hermes stations, and reading it as "anything starting with hermes:"
-  // stays the same until somebody writes `her*`.
-  const rest = stationKey.slice(prefix.length);
+  const prefix = pattern.slice(0, -1);
+  if (!value.startsWith(prefix)) return false;
+  const rest = value.slice(prefix.length);
   return !prefix.includes(":") || !rest.includes(":");
 }
 
+/**
+ * Does one namespaced value permit dispatching this station?
+ *
+ * Only `agentpod:` values are considered; anything else belongs to another plane
+ * and is ignored rather than denied.
+ *
+ * A value without a `/` is the earlier two-part form (`agentpod:hermes:*`). It
+ * matches NOTHING — deliberately, because it cannot say which node it meant, and
+ * silently reading it as "any node" is exactly the over-grant this shape exists
+ * to remove.
+ */
+export function patternMatchesStation(pattern: string, station: StationRef): boolean {
+  if (!pattern.startsWith(AGENTPOD_NS)) return false; // another plane's business
+
+  const target = pattern.slice(AGENTPOD_NS.length);
+  const slash = target.indexOf("/");
+  if (slash === -1) return false; // the retired two-part form names no node
+
+  const nodePattern = target.slice(0, slash);
+  const keyPattern = target.slice(slash + 1);
+  if (!nodePattern || !keyPattern) return false;
+
+  return segmentMatches(nodePattern, station.nodeName) && segmentMatches(keyPattern, station.stationKey);
+}
+
 /** May this principal dispatch this station, given their grant? */
-export function grantAllowsStation(grant: Grant | null, stationKey: string): boolean {
+export function grantAllowsStation(grant: Grant | null, station: StationRef): boolean {
   if (!grant) return false; // no grant is not an unrestricted grant
-  return grant.mayDispatch.some((p) => patternMatchesStation(p, stationKey));
+  return grant.mayDispatch.some((p) => patternMatchesStation(p, station));
 }

--- a/apps/hub/tests/integration/control-pair-dispatch.test.ts
+++ b/apps/hub/tests/integration/control-pair-dispatch.test.ts
@@ -25,6 +25,7 @@ import { setGrant, deleteGrant } from "../../src/services/grants";
 
 const USER = "test-user-controlpair";
 let nodeId = "";
+let nodeName = "";
 let stationKey = "";
 let stationId = "";
 
@@ -40,6 +41,9 @@ beforeAll(async () => {
     cpuCount: 2,
   });
   nodeId = enrolled.nodeId;
+  // The grant names the node, so the test has to know what this fleet ended up
+  // calling it — enrolment suffixes a hostname collision.
+  nodeName = (await rawSql`SELECT name FROM nodes WHERE id = ${nodeId}`)[0]!.name as string;
 
   stationKey = "hermes:cp-agent";
   await adoptStations(USER, nodeId, [stationKey], [
@@ -89,7 +93,7 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
   test("refuses a grant that does not cover this station", async () => {
     process.env.ENFORCE_CONTROL_PAIR = "true";
     await setGrant(USER, {
-      mayDispatch: ["agentpod:hermes:some-other-agent"],
+      mayDispatch: [`agentpod:${nodeName}/hermes:some-other-agent`],
       mayGrantReach: false,
     });
 
@@ -110,12 +114,17 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
     ).rejects.toThrow(/permission/i);
   });
 
-  test("refuses the retired unprefixed format rather than honouring it", async () => {
-    // `hermes:*` was valid in CONTROL_PAIR_GRANTS. If it still matched here, a
-    // half-migrated deployment would enforce two different rules depending on
-    // which reader ran.
+  test("refuses the retired formats rather than honouring them", async () => {
+    // `hermes:*` was valid in CONTROL_PAIR_GRANTS, and `agentpod:hermes:*` was
+    // valid before a grant named a node. Neither may still match: the first
+    // would let a half-migrated deployment enforce two rules at once, and the
+    // second cannot say WHICH node it meant, which is the over-grant that shape
+    // exists to remove.
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await setGrant(USER, { mayDispatch: ["hermes:*"], mayGrantReach: false });
+    await setGrant(USER, {
+      mayDispatch: ["hermes:*", "agentpod:hermes:*"],
+      mayGrantReach: false,
+    });
 
     await expect(
       createSession({ stationId, userId: USER, mode: "default" })
@@ -135,7 +144,31 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
     // With a grant, the SAME call gets past the control and fails on readiness
     // instead — which is what proves the refusal above came from the control
     // and not from the node being unreachable.
-    await setGrant(USER, { mayDispatch: ["agentpod:hermes:*"], mayGrantReach: false });
+    await setGrant(USER, { mayDispatch: [`agentpod:${nodeName}/hermes:*`], mayGrantReach: false });
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/offline|not ready|does not support/i);
+  });
+
+  test("a grant for the same station key on another node does not reach this one", async () => {
+    // The defect that produced the node-qualified shape: station keys repeat
+    // across nodes — `opencode:c52ddf65` exists on two in production — so a
+    // permission for one host must not silently cover another.
+    process.env.ENFORCE_CONTROL_PAIR = "true";
+    await setGrant(USER, {
+      mayDispatch: [`agentpod:some-other-host/${stationKey}`],
+      mayGrantReach: false,
+    });
+
+    await expect(
+      createSession({ stationId, userId: USER, mode: "default" })
+    ).rejects.toThrow(/permission/i);
+  });
+
+  test("a node wildcard reaches it, because that says every node out loud", async () => {
+    process.env.ENFORCE_CONTROL_PAIR = "true";
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
 
     await expect(
       createSession({ stationId, userId: USER, mode: "default" })

--- a/apps/hub/tests/integration/grants.test.ts
+++ b/apps/hub/tests/integration/grants.test.ts
@@ -106,36 +106,57 @@ describe("the grant store", () => {
   });
 });
 
-describe("namespaced matching", () => {
-  test("matches this plane's namespace exactly", () => {
-    expect(patternMatchesStation("agentpod:hermes:analyst-echo", "hermes:analyst-echo")).toBe(true);
-    expect(patternMatchesStation("agentpod:hermes:analyst-echo", "hermes:coder-kai")).toBe(false);
+describe("a grant names a node and a station", () => {
+  const on = (nodeName: string, stationKey: string) => ({ nodeName, stationKey });
+
+  test("matches an exact node and station", () => {
+    expect(patternMatchesStation("agentpod:molt-bot/hermes:analyst-echo", on("molt-bot", "hermes:analyst-echo"))).toBe(true);
+    expect(patternMatchesStation("agentpod:molt-bot/hermes:analyst-echo", on("superchotu", "hermes:analyst-echo"))).toBe(false);
   });
 
-  test("a trailing wildcard does not cross the separator", () => {
-    expect(patternMatchesStation("agentpod:hermes:*", "hermes:anything")).toBe(true);
-    expect(patternMatchesStation("agentpod:hermes:*", "openclaw:anything")).toBe(false);
+  test("distinguishes the same station key on different nodes", () => {
+    // The defect that produced this shape. `opencode:c52ddf65` exists on two
+    // nodes in production; a grant for one must not authorise the other, which
+    // is a different host with different credentials and a different workspace.
+    const pattern = "agentpod:9247e5a88cfa/opencode:c52ddf65";
+    expect(patternMatchesStation(pattern, on("9247e5a88cfa", "opencode:c52ddf65"))).toBe(true);
+    expect(patternMatchesStation(pattern, on("cloudchamber", "opencode:c52ddf65"))).toBe(false);
+  });
+
+  test("a node wildcard means every node, said out loud", () => {
+    // Fleet-wide permission is still expressible — it just has to be written
+    // rather than obtained by accident, which is what the old two-part form gave.
+    expect(patternMatchesStation("agentpod:*/hermes:*", on("molt-bot", "hermes:x"))).toBe(true);
+    expect(patternMatchesStation("agentpod:*/hermes:*", on("superchotu", "hermes:y"))).toBe(true);
+    expect(patternMatchesStation("agentpod:*/hermes:*", on("molt-bot", "openclaw:z"))).toBe(false);
+  });
+
+  test("a station wildcard is scoped to its node", () => {
+    expect(patternMatchesStation("agentpod:molt-bot/hermes:*", on("molt-bot", "hermes:anything"))).toBe(true);
+    expect(patternMatchesStation("agentpod:molt-bot/hermes:*", on("superchotu", "hermes:anything"))).toBe(false);
+  });
+
+  test("a station wildcard still does not cross the colon", () => {
+    expect(patternMatchesStation("agentpod:molt-bot/hermes:*", on("molt-bot", "openclaw:x"))).toBe(false);
+  });
+
+  test("the retired two-part form matches nothing", () => {
+    // `agentpod:hermes:*` cannot say which node it meant. Reading it as "any
+    // node" is precisely the over-grant this shape removes, so it is refused
+    // rather than generously interpreted.
+    expect(patternMatchesStation("agentpod:hermes:*", on("molt-bot", "hermes:x"))).toBe(false);
+    expect(patternMatchesStation("agentpod:hermes:analyst-echo", on("molt-bot", "hermes:analyst-echo"))).toBe(false);
   });
 
   test("ignores another plane's namespace rather than denying on it", () => {
-    // The rule from the decision. A plane that refused values it did not
-    // understand would break the day a third plane appeared — and a claim is
-    // read by MORE planes over time, not fewer.
-    expect(patternMatchesStation("kaambaan:agt_7abfe2d7b3c64880", "hermes:analyst-echo")).toBe(false);
-    expect(patternMatchesStation("org-plane:agent:xyz", "hermes:analyst-echo")).toBe(false);
-
-    // And a grant holding only other planes' values permits nothing here, while
-    // still being a perfectly valid grant over there.
+    expect(patternMatchesStation("kaambaan:agt_x", on("molt-bot", "hermes:x"))).toBe(false);
+    expect(patternMatchesStation("org-plane:agent:xyz", on("molt-bot", "hermes:x"))).toBe(false);
     expect(
-      grantAllowsStation({ mayDispatch: ["kaambaan:agt_x"], mayGrantReach: false }, "hermes:analyst-echo")
+      grantAllowsStation({ mayDispatch: ["kaambaan:agt_x"], mayGrantReach: false }, on("molt-bot", "hermes:x"))
     ).toBe(false);
   });
 
   test("an unnamespaced value matches nothing", () => {
-    // The old `CONTROL_PAIR_GRANTS` format. It must not silently keep working
-    // against the new store, or a half-migrated deployment would enforce two
-    // different rules depending on which reader ran.
-    expect(patternMatchesStation("hermes:analyst-echo", "hermes:analyst-echo")).toBe(false);
-    expect(patternMatchesStation("hermes:*", "hermes:analyst-echo")).toBe(false);
+    expect(patternMatchesStation("molt-bot/hermes:*", on("molt-bot", "hermes:x"))).toBe(false);
   });
 });

--- a/apps/hub/tests/integration/node-name-unique.test.ts
+++ b/apps/hub/tests/integration/node-name-unique.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { mintEnrollmentToken, enrollNode } from "../../src/services/enrollment";
+
+/**
+ * A node name identifies one machine.
+ *
+ * It did not have to before: a name was a label, and `hostname` supplied it
+ * unaltered. It has to now, because a grant names a node —
+ * `agentpod:<node>/<stationKey>` — and an ambiguous name is an ambiguous
+ * permission, which would let a grant written for a staging box silently cover
+ * production.
+ *
+ * Two machines sharing a hostname is ordinary rather than exotic: Fly machines
+ * from one image, containers, laptops called `localhost`.
+ */
+
+const USER = "test-user-nodename";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "nodename@example.com", name: "NN" });
+  // Start from a clean slate: this file asserts on the exact suffix sequence, so
+  // rows left by an interrupted run would make the first enrolment land on
+  // `collide-host-4` and read as a bug in the naming.
+  await rawSql`DELETE FROM nodes WHERE user_id = ${USER}`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM nodes WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+async function enroll(hostname: string) {
+  const { token } = await mintEnrollmentToken(USER);
+  return enrollNode(token, { hostname, os: "linux", arch: "amd64", cpuCount: 2 });
+}
+
+describe("node names are unique within a tenant", () => {
+  test("the first machine keeps its hostname", async () => {
+    const { nodeId } = await enroll("collide-host");
+    const [row] = await rawSql`SELECT name, hostname FROM nodes WHERE id = ${nodeId}`;
+    expect(row!.name).toBe("collide-host");
+    expect(row!.hostname).toBe("collide-host");
+  });
+
+  test("a second machine with the same hostname gets a suffix", async () => {
+    const { nodeId } = await enroll("collide-host");
+    const [row] = await rawSql`SELECT name, hostname FROM nodes WHERE id = ${nodeId}`;
+
+    expect(row!.name).toBe("collide-host-2");
+    // The machine's own answer about itself is untouched — only the name this
+    // fleet calls it by is disambiguated.
+    expect(row!.hostname).toBe("collide-host");
+  });
+
+  test("and a third keeps counting", async () => {
+    const { nodeId } = await enroll("collide-host");
+    const [row] = await rawSql`SELECT name FROM nodes WHERE id = ${nodeId}`;
+    expect(row!.name).toBe("collide-host-3");
+  });
+
+  test("a suffix is numeric rather than a hash, because a person reads it", async () => {
+    // `molt-bot-2` tells you which machine you are granting. `molt-bot-a3f9c1`
+    // does not, and a grant nobody can read is a grant nobody checks.
+    const [row] = await rawSql`
+      SELECT name FROM nodes WHERE user_id = ${USER} AND name LIKE 'collide-host-%' ORDER BY name LIMIT 1`;
+    expect(row!.name).toMatch(/^collide-host-\d+$/);
+  });
+
+  test("the database refuses a duplicate even if the service is bypassed", async () => {
+    // The loop makes the common case readable; the constraint is the guarantee.
+    // A race that slips past the check must fail loudly rather than produce two
+    // machines a grant cannot tell apart.
+    //
+    // Caught explicitly rather than through `expect(...).rejects`: a rejected
+    // query left the pool holding an errored connection and the runner never
+    // exited, which reads as a hung suite rather than a failing test.
+    const [existing] = await rawSql`
+      SELECT tenant_id, name FROM nodes WHERE user_id = ${USER} LIMIT 1`;
+
+    let refused: unknown = null;
+    try {
+      await rawSql`
+        INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+        VALUES ('node_dupe_test', ${existing!.tenant_id}, ${USER}, ${existing!.name},
+                'collide-host', 'linux', 'amd64', 2, 'offline', 'x', now())`;
+    } catch (e) {
+      refused = e;
+    }
+
+    expect(refused).not.toBeNull();
+    expect(String(refused)).toMatch(/unique|duplicate/i);
+  });
+});

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -393,8 +393,26 @@ every dispatch is refused — which is correct, and is also an outage.
 
 | Field | Meaning |
 |---|---|
-| `mayDispatch` | Namespaced agent patterns. `agentpod:<stationKey>` is matched here; `kaambaan:<agentId>` is matched by kaambaan and **ignored** here. One trailing `*` is a prefix wildcard that may not cross the `:` it was written inside, so `agentpod:hermes:*` never reaches an OpenClaw station. An **unprefixed** value (the retired format) matches nothing. `[]` denies — it is what you write to suspend someone without deleting their grant. |
+| `mayDispatch` | Namespaced patterns. AgentPod's name a **node and a station**: `agentpod:<nodeName>/<stationKey>`. `kaambaan:<agentId>` is matched by kaambaan and **ignored** here. |
 | `mayGrantReach` | Whether this principal may grant an agent its reach. Required. Dispatch control alone is decorative: anyone who can grant an agent production credentials does not need permission to dispatch it. |
+
+```sh
+agentpod:molt-bot/hermes:analyst-echo   # exactly one agent, on one host
+agentpod:molt-bot/hermes:*              # every Hermes agent on molt-bot
+agentpod:*/hermes:*                     # every Hermes agent, anywhere
+```
+
+**Why a node, not just a station.** Station keys are **not unique across the
+fleet** — uniqueness is `(node, key)`, and `opencode:c52ddf65` exists on two
+nodes right now. A grant naming only the key would let a permission written for
+a staging box silently cover production. Node **names** are unique within a
+tenant by construction: enrolment suffixes a hostname collision (`molt-bot`,
+`molt-bot-2`) and a unique index enforces it.
+
+**Two retired forms match nothing**, deliberately: an unprefixed `hermes:*` (the
+old `CONTROL_PAIR_GRANTS` format) and a two-part `agentpod:hermes:*`, which
+cannot say which node it meant. `[]` denies — it is what you write to suspend
+someone without deleting their grant.
 
 Why values are namespaced, and where that ends:
 `charter` → `decisions/2026-08-15-a-grant-names-an-agent-per-plane.md`.

--- a/fixtures/ecosystem-identity/token_claims.json
+++ b/fixtures/ecosystem-identity/token_claims.json
@@ -1,6 +1,6 @@
 {
   "corpus": "ecosystem-identity/token-claims",
-  "version": 2,
+  "version": 3,
   "authoredAt": "2026-08-15",
   "authoredFrom": "code and two runs: the claim shape was observed in a token issued by better-auth 1.6.26 and verified from a Cloudflare Worker (agentpod#331), and the control pair moved from reserved to issued when grants became data the issuer can read (principal_grants)",
   "purpose": "One issuer, and every other plane verifies offline against a JWKS (charter decisions/2026-08-15-one-issuer-and-offline-verification.md). The moment a second plane reads a claim, the claim's NAME is a contract: a rename in the hub is a silent authorization failure in kaambaan, which fails in the direction that looks like the caller having no permission. This corpus is what makes that a failing test instead.",
@@ -45,14 +45,16 @@
     {
       "claim": "mayDispatch",
       "type": "string[]",
-      "meaning": "First half of the control pair \u2014 which agents this principal may dispatch. Values are NAMESPACED by the plane whose id space they belong to: `agentpod:<stationKey>` is matched by AgentPod, `kaambaan:<agentId>` by kaambaan.",
+      "meaning": "First half of the control pair \u2014 which agents this principal may dispatch. Values are NAMESPACED by plane, and AgentPod's also name a node: `agentpod:<nodeName>/<stationKey>`, `kaambaan:<agentId>`.",
       "required": true,
       "grammar": "^[a-z][a-z0-9-]*:.+$",
       "valueRules": {
         "namespaced": "Every value carries a plane prefix. An UNPREFIXED value matches nothing anywhere \u2014 that was the retired CONTROL_PAIR_GRANTS format, and letting it keep working would mean a half-migrated deployment enforcing two different rules depending on which reader ran.",
         "unknownNamespaceIsIgnored": "A consumer IGNORES a namespace it does not recognise; it must never deny on one. A plane that refused what it did not understand would break the day a third plane appeared, and a claim is read by more planes over time, not fewer.",
-        "wildcard": "One trailing `*` is a prefix wildcard that may not cross the `:` it was written inside: `agentpod:hermes:*` reaches every Hermes station and no OpenClaw one.",
-        "emptyDenies": "`[]` is a decision, and the decision is no. It is what an operator writes to suspend someone without deleting their grant."
+        "wildcard": "One trailing `*` per segment. In the station half it may not cross the `:` it was written inside, so `hermes:*` never reaches an OpenClaw station.",
+        "emptyDenies": "`[]` is a decision, and the decision is no. It is what an operator writes to suspend someone without deleting their grant.",
+        "agentpodNamesANode": "A station key is NOT unique across the fleet \u2014 uniqueness is (node, key), and `opencode:c52ddf65` exists on two nodes in production. So an agentpod value names both: `agentpod:molt-bot/hermes:*` is Hermes stations on molt-bot, `agentpod:*/hermes:*` is Hermes stations anywhere. A two-part value (`agentpod:hermes:*`) cannot say which node it meant and MATCHES NOTHING \u2014 reading it as 'any node' is the over-grant this shape removes.",
+        "nodeNamesAreUnique": "Within a tenant, by construction: enrolment suffixes a hostname collision (`molt-bot`, `molt-bot-2`) and a unique index enforces it. Names rather than ids because a grant must be readable by whoever writes it."
       },
       "source": "charter decisions/2026-08-15-a-grant-names-an-agent-per-plane.md"
     },
@@ -119,6 +121,10 @@
     {
       "case": "mayDispatch-absent",
       "why": "A token from an issuer that predates the control pair. A consumer must not treat absence as an empty grant, nor as an unrestricted one \u2014 it means the issuer cannot answer, and the consumer decides its own posture."
+    },
+    {
+      "case": "agentpod-value-without-a-node",
+      "why": "`agentpod:hermes:*` \u2014 the two-part form. It names no node, and station keys repeat across nodes, so it must match nothing rather than be read as fleet-wide."
     }
   ]
 }


### PR DESCRIPTION
Found by the operator asking whether multiple nodes with the same harness had been accounted for. **They had not.**

## The hole

Station key uniqueness is `(node_id, station_key)` — **not the key alone** — and `opencode:c52ddf65` exists on **two nodes in production right now**.

So `agentpod:opencode:c52ddf65` authorised dispatch to both: a Fly runtime and a VPS, different hosts with different workspaces and different credentials. **A permission written for a staging box would have silently covered production.**

It is the same defect as the `run_` collision this suite already undid once — uniqueness assumed rather than checked. I carried it forward from #337 without asking whether the thing being named was unique.

Enforcement was still **off**, so nothing had been decided by it. Nothing was broken; a control that was about to be switched on was wrong.

## The shape now

```
agentpod:molt-bot/hermes:analyst-echo   exactly one agent, on one host
agentpod:molt-bot/hermes:*              every Hermes agent on molt-bot
agentpod:*/hermes:*                     every Hermes agent, anywhere
```

**Fleet-wide permission has to be said out loud** rather than obtained by accident. Both retired forms match nothing: the unprefixed `CONTROL_PAIR_GRANTS` shape, and the two-part `agentpod:hermes:*` which cannot say which node it meant.

`kaambaan:<agentId>` is unchanged — agent ids are already unique within a tenant.

## Node names are now unique by construction

They were not before; nothing constrained them. Enrolment suffixes a hostname collision (`molt-bot`, `molt-bot-2`) and migration `0043` enforces it, **renaming existing duplicates first** so the constraint can land on a live fleet.

**Names rather than ids**, because a grant nobody can read is a grant nobody checks — and ids change when a runtime is reprovisioned. `hostname` keeps the machine's own answer about itself, unaltered.

A numeric suffix rather than a hash, for the same reason: `molt-bot-2` tells you which machine you are granting; `molt-bot-a3f9c1` does not.

## Two things from writing the tests, both recorded in the code

**A test asserting the constraint via `expect(...).rejects` hung the runner.** A rejected query left the pool holding an errored connection and bun never exited — which reads as a hung suite rather than a failing test, and cost three attempts to find. Catching explicitly fixed it.

**The naming tests assert an exact suffix sequence**, so rows left by an interrupted run made the first enrolment land on `collide-host-4` and read as a bug in the naming. They clear their own slate now.

## Verification

- **hub: 1134 pass, 0 fail** (92 files; 13 new/rewritten)
- `bun run typecheck`: 15, the documented baseline
- Charter decision amended; fixture at v3 with the node rule and a new reject case; `DEPLOYMENT.md` rewritten