### PR TITLE
feat(console): a page for the control pair

### DIFF
--- a/apps/console/src/lib/api/grants.ts
+++ b/apps/console/src/lib/api/grants.ts
@@ -1,0 +1,101 @@
+/**
+ * Grants — the control pair, over the admin API.
+ *
+ * Who may dispatch which agent, and who may grant an agent its reach
+ * (`charter` → `decisions/2026-08-13-ecosystem-identity.md`, Decision 4). The
+ * hub puts these into every token it issues, and both planes enforce them.
+ *
+ * This client exists because a control nobody can see is one people route
+ * around: until now the only ways to read or change a grant were `curl` and a
+ * database client.
+ */
+
+import { http } from "./client";
+
+export interface Grant {
+  /**
+   * Namespaced patterns. AgentPod's name a node AND a station —
+   * `agentpod:<nodeName>/<stationKey>` — because station keys repeat across
+   * nodes. `kaambaan:<agentId>` is matched by the board.
+   */
+  mayDispatch: string[];
+  mayGrantReach: boolean;
+}
+
+export interface PrincipalGrant extends Grant {
+  principalId: string;
+}
+
+/**
+ * Every grant, and whether anything is enforcing them.
+ *
+ * `enforced` travels with the data because a page that showed a narrow grant
+ * without it would tell an operator the fleet was locked down while
+ * `ENFORCE_CONTROL_PAIR` was unset and nothing was checking anything.
+ */
+export async function listGrants(): Promise<{ grants: PrincipalGrant[]; enforced: boolean }> {
+  return http<{ grants: PrincipalGrant[]; enforced: boolean }>("/api/admin/grants");
+}
+
+/**
+ * One principal's grant.
+ *
+ * `granted: false` with an empty grant is a real answer, not an error: it means
+ * this person has been given nothing, which under enforcement is a refusal.
+ */
+export async function getGrant(
+  principalId: string
+): Promise<{ principalId: string; granted: boolean; grant: Grant }> {
+  return http(`/api/admin/grants/${encodeURIComponent(principalId)}`);
+}
+
+/**
+ * Replace a principal's grant.
+ *
+ * Whole-object, never a merge: an authorization surface must not be easier to
+ * widen than to narrow, and a patch that merged arrays would make removing a
+ * permission the harder operation.
+ */
+export async function setGrant(principalId: string, grant: Grant): Promise<void> {
+  await http(`/api/admin/grants/${encodeURIComponent(principalId)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(grant),
+  });
+}
+
+/** Remove a grant entirely — distinct from emptying it, though both deny. */
+export async function deleteGrant(principalId: string): Promise<void> {
+  await http(`/api/admin/grants/${encodeURIComponent(principalId)}`, { method: "DELETE" });
+}
+
+/** The planes a value may name. Mirrors the writer's allowlist on the hub. */
+export const KNOWN_PLANES = ["agentpod", "kaambaan", "org-plane"] as const;
+
+/**
+ * Why a value would be rejected, or null when it is fine.
+ *
+ * Checked here as well as on the server so a typo is answered while the person
+ * is still looking at it. The server remains the authority — this only saves a
+ * round trip and gives a better sentence than a 400 does.
+ */
+export function grantValueProblem(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return "empty";
+
+  const plane = KNOWN_PLANES.find((p) => trimmed.startsWith(`${p}:`));
+  if (!plane) {
+    return `must name a plane: ${KNOWN_PLANES.map((p) => `${p}:…`).join(", ")}`;
+  }
+  const rest = trimmed.slice(plane.length + 1);
+  if (rest === "") return "names a plane but nothing in it";
+
+  if (plane === "agentpod" && !rest.includes("/")) {
+    // The trap worth catching early: `agentpod:hermes:*` looks right and matches
+    // nothing, because station keys repeat across nodes and it cannot say which
+    // node it meant.
+    return "must name a node too — agentpod:<node>/<stationKey>, e.g. agentpod:*/hermes:*";
+  }
+
+  return null;
+}

--- a/apps/console/src/lib/components/admin/AdminTabs.svelte
+++ b/apps/console/src/lib/components/admin/AdminTabs.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  /**
+   * AdminTabs.svelte
+   *
+   * Section switcher for the admin area, shared so a new section appears on
+   * every admin page at once. The sidebar keeps a single "Admin" entry on
+   * purpose — one more top-level item per admin page would crowd out the fleet,
+   * which is what people are actually here for.
+   *
+   * Anchors rather than `PageHeader`'s tabs: each section is a real URL worth
+   * bookmarking and middle-clicking, and the header's tab strip pulls in a
+   * tooltip context that only exists inside the app shell.
+   */
+  import { cn } from "$lib/utils";
+
+  interface Props {
+    /** The section this page is. */
+    active: "users" | "grants";
+  }
+
+  let { active }: Props = $props();
+
+  const sections = [
+    { id: "users", label: "Users", href: "/admin/users" },
+    { id: "grants", label: "Grants", href: "/admin/grants" },
+  ] as const;
+</script>
+
+<nav class="flex gap-1 border-b" aria-label="Admin sections">
+  {#each sections as section (section.id)}
+    <a
+      href={section.href}
+      aria-current={active === section.id ? "page" : undefined}
+      class={cn(
+        "-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+        active === section.id
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
+      )}
+    >
+      {section.label}
+    </a>
+  {/each}
+</nav>

--- a/apps/console/src/lib/components/admin/GrantDialog.svelte
+++ b/apps/console/src/lib/components/admin/GrantDialog.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  /**
+   * GrantDialog.svelte
+   *
+   * Edits one principal's control pair — what they may dispatch, and whether
+   * they may grant an agent its reach.
+   *
+   * The form is deliberately a list of exact strings rather than a set of
+   * checkboxes over live stations. A grant outlives the station it names: nodes
+   * are reprovisioned, stations are re-adopted, and a permission that quietly
+   * disappeared with its station would be a silent widening or narrowing nobody
+   * ordered. Live stations appear as *suggestions* instead, so the common case is
+   * one click and the uncommon case is still expressible.
+   */
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import { Switch } from "$lib/components/ui/switch";
+  import { Badge } from "$lib/components/ui/badge";
+  import { toast } from "svelte-sonner";
+  import XIcon from "@lucide/svelte/icons/x";
+  import { setGrant, grantValueProblem, type Grant } from "$lib/api/grants";
+
+  interface GrantPrincipal {
+    id: string;
+    label: string;
+  }
+
+  interface Props {
+    open: boolean;
+    principal: GrantPrincipal | null;
+    grant: Grant;
+    /** Live `agentpod:<node>/<stationKey>` values, offered as suggestions. */
+    stationValues: string[];
+    onSaved: () => void;
+  }
+
+  let {
+    open = $bindable(false),
+    principal,
+    grant,
+    stationValues = [],
+    onSaved,
+  }: Props = $props();
+
+  let values = $state<string[]>([]);
+  let mayGrantReach = $state(false);
+  let draft = $state("");
+  let problem = $state<string | null>(null);
+  let isSaving = $state(false);
+
+  // Seed from the principal's current grant each time the dialog opens. Edits
+  // are local until Save — a half-typed narrowing must never be live.
+  $effect(() => {
+    if (open) {
+      values = [...grant.mayDispatch];
+      mayGrantReach = grant.mayGrantReach;
+      draft = "";
+      problem = null;
+    }
+  });
+
+  let unusedSuggestions = $derived(stationValues.filter((v) => !values.includes(v)).slice(0, 8));
+
+  function addValue(value: string): boolean {
+    const trimmed = value.trim();
+    const why = grantValueProblem(trimmed);
+    if (why) {
+      problem = why;
+      return false;
+    }
+    // A duplicate grants nothing extra and makes the list harder to read, which
+    // is how an over-wide value hides in a long grant.
+    if (!values.includes(trimmed)) values = [...values, trimmed];
+    draft = "";
+    problem = null;
+    return true;
+  }
+
+  function removeValue(value: string) {
+    values = values.filter((v) => v !== value);
+  }
+
+  async function handleSave() {
+    if (!principal || isSaving) return;
+
+    // A value still in the box is a value the person believes they are saving.
+    // Adding it here means Save-without-Add works; refusing to save while it is
+    // invalid means a rejected value is never silently dropped, which would
+    // leave someone certain they had granted something they had not.
+    if (draft.trim() !== "" && !addValue(draft)) return;
+
+    isSaving = true;
+    try {
+      // Whole-object: the endpoint replaces rather than merges, so this is the
+      // grant afterwards, not an addition to it.
+      await setGrant(principal.id, { mayDispatch: values, mayGrantReach });
+      toast.success(`Grant saved for ${principal.label}`);
+      open = false;
+      onSaved();
+    } catch (e) {
+      // The dialog stays open with the edits intact: losing a half-written grant
+      // to a network blip is how people end up applying a wider one next time.
+      toast.error("Couldn’t save grant", { description: (e as Error).message });
+    } finally {
+      isSaving = false;
+    }
+  }
+</script>
+
+<Dialog.Root {open} onOpenChange={(v) => (open = v)}>
+  <Dialog.Portal>
+    <Dialog.Overlay />
+    <Dialog.Content showCloseButton={false} class="max-w-lg">
+      <Dialog.Header>
+        <Dialog.Title>Grant</Dialog.Title>
+        <Dialog.Description>
+          What {principal?.label ?? "this principal"} may dispatch. Replaces the current grant.
+        </Dialog.Description>
+      </Dialog.Header>
+
+      <div class="space-y-4 py-2">
+        <div class="space-y-2">
+          <Label>May dispatch</Label>
+          {#if values.length === 0}
+            <p class="text-xs text-muted-foreground" data-testid="grant-empty">
+              Nothing. Under enforcement this principal is refused everywhere.
+            </p>
+          {:else}
+            <ul class="flex flex-wrap gap-2">
+              {#each values as value (value)}
+                <li>
+                  <Badge variant="outline" class="gap-1 font-mono text-xs">
+                    {value}
+                    <button
+                      type="button"
+                      aria-label="Remove value {value}"
+                      class="text-muted-foreground hover:text-destructive"
+                      onclick={() => removeValue(value)}
+                    >
+                      <XIcon class="h-3 w-3" />
+                    </button>
+                  </Badge>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+
+        <div class="space-y-2">
+          <Label for="grant-value">Add a value</Label>
+          <div class="flex gap-2">
+            <Input
+              id="grant-value"
+              bind:value={draft}
+              placeholder="agentpod:node/hermes:agent — or kaambaan:agt_…"
+              class="font-mono text-xs"
+              onkeydown={(e: KeyboardEvent) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addValue(draft);
+                }
+              }}
+            />
+            <Button variant="outline" onclick={() => addValue(draft)}>Add</Button>
+          </div>
+          {#if problem}
+            <p class="text-xs text-destructive" role="alert">{problem}</p>
+          {:else}
+            <p class="text-xs text-muted-foreground">
+              An AgentPod value names a node as well as a station — station keys repeat across
+              nodes. Fleet-wide is written out: <code>agentpod:*/hermes:*</code>.
+            </p>
+          {/if}
+
+          {#if unusedSuggestions.length > 0}
+            <div class="flex flex-wrap gap-1 pt-1">
+              {#each unusedSuggestions as suggestion (suggestion)}
+                <button
+                  type="button"
+                  class="rounded border border-dashed px-2 py-0.5 font-mono text-[11px] text-muted-foreground hover:border-primary hover:text-primary"
+                  onclick={() => addValue(suggestion)}
+                >
+                  + {suggestion}
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+
+        <div class="flex items-start justify-between gap-4 rounded-lg border p-3">
+          <div class="space-y-0.5">
+            <Label for="may-grant-reach">May grant reach</Label>
+            <p class="text-xs text-muted-foreground">
+              The second half of the pair: whether this principal may widen what an agent can
+              reach. Not yet enforced anywhere — recorded so it is decided before it is needed.
+            </p>
+          </div>
+          <Switch id="may-grant-reach" bind:checked={mayGrantReach} />
+        </div>
+      </div>
+
+      <Dialog.Footer>
+        <Button variant="outline" onclick={() => (open = false)} disabled={isSaving}>Cancel</Button>
+        <Button onclick={handleSave} disabled={isSaving}>
+          {isSaving ? "Saving…" : "Save grant"}
+        </Button>
+      </Dialog.Footer>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/console/src/lib/components/admin/GrantDialog.svelte.test.ts
+++ b/apps/console/src/lib/components/admin/GrantDialog.svelte.test.ts
@@ -1,0 +1,167 @@
+/**
+ * GrantDialog.svelte.test.ts
+ *
+ * Editing the control pair — who may dispatch which agent, and who may grant an
+ * agent its reach (`charter` → `decisions/2026-08-13-ecosystem-identity.md`).
+ *
+ * The stakes here are not the usual form stakes. A grant that stores happily and
+ * matches nothing reads exactly like a working grant, and the person who wrote it
+ * believes an agent is reachable when it is not — or, worse, believes the fleet
+ * is narrowed when the value they typed narrowed nothing. So most of what is
+ * asserted below is about **refusing** values, and about the save being a
+ * replacement rather than a merge.
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+
+vi.mock("svelte-sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("$lib/api/grants", async () => {
+  const actual = await vi.importActual<typeof import("$lib/api/grants")>("$lib/api/grants");
+  return {
+    // The validator is pure and shared with the server's rule — mocking it would
+    // test a stub instead of the thing that decides.
+    grantValueProblem: actual.grantValueProblem,
+    KNOWN_PLANES: actual.KNOWN_PLANES,
+    setGrant: vi.fn(),
+    deleteGrant: vi.fn(),
+  };
+});
+
+import * as grantsApi from "$lib/api/grants";
+import GrantDialog from "./GrantDialog.svelte";
+
+const PRINCIPAL = { id: "user_abc", label: "jo@example.com" };
+
+function open(props: Record<string, unknown> = {}) {
+  return render(GrantDialog, {
+    props: {
+      open: true,
+      principal: PRINCIPAL,
+      grant: { mayDispatch: [], mayGrantReach: false },
+      stationValues: [],
+      onSaved: vi.fn(),
+      ...props,
+    },
+  });
+}
+
+async function addValue(getByLabelText: (m: RegExp) => HTMLElement, getByRole: any, value: string) {
+  await fireEvent.input(getByLabelText(/add a value/i), { target: { value } });
+  await fireEvent.click(getByRole("button", { name: /^add$/i }));
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(cleanup);
+
+test("shows the values the principal already has", () => {
+  const { getByText } = open({
+    grant: { mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_7abf"], mayGrantReach: true },
+  });
+
+  expect(getByText("agentpod:molt-bot/hermes:*")).toBeTruthy();
+  expect(getByText("kaambaan:agt_7abf")).toBeTruthy();
+});
+
+test("refuses an AgentPod value that names no node", async () => {
+  // The shape everyone writes first. Station keys repeat across nodes, so this
+  // matches nothing anywhere — and stored, it looks like a working grant.
+  const { getByLabelText, getByRole, findByText } = open();
+
+  await addValue(getByLabelText, getByRole, "agentpod:hermes:*");
+
+  expect(await findByText(/must name a node/i)).toBeTruthy();
+  await fireEvent.click(getByRole("button", { name: /save/i }));
+  expect(grantsApi.setGrant).not.toHaveBeenCalled();
+});
+
+test("refuses a value that names no plane", async () => {
+  const { getByLabelText, getByRole, findByText } = open();
+
+  await addValue(getByLabelText, getByRole, "hermes:*");
+
+  expect(await findByText(/must name a plane/i)).toBeTruthy();
+});
+
+test("saves the whole grant, so removing a value actually narrows it", async () => {
+  // Whole-object on purpose: an authorization surface must never be easier to
+  // widen than to narrow. A merge would make removal the harder operation.
+  const onSaved = vi.fn();
+  const { getByRole, getAllByRole } = open({
+    grant: {
+      mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_7abf"],
+      mayGrantReach: false,
+    },
+    onSaved,
+  });
+
+  await fireEvent.click(getAllByRole("button", { name: /remove value/i })[0]!);
+  await fireEvent.click(getByRole("button", { name: /save/i }));
+
+  await waitFor(() =>
+    expect(grantsApi.setGrant).toHaveBeenCalledWith("user_abc", {
+      mayDispatch: ["kaambaan:agt_7abf"],
+      mayGrantReach: false,
+    })
+  );
+  await waitFor(() => expect(onSaved).toHaveBeenCalled());
+});
+
+test("adds a valid value and carries it into the save", async () => {
+  const { getByLabelText, getByRole } = open();
+
+  await addValue(getByLabelText, getByRole, "agentpod:*/hermes:*");
+  await fireEvent.click(getByRole("button", { name: /save/i }));
+
+  await waitFor(() =>
+    expect(grantsApi.setGrant).toHaveBeenCalledWith("user_abc", {
+      mayDispatch: ["agentpod:*/hermes:*"],
+      mayGrantReach: false,
+    })
+  );
+});
+
+test("does not add the same value twice", async () => {
+  // A duplicate grants nothing extra and makes the list harder to read, which is
+  // how an over-wide grant hides in plain sight.
+  const { getByLabelText, getByRole, getAllByText } = open({
+    grant: { mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+  });
+
+  await addValue(getByLabelText, getByRole, "kaambaan:agt_7abf");
+
+  expect(getAllByText("kaambaan:agt_7abf")).toHaveLength(1);
+});
+
+test("an empty grant is savable, because 'permitted nothing' is a real decision", async () => {
+  const { getByRole } = open({
+    grant: { mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+  });
+
+  await fireEvent.click(getByRole("button", { name: /remove value/i }));
+  await fireEvent.click(getByRole("button", { name: /save/i }));
+
+  await waitFor(() =>
+    expect(grantsApi.setGrant).toHaveBeenCalledWith("user_abc", {
+      mayDispatch: [],
+      mayGrantReach: false,
+    })
+  );
+});
+
+test("a failed save keeps the dialog open with the edits intact", async () => {
+  // Losing a half-written grant to a network blip is how people end up applying
+  // a wider one the second time, just to be done with it.
+  vi.mocked(grantsApi.setGrant).mockRejectedValueOnce(new Error("hub unreachable"));
+  const { getByLabelText, getByRole, getByText } = open();
+
+  await addValue(getByLabelText, getByRole, "kaambaan:agt_7abf");
+  await fireEvent.click(getByRole("button", { name: /save/i }));
+
+  const { toast } = await import("svelte-sonner");
+  await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  expect(getByText("kaambaan:agt_7abf")).toBeTruthy();
+});

--- a/apps/console/src/routes/admin/grants/+page.svelte
+++ b/apps/console/src/routes/admin/grants/+page.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+  /**
+   * Grants — who may dispatch which agent.
+   *
+   * The control pair used to be operable only by `curl` or a database client,
+   * which is not a control an organisation can actually use: an authorization
+   * system nobody can inspect is one people route around. This page is the
+   * inspection.
+   *
+   * Two things it must never do. It must not imply a grant is being enforced
+   * when `ENFORCE_CONTROL_PAIR` is unset — hence the banner, driven by the
+   * server's own answer rather than a build flag. And it must not hide a grant
+   * whose principal no longer exists: those still match tokens if that id is ever
+   * reissued, and they are exactly what nobody goes looking for.
+   */
+  import { onMount } from "svelte";
+  import { toast } from "svelte-sonner";
+  import { listUsers } from "$lib/api/admin";
+  import { listGrants, deleteGrant, type PrincipalGrant, type Grant } from "$lib/api/grants";
+  import { listNodes, listStations } from "$lib/api/client";
+  import type { AdminUserView } from "@agentpod/types";
+  import { Button } from "$lib/components/ui/button";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Skeleton } from "$lib/components/ui/skeleton";
+  import PageHeader from "$lib/components/page-header.svelte";
+  import AdminTabs from "$lib/components/admin/AdminTabs.svelte";
+  import GrantDialog from "$lib/components/admin/GrantDialog.svelte";
+  import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
+  import ShieldIcon from "@lucide/svelte/icons/shield";
+  import ShieldOffIcon from "@lucide/svelte/icons/shield-off";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
+  import Trash2Icon from "@lucide/svelte/icons/trash-2";
+
+  const NO_GRANT: Grant = { mayDispatch: [], mayGrantReach: false };
+
+  interface Row {
+    principalId: string;
+    label: string;
+    sublabel: string | null;
+    grant: Grant;
+    granted: boolean;
+    /** A grant whose principal is not a user here — kept visible on purpose. */
+    orphan: boolean;
+  }
+
+  let isLoading = $state(true);
+  let error = $state<string | null>(null);
+  let enforced = $state(false);
+  let rows = $state<Row[]>([]);
+  let stationValues = $state<string[]>([]);
+
+  let showDialog = $state(false);
+  let editing = $state<Row | null>(null);
+  let showRemove = $state(false);
+  let removing = $state<Row | null>(null);
+
+  async function loadData() {
+    isLoading = true;
+    error = null;
+    try {
+      const [usersResponse, grantsResponse] = await Promise.all([
+        listUsers({ limit: 200 }),
+        listGrants(),
+      ]);
+
+      enforced = grantsResponse.enforced;
+      const byPrincipal = new Map<string, PrincipalGrant>(
+        grantsResponse.grants.map((g) => [g.principalId, g])
+      );
+
+      const users: Row[] = usersResponse.users.map((u: AdminUserView) => {
+        const grant = byPrincipal.get(u.id);
+        byPrincipal.delete(u.id);
+        return {
+          principalId: u.id,
+          label: u.name || u.email,
+          sublabel: u.name ? u.email : null,
+          grant: grant ?? NO_GRANT,
+          granted: grant !== undefined,
+          orphan: false,
+        };
+      });
+
+      // Whatever is left names a principal this hub has no user for — a deleted
+      // account, or an id from another issuer. Shown last, and marked.
+      const orphans: Row[] = [...byPrincipal.values()].map((g) => ({
+        principalId: g.principalId,
+        label: g.principalId,
+        sublabel: null,
+        grant: { mayDispatch: g.mayDispatch, mayGrantReach: g.mayGrantReach },
+        granted: true,
+        orphan: true,
+      }));
+
+      rows = [...users, ...orphans];
+    } catch (e) {
+      error = (e as Error).message || "Couldn’t load grants.";
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  /**
+   * Live stations, as grant values.
+   *
+   * Best-effort and non-blocking: these are suggestions, and a fleet that is
+   * unreachable must not stop someone editing a grant — narrowing one is exactly
+   * what you do when something has gone wrong.
+   */
+  async function loadStationValues() {
+    try {
+      const nodes = await listNodes();
+      const perNode = await Promise.all(
+        nodes.map(async (n) => {
+          try {
+            const stations = await listStations(n.id);
+            return stations.map((s) => `agentpod:${n.name}/${s.stationKey}`);
+          } catch {
+            return [];
+          }
+        })
+      );
+      stationValues = [...new Set(perNode.flat())].sort();
+    } catch {
+      stationValues = [];
+    }
+  }
+
+  onMount(() => {
+    loadData();
+    loadStationValues();
+  });
+
+  function openEdit(row: Row) {
+    editing = row;
+    showDialog = true;
+  }
+
+  function openRemove(row: Row) {
+    removing = row;
+    showRemove = true;
+  }
+
+  async function handleRemove() {
+    if (!removing) return;
+    const target = removing;
+    try {
+      await deleteGrant(target.principalId);
+      toast.success(`Grant removed for ${target.label}`);
+      await loadData();
+    } catch (e) {
+      toast.error("Couldn’t remove grant", { description: (e as Error).message });
+    } finally {
+      showRemove = false;
+      removing = null;
+    }
+  }
+
+  let grantedCount = $derived(rows.filter((r) => r.granted).length);
+</script>
+
+<svelte:head>
+  <title>Grants · Admin · AgentPod</title>
+</svelte:head>
+
+<PageHeader title="Admin" subtitle="Who may dispatch which agent" />
+
+<div class="container mx-auto max-w-5xl space-y-6 px-4 py-6">
+  <AdminTabs active="grants" />
+
+  {#if !isLoading && !error}
+    <div
+      class="flex items-start gap-3 rounded-lg border p-4 {enforced
+        ? 'border-primary/40 bg-primary/5'
+        : 'border-amber-500/50 bg-amber-500/5'}"
+      data-testid="enforcement-banner"
+    >
+      {#if enforced}
+        <ShieldIcon class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+        <div class="space-y-0.5">
+          <p class="text-sm font-medium">Enforced</p>
+          <p class="text-xs text-muted-foreground">
+            Dispatch is refused unless a grant permits it. A principal with no grant is refused
+            everywhere — on this console and on the kaambaan board.
+          </p>
+        </div>
+      {:else}
+        <ShieldOffIcon class="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+        <div class="space-y-0.5">
+          <p class="text-sm font-medium">Not enforced</p>
+          <p class="text-xs text-muted-foreground">
+            These grants are recorded and nothing is checking them: every principal can dispatch
+            every agent. Set <code>ENFORCE_CONTROL_PAIR=true</code> on the hub to make them real.
+          </p>
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if isLoading}
+    <div class="space-y-2">
+      {#each [1, 2, 3] as _}
+        <Skeleton class="h-16 rounded-sm" />
+      {/each}
+    </div>
+  {:else if error}
+    <div
+      class="flex items-start justify-between gap-3 rounded-lg border border-destructive/50 bg-destructive/5 p-4"
+      role="alert"
+    >
+      <p class="text-sm text-destructive">{error}</p>
+      <Button variant="outline" size="sm" onclick={loadData}>Retry</Button>
+    </div>
+  {:else}
+    <p class="text-xs text-muted-foreground">
+      {grantedCount} of {rows.length} principals have a grant.
+    </p>
+
+    <ul class="space-y-2">
+      {#each rows as row (row.principalId)}
+        <li class="rounded-lg border p-4" data-testid="grant-row">
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0 space-y-1">
+              <div class="flex items-center gap-2">
+                <p class="text-sm font-medium">{row.label}</p>
+                {#if row.orphan}
+                  <Badge variant="outline" class="text-amber-600">No such user</Badge>
+                {/if}
+                {#if row.grant.mayGrantReach}
+                  <Badge variant="outline">May grant reach</Badge>
+                {/if}
+              </div>
+              {#if row.sublabel}
+                <p class="text-xs text-muted-foreground">{row.sublabel}</p>
+              {/if}
+
+              {#if row.grant.mayDispatch.length > 0}
+                <ul class="flex flex-wrap gap-1 pt-1">
+                  {#each row.grant.mayDispatch as value (value)}
+                    <li>
+                      <Badge variant="secondary" class="font-mono text-[11px]">{value}</Badge>
+                    </li>
+                  {/each}
+                </ul>
+              {:else}
+                <p class="pt-1 text-xs text-muted-foreground">
+                  {row.granted
+                    ? "Granted nothing — considered, and permitted nothing."
+                    : "No grant."}
+                </p>
+              {/if}
+            </div>
+
+            <div class="flex shrink-0 items-center gap-2">
+              <Button variant="outline" size="sm" onclick={() => openEdit(row)}>
+                <PencilIcon class="mr-1 h-3.5 w-3.5" />
+                {row.granted ? "Edit" : "Grant"}
+              </Button>
+              {#if row.granted}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  onclick={() => openRemove(row)}
+                  aria-label="Remove grant for {row.label}"
+                >
+                  <Trash2Icon class="h-3.5 w-3.5" />
+                </Button>
+              {/if}
+            </div>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<GrantDialog
+  bind:open={showDialog}
+  principal={editing ? { id: editing.principalId, label: editing.label } : null}
+  grant={editing?.grant ?? NO_GRANT}
+  {stationValues}
+  onSaved={loadData}
+/>
+
+<ConfirmDialog
+  open={showRemove}
+  title="Remove grant"
+  message="{removing?.label} keeps no permissions. Under enforcement they are refused everywhere — 'never considered' rather than 'considered and permitted nothing', though both deny."
+  confirmLabel="Remove grant"
+  destructive
+  onConfirm={handleRemove}
+  onCancel={() => {
+    showRemove = false;
+    removing = null;
+  }}
+/>

--- a/apps/console/src/routes/admin/grants/page.svelte.test.ts
+++ b/apps/console/src/routes/admin/grants/page.svelte.test.ts
@@ -1,0 +1,162 @@
+/**
+ * page.svelte.test.ts
+ *
+ * The grants page — the first place an operator can see who may dispatch what.
+ *
+ * Two beliefs this page must never create, and both are asserted here:
+ *
+ *  - that a grant is being enforced when nothing is enforcing it. With
+ *    `ENFORCE_CONTROL_PAIR` unset every row here is decoration, and a narrow
+ *    grant would read as a locked-down fleet.
+ *  - that the list is complete when a grant names a principal this hub has no
+ *    user for. Those still match if that id is ever reissued, and they are
+ *    exactly what nobody goes looking for.
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+
+vi.mock("svelte-sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("$lib/api/admin", () => ({
+  listUsers: vi.fn(),
+}));
+
+vi.mock("$lib/api/client", () => ({
+  listNodes: vi.fn(),
+  listStations: vi.fn(),
+}));
+
+vi.mock("$lib/api/grants", async () => {
+  const actual = await vi.importActual<typeof import("$lib/api/grants")>("$lib/api/grants");
+  return {
+    grantValueProblem: actual.grantValueProblem,
+    KNOWN_PLANES: actual.KNOWN_PLANES,
+    listGrants: vi.fn(),
+    setGrant: vi.fn(),
+    deleteGrant: vi.fn(),
+  };
+});
+
+import * as adminApi from "$lib/api/admin";
+import * as clientApi from "$lib/api/client";
+import * as grantsApi from "$lib/api/grants";
+import GrantsPage from "./+page.svelte";
+
+function user(id: string, email: string) {
+  return {
+    id,
+    email,
+    name: "",
+    image: null,
+    emailVerified: true,
+    role: "user",
+    banned: false,
+    bannedReason: null,
+    bannedAt: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  };
+}
+
+function setup({
+  users = [user("user_1", "jo@example.com")],
+  grants = [] as Array<{ principalId: string; mayDispatch: string[]; mayGrantReach: boolean }>,
+  enforced = true,
+} = {}) {
+  vi.mocked(adminApi.listUsers).mockResolvedValue({ users, total: users.length } as never);
+  vi.mocked(grantsApi.listGrants).mockResolvedValue({ grants, enforced });
+  vi.mocked(clientApi.listNodes).mockResolvedValue([] as never);
+  return render(GrantsPage);
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(cleanup);
+
+test("lists a principal's grant values", async () => {
+  const { findByText } = setup({
+    grants: [
+      { principalId: "user_1", mayDispatch: ["agentpod:molt-bot/hermes:*"], mayGrantReach: false },
+    ],
+  });
+
+  expect(await findByText("jo@example.com")).toBeTruthy();
+  expect(await findByText("agentpod:molt-bot/hermes:*")).toBeTruthy();
+});
+
+test("says so loudly when nothing is enforcing these grants", async () => {
+  const { findByTestId } = setup({ enforced: false });
+
+  const banner = await findByTestId("enforcement-banner");
+  // Collapsed: the copy wraps, so the rendered text carries newlines mid-phrase.
+  const text = banner.textContent!.replace(/\s+/g, " ");
+  expect(text).toMatch(/not enforced/i);
+  // The consequence, not just the state: a page that said "disabled" and stopped
+  // would still let someone read a narrow grant as a narrow fleet.
+  expect(text).toMatch(/every principal can dispatch every agent/i);
+});
+
+test("shows a principal with no grant rather than hiding them", async () => {
+  // "No grant" is the state that denies everything under enforcement — the last
+  // thing to discover by having dispatch fail.
+  const { findByText } = setup({ grants: [] });
+
+  expect(await findByText("jo@example.com")).toBeTruthy();
+  // Exact: the enforced banner also explains what having no grant costs.
+  expect(await findByText("No grant.")).toBeTruthy();
+});
+
+test("keeps a grant whose principal is not a user here, and marks it", async () => {
+  const { findByText } = setup({
+    grants: [
+      { principalId: "user_gone", mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+    ],
+  });
+
+  expect(await findByText("user_gone")).toBeTruthy();
+  expect(await findByText(/no such user/i)).toBeTruthy();
+});
+
+test("distinguishes granted-nothing from never-granted", async () => {
+  // Both deny. They read differently to whoever comes next, and the difference
+  // is the only record of whether anyone considered this principal at all.
+  const { findByText } = setup({
+    users: [user("user_1", "jo@example.com")],
+    grants: [{ principalId: "user_1", mayDispatch: [], mayGrantReach: false }],
+  });
+
+  expect(await findByText(/considered, and permitted nothing/i)).toBeTruthy();
+});
+
+test("removing a grant asks first, then reloads", async () => {
+  const { findByRole, getByRole } = setup({
+    grants: [
+      { principalId: "user_1", mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+    ],
+  });
+
+  await fireEvent.click(await findByRole("button", { name: /remove grant for/i }));
+  await fireEvent.click(getByRole("button", { name: /^remove grant$/i }));
+
+  await waitFor(() => expect(grantsApi.deleteGrant).toHaveBeenCalledWith("user_1"));
+  // Reloaded rather than patched locally: the server is the authority on what a
+  // grant is now, and a stale row here is a wrong belief about permission.
+  await waitFor(() => expect(grantsApi.listGrants).toHaveBeenCalledTimes(2));
+});
+
+test("an unreachable fleet does not stop grant editing", async () => {
+  // Narrowing a grant is exactly what you do when something has gone wrong, so
+  // station suggestions failing must not take the page with them.
+  vi.mocked(clientApi.listNodes).mockRejectedValue(new Error("nodes unreachable"));
+  const { findByText } = setup({
+    grants: [
+      { principalId: "user_1", mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+    ],
+  });
+
+  expect(await findByText("kaambaan:agt_7abf")).toBeTruthy();
+});

--- a/apps/console/src/routes/admin/users/+page.svelte
+++ b/apps/console/src/routes/admin/users/+page.svelte
@@ -21,6 +21,7 @@
   import { Badge, badgeVariants } from "$lib/components/ui/badge";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import PageHeader from "$lib/components/page-header.svelte";
+  import AdminTabs from "$lib/components/admin/AdminTabs.svelte";
   import AdminStats from "$lib/components/admin/AdminStats.svelte";
   import AdminSettingsBar from "$lib/components/admin/AdminSettingsBar.svelte";
   import UserFilters from "$lib/components/admin/UserFilters.svelte";
@@ -241,6 +242,8 @@
 <PageHeader title="Admin" subtitle="User management" />
 
 <div class="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+  <AdminTabs active="users" />
+
   {#if stats}
     <AdminStats {stats} />
   {/if}

--- a/apps/hub/src/routes/admin-grants.ts
+++ b/apps/hub/src/routes/admin-grants.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { createLogger } from "../utils/logger";
 import { getGrant, setGrant, deleteGrant, listGrants, NO_GRANT } from "../services/grants";
+import { isControlPairEnforced } from "../services/control-pair";
 
 const log = createLogger("admin-grants");
 
@@ -45,6 +46,21 @@ const grantValue = z
   .refine(
     (v) => KNOWN_PLANES.some((p) => v.startsWith(`${p}:`) && v.length > p.length + 1),
     `a grant value must name a known plane: ${KNOWN_PLANES.map((p) => `${p}:…`).join(", ")}`
+  )
+  /**
+   * An AgentPod value names a node as well as a station.
+   *
+   * `agentpod:hermes:*` is the shape everyone writes first and it matches no
+   * station on any node, because uniqueness is `(node, stationKey)`
+   * (`charter` → `decisions/2026-08-15-a-grant-names-an-agent-per-plane.md`,
+   * amended). The reader already ignores it; refusing it here is the difference
+   * between a typo answered in a form and a grant that looks live and permits
+   * nothing. Fleet-wide is still available — it just has to be said out loud,
+   * with an explicit wildcard in the node half.
+   */
+  .refine(
+    (v) => !v.startsWith("agentpod:") || v.slice("agentpod:".length).includes("/"),
+    "an agentpod value must name a node too: agentpod:<node>/<stationKey>, e.g. agentpod:*/hermes:*"
   );
 
 const grantBody = z.object({
@@ -53,9 +69,17 @@ const grantBody = z.object({
 });
 
 export const adminGrantsRouter = new Hono()
-  /** Every grant. The answer to "who may dispatch what", which nothing else answers. */
+  /**
+   * Every grant, and whether anything is enforcing them.
+   *
+   * `enforced` is not decoration. With `ENFORCE_CONTROL_PAIR` unset these rows
+   * are recorded and nothing checks them, and a console that showed a narrow
+   * grant without saying so would tell an operator the fleet was locked down
+   * while it was wide open. That is the one wrong belief this surface must never
+   * create, so the switch travels with the data.
+   */
   .get("/", async (c) => {
-    return c.json({ grants: await listGrants() });
+    return c.json({ grants: await listGrants(), enforced: isControlPairEnforced() });
   })
 
   /**

--- a/apps/hub/tests/integration/admin-grants-route.test.ts
+++ b/apps/hub/tests/integration/admin-grants-route.test.ts
@@ -62,14 +62,14 @@ describe("/api/admin/grants", () => {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+        mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_x"],
         mayGrantReach: true,
       }),
     });
     expect(res.status).toBe(200);
 
     expect(await getGrant(SUBJECT)).toEqual({
-      mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+      mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_x"],
       mayGrantReach: true,
     });
   });
@@ -94,28 +94,28 @@ describe("/api/admin/grants", () => {
     const res = await app().request(`/grants/${SUBJECT}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["agentpod:hermes:*"] }),
