### PR TITLE
fix(hub): a control-pair denial is 403, not 502

### DIFF
--- a/apps/hub/src/routes/station-acp.ts
+++ b/apps/hub/src/routes/station-acp.ts
@@ -47,6 +47,7 @@ import { acpEvents } from "../db/schema/acp";
 import { isAllowedOrigin } from "../config";
 import { getStation } from "../services/station-registry";
 import * as acp from "../services/acp-sessions";
+import { isControlPairDenied } from "../services/control-pair";
 import type { AuthUser } from "../auth/middleware";
 
 // ─── Error-to-status helper ───────────────────────────────────────────────────
@@ -124,6 +125,13 @@ export const stationAcpRoutes = new Hono()
         const row = await acp.createSession({ stationId, userId: user.id, mode });
         return c.json(row, 201);
       } catch (err) {
+        // A refusal by the control pair is 403, not the 502 the generic mapper
+        // gives it. 502 says the node failed, which is a different thing to a
+        // caller: it invites a retry that can never succeed, and it hides an
+        // authorization decision behind an infrastructure one.
+        if (isControlPairDenied(err)) {
+          return c.json({ error: err.message }, 403);
+        }
         const message = err instanceof Error ? err.message : String(err);
         return c.json({ error: message }, createErrorStatus(message));
       }

--- a/apps/hub/tests/integration/control-pair-dispatch.test.ts
+++ b/apps/hub/tests/integration/control-pair-dispatch.test.ts
@@ -4,7 +4,9 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { mintEnrollmentToken, enrollNode } from "../../src/services/enrollment";
 import { adoptStations, listAdopted } from "../../src/services/station-registry";
+import { Hono } from "hono";
 import { createSession } from "../../src/services/acp-sessions";
+import { stationAcpRoutes } from "../../src/routes/station-acp";
 import { setGrant, deleteGrant } from "../../src/services/grants";
 
 /**
@@ -184,5 +186,32 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
     await expect(
       createSession({ stationId, userId: USER, mode: "default" })
     ).rejects.toThrow(/offline|not ready|does not support/i);
+  });
+});
+
+describe("the route reports a denial as a refusal, not a gateway failure", () => {
+  test("403, because 502 says the node failed and invites a retry", async () => {
+    // Observed in production before this: a permission refusal came back as
+    // 502. A caller cannot tell "you may not" from "the upstream broke", and
+    // will retry something that can never succeed — an authorization decision
+    // hidden behind an infrastructure one.
+    process.env.ENFORCE_CONTROL_PAIR = "true";
+    await deleteGrant(USER).catch(() => {});
+
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("user", { id: USER });
+      await next();
+    });
+    app.route("/api", stationAcpRoutes); // mounted at /api, as in index.ts
+
+    const res = await app.request(`/api/stations/${stationId}/acp/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mode: "ask" }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toMatch(/permission/i);
   });
 });


### PR DESCRIPTION
Found by running the control pair against production.

A refusal came back as **502**:

```
POST /api/stations/station_aae9f224…/acp/sessions
{"error":"You do not have permission to dispatch this agent."}
http=502
```

502 says *the node failed*. That is a different thing to a caller: it hides an authorization decision behind an infrastructure one, and it invites a retry that can never succeed. A permission refusal is **403**.

The generic mapper reserves 502 for "the failure came from the node", which is correct for everything else thrown at that point and wrong for this one — so the denial is recognised before the mapper runs.

## Also worth knowing

The test mounts the router at `/api`, the prefix `index.ts` actually uses. Mounting at `/api/stations` returned **404** and briefly looked like the status fix not working — the comment stays so the next person does not lose the same ten minutes.

## Verification

- **hub: 1135 pass, 0 fail** (92 files)
- `bun run typecheck`: 15, the documented baseline

## Production state as of this PR

Enforcement is **on** in production and verified end to end:

- a permitted dispatch opened a real ACP session on `molt-bot/hermes:research-ray`
- narrowing the grant to exclude Hermes refused the same call, with a log line naming principal, node and station
- the grant has been restored and the test session ended