+      body: JSON.stringify({ mayDispatch: ["agentpod:molt-bot/hermes:*"] }),
     });
     expect(res.status).toBe(400);
   });
 
   test("replaces rather than merges, so narrowing is as easy as widening", async () => {
     await setGrant(SUBJECT, {
-      mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+      mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_x"],
       mayGrantReach: true,
     });
 
     await app().request(`/grants/${SUBJECT}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["agentpod:hermes:analyst-echo"], mayGrantReach: false }),
+      body: JSON.stringify({ mayDispatch: ["agentpod:molt-bot/hermes:analyst-echo"], mayGrantReach: false }),
     });
 
     // A PATCH that merged arrays would make removing a permission harder than
     // adding one, and an authorization surface must never be easier to widen
     // than to narrow.
     expect(await getGrant(SUBJECT)).toEqual({
-      mayDispatch: ["agentpod:hermes:analyst-echo"],
+      mayDispatch: ["agentpod:molt-bot/hermes:analyst-echo"],
       mayGrantReach: false,
     });
   });
@@ -124,6 +124,50 @@ describe("/api/admin/grants", () => {
     const res = await app().request("/grants");
     const body = (await res.json()) as { grants: Array<{ principalId: string }> };
     expect(body.grants.some((g) => g.principalId === SUBJECT)).toBe(true);
+  });
+
+  test("says whether anything is actually enforcing these grants", async () => {
+    // A console that showed grants without this would be showing a control that
+    // may or may not be connected to anything: with `ENFORCE_CONTROL_PAIR`
+    // unset, every grant here is recorded and nothing checks it. An operator
+    // reading a narrow grant would believe the fleet was locked down when it was
+    // wide open, which is the one wrong belief this page must never create.
+    const before = process.env.ENFORCE_CONTROL_PAIR;
+    try {
+      process.env.ENFORCE_CONTROL_PAIR = "false";
+      const off = (await (await app().request("/grants")).json()) as { enforced: boolean };
+      expect(off.enforced).toBe(false);
+
+      process.env.ENFORCE_CONTROL_PAIR = "true";
+      const on = (await (await app().request("/grants")).json()) as { enforced: boolean };
+      expect(on.enforced).toBe(true);
+    } finally {
+      if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;
+      else process.env.ENFORCE_CONTROL_PAIR = before;
+    }
+  });
+
+  test("refuses an AgentPod value that names no node, because it matches nothing", async () => {
+    // `agentpod:hermes:*` is the shape everyone writes first, and since the
+    // amendment it matches no station on any node — uniqueness is (node, key).
+    // Stored, it reads as a working grant and permits nothing, which is the
+    // failure this writer exists to prevent. Fleet-wide has to be said out loud.
+    const res = await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mayDispatch: ["agentpod:hermes:*"], mayGrantReach: false }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/node/i);
+  });
+
+  test("accepts fleet-wide only when it is written out", async () => {
+    const res = await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false }),
+    });
+    expect(res.status).toBe(200);
   });
 
   test("removing a grant is not the same as emptying it", async () => {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -409,10 +409,20 @@ a staging box silently cover production. Node **names** are unique within a
 tenant by construction: enrolment suffixes a hostname collision (`molt-bot`,
 `molt-bot-2`) and a unique index enforces it.
 
-**Two retired forms match nothing**, deliberately: an unprefixed `hermes:*` (the
+**Two retired forms are refused when written**: an unprefixed `hermes:*` (the
 old `CONTROL_PAIR_GRANTS` format) and a two-part `agentpod:hermes:*`, which
-cannot say which node it meant. `[]` denies — it is what you write to suspend
-someone without deleting their grant.
+cannot say which node it meant. Both used to store happily and match nothing,
+which reads exactly like a working grant — the writer now answers `400` instead,
+while a *reader* still ignores anything it does not recognise. `[]` denies — it
+is what you write to suspend someone without deleting their grant.
+
+**Manage them in the console: Admin → Grants.** It lists every principal with
+their values, marks grants whose principal is no longer a user here, and — read
+this before trusting a narrow grant — says at the top whether
+`ENFORCE_CONTROL_PAIR` is actually on. With it off the page is a plan, not a
+control. `GET|PUT|DELETE /api/admin/grants[/:principalId]` is the same surface
+for scripts; `PUT` replaces the whole grant rather than merging, so narrowing is
+never harder than widening.
 
 Why values are namespaced, and where that ends:
 `charter` → `decisions/2026-08-15-a-grant-names-an-agent-per-plane.md`.


### PR DESCRIPTION
The last piece of the issuer-driven Organization layer. Grants were operable only by `curl` or a database client — an authorization system nobody can inspect is one people route around.

## Admin → Grants

Lists every principal with their `mayDispatch` values and `mayGrantReach`, edits them in place, and removes them. Three things it has to get right, all of them about wrong beliefs an operator could otherwise form:

- **Enforcement travels with the data.** `GET /api/admin/grants` now answers `enforced` as well. Without it, a narrow grant shown on a hub with `ENFORCE_CONTROL_PAIR` unset would read as a locked-down fleet while every principal could dispatch every agent. The banner says which it is, and what that costs.
- **Orphan grants stay visible.** A grant naming a principal this hub has no user for is marked, not hidden: it still matches if that id is ever reissued.
- **Granted-nothing ≠ never-granted.** Both deny under enforcement; they read differently to whoever comes next, and the difference is the only record that anyone considered this principal at all.

Live stations are offered as suggestions (`agentpod:<node>/<stationKey>`), best-effort — an unreachable fleet must not stop someone *narrowing* a grant, which is exactly what you do when something has gone wrong. Values remain exact strings rather than checkboxes over stations, because a grant outlives the station it names.

## The writer now refuses grants that match nothing

`agentpod:hermes:*` is the shape everyone writes first, and it has matched nothing since a value learned to name a node (station keys repeat across the fleet — `opencode:c52ddf65` exists on two nodes). It stored happily and read as a working grant. It is a `400` now, in both the API and the form. Fleet-wide is still available; it just has to be said out loud as `agentpod:*/hermes:*`. The **reader** is unchanged and still ignores what it does not recognise — a claim is read by more planes over time, not fewer.

## Notes

- The dialog refuses to save while a rejected value sits in the input rather than dropping it silently — the one defect the tests caught rather than confirmed.
- Admin sections are anchors above the page, not `PageHeader` tabs: each is a real URL, and the header's tab strip needs a tooltip context that only exists inside the app shell.
- `docs/DEPLOYMENT.md` points at the page and records the refusal.

## Tests

- `apps/hub` — 1138 pass, including `enforced` in the list response and the two-part refusal.
- `apps/console` — 15 new (`GrantDialog.svelte.test.ts` 8, `admin/grants/page.svelte.test.ts` 7); `pnpm check` clean, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW