### PR TITLE
docs(spec): granting an agent its reach — design for #345

### DIFF
--- a/apps/console/src/lib/api/my-grant.test.ts
+++ b/apps/console/src/lib/api/my-grant.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./client", () => ({ http: vi.fn() }));
+
+import { http } from "./client";
+import { myReach, forgetMyReach } from "./my-grant";
+
+/**
+ * What this browser's principal may do, according to the issuer.
+ *
+ * Advisory only — the hub decides. This exists so a control that would be
+ * refused can say so before it is clicked, which is the difference between a
+ * greyed button with a reason and a 403 that looks like a bug.
+ *
+ * The interesting case is the failure one. Guessing "denied" when we cannot find
+ * out would hide a control the operator actually holds, possibly on a deployment
+ * where the pair is not even enforced — a worse wrong answer than letting the
+ * hub refuse.
+ */
+
+function tokenWith(claims: Record<string, unknown>): string {
+  const payload = btoa(JSON.stringify(claims)).replace(/=+$/, "");
+  return `header.${payload}.signature`;
+}
+
+beforeEach(() => {
+  forgetMyReach();
+  vi.clearAllMocks();
+});
+afterEach(() => forgetMyReach());
+
+test("reports the claim the issuer put in the token", async () => {
+  vi.mocked(http).mockResolvedValue({ token: tokenWith({ mayGrantReach: true }) });
+  expect((await myReach()).mayGrantReach).toBe(true);
+});
+
+test("reports false when the claim says false", async () => {
+  vi.mocked(http).mockResolvedValue({ token: tokenWith({ mayGrantReach: false }) });
+  expect((await myReach()).mayGrantReach).toBe(false);
+});
+
+test("assumes permitted when it cannot find out, and lets the hub refuse", async () => {
+  vi.mocked(http).mockRejectedValue(new Error("hub unreachable"));
+  expect((await myReach()).mayGrantReach).toBe(true);
+});
+
+test("assumes permitted when the token carries no such claim", async () => {
+  // An older hub that does not issue the pair must not have its console decide
+  // everything is forbidden.
+  vi.mocked(http).mockResolvedValue({ token: tokenWith({ sub: "user_1" }) });
+  expect((await myReach()).mayGrantReach).toBe(true);
+});
+
+test("asks once per page load", async () => {
+  vi.mocked(http).mockResolvedValue({ token: tokenWith({ mayGrantReach: true }) });
+
+  await myReach();
+  await myReach();
+  await myReach();
+
+  expect(http).toHaveBeenCalledTimes(1);
+});

--- a/apps/console/src/lib/api/my-grant.ts
+++ b/apps/console/src/lib/api/my-grant.ts
@@ -1,0 +1,59 @@
+/**
+ * What this browser's principal may do, according to the issuer.
+ *
+ * Read out of the principal's own token rather than from a new endpoint — the
+ * hub already mints one at `/api/auth/token` carrying `mayDispatch` and
+ * `mayGrantReach`, and kaambaan's web app reads it the same way (kaambaan#43).
+ *
+ * **Advisory only.** The hub decides; this exists so a control that will be
+ * refused can say so before it is clicked. When it cannot find out it answers
+ * *permitted* and lets the hub refuse: guessing "denied" would hide a control
+ * the operator actually holds — possibly on a deployment where the pair is not
+ * even enforced — which is the worse of the two wrong answers.
+ */
+
+import { http } from "./client";
+
+export interface MyReach {
+  mayGrantReach: boolean;
+}
+
+/** The answer when the issuer cannot be asked, or does not speak the pair yet. */
+const PERMITTED: MyReach = { mayGrantReach: true };
+
+let cached: Promise<MyReach> | null = null;
+
+/** Claims without verifying — the hub verifies; this only decides what to grey out. */
+function claimsOf(jwt: string): Record<string, unknown> | null {
+  try {
+    const [, payload] = jwt.split(".");
+    if (!payload) return null;
+    return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+  } catch {
+    return null;
+  }
+}
+
+export function myReach(): Promise<MyReach> {
+  // One mint per page load. The claim cannot change without an admin editing a
+  // grant, and a stale answer only ever costs a 403 the hub would give anyway.
+  if (cached) return cached;
+
+  cached = (async () => {
+    try {
+      const { token } = await http<{ token?: string }>("/api/auth/token");
+      const claims = token ? claimsOf(token) : null;
+      if (!claims || typeof claims.mayGrantReach !== "boolean") return PERMITTED;
+      return { mayGrantReach: claims.mayGrantReach };
+    } catch {
+      return PERMITTED;
+    }
+  })();
+
+  return cached;
+}
+
+/** Drop the cached answer — after signing out, or in tests. */
+export function forgetMyReach(): void {
+  cached = null;
+}

--- a/apps/console/src/lib/components/admin/GrantDialog.svelte
+++ b/apps/console/src/lib/components/admin/GrantDialog.svelte
@@ -193,8 +193,9 @@
           <div class="space-y-0.5">
             <Label for="may-grant-reach">May grant reach</Label>
             <p class="text-xs text-muted-foreground">
-              The second half of the pair: whether this principal may widen what an agent can
-              reach. Not yet enforced anywhere — recorded so it is decided before it is needed.
+              The second half of the pair: whether this principal may change what an agent
+              <em>is</em> — write into its workspace, open a terminal on it, delete its files, or
+              add a machine to the fleet. Dispatching an agent needs only the values above.
             </p>
           </div>
           <Switch id="may-grant-reach" bind:checked={mayGrantReach} />

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -14,6 +14,7 @@
   import PostureBanner from "$lib/components/stations/PostureBanner.svelte";
   import ActivityPanel from "$lib/components/stations/ActivityPanel.svelte";
   import { listStations } from "$lib/api/client";
+  import { myReach } from "$lib/api/my-grant";
   import type { StationRow } from "$lib/api/client";
   import PageHeader from "$lib/components/page-header.svelte";
   import { Button } from "$lib/components/ui/button";
@@ -107,8 +108,20 @@
     Array.isArray(station?.capabilities) && station!.capabilities.includes("terminal")
   );
 
+  /**
+   * Whether this principal may change what this agent *is* — the reach half of
+   * the control pair (#345).
+   *
+   * Advisory: the hub refuses regardless. It is read so a control that would be
+   * refused can say so rather than 403 on click, and it defaults to true so a
+   * hub that cannot be asked never hides a control the operator holds.
+   */
+  let mayGrantReach = $state(true);
+
   const canWrite = $derived(
-    Array.isArray(station?.capabilities) && station!.capabilities.includes("fs.write")
+    Array.isArray(station?.capabilities) &&
+      station!.capabilities.includes("fs.write") &&
+      mayGrantReach
   );
 
   const canLifecycle = $derived(
@@ -140,6 +153,7 @@
 
   onMount(() => {
     void loadStation();
+    void myReach().then((r) => (mayGrantReach = r.mayGrantReach));
   });
 
   const tabs = $derived.by(() => [
@@ -147,7 +161,20 @@
     { id: "health", label: "Health", icon: HeartPulseIcon },
     { id: "logs", label: "Logs", icon: ScrollTextIcon },
     { id: "files", label: "Files", icon: FolderIcon },
-    ...(hasTerminal ? [{ id: "terminal", label: "Terminal", icon: TerminalIcon }] : []),
+    ...(hasTerminal
+      ? [
+          {
+            id: "terminal",
+            label: "Terminal",
+            icon: TerminalIcon,
+            // A shell changes what an agent is, so it sits behind mayGrantReach.
+            // Shown-and-locked rather than hidden: a missing tab reads as "this
+            // agent has no terminal", which is a different and wrong answer.
+            disabled: !mayGrantReach,
+            disabledReason: "You may dispatch this agent but not change it",
+          },
+        ]
+      : []),
     ...(hasChangeset ? [{ id: "changes", label: "Changes", icon: GitCompareIcon }] : []),
     ...(hasCleanup ? [{ id: "cleanup", label: "Cleanup", icon: Trash2Icon }] : []),
     { id: "activity", label: "Activity", icon: ActivityIcon },

--- a/apps/hub/src/routes/enrollment-tokens.ts
+++ b/apps/hub/src/routes/enrollment-tokens.ts
@@ -1,13 +1,34 @@
 import { Hono } from "hono";
 import { mintEnrollmentToken } from "../services/enrollment";
+import { requireFleetGrantReach } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
 
 /**
  * POST /api/enrollment-tokens
  * Authenticated route — mints a one-time enrollment token for the current user.
  * Returns { token, expiresAt } where `token` is the plaintext token (shown once).
+ *
+ * Behind the reach half of the control pair (#345). A machine joining the fleet
+ * is an agent being *registered*, which charter Decision 4 names as granting
+ * reach: "anyone who can register an agent and grant it production credentials
+ * … they build the agent they want."
+ *
+ * It names no station, so there is no pattern to match against and the rule is
+ * the narrower one — you may grow a fleet only if your authority already spans
+ * it. Enforced on the route rather than in `mintEnrollmentToken`, because the
+ * service is also how the *node* re-enrols itself and how tests build fixtures;
+ * this is a check on a person asking, not on a token being made.
  */
 export const enrollmentTokenRoutes = new Hono().post("/", async (c) => {
   const user = c.get("user");
+
+  try {
+    await requireFleetGrantReach(user.id);
+  } catch (e) {
+    if (!isGrantReachDenied(e)) throw e;
+    return c.json({ error: "You do not have permission to add machines to this fleet." }, 403);
+  }
+
   const { token, expiresAt } = await mintEnrollmentToken(user.id);
   return c.json({ token, expiresAt: expiresAt.toISOString() });
 });

--- a/apps/hub/src/routes/station-cleanup.ts
+++ b/apps/hub/src/routes/station-cleanup.ts
@@ -25,7 +25,7 @@ import { db } from "../db/drizzle";
 import * as broker from "../services/broker";
 import { getStation } from "../services/station-registry";
 import { recordAudit } from "../services/audit";
-import { gateCapability } from "./station-writes";
+import { gateCapability, refuseWithoutReach } from "./station-writes";
 import type { AuthUser } from "../auth/middleware";
 
 // ─── Error-to-status helper ───────────────────────────────────────────────────
@@ -132,6 +132,14 @@ export const stationCleanupRoutes = new Hono()
           403
         );
       }
+
+      // ── 3b. Reach gate (#345) ──────────────────────────────────────────────
+      // `plan` above shares this capability and is a read; deleting an agent's
+      // files is not. So the split is on the route's effect, not the capability
+      // word — guarding the word would refuse someone permission to find out
+      // what a cleanup would remove.
+      const denial = await refuseWithoutReach(c, user.id, station, "cleanup");
+      if (denial) return denial;
 
       const { paths } = c.req.valid("json");
 

--- a/apps/hub/src/routes/station-terminal.test.ts
+++ b/apps/hub/src/routes/station-terminal.test.ts
@@ -26,6 +26,7 @@ import { createTestUser } from "../../tests/helpers/database";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
 import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { setGrant } from "../services/grants";
 import { gatewayRoutes } from "./gateway";
 import { stationTerminalRoutes } from "./station-terminal";
 import { stationRoutes } from "./stations";
@@ -584,4 +585,137 @@ test(
     }
   },
   20_000
+);
+
+// ─── The reach half of the control pair (#345) ────────────────────────────────
+
+test(
+  "a principal who may dispatch but not change is refused — no shell opens, and it is recorded",
+  async () => {
+    // A terminal is the most complete way to change what an agent is; the route
+    // itself calls it "the most powerful mutation". So it is the clearest case
+    // for the second half of the pair: dispatch permission is not permission to
+    // rewrite (charter Decision 4).
+    //
+    // Asserted on what is unambiguous — the shell never opened and the refusal
+    // was recorded — rather than on the close code, which Bun surfaces
+    // inconsistently for policy violations (see the unauthenticated test above).
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+    const baseUrl = `http://localhost:${server.port}`;
+    process.env.ENFORCE_CONTROL_PAIR = "true";
+
+    try {
+      const { token } = await mintEnrollmentToken(TEST_USER);
+      const { nodeId, nodeSecret } = await enrollNode(token, {
+        hostname: "sterm-reach-host",
+        os: "linux",
+        arch: "amd64",
+        cpuCount: 2,
+      });
+
+      const nodeReceivedMsgs: string[] = [];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        capturedNodeMsgs: nodeReceivedMsgs,
+      });
+      const station = await adoptStation(baseUrl, nodeId);
+
+      // Dispatch as wide as it goes, and no reach.
+      await setGrant(TEST_USER, { mayDispatch: ["agentpod:*/sterm-station"], mayGrantReach: false });
+      await rawSql`DELETE FROM station_audit WHERE user_id = ${TEST_USER} AND verb = 'terminal'`;
+
+      await new Promise<void>((resolve) => {
+        const clientWs = new WebSocket(
+          `ws://localhost:${server.port}/api/stations/${station.id}/terminal`,
+          { headers: { "X-Test-User-Id": TEST_USER } } as RequestInit & {
+            headers: Record<string, string>;
+          }
+        );
+        clientWs.onclose = () => resolve();
+        clientWs.onerror = () => resolve();
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const termOpenSent = nodeReceivedMsgs.some((raw) => {
+        try {
+          const m = JSON.parse(raw);
+          return m?.type === "req" && m?.verb === "term.open";
+        } catch {
+          return false;
+        }
+      });
+      expect(termOpenSent).toBe(false);
+
+      // Refused and recorded. An attempt refused and recorded nowhere is
+      // indistinguishable from an attempt nobody made.
+      const rows = await rawSql`
+        SELECT result FROM station_audit WHERE user_id = ${TEST_USER} AND verb = 'terminal'`;
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.result).toBe("error");
+
+      fakeNode.close();
+    } finally {
+      delete process.env.ENFORCE_CONTROL_PAIR;
+      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${TEST_USER}`;
+      server.stop(true);
+    }
+  },
+  20000
+);
+
+test(
+  "a principal holding reach in scope opens the shell as before",
+  async () => {
+    const server = Bun.serve({ fetch: testApp.fetch, websocket, port: 0 });
+    const baseUrl = `http://localhost:${server.port}`;
+    process.env.ENFORCE_CONTROL_PAIR = "true";
+
+    try {
+      const { token } = await mintEnrollmentToken(TEST_USER);
+      const { nodeId, nodeSecret } = await enrollNode(token, {
+        hostname: "sterm-reach-ok-host",
+        os: "linux",
+        arch: "amd64",
+        cpuCount: 2,
+      });
+
+      const nodeReceivedMsgs: string[] = [];
+      const fakeNode = await connectFakeNode(server.port!, nodeId, nodeSecret, {
+        capturedNodeMsgs: nodeReceivedMsgs,
+      });
+      const station = await adoptStation(baseUrl, nodeId);
+
+      await setGrant(TEST_USER, { mayDispatch: ["agentpod:*/sterm-station"], mayGrantReach: true });
+
+      const clientWs = new WebSocket(
+        `ws://localhost:${server.port}/api/stations/${station.id}/terminal`,
+        { headers: { "X-Test-User-Id": TEST_USER } } as RequestInit & {
+          headers: Record<string, string>;
+        }
+      );
+      await new Promise<void>((resolve) => {
+        clientWs.onopen = () => resolve();
+        clientWs.onerror = () => resolve();
+      });
+      await new Promise((r) => setTimeout(r, 300));
+
+      const termOpenSent = nodeReceivedMsgs.some((raw) => {
+        try {
+          const m = JSON.parse(raw);
+          return m?.type === "req" && m?.verb === "term.open";
+        } catch {
+          return false;
+        }
+      });
+      expect(termOpenSent).toBe(true);
+
+      clientWs.close();
+      fakeNode.close();
+    } finally {
+      delete process.env.ENFORCE_CONTROL_PAIR;
+      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${TEST_USER}`;
+      server.stop(true);
+    }
+  },
+  20000
 );

--- a/apps/hub/src/routes/station-terminal.ts
+++ b/apps/hub/src/routes/station-terminal.ts
@@ -32,6 +32,8 @@ import { upgradeWebSocket } from "../ws";
 import * as broker from "../services/broker";
 import { getStation } from "../services/station-registry";
 import { gateCapability } from "./station-writes";
+import { requireGrantReach } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
 import { connectionManager } from "../services/connection-manager";
 import { recordAudit } from "../services/audit";
 import { db } from "../db/drizzle";
@@ -94,6 +96,29 @@ export const stationTerminalRoutes = new Hono().get(
         if (!gateCapability(station, "terminal")) {
           ws.send(JSON.stringify({ t: "exit" }));
           ws.close(1008, "Forbidden: terminal capability");
+          return;
+        }
+
+        // ── 2c. Reach gate (#345) ─────────────────────────────────────────
+        // A shell is the most complete way to change what an agent is, which
+        // makes it the clearest case for the second half of the control pair:
+        // permission to dispatch an agent is not permission to rewrite it
+        // (charter Decision 4). Refused here rather than at the PTY, so no
+        // process is ever started.
+        try {
+          await requireGrantReach(user.id, station, "terminal", "mutate");
+        } catch (e) {
+          if (!isGrantReachDenied(e)) throw e;
+          const denied = await recordAudit(db, {
+            userId: user.id,
+            nodeId: station.nodeId,
+            stationKey: station.stationKey,
+            verb: "terminal",
+            params: { refused: "grant-reach" },
+          });
+          await denied.done("error", "refused by the control pair");
+          ws.send(JSON.stringify({ t: "exit" }));
+          ws.close(1008, "Forbidden: you may not change this agent");
           return;
         }
 

--- a/apps/hub/src/routes/station-writes.ts
+++ b/apps/hub/src/routes/station-writes.ts
@@ -24,9 +24,13 @@
  */
 
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
+import type { Capability } from "@agentpod/contract";
 import { db } from "../db/drizzle";
+import { requireGrantReach } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
 import * as broker from "../services/broker";
 import { getStation } from "../services/station-registry";
 import { recordAudit } from "../services/audit";
@@ -43,6 +47,45 @@ import type { StationRow } from "../services/station-registry";
  */
 export function gateCapability(station: StationRow, cap: string): boolean {
   return Array.isArray(station.capabilities) && station.capabilities.includes(cap);
+}
+
+// ─── Reach gate ───────────────────────────────────────────────────────────────
+
+/**
+ * Refuse a mutation the principal may not make, or return null to continue.
+ *
+ * A sibling of `gateCapability` rather than part of it: that function is called
+ * for reads too (`changeset/status`, `cleanup/plan`), and a check inside it
+ * would refuse someone permission to look at a diff, which is nobody's idea of
+ * granting reach.
+ *
+ * The refusal is audited as well as logged. An attempt refused and recorded
+ * nowhere is indistinguishable from an attempt nobody made, which is precisely
+ * what an operator reading the activity trail is trying to tell apart.
+ */
+export async function refuseWithoutReach(
+  c: Context,
+  userId: string,
+  station: StationRow,
+  cap: Capability
+): Promise<Response | null> {
+  try {
+    await requireGrantReach(userId, station, cap, "mutate");
+    return null;
+  } catch (e) {
+    if (!isGrantReachDenied(e)) throw e;
+
+    const audit = await recordAudit(db, {
+      userId,
+      nodeId: station.nodeId,
+      stationKey: station.stationKey,
+      verb: cap,
+      params: { refused: "grant-reach" },
+    });
+    await audit.done("error", "refused by the control pair");
+
+    return c.json({ error: e.message }, 403);
+  }
 }
 
 // ─── Error-to-status helper ───────────────────────────────────────────────────
@@ -122,6 +165,16 @@ export const stationWriteRoutes = new Hono()
         );
       }
 
+      // ── 3b. Reach gate ──────────────────────────────────────────────────────
+      // Writing into a workspace is how an agent acquires credentials it did
+      // not have, so this is the second half of the control pair, not a repeat
+      // of the first: dispatch permission is not permission to rewrite.
+      //
+      // After the capability gate on purpose — "this station cannot" and "you
+      // may not" send an operator to different places.
+      const denial = await refuseWithoutReach(c, user.id, station, "fs.write");
+      if (denial) return denial;
+
       const body = c.req.valid("json");
 
       // ── 4. Audit (safe params only — no content) ────────────────────────────
@@ -192,6 +245,16 @@ export const stationWriteRoutes = new Hono()
         );
       }
 
+      // ── 3b. Reach gate ──────────────────────────────────────────────────────
+      // Writing into a workspace is how an agent acquires credentials it did
+      // not have, so this is the second half of the control pair, not a repeat
+      // of the first: dispatch permission is not permission to rewrite.
+      //
+      // After the capability gate on purpose — "this station cannot" and "you
+      // may not" send an operator to different places.
+      const denial = await refuseWithoutReach(c, user.id, station, "fs.write");
+      if (denial) return denial;
+
       const body = c.req.valid("json");
 
       // ── 4. Audit ────────────────────────────────────────────────────────────
@@ -254,6 +317,16 @@ export const stationWriteRoutes = new Hono()
           403
         );
       }
+
+      // ── 3b. Reach gate ──────────────────────────────────────────────────────
+      // Writing into a workspace is how an agent acquires credentials it did
+      // not have, so this is the second half of the control pair, not a repeat
+      // of the first: dispatch permission is not permission to rewrite.
+      //
+      // After the capability gate on purpose — "this station cannot" and "you
+      // may not" send an operator to different places.
+      const denial = await refuseWithoutReach(c, user.id, station, "fs.write");
+      if (denial) return denial;
 
       const body = c.req.valid("json");
 
@@ -319,6 +392,16 @@ export const stationWriteRoutes = new Hono()
           403
         );
       }
+
+      // ── 3b. Reach gate ──────────────────────────────────────────────────────
+      // Writing into a workspace is how an agent acquires credentials it did
+      // not have, so this is the second half of the control pair, not a repeat
+      // of the first: dispatch permission is not permission to rewrite.
+      //
+      // After the capability gate on purpose — "this station cannot" and "you
+      // may not" send an operator to different places.
+      const denial = await refuseWithoutReach(c, user.id, station, "fs.write");
+      if (denial) return denial;
 
       const body = c.req.valid("json");
 

--- a/apps/hub/src/services/control-pair.ts
+++ b/apps/hub/src/services/control-pair.ts
@@ -59,3 +59,32 @@ export class ControlPairDenied extends Error {
 export function isControlPairDenied(e: unknown): e is ControlPairDenied {
   return e instanceof ControlPairDenied || (e as { name?: string })?.name === "ControlPairDenied";
 }
+
+/**
+ * An act refused by the second half of the pair.
+ *
+ * A separate type rather than a subclass of `ControlPairDenied`, deliberately:
+ * the kaambaan bridge treats a `ControlPairDenied` as a **permanent** dispatch
+ * refusal and stops retrying that card. A refusal to *write into* an agent must
+ * never be mistaken for one, or a workspace-permission problem would be
+ * diagnosed — and given up on — as a dispatch grant problem.
+ */
+export class GrantReachDenied extends Error {
+  readonly principalId: string;
+  /** The station key, or "fleet" for acts that name no station. */
+  readonly target: string;
+  readonly capability: string | null;
+
+  constructor(principalId: string, target: string, capability: string | null) {
+    super("You do not have permission to change this agent.");
+    this.name = "GrantReachDenied";
+    this.principalId = principalId;
+    this.target = target;
+    this.capability = capability;
+  }
+}
+
+/** Is this the reach half refusing, rather than something transient? */
+export function isGrantReachDenied(e: unknown): e is GrantReachDenied {
+  return e instanceof GrantReachDenied || (e as { name?: string })?.name === "GrantReachDenied";
+}

--- a/apps/hub/src/services/grant-reach.ts
+++ b/apps/hub/src/services/grant-reach.ts
@@ -1,0 +1,129 @@
+/**
+ * Who may change what an agent *is*.
+ *
+ * `mayDispatch` asks whether you may ask an agent to work. This asks whether you
+ * may rewrite it — put bytes in its workspace, run commands as it, destroy its
+ * files, or bring a new machine into the fleet. Decision 4 of
+ * `charter/decisions/2026-08-13-ecosystem-identity.md` requires both, because
+ * dispatch control alone is decorative: anyone who can grant an agent production
+ * credentials does not need permission to dispatch it — they build the agent
+ * they want.
+ *
+ * Design: `docs/superpowers/specs/2026-08-15-granting-reach-design.md`.
+ */
+
+import { eq } from "drizzle-orm";
+import { Capability } from "@agentpod/contract";
+import { db } from "../db/drizzle";
+import { nodes } from "../db/schema";
+import { getGrant, grantAllowsStation, AGENTPOD_NS } from "./grants";
+import { isControlPairEnforced, GrantReachDenied } from "./control-pair";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("grant-reach");
+
+/**
+ * Which capabilities can hand an agent reach it did not have.
+ *
+ * A `Record<Capability, boolean>` and not a Set: this is exhaustive **by type**,
+ * so adding an eleventh capability to the contract enum stops the build until
+ * somebody decides what it is. The same manoeuvre `db/tenant-scope.ts` uses to
+ * stop a new table quietly escaping tenancy.
+ *
+ * `cleanup` is listed true even though half its surface is a read — a capability
+ * belongs here if ANY route under it can change the agent, and the caller's
+ * `effect` argument settles the rest.
+ */
+export const REACH_BEARING: Record<Capability, boolean> = {
+  "fs.write": true, // one request writes a credential file
+  terminal: true, // arbitrary shell as the agent's user
+  cleanup: true, // `apply` deletes; `plan` is a read and passes on effect
+
+  changeset: false, // status/diff are reads
+  lifecycle: false, // operating an agent, not widening it
+  acp: false, // dispatch — mayDispatch already guards it
+  inventory: false,
+  health: false,
+  logs: false,
+  "fs.read": false,
+};
+
+export function isReachBearing(cap: Capability): boolean {
+  return REACH_BEARING[cap] === true;
+}
+
+/**
+ * Guard a station-scoped act.
+ *
+ * Two conditions, both required: the principal holds `mayGrantReach`, AND their
+ * dispatch scope covers this station. One scope list, shared with dispatch, so
+ * the two can never disagree about what a pattern means — `grantAllowsStation`
+ * is the same function `acp.createSession` calls.
+ */
+export async function requireGrantReach(
+  userId: string,
+  station: { nodeId: string; stationKey: string },
+  cap: Capability,
+  effect: "read" | "mutate"
+): Promise<void> {
+  if (!isControlPairEnforced()) return;
+  if (effect === "read" || !isReachBearing(cap)) return;
+
+  const grant = await getGrant(userId);
+  if (!grant?.mayGrantReach) {
+    log.warn("reach refused by the control pair: principal may not change agents", {
+      principalId: userId,
+      stationKey: station.stationKey,
+      capability: cap,
+    });
+    throw new GrantReachDenied(userId, station.stationKey, cap);
+  }
+
+  // The node name, because a grant names a node as well as a station — station
+  // keys repeat across the fleet.
+  const [node] = await db
+    .select({ name: nodes.name })
+    .from(nodes)
+    .where(eq(nodes.id, station.nodeId))
+    .limit(1);
+
+  const inScope =
+    node !== undefined &&
+    grantAllowsStation(grant, { nodeName: node.name, stationKey: station.stationKey });
+
+  if (!inScope) {
+    log.warn("reach refused by the control pair: station out of scope", {
+      principalId: userId,
+      node: node?.name,
+      stationKey: station.stationKey,
+      capability: cap,
+    });
+    throw new GrantReachDenied(userId, station.stationKey, cap);
+  }
+}
+
+/**
+ * Guard an act that names no station — minting an enrollment token today, the
+ * credential broker later.
+ *
+ * There is no station to match a pattern against, so the rule is narrower: you
+ * may grow a fleet only if your authority already spans it. The alternative —
+ * the boolean alone — would let a principal scoped to one node add machines
+ * indefinitely, which is the "register an agent" half of Decision 4's threat
+ * restated.
+ */
+export async function requireFleetGrantReach(userId: string): Promise<void> {
+  if (!isControlPairEnforced()) return;
+
+  const grant = await getGrant(userId);
+  const fleetWide =
+    grant?.mayGrantReach === true &&
+    grant.mayDispatch.some(
+      (v) => v.startsWith(AGENTPOD_NS) && v.slice(AGENTPOD_NS.length).startsWith("*/")
+    );
+
+  if (!fleetWide) {
+    log.warn("fleet-level reach refused by the control pair", { principalId: userId });
+    throw new GrantReachDenied(userId, "fleet", null);
+  }
+}

--- a/apps/hub/tests/integration/enrollment-token-reach.test.ts
+++ b/apps/hub/tests/integration/enrollment-token-reach.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { setGrant } from "../../src/services/grants";
+import { enrollmentTokenRoutes } from "../../src/routes/enrollment-tokens";
+
+/**
+ * Minting an enrollment token is granting reach.
+ *
+ * Decision 4 states the threat as "anyone who can **register an agent** and
+ * grant it production credentials … they build the agent they want." A machine
+ * joining the fleet is that registration, and it arrives carrying whatever the
+ * person who added it put on it.
+ *
+ * It names no station, so the composition rule the station routes use has
+ * nothing to match against. The rule here is narrower instead: you may grow a
+ * fleet only if your authority already spans it.
+ */
+
+const USER = "test-user-enroll-reach";
+
+function app() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: USER, role: "user" });
+    await next();
+  });
+  a.route("/", enrollmentTokenRoutes);
+  return a;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "enroll-reach@example.com", name: "ER" });
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("growing the fleet requires fleet-wide authority", () => {
+  test("refused for a node-scoped principal", async () => {
+    // Their grant describes one machine. A machine they add is one it never
+    // described — and on a wildcard-free grant they could keep adding them.
+    await setGrant(USER, { mayDispatch: ["agentpod:one-box/hermes:*"], mayGrantReach: true });
+
+    const res = await app().request("/", { method: "POST" });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/add machines/i);
+  });
+
+  test("permitted when the principal's authority already spans the fleet", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+
+    const res = await app().request("/", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { token: string }).token).toBeTruthy();
+  });
+
+  test("refused without the boolean, however wide the scope", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    expect((await app().request("/", { method: "POST" })).status).toBe(403);
+  });
+
+  test("refused for a principal with no grant at all", async () => {
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    expect((await app().request("/", { method: "POST" })).status).toBe(403);
+  });
+
+  test("is a no-op when the pair is not enforced", async () => {
+    // A deployment that has not switched the pair on must enrol exactly as it
+    // did before — this control ships live, so its off-state has to be silent.
+    const before = process.env.ENFORCE_CONTROL_PAIR;
+    try {
+      process.env.ENFORCE_CONTROL_PAIR = "false";
+      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+
+      const res = await app().request("/", { method: "POST" });
+      expect(res.status).toBe(200);
+    } finally {
+      if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;
+      else process.env.ENFORCE_CONTROL_PAIR = before;
+    }
+  });
+});

--- a/apps/hub/tests/integration/grant-reach.test.ts
+++ b/apps/hub/tests/integration/grant-reach.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Capability } from "@agentpod/contract";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { setGrant, deleteGrant } from "../../src/services/grants";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import {
+  REACH_BEARING,
+  isReachBearing,
+  requireGrantReach,
+  requireFleetGrantReach,
+} from "../../src/services/grant-reach";
+import { isGrantReachDenied } from "../../src/services/control-pair";
+
+/**
+ * The second half of the control pair.
+ *
+ * `mayDispatch` asks whether you may ask an agent to work. This asks whether you
+ * may change what it *is*. Without the second, the first guards the front door
+ * of a building with no walls: a principal refused one agent opens a terminal on
+ * an agent they ARE allowed to dispatch and writes credentials into it.
+ */
+
+const USER = "test-user-grant-reach";
+const NODE = "node_grant_reach";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "grant-reach@example.com", name: "GR" });
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  const tenant = await resolveTenantForUser(USER);
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${USER},
+            'reach-box', 'reach-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+
+  // The guards are no-ops when the pair is off — which is itself asserted below.
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+const STATION = { nodeId: NODE, stationKey: "hermes:analyst-echo" };
+
+async function denial(fn: () => Promise<void>): Promise<unknown> {
+  try {
+    await fn();
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+describe("the capability classification", () => {
+  test("covers every capability the contract defines", () => {
+    // The Record type already fails the build when a capability is added. This
+    // asserts the same thing at runtime, so widening the type later cannot
+    // silently reopen the hole.
+    expect(Object.keys(REACH_BEARING).sort()).toEqual([...Capability.options].sort());
+  });
+
+  test("names writes, shells and destruction — and nothing else", () => {
+    expect(isReachBearing("fs.write")).toBe(true);
+    expect(isReachBearing("terminal")).toBe(true);
+    expect(isReachBearing("cleanup")).toBe(true);
+
+    // Reads are not reach. A console that refused to show a diff or a log would
+    // be routed around within a day.
+    expect(isReachBearing("changeset")).toBe(false);
+    expect(isReachBearing("fs.read")).toBe(false);
+    expect(isReachBearing("logs")).toBe(false);
+    expect(isReachBearing("health")).toBe(false);
+    expect(isReachBearing("inventory")).toBe(false);
+
+    // Operating an agent is not widening it, and dispatch already guards acp.
+    expect(isReachBearing("lifecycle")).toBe(false);
+    expect(isReachBearing("acp")).toBe(false);
+  });
+});
+
+describe("requireGrantReach", () => {
+  test("permits when the principal holds reach and the scope matches", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:reach-box/hermes:*"], mayGrantReach: true });
+    expect(await denial(() => requireGrantReach(USER, STATION, "fs.write", "mutate"))).toBeNull();
+  });
+
+  test("refuses without the boolean, however wide the dispatch scope", async () => {
+    // The whole point: dispatch permission is not permission to rewrite.
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const e = await denial(() => requireGrantReach(USER, STATION, "fs.write", "mutate"));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("refuses when the boolean is held but this station is out of scope", async () => {
+    // One scope, shared with dispatch: you may rewrite only agents you may talk to.
+    await setGrant(USER, { mayDispatch: ["agentpod:other-box/hermes:*"], mayGrantReach: true });
+
+    const e = await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("refuses a principal with no grant at all", async () => {
+    await deleteGrant(USER);
+    const e = await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("lets a read through even on a reach-bearing capability", async () => {
+    // `cleanup` covers plan (read) and apply (destroys) under one word.
+    await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+    expect(await denial(() => requireGrantReach(USER, STATION, "cleanup", "read"))).toBeNull();
+  });
+
+  test("lets an open capability through even when mutating", async () => {
+    await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+    expect(await denial(() => requireGrantReach(USER, STATION, "lifecycle", "mutate"))).toBeNull();
+  });
+
+  test("is a no-op when the pair is not enforced", async () => {
+    const before = process.env.ENFORCE_CONTROL_PAIR;
+    try {
+      process.env.ENFORCE_CONTROL_PAIR = "false";
+      await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+      expect(await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"))).toBeNull();
+    } finally {
+      if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;
+      else process.env.ENFORCE_CONTROL_PAIR = before;
+    }
+  });
+});
+
+describe("requireFleetGrantReach", () => {
+  test("permits a principal whose authority already spans the fleet", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    expect(await denial(() => requireFleetGrantReach(USER))).toBeNull();
+  });
+
+  test("refuses a node-scoped principal, who could otherwise grow the fleet forever", async () => {
+    // Decision 4 counts *registering* an agent as granting reach: build the
+    // agent you want, then dispatch it. A machine added under a node-scoped
+    // grant is a machine that grant never described.
+    await setGrant(USER, { mayDispatch: ["agentpod:reach-box/hermes:*"], mayGrantReach: true });
+
+    const e = await denial(() => requireFleetGrantReach(USER));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("refuses fleet-wide dispatch without the boolean", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    expect(isGrantReachDenied(await denial(() => requireFleetGrantReach(USER)))).toBe(true);
+  });
+});

--- a/apps/hub/tests/integration/station-cleanup-reach.test.ts
+++ b/apps/hub/tests/integration/station-cleanup-reach.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { setGrant } from "../../src/services/grants";
+import { stationCleanupRoutes } from "../../src/routes/station-cleanup";
+import { stationChangesetRoutes } from "../../src/routes/station-changeset";
+import { stationLifecycleRoutes } from "../../src/routes/station-lifecycle";
+
+/**
+ * Where the line falls inside a single capability, and where it does not fall
+ * at all.
+ *
+ * `cleanup` covers a read (`plan`) and a destruction (`apply`) under one word,
+ * so the classification alone cannot decide — the route's effect has to. And the
+ * negative cases below are the ones that matter most: an over-broad
+ * classification refuses people work they are entitled to do, which is how a
+ * control gets switched off rather than narrowed.
+ */
+
+const USER = "test-user-cleanup-reach";
+const NODE = "node_cleanup_reach";
+const STATION = "station_cleanup_reach";
+
+function mount(routes: Hono) {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: USER, role: "user" });
+    await next();
+  });
+  a.route("/", routes);
+  return a;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "cleanup-reach@example.com", name: "CR" });
+  const tenant = await resolveTenantForUser(USER);
+  await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${USER}, 'cleanup-box', 'cleanup-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'hermes', 'hermes:cleanup', 'leaf', 'Cleanup',
+            '["cleanup","changeset","lifecycle"]'::jsonb, now(), now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+function post(routes: Hono, path: string, body: Record<string, unknown> = {}) {
+  return mount(routes).request(`/stations/${STATION}/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Dispatch as wide as it goes, and no reach — the principal this control is for. */
+async function dispatchOnly() {
+  await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+}
+
+describe("cleanup splits on the effect, not the capability", () => {
+  test("apply is refused without reach", async () => {
+    await dispatchOnly();
+
+    const res = await post(stationCleanupRoutes, "cleanup/apply", { paths: ["node_modules"] });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/permission to change this agent/i);
+  });
+
+  test("plan is not, because looking is not changing", async () => {
+    // Guarding the capability word would refuse someone permission to find out
+    // what a cleanup would delete — a read, and the one you want before the write.
+    await dispatchOnly();
+
+    const res = await post(stationCleanupRoutes, "cleanup/plan");
+
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe("the open capabilities are untouched", () => {
+  test("changeset status is allowed without reach", async () => {
+    await dispatchOnly();
+    const res = await post(stationChangesetRoutes, "changeset/status");
+    expect(res.status).not.toBe(403);
+  });
+
+  test("changeset diff is allowed without reach", async () => {
+    await dispatchOnly();
+    const res = await post(stationChangesetRoutes, "changeset/diff", { path: "a.txt" });
+    expect(res.status).not.toBe(403);
+  });
+
+  test("lifecycle is allowed without reach", async () => {
+    // Starting and stopping an agent grants it no capability it did not have.
+    // Recorded as a judgement call in the design, not an oversight.
+    await dispatchOnly();
+    const res = await post(stationLifecycleRoutes, "lifecycle", { action: "restart" });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/hub/tests/integration/station-writes-reach.test.ts
+++ b/apps/hub/tests/integration/station-writes-reach.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { setGrant } from "../../src/services/grants";
+import { stationWriteRoutes } from "../../src/routes/station-writes";
+
+/**
+ * Writing into an agent's workspace is granting it reach.
+ *
+ * One request writes `~/.claude/settings.json` or an `.env`. That is the act
+ * `mayGrantReach` exists to govern, and until this file existed the dispatch
+ * check was guarding the front door of a building with no walls: refuse someone
+ * an agent, and they write credentials into one they are allowed to dispatch.
+ */
+
+const USER = "test-user-writes-reach";
+const NODE = "node_writes_reach";
+const STATION = "station_writes_reach";
+
+function app() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: USER, role: "user" });
+    await next();
+  });
+  a.route("/", stationWriteRoutes);
+  return a;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "writes-reach@example.com", name: "WR" });
+  const tenant = await resolveTenantForUser(USER);
+  await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${USER}, 'writes-box', 'writes-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'hermes', 'hermes:writes', 'leaf', 'Writes',
+            '["fs.write"]'::jsonb, now(), now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+const MUTATIONS: Array<[string, Record<string, unknown>]> = [
+  ["fs/write", { path: "a.txt", content: "x", encoding: "utf8" }],
+  ["fs/mkdir", { path: "d" }],
+  ["fs/move", { from: "a.txt", to: "b.txt" }],
+  ["fs/delete", { path: "a.txt" }],
+];
+
+function post(path: string, body: Record<string, unknown>) {
+  return app().request(`/stations/${STATION}/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("fs mutations require reach", () => {
+  for (const [path, body] of MUTATIONS) {
+    test(`${path} is refused without mayGrantReach`, async () => {
+      // Wide dispatch, no reach: exactly the principal this control exists for.
+      await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+      const res = await post(path, body);
+
+      // 403, not 502: this is a decision, not an upstream failure (#342).
+      expect(res.status).toBe(403);
+      expect(await res.text()).toMatch(/permission to change this agent/i);
+    });
+  }
+
+  test("is refused when reach is held but the station is out of scope", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:other-box/hermes:*"], mayGrantReach: true });
+    expect((await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" })).status).toBe(403);
+  });
+
+  test("a refusal is audited, not only logged", async () => {
+    // An attempt refused and recorded nowhere is indistinguishable from an
+    // attempt nobody made — which is what an operator is trying to tell apart.
+    await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" });
+
+    const rows = await rawSql`
+      SELECT verb, result FROM station_audit WHERE user_id = ${USER} AND verb = 'fs.write'`;
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.result).toBe("error");
+  });
+
+  test("the capability gate still answers first, because the two refusals mean different things", async () => {
+    // "This station cannot" and "you may not" send an operator to different
+    // places. Reordering these would send them to the wrong one.
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await rawSql`UPDATE stations SET capabilities = '[]'::jsonb WHERE id = ${STATION}`;
+
+    const res = await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/does not advertise/i);
+
+    await rawSql`UPDATE stations SET capabilities = '["fs.write"]'::jsonb WHERE id = ${STATION}`;
+  });
+
+  test("a principal with reach in scope gets past the gate", async () => {
+    // Past the gate is as far as this suite goes: there is no live node, so the
+    // broker answers "node offline" (409). What matters is that it is not 403.
+    await setGrant(USER, { mayDispatch: ["agentpod:writes-box/hermes:*"], mayGrantReach: true });
+
+    const res = await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -394,7 +394,31 @@ every dispatch is refused — which is correct, and is also an outage.
 | Field | Meaning |
 |---|---|
 | `mayDispatch` | Namespaced patterns. AgentPod's name a **node and a station**: `agentpod:<nodeName>/<stationKey>`. `kaambaan:<agentId>` is matched by kaambaan and **ignored** here. |
-| `mayGrantReach` | Whether this principal may grant an agent its reach. Required. Dispatch control alone is decorative: anyone who can grant an agent production credentials does not need permission to dispatch it. |
+| `mayGrantReach` | Whether this principal may **change what an agent is**. Required, and enforced — see the table below. Dispatch control alone is decorative: anyone who can grant an agent production credentials does not need permission to dispatch it. |
+
+**What `mayGrantReach` gates**, as of #345. `mayDispatch` asks whether you may
+ask an agent to work; this asks whether you may rewrite it:
+
+| Act | Guarded |
+|---|---|
+| `fs/write`, `fs/mkdir`, `fs/move`, `fs/delete` | **yes** — one request writes a credential file |
+| Terminal attach | **yes** — arbitrary shell as the agent's user |
+| `cleanup/apply` | **yes** — deletes workspace files (`cleanup/plan` is a read, and is not) |
+| `POST /api/enrollment-tokens` | **yes**, and additionally requires a fleet-wide (`agentpod:*/…`) dispatch value |
+| `changeset/status`, `changeset/diff`, `lifecycle`, every read | no |
+
+A station-scoped act needs `mayGrantReach` **and** a `mayDispatch` value matching
+that station — one scope, shared with dispatch, so narrowing what someone may
+dispatch narrows what they may rewrite. Growing the fleet names no station, so it
+asks the narrower question instead: your authority must already span the fleet.
+
+Refusals are `403` on HTTP and a `1008` close on the terminal socket, and each is
+written to the station's activity trail as well as the hub log — an attempt
+refused and recorded nowhere is indistinguishable from an attempt nobody made.
+
+**If you lock yourself out**, `/api/admin/grants` is guarded by *admin*, not by
+the control pair: an admin can always restore their own grant from **Admin →
+Grants**. The control cannot lock you out of the control.
 
 ```sh
 agentpod:molt-bot/hermes:analyst-echo   # exactly one agent, on one host

--- a/docs/superpowers/plans/2026-08-15-enforce-grant-reach.md
+++ b/docs/superpowers/plans/2026-08-15-enforce-grant-reach.md
@@ -1,0 +1,1276 @@
+# Enforce `mayGrantReach` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mayGrantReach` a control that runs — refuse the acts that change what an agent *is* (workspace writes, terminal, destructive cleanup, fleet growth) to principals who do not hold it.
+
+**Architecture:** A classification of station capabilities, typed `Record<Capability, boolean>` so a new capability breaks the build until someone classifies it, plus two guard functions that combine the boolean with the *existing* dispatch scope matcher. Guards are called beside the existing `gateCapability` checks — never folded into it, because two of its five callers are reads. Refusals reuse the pair's denial vocabulary: 403 on HTTP, close 1008 on the terminal WS, audited as well as logged.
+
+**Tech Stack:** Bun + Hono + Drizzle/Postgres (hub), SvelteKit 5 runes (console), zod contract package.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-granting-reach-design.md`
+
+## Global Constraints
+
+- **The switch is `ENFORCE_CONTROL_PAIR === "true"`** (literal lowercase). No new flag. When it is off, every guard added here is a no-op.
+- **Composition rule:** a station-scoped act requires `mayGrantReach === true` **and** a `mayDispatch` value matching that station. A fleet-level act requires `mayGrantReach === true` **and** at least one `agentpod:` value whose node half is exactly `*`.
+- **Reach-bearing capabilities:** `fs.write`, `terminal`, `cleanup`. Everything else in the contract enum is open: `changeset`, `lifecycle`, `acp`, `inventory`, `health`, `logs`, `fs.read`.
+- **Effect matters:** the guard fires only for `effect: "mutate"`. `cleanup/plan` is a read and stays open; `cleanup/apply` mutates and is guarded.
+- **Reads are never guarded.** Observation is not reach.
+- **Hub tests** need `DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod"` and a pgvector Postgres on :5434.
+- **Console tests** run under Node 22 (`nvm use 22`); Node 26 fails jsdom in ways that look like broken code.
+- **TDD:** failing test first, every task.
+
+### Deviation from the spec, and why
+
+The spec put the guards in `services/control-pair.ts`. That file's own docstring says it holds "the part that is neither storage nor policy: whether the control runs at all, and what a refusal *is*" — and the guards are policy plus two database reads. So:
+
+- `services/control-pair.ts` gains **only** the error type (`GrantReachDenied`) and its type guard.
+- `services/grant-reach.ts` (new) holds the classification table and the two guard functions.
+
+Nothing else about the spec changes.
+
+---
+
+### Task 1: The classification and the guards
+
+**Files:**
+- Modify: `apps/hub/src/services/control-pair.ts` (append the error type)
+- Create: `apps/hub/src/services/grant-reach.ts`
+- Test: `apps/hub/tests/integration/grant-reach.test.ts`
+
+**Interfaces:**
+- Consumes: `getGrant`, `grantAllowsStation`, `AGENTPOD_NS` from `services/grants.ts`; `isControlPairEnforced` from `services/control-pair.ts`; `nodes` from `db/schema`; `Capability` from `@agentpod/contract`.
+- Produces:
+  - `class GrantReachDenied extends Error { principalId: string; target: string; capability: string | null }`
+  - `function isGrantReachDenied(e: unknown): e is GrantReachDenied`
+  - `const REACH_BEARING: Record<Capability, boolean>`
+  - `function isReachBearing(cap: Capability): boolean`
+  - `async function requireGrantReach(userId: string, station: { nodeId: string; stationKey: string }, cap: Capability, effect: "read" | "mutate"): Promise<void>`
+  - `async function requireFleetGrantReach(userId: string): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/hub/tests/integration/grant-reach.test.ts`:
+
+```ts
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Capability } from "@agentpod/contract";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { setGrant, deleteGrant } from "../../src/services/grants";
+import {
+  REACH_BEARING,
+  isReachBearing,
+  requireGrantReach,
+  requireFleetGrantReach,
+} from "../../src/services/grant-reach";
+import { isGrantReachDenied } from "../../src/services/control-pair";
+
+/**
+ * The second half of the control pair.
+ *
+ * `mayDispatch` asks may I ask this agent to work; `mayGrantReach` asks may I
+ * change what this agent is. Without the second, the first guards the front door
+ * of a building with no walls: a principal refused one agent opens a terminal on
+ * an agent they ARE allowed to dispatch and writes credentials into it.
+ */
+
+const USER = "test-user-grant-reach";
+const NODE = "node_grant_reach";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "grant-reach@example.com", name: "GR" });
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, (SELECT tenant_id FROM "user" WHERE id = ${USER}), ${USER},
+            'reach-box', 'reach-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+const STATION = { nodeId: NODE, stationKey: "hermes:analyst-echo" };
+
+async function denial(fn: () => Promise<void>): Promise<unknown> {
+  try {
+    await fn();
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+describe("the capability classification", () => {
+  test("covers every capability the contract defines", () => {
+    // The Record type already fails the build when a capability is added. This
+    // asserts the same thing at runtime, so widening the type later cannot
+    // silently reopen the hole.
+    expect(Object.keys(REACH_BEARING).sort()).toEqual([...Capability.options].sort());
+  });
+
+  test("names writes, shells and destruction — and nothing else", () => {
+    expect(isReachBearing("fs.write")).toBe(true);
+    expect(isReachBearing("terminal")).toBe(true);
+    expect(isReachBearing("cleanup")).toBe(true);
+
+    // Reads are not reach. A console that refused to show a diff or a log would
+    // be routed around within a day.
+    expect(isReachBearing("changeset")).toBe(false);
+    expect(isReachBearing("fs.read")).toBe(false);
+    expect(isReachBearing("logs")).toBe(false);
+    expect(isReachBearing("health")).toBe(false);
+    expect(isReachBearing("inventory")).toBe(false);
+
+    // Operating an agent is not widening it, and dispatch already guards acp.
+    expect(isReachBearing("lifecycle")).toBe(false);
+    expect(isReachBearing("acp")).toBe(false);
+  });
+});
+
+describe("requireGrantReach", () => {
+  test("permits when the principal holds reach and the scope matches", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:reach-box/hermes:*"], mayGrantReach: true });
+    expect(await denial(() => requireGrantReach(USER, STATION, "fs.write", "mutate"))).toBeNull();
+  });
+
+  test("refuses without the boolean, however wide the dispatch scope", async () => {
+    // The whole point: dispatch permission is not permission to rewrite.
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const e = await denial(() => requireGrantReach(USER, STATION, "fs.write", "mutate"));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("refuses when the boolean is held but this station is out of scope", async () => {
+    // One scope, shared with dispatch: you may rewrite only agents you may talk to.
+    await setGrant(USER, { mayDispatch: ["agentpod:other-box/hermes:*"], mayGrantReach: true });
+
+    const e = await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("refuses a principal with no grant at all", async () => {
+    await deleteGrant(USER);
+    const e = await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("lets a read through even on a reach-bearing capability", async () => {
+    // `cleanup` covers plan (read) and apply (destroys) under one word.
+    await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+    expect(await denial(() => requireGrantReach(USER, STATION, "cleanup", "read"))).toBeNull();
+  });
+
+  test("lets an open capability through even when mutating", async () => {
+    await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+    expect(await denial(() => requireGrantReach(USER, STATION, "lifecycle", "mutate"))).toBeNull();
+  });
+
+  test("is a no-op when the pair is not enforced", async () => {
+    const before = process.env.ENFORCE_CONTROL_PAIR;
+    try {
+      process.env.ENFORCE_CONTROL_PAIR = "false";
+      await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+      expect(await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"))).toBeNull();
+    } finally {
+      if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;
+      else process.env.ENFORCE_CONTROL_PAIR = before;
+    }
+  });
+});
+
+describe("requireFleetGrantReach", () => {
+  test("permits a principal whose authority already spans the fleet", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    expect(await denial(() => requireFleetGrantReach(USER))).toBeNull();
+  });
+
+  test("refuses a node-scoped principal, who could otherwise grow the fleet forever", async () => {
+    // Decision 4 counts *registering* an agent as granting reach: build the
+    // agent you want, then dispatch it. A machine added under a node-scoped
+    // grant is a machine that grant never described.
+    await setGrant(USER, { mayDispatch: ["agentpod:reach-box/hermes:*"], mayGrantReach: true });
+
+    const e = await denial(() => requireFleetGrantReach(USER));
+    expect(isGrantReachDenied(e)).toBe(true);
+  });
+
+  test("refuses fleet-wide dispatch without the boolean", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    expect(isGrantReachDenied(await denial(() => requireFleetGrantReach(USER)))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/grant-reach.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../../src/services/grant-reach'`.
+
+- [ ] **Step 3: Add the error type**
+
+Append to `apps/hub/src/services/control-pair.ts`:
+
+```ts
+/**
+ * An act refused by the second half of the pair.
+ *
+ * Separate from `ControlPairDenied` rather than a subclass of it, deliberately:
+ * the kaambaan bridge treats a `ControlPairDenied` as a permanent dispatch
+ * refusal and stops retrying. A refusal to *write into* an agent must never be
+ * mistaken for one, or a bridge fault would be diagnosed as a grant problem.
+ */
+export class GrantReachDenied extends Error {
+  readonly principalId: string;
+  /** The station key, or "fleet" for acts that name no station. */
+  readonly target: string;
+  readonly capability: string | null;
+
+  constructor(principalId: string, target: string, capability: string | null) {
+    super("You do not have permission to change this agent.");
+    this.name = "GrantReachDenied";
+    this.principalId = principalId;
+    this.target = target;
+    this.capability = capability;
+  }
+}
+
+/** Is this the reach half refusing, rather than something transient? */
+export function isGrantReachDenied(e: unknown): e is GrantReachDenied {
+  return e instanceof GrantReachDenied || (e as { name?: string })?.name === "GrantReachDenied";
+}
+```
+
+- [ ] **Step 4: Write the guards**
+
+Create `apps/hub/src/services/grant-reach.ts`:
+
+```ts
+/**
+ * Who may change what an agent *is*.
+ *
+ * `mayDispatch` asks whether you may ask an agent to work. This asks whether you
+ * may rewrite it — put bytes in its workspace, run commands as it, destroy its
+ * files, or bring a new machine into the fleet. Decision 4 of
+ * `charter/decisions/2026-08-13-ecosystem-identity.md` requires both, because
+ * dispatch control alone is decorative: anyone who can grant an agent production
+ * credentials does not need permission to dispatch it — they build the agent
+ * they want.
+ *
+ * Design: `docs/superpowers/specs/2026-08-15-granting-reach-design.md`.
+ */
+
+import { eq } from "drizzle-orm";
+import { Capability } from "@agentpod/contract";
+import { db } from "../db/drizzle";
+import { nodes } from "../db/schema";
+import { getGrant, grantAllowsStation, AGENTPOD_NS } from "./grants";
+import { isControlPairEnforced, GrantReachDenied } from "./control-pair";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("grant-reach");
+
+/**
+ * Which capabilities can hand an agent reach it did not have.
+ *
+ * `Record<Capability, boolean>` and not a Set: this is exhaustive by type, so
+ * adding an eleventh capability to the contract enum stops the build until
+ * somebody decides what it is. The same manoeuvre `db/tenant-scope.ts` uses to
+ * stop a new table quietly escaping tenancy.
+ *
+ * `cleanup` is true even though half its surface is a read — the effect
+ * argument, not the capability, decides that. A capability is listed here if
+ * ANY route under it can change the agent.
+ */
+export const REACH_BEARING: Record<Capability, boolean> = {
+  "fs.write": true,   // writes a credential file in one request
+  terminal: true,     // arbitrary shell as the agent's user
+  cleanup: true,      // `apply` deletes; `plan` is a read and passes on effect
+
+  changeset: false,   // status/diff are reads
+  lifecycle: false,   // operating an agent, not widening it
+  acp: false,         // dispatch — mayDispatch already guards it
+  inventory: false,
+  health: false,
+  logs: false,
+  "fs.read": false,
+};
+
+export function isReachBearing(cap: Capability): boolean {
+  return REACH_BEARING[cap] === true;
+}
+
+/**
+ * Guard a station-scoped act.
+ *
+ * Two conditions, both required: the principal holds `mayGrantReach`, AND their
+ * dispatch scope covers this station. One scope list, shared with dispatch, so
+ * the two can never disagree about what a pattern means — `grantAllowsStation`
+ * is the same function `acp.createSession` calls.
+ */
+export async function requireGrantReach(
+  userId: string,
+  station: { nodeId: string; stationKey: string },
+  cap: Capability,
+  effect: "read" | "mutate"
+): Promise<void> {
+  if (!isControlPairEnforced()) return;
+  if (effect === "read" || !isReachBearing(cap)) return;
+
+  const grant = await getGrant(userId);
+  if (!grant?.mayGrantReach) {
+    log.warn("reach refused by the control pair: principal may not change agents", {
+      principalId: userId,
+      stationKey: station.stationKey,
+      capability: cap,
+    });
+    throw new GrantReachDenied(userId, station.stationKey, cap);
+  }
+
+  // The node name, because a grant names a node as well as a station — station
+  // keys repeat across the fleet.
+  const [node] = await db
+    .select({ name: nodes.name })
+    .from(nodes)
+    .where(eq(nodes.id, station.nodeId))
+    .limit(1);
+
+  const inScope =
+    node !== undefined &&
+    grantAllowsStation(grant, { nodeName: node.name, stationKey: station.stationKey });
+
+  if (!inScope) {
+    log.warn("reach refused by the control pair: station out of scope", {
+      principalId: userId,
+      node: node?.name,
+      stationKey: station.stationKey,
+      capability: cap,
+    });
+    throw new GrantReachDenied(userId, station.stationKey, cap);
+  }
+}
+
+/**
+ * Guard an act that names no station — minting an enrollment token today, the
+ * credential broker later.
+ *
+ * There is no station to match a pattern against, so the rule is narrower: you
+ * may grow a fleet only if your authority already spans it. The alternative —
+ * the boolean alone — would let a principal scoped to one node add machines
+ * indefinitely, which is the "register an agent" half of Decision 4's threat
+ * restated.
+ */
+export async function requireFleetGrantReach(userId: string): Promise<void> {
+  if (!isControlPairEnforced()) return;
+
+  const grant = await getGrant(userId);
+  const fleetWide =
+    grant?.mayGrantReach === true &&
+    grant.mayDispatch.some(
+      (v) => v.startsWith(AGENTPOD_NS) && v.slice(AGENTPOD_NS.length).startsWith("*/")
+    );
+
+  if (!fleetWide) {
+    log.warn("fleet-level reach refused by the control pair", { principalId: userId });
+    throw new GrantReachDenied(userId, "fleet", null);
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/grant-reach.test.ts
+```
+
+Expected: PASS, 13 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/services/grant-reach.ts apps/hub/src/services/control-pair.ts \
+        apps/hub/tests/integration/grant-reach.test.ts
+git commit -m "feat(hub): classify which capabilities grant an agent its reach"
+```
+
+---
+
+### Task 2: Guard the four `fs.write` routes
+
+**Files:**
+- Modify: `apps/hub/src/routes/station-writes.ts` (4 route handlers)
+- Test: `apps/hub/tests/integration/station-writes-reach.test.ts`
+
+**Interfaces:**
+- Consumes: `requireGrantReach` and `isGrantReachDenied` from Task 1.
+- Produces: nothing new — routes answer 403 with `{ error: "You do not have permission to change this agent." }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/hub/tests/integration/station-writes-reach.test.ts`:
+
+```ts
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { setGrant } from "../../src/services/grants";
+import { stationWriteRoutes } from "../../src/routes/station-writes";
+
+/**
+ * Writing into an agent's workspace is granting it reach.
+ *
+ * One request writes `~/.claude/settings.json` or an `.env`. That is the act
+ * `mayGrantReach` exists to govern, and until this test existed the dispatch
+ * check was guarding the front door of a building with no walls.
+ */
+
+const USER = "test-user-writes-reach";
+const NODE = "node_writes_reach";
+const STATION = "station_writes_reach";
+
+function app() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: USER, role: "user" });
+    await next();
+  });
+  a.route("/", stationWriteRoutes);
+  return a;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "writes-reach@example.com", name: "WR" });
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, (SELECT tenant_id FROM "user" WHERE id = ${USER}), ${USER},
+            'writes-box', 'writes-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, (SELECT tenant_id FROM "user" WHERE id = ${USER}), ${USER}, ${NODE},
+            'hermes', 'hermes:writes', 'leaf', 'Writes', '["fs.write"]'::jsonb, now(), now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+const BODIES: Array<[string, unknown]> = [
+  ["fs/write", { path: "a.txt", content: "x", encoding: "utf8" }],
+  ["fs/mkdir", { path: "d" }],
+  ["fs/move", { from: "a.txt", to: "b.txt" }],
+  ["fs/delete", { path: "a.txt" }],
+];
+
+describe("fs mutations require reach", () => {
+  test.each(BODIES)("%s is refused without mayGrantReach", async (path, body) => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const res = await app().request(`/stations/${STATION}/${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    // 403, not 502: this is a decision, not an upstream failure (#342).
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/permission to change this agent/i);
+  });
+
+  test("a refusal is audited, not only logged", async () => {
+    // An attempt refused and recorded nowhere is indistinguishable from an
+    // attempt nobody made.
+    await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    await app().request(`/stations/${STATION}/fs/write`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "a.txt", content: "x", encoding: "utf8" }),
+    });
+
+    const rows = await rawSql`
+      SELECT verb, result FROM station_audit WHERE user_id = ${USER} AND verb = 'fs.write'`;
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.result).toBe("error");
+  });
+
+  test("the guard runs after the capability gate, so a station without fs.write still 403s on capability", async () => {
+    // Ordering matters for the message: "this station cannot" and "you may not"
+    // are different answers and an operator needs the right one.
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await rawSql`UPDATE stations SET capabilities = '[]'::jsonb WHERE id = ${STATION}`;
+
+    const res = await app().request(`/stations/${STATION}/fs/write`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "a.txt", content: "x", encoding: "utf8" }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/does not advertise/i);
+
+    await rawSql`UPDATE stations SET capabilities = '["fs.write"]'::jsonb WHERE id = ${STATION}`;
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-writes-reach.test.ts
+```
+
+Expected: FAIL — the routes answer 409/502 (broker: node offline) instead of 403, because no guard exists yet.
+
+- [ ] **Step 3: Add the guard to all four routes**
+
+In `apps/hub/src/routes/station-writes.ts`, add the import:
+
+```ts
+import { requireGrantReach } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
+```
+
+Then in **each** of the four handlers, immediately after the existing capability gate block (`if (!gateCapability(station, "fs.write")) { … }`) and before the audit call, insert:
+
+```ts
+      // ── 3b. Reach gate ──────────────────────────────────────────────────────
+      // Writing into a workspace is how an agent gets credentials it did not
+      // have. Dispatch permission is not permission to rewrite (Decision 4).
+      try {
+        await requireGrantReach(user.id, station, "fs.write", "mutate");
+      } catch (e) {
+        if (!isGrantReachDenied(e)) throw e;
+        const denied = await recordAudit(db, {
+          userId: user.id,
+          nodeId: station.nodeId,
+          stationKey: station.stationKey,
+          verb: "fs.write",
+          params: { refused: "grant-reach" },
+        });
+        await denied.done("error", "refused by the control pair");
+        return c.json({ error: e.message }, 403);
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-writes-reach.test.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Run the existing write tests for regression**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-writes.test.ts
+```
+
+Expected: PASS — those tests do not set `ENFORCE_CONTROL_PAIR`, so the guard is a no-op.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/routes/station-writes.ts apps/hub/tests/integration/station-writes-reach.test.ts
+git commit -m "feat(hub): a workspace write requires mayGrantReach"
+```
+
+---
+
+### Task 3: Guard the terminal socket
+
+**Files:**
+- Modify: `apps/hub/src/routes/station-terminal.ts` (after the capability gate, before `recordAudit`)
+- Test: `apps/hub/tests/integration/station-terminal-reach.test.ts`
+
+**Interfaces:**
+- Consumes: `requireGrantReach`, `isGrantReachDenied`.
+- Produces: WS close code **1008** with an `{ t: "exit" }` frame first, matching the capability gate beside it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/hub/tests/integration/station-terminal-reach.test.ts`, modelled on the existing `station-terminal.test.ts` harness (read it first for the WS client helper it uses):
+
+```ts
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { setGrant } from "../../src/services/grants";
+
+/**
+ * A terminal is the most complete way to change what an agent is.
+ *
+ * The route's own comment already calls it "the most powerful mutation". It is
+ * the one surface where a refusal has to be unmistakable — a shell that opens
+ * and then does nothing would read as a broken node.
+ */
+
+const USER = "test-user-terminal-reach";
+const NODE = "node_terminal_reach";
+const STATION = "station_terminal_reach";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "terminal-reach@example.com", name: "TR" });
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, (SELECT tenant_id FROM "user" WHERE id = ${USER}), ${USER},
+            'term-box', 'term-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, (SELECT tenant_id FROM "user" WHERE id = ${USER}), ${USER}, ${NODE},
+            'hermes', 'hermes:term', 'leaf', 'Term', '["terminal"]'::jsonb, now(), now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("the terminal requires reach", () => {
+  test("closes 1008 for a principal who may dispatch but not change", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const { code } = await openTerminal(USER, STATION);
+    expect(code).toBe(1008);
+  });
+
+  test("opens for a principal who holds reach in scope", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:term-box/hermes:*"], mayGrantReach: true });
+
+    const { code } = await openTerminal(USER, STATION);
+    // Not 1008: the refusal is gone. (It closes on "node offline" instead —
+    // there is no live node in this suite, which is the next gate down.)
+    expect(code).not.toBe(1008);
+  });
+});
+```
+
+> The `openTerminal(userId, stationId)` helper: copy the WS-client helper out of
+> the existing `apps/hub/tests/integration/station-terminal.test.ts` — it builds a
+> minimal Hono app with a stub auth middleware, serves it on an ephemeral port,
+> connects a `WebSocket`, and resolves `{ code, frames }` on close. Do not import
+> `src/index.ts`; it starts the sweeper.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-terminal-reach.test.ts
+```
+
+Expected: FAIL — first case closes on "node offline" (1011), not 1008.
+
+- [ ] **Step 3: Add the guard**
+
+In `apps/hub/src/routes/station-terminal.ts`, after the `gateCapability(station, "terminal")` block and **before** the node-reachability check:
+
+```ts
+        // ── 2c. Reach gate ────────────────────────────────────────────────
+        // A shell is the most complete way to change what an agent is, so it
+        // is the clearest case for the second half of the pair.
+        try {
+          await requireGrantReach(user.id, station, "terminal", "mutate");
+        } catch (e) {
+          if (!isGrantReachDenied(e)) throw e;
+          const denied = await recordAudit(db, {
+            userId: user.id,
+            nodeId: station.nodeId,
+            stationKey: station.stationKey,
+            verb: "term.attach",
+            params: { refused: "grant-reach" },
+          });
+          await denied.done("error", "refused by the control pair");
+          ws.send(JSON.stringify({ t: "exit" }));
+          ws.close(1008, "Forbidden: may not change this agent");
+          return;
+        }
+```
+
+with the imports added at the top:
+
+```ts
+import { requireGrantReach } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
+```
+
+- [ ] **Step 4: Run both terminal test files**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-terminal-reach.test.ts tests/integration/station-terminal.test.ts
+```
+
+Expected: PASS both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/routes/station-terminal.ts apps/hub/tests/integration/station-terminal-reach.test.ts
+git commit -m "feat(hub): a terminal requires mayGrantReach"
+```
+
+---
+
+### Task 4: Guard `cleanup/apply`, and prove the open capabilities stay open
+
+**Files:**
+- Modify: `apps/hub/src/routes/station-cleanup.ts` (the `apply` handler only)
+- Test: `apps/hub/tests/integration/station-cleanup-reach.test.ts`
+
+**Interfaces:**
+- Consumes: `requireGrantReach`, `isGrantReachDenied`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/hub/tests/integration/station-cleanup-reach.test.ts`. Set up a user, node and station exactly as Task 2 does (capabilities `'["cleanup","changeset","lifecycle"]'::jsonb`), then:
+
+```ts
+describe("cleanup splits along the effect, not the capability", () => {
+  test("apply is refused without reach", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const res = await app().request(`/stations/${STATION}/cleanup/apply`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ targets: ["node_modules"] }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/permission to change this agent/i);
+  });
+
+  test("plan is not, because looking is not changing", async () => {
+    // One capability word covers a read and a destruction. Guarding the word
+    // would refuse someone permission to find out what would be deleted.
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const res = await app().request(`/stations/${STATION}/cleanup/plan`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe("the open capabilities are untouched", () => {
+  // These are the negative cases that catch an over-broad classification — the
+  // failure that would have people turn the control off rather than narrow it.
+  test("changeset status is allowed without reach", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    const res = await changesetApp().request(`/stations/${STATION}/changeset/status`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).not.toBe(403);
+  });
+
+  test("lifecycle is allowed without reach", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    const res = await lifecycleApp().request(`/stations/${STATION}/lifecycle`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "restart" }),
+    });
+    expect(res.status).not.toBe(403);
+  });
+});
+```
+
+`app()`, `changesetApp()` and `lifecycleApp()` are the same minimal-Hono pattern as Task 2, each mounting `stationCleanupRoutes`, `stationChangesetRoutes` and `stationLifecycleRoutes` respectively.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-cleanup-reach.test.ts
+```
+
+Expected: FAIL on the apply case (not 403); the three others pass already.
+
+- [ ] **Step 3: Guard only the apply handler**
+
+In `apps/hub/src/routes/station-cleanup.ts`, in the **apply** handler only, after its `gateCapability(station, "cleanup")` check:
+
+```ts
+      // ── Reach gate (apply only) ─────────────────────────────────────────
+      // `plan` above shares this capability and is a read; deleting an agent's
+      // files is not.
+      try {
+        await requireGrantReach(user.id, station, "cleanup", "mutate");
+      } catch (e) {
+        if (!isGrantReachDenied(e)) throw e;
+        return c.json({ error: e.message }, 403);
+      }
+```
+
+plus the two imports used in Tasks 2 and 3.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/station-cleanup-reach.test.ts
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/routes/station-cleanup.ts apps/hub/tests/integration/station-cleanup-reach.test.ts
+git commit -m "feat(hub): cleanup apply requires mayGrantReach; plan stays a read"
+```
+
+---
+
+### Task 5: Guard enrollment — growing the fleet
+
+**Files:**
+- Modify: `apps/hub/src/routes/enrollment-tokens.ts`
+- Test: `apps/hub/tests/integration/enrollment-token-reach.test.ts`
+
+**Interfaces:**
+- Consumes: `requireFleetGrantReach`, `isGrantReachDenied`.
+- Produces: 403 on `POST /api/enrollment-tokens` for a principal without fleet-wide authority.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe("minting an enrollment token is granting reach", () => {
+  test("refused for a node-scoped principal", async () => {
+    // Decision 4: "anyone who can register an agent and grant it production
+    // credentials … they build the agent they want."
+    await setGrant(USER, { mayDispatch: ["agentpod:one-box/hermes:*"], mayGrantReach: true });
+
+    const res = await app().request("/", { method: "POST" });
+    expect(res.status).toBe(403);
+  });
+
+  test("permitted when the principal's authority already spans the fleet", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+
+    const res = await app().request("/", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { token: string }).token).toBeTruthy();
+  });
+
+  test("refused without the boolean, however wide the scope", async () => {
+    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    expect((await app().request("/", { method: "POST" })).status).toBe(403);
+  });
+});
+```
+
+with the same `beforeAll`/`afterAll` shape as Task 2 (user + `ENFORCE_CONTROL_PAIR = "true"`, cleaning `enrollment_tokens` too), and `app()` mounting `enrollmentTokenRoutes` at `/`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/enrollment-token-reach.test.ts
+```
+
+Expected: FAIL — all three mint a token (200).
+
+- [ ] **Step 3: Add the guard**
+
+Rewrite `apps/hub/src/routes/enrollment-tokens.ts`:
+
+```ts
+import { Hono } from "hono";
+import { mintEnrollmentToken } from "../services/enrollment";
+import { requireFleetGrantReach } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
+
+/**
+ * POST /api/enrollment-tokens
+ * Authenticated route — mints a one-time enrollment token for the current user.
+ * Returns { token, expiresAt } where `token` is the plaintext token (shown once).
+ *
+ * Behind the reach half of the control pair: a machine joining the fleet is an
+ * agent being *registered*, which Decision 4 names as granting reach. It has no
+ * station to scope against, so it asks the narrower question — does this
+ * principal's authority already span the fleet.
+ */
+export const enrollmentTokenRoutes = new Hono().post("/", async (c) => {
+  const user = c.get("user");
+  try {
+    await requireFleetGrantReach(user.id);
+  } catch (e) {
+    if (!isGrantReachDenied(e)) throw e;
+    return c.json({ error: "You do not have permission to add machines to this fleet." }, 403);
+  }
+  const { token, expiresAt } = await mintEnrollmentToken(user.id);
+  return c.json({ token, expiresAt: expiresAt.toISOString() });
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test tests/integration/enrollment-token-reach.test.ts
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Run the whole hub suite**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+```
+
+Expected: PASS (1138 + the new tests). Any failure here is a real regression — earlier suites do not set the flag, so a break means a guard is firing when the pair is off.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/routes/enrollment-tokens.ts apps/hub/tests/integration/enrollment-token-reach.test.ts
+git commit -m "feat(hub): growing the fleet requires fleet-wide authority"
+```
+
+---
+
+### Task 6: The console says why, before you click
+
+**Files:**
+- Create: `apps/console/src/lib/api/my-grant.ts`
+- Create: `apps/console/src/lib/api/my-grant.test.ts`
+- Modify: `apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte` (tab list)
+- Modify: `apps/console/src/lib/components/admin/GrantDialog.svelte` (copy only)
+
+**Interfaces:**
+- Consumes: `/api/auth/token` on the hub (already public to authenticated callers).
+- Produces: `async function myReach(): Promise<{ mayGrantReach: boolean }>` — cached per page load, never throwing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/console/src/lib/api/my-grant.test.ts`:
+
+```ts
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { myReach, forgetMyReach } from "./my-grant";
+
+/**
+ * What this browser may do, according to the issuer.
+ *
+ * Read from the principal's own token rather than a new endpoint — the same
+ * mechanism kaambaan's web app uses. It is advisory: the hub decides. A console
+ * that guessed "allowed" and let a click 403 is a worse experience than a
+ * disabled button, and a console that guessed "denied" would hide a control
+ * someone actually holds — so a failure to find out must read as neither.
+ */
+
+function tokenWith(claims: Record<string, unknown>): string {
+  const payload = btoa(JSON.stringify(claims)).replace(/=+$/, "");
+  return `header.${payload}.signature`;
+}
+
+beforeEach(() => {
+  forgetMyReach();
+  vi.restoreAllMocks();
+});
+afterEach(() => forgetMyReach());
+
+test("reports the claim the issuer put in the token", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () =>
+    new Response(JSON.stringify({ token: tokenWith({ mayGrantReach: true }) }), { status: 200 })
+  ));
+  expect((await myReach()).mayGrantReach).toBe(true);
+});
+
+test("reports false when the claim says false", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () =>
+    new Response(JSON.stringify({ token: tokenWith({ mayGrantReach: false }) }), { status: 200 })
+  ));
+  expect((await myReach()).mayGrantReach).toBe(false);
+});
+
+test("assumes permitted when it cannot find out, and lets the hub refuse", async () => {
+  // The hub is the authority. Guessing "denied" here would hide a control the
+  // operator holds, on a deployment where the pair may not even be enforced.
+  vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("offline"); }));
+  expect((await myReach()).mayGrantReach).toBe(true);
+});
+
+test("asks once per page load", async () => {
+  const spy = vi.fn(async () =>
+    new Response(JSON.stringify({ token: tokenWith({ mayGrantReach: true }) }), { status: 200 })
+  );
+  vi.stubGlobal("fetch", spy);
+
+  await myReach();
+  await myReach();
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/console && pnpm vitest run src/lib/api/my-grant.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/console/src/lib/api/my-grant.ts`:
+
+```ts
+/**
+ * What this browser's principal may do, according to the issuer.
+ *
+ * Read out of the principal's own token rather than from a new endpoint — the
+ * hub already mints one at `/api/auth/token` carrying `mayDispatch` and
+ * `mayGrantReach`, and kaambaan's web app reads it the same way (kaambaan#43).
+ *
+ * **Advisory only.** The hub decides; this exists so a control that will be
+ * refused can say so before it is clicked. When it cannot find out it answers
+ * *permitted* and lets the hub refuse: guessing "denied" would hide a control
+ * the operator actually holds — on a deployment where the pair may not even be
+ * enforced — which is the worse of the two wrong answers.
+ */
+
+import { http } from "./client";
+
+export interface MyReach {
+  mayGrantReach: boolean;
+}
+
+const PERMITTED: MyReach = { mayGrantReach: true };
+
+let cached: Promise<MyReach> | null = null;
+
+function claimsOf(jwt: string): Record<string, unknown> | null {
+  try {
+    const [, payload] = jwt.split(".");
+    if (!payload) return null;
+    return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+  } catch {
+    return null;
+  }
+}
+
+export function myReach(): Promise<MyReach> {
+  if (cached) return cached;
+
+  cached = (async () => {
+    try {
+      const { token } = await http<{ token?: string }>("/api/auth/token");
+      const claims = token ? claimsOf(token) : null;
+      if (!claims || typeof claims.mayGrantReach !== "boolean") return PERMITTED;
+      return { mayGrantReach: claims.mayGrantReach };
+    } catch {
+      return PERMITTED;
+    }
+  })();
+
+  return cached;
+}
+
+/** Drop the cached answer — after signing out, or in tests. */
+export function forgetMyReach(): void {
+  cached = null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/console && pnpm vitest run src/lib/api/my-grant.test.ts
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Disable the Terminal tab when reach is absent**
+
+In `apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte`, add near the other state:
+
+```svelte
+  import { myReach } from "$lib/api/my-grant";
+
+  let mayGrantReach = $state(true);
+  onMount(async () => {
+    mayGrantReach = (await myReach()).mayGrantReach;
+  });
+```
+
+and change the terminal entry in the tabs array (currently line ~150) to:
+
+```svelte
+    ...(hasTerminal
+      ? [{
+          id: "terminal",
+          label: "Terminal",
+          icon: TerminalIcon,
+          disabled: !mayGrantReach,
+          // PageHeader renders a lock and this text as a tooltip.
+          disabledReason: "You may dispatch this agent but not change it — mayGrantReach",
+        }]
+      : []),
+```
+
+`Tab` already carries `disabled` and `disabledReason` (`lib/components/page-header.svelte:8`), so no component change is needed.
+
+- [ ] **Step 6: Update the dialog copy**
+
+In `apps/console/src/lib/components/admin/GrantDialog.svelte`, replace the `May grant reach` description paragraph with:
+
+```svelte
+            <p class="text-xs text-muted-foreground">
+              The second half of the pair: whether this principal may change what an agent
+              <em>is</em> — write into its workspace, open a terminal on it, delete its files, or
+              add a machine to the fleet. Dispatching an agent needs only the values above.
+            </p>
+```
+
+- [ ] **Step 7: Run the console suite**
+
+```bash
+cd apps/console && pnpm check && pnpm vitest run src/lib src/routes/nodes
+```
+
+Expected: PASS. (The full `pnpm test` also passes; on Node 26 it shows ~132 unrelated pre-existing failures — use Node 22.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/console/src/lib/api/my-grant.ts apps/console/src/lib/api/my-grant.test.ts \
+        "apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte" \
+        apps/console/src/lib/components/admin/GrantDialog.svelte
+git commit -m "feat(console): say what you may not change, before the click"
+```
+
+---
+
+### Task 7: Documentation and the charter decision
+
+**Files:**
+- Modify: `docs/DEPLOYMENT.md` (the control-pair section)
+- Create: `../charter/decisions/2026-08-15-granting-reach-is-changing-an-agent.md`
+- Modify: `docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md` (tick §3)
+
+- [ ] **Step 1: Add the capability table to DEPLOYMENT.md**
+
+After the `mayGrantReach` row in the field table, insert:
+
+```markdown
+**What `mayGrantReach` gates.** The acts that change what an agent *is*, rather
+than asking it to work:
+
+| Act | Guarded |
+|---|---|
+| `fs/write`, `fs/mkdir`, `fs/move`, `fs/delete` | yes — one request writes a credential file |
+| Terminal attach | yes — arbitrary shell as the agent's user |
+| `cleanup/apply` | yes — deletes workspace files (`cleanup/plan` is a read, and is not) |
+| `POST /api/enrollment-tokens` | yes — and additionally requires a fleet-wide (`agentpod:*/…`) dispatch value |
+| `changeset/status`, `changeset/diff`, `lifecycle`, all reads | no |
+
+A station-scoped act needs `mayGrantReach` **and** a `mayDispatch` value matching
+that station: one scope, shared with dispatch, so narrowing what someone may
+dispatch narrows what they may rewrite.
+
+**If you lock yourself out**, `/api/admin/grants` is guarded by *admin*, not by
+the pair — an admin can always restore their own grant from the console. The
+control cannot lock you out of the control.
+```
+
+- [ ] **Step 2: Write the charter decision**
+
+Create `charter/decisions/2026-08-15-granting-reach-is-changing-an-agent.md` recording: the line (dispatch = ask it to work, reach = change what it is); the shared-scope composition and why a second list was rejected; the capability classification with `lifecycle` on the dispatch side and the argument against it; the fleet-wide rule for station-less acts; and the credential broker as where this ends. Cross-link `[[2026-08-13-ecosystem-identity]]` and `[[2026-08-15-a-grant-names-an-agent-per-plane]]`.
+
+- [ ] **Step 3: Tick the plan item**
+
+In `docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md`, replace the `STILL OPEN` bullet in §3 with a ticked box naming this plan and the issue.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/DEPLOYMENT.md docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md
+git commit -m "docs: what mayGrantReach gates, and how not to lock yourself out"
+```
+
+(The charter is a separate repo — commit and push it there on its own branch.)
+
+---
+
+### Task 8: Verify against production
+
+Production is the test environment for this work, by the operator's decision. Enforcement is already on and the only principal holds `mayGrantReach: true` with fleet-wide values, so step 1 must show **no change at all**.
+
+- [ ] **Step 1: Confirm the no-op**
+
+Merge, deploy the hub (`git merge --ff-only` on `/opt/agentpod` at `root@178.105.68.68`, then `systemctl restart agentpod-hub`), redeploy the console (`PUBLIC_HUB_URL=https://hub.agentpod.dev pnpm --filter @agentpod/console build`, then `npx wrangler pages deploy apps/console/build --project-name agentpod-console`). Then, in the console: open a terminal on a live station, write a file. Both must work exactly as before.
+
+- [ ] **Step 2: Prove the refusal**
+
+Set your own `mayGrantReach` to false in **Admin → Grants**. Reload the station page:
+
+- the Terminal tab shows a lock with the reason,
+- forcing the socket anyway closes 1008,
+- a file write answers 403,
+- both refusals appear in the station's Activity tab, not only in the hub log,
+- the Chat tab still works — dispatch is unaffected.
+
+- [ ] **Step 3: Restore and confirm recovery**
+
+Set `mayGrantReach` back to true. Terminal and writes work again. Record the run in the issue.
+
+---
+
+## Self-review
+
+**Spec coverage.** The line (Tasks 2–5), composition (Task 1), fleet rule (Tasks 1, 5), classification table with `cleanup` effect-splitting (Tasks 1, 4), guards beside `gateCapability` (Tasks 2–4), 403 / 1008 / audited refusals (Tasks 2, 3), console advisory (Task 6), same switch (Global Constraints, asserted in Task 1), lockout recoverable (Task 7), production verification (Task 8), credential-broker migration (Task 7's decision doc). No spec section is unclaimed.
+
+**Deviation.** Guards live in `services/grant-reach.ts` rather than `control-pair.ts`; the error type stays in `control-pair.ts`. Reasoned above.
+
+**Type consistency.** `requireGrantReach(userId, station, cap, effect)` and `requireFleetGrantReach(userId)` are used with those exact signatures in Tasks 2–5; `isGrantReachDenied` is the guard everywhere; `myReach()`/`forgetMyReach()` match between the test and the implementation in Task 6; `REACH_BEARING` keys match `Capability.options` by construction and by assertion.

--- a/docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md
+++ b/docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md
@@ -77,16 +77,13 @@ dispatchable — because nobody with authority ever asked for it to run.
 
 - [x] `mayDispatch` reads `principal_grants`, not the environment.
 - [x] Values matched with the `agentpod:` prefix; other namespaces ignored.
-- [ ] **STILL OPEN — the only item of this plan that is.** `mayGrantReach` is
-      issued in every token, stored, and editable in the console, and it is
-      **enforced nowhere**. That makes the dispatch half decorative in the way
-      this plan itself warned about: anyone who can hand an agent production
-      credentials does not need permission to dispatch it. It needs
-      an answer to a question this plan cannot assume: *what is "granting an agent
-      its reach" in AgentPod?* Candidates, to be decided in the PR that does it:
-      minting an enrollment token, provisioning a runtime with credentials, and
-      editing node config (#237/#238). Whichever it is, the check goes at the
-      choke point those share.
+- [x] **`mayGrantReach` is enforced**, as of #345 — the acts that change what an
+      agent *is*: workspace writes, the terminal, `cleanup/apply`, and minting an
+      enrollment token (which additionally requires fleet-wide authority, since
+      it names no station). Design:
+      `docs/superpowers/specs/2026-08-15-granting-reach-design.md`; decision:
+      `charter/decisions/2026-08-15-granting-reach-is-changing-an-agent.md`.
+      Reads stay open, and `lifecycle` was judged operating rather than widening.
 
 ### 4. kaambaan accepts an authorising token on the routes that queue (api)
 

--- a/docs/superpowers/specs/2026-08-15-granting-reach-design.md
+++ b/docs/superpowers/specs/2026-08-15-granting-reach-design.md
@@ -1,0 +1,204 @@
+# Granting an agent its reach — enforcing the second half of the control pair
+
+**Date:** 2026-08-15
+**Issue:** #345
+**Status:** Design, approved in conversation. Unbuilt.
+**Follows:** `charter` → `decisions/2026-08-13-ecosystem-identity.md` Decision 4,
+and `decisions/2026-08-15-a-grant-names-an-agent-per-plane.md`.
+**Closes the last open item of:** `docs/superpowers/plans/2026-08-15-issuer-driven-organization-layer.md` §3.
+
+## The problem
+
+`mayGrantReach` is minted into every token, stored in `principal_grants`, and
+editable in **Admin → Grants**. Nothing reads it.
+
+That is not a missing feature, it is a hole in the one that shipped. Decision 4
+states the reason plainly: *"Dispatch control alone is decorative: anyone who can
+register an agent and grant it production credentials does not need permission to
+dispatch anything — they build the agent they want."* A principal denied
+`agentpod:*/hermes:prod-deploy` today can open a terminal on an agent they *are*
+permitted to dispatch, write credentials into its workspace, and reach exactly as
+far. The dispatch check refuses the front door of a building with no walls.
+
+There is a second cost, and it is the one that made this urgent: the console now
+*shows* the switch. A control on screen reads as a control in force.
+
+## The line
+
+**`mayDispatch` — may I ask this agent to work.
+`mayGrantReach` — may I change what this agent is.**
+
+Reading, observing and chatting stay on the dispatch side. Anything that puts
+bytes into an agent's environment, runs commands as it, or brings a new machine
+into the fleet moves behind the second half.
+
+## How the two compose
+
+`mayGrantReach` is a boolean; `mayDispatch` is a scoped list. The boolean answers
+*may this person change agents at all*, the list answers *which agents are
+theirs*. To act on station X a principal needs **`mayGrantReach === true` and a
+`mayDispatch` value matching X**.
+
+One scope, held in one place. Narrowing someone's dispatch narrows what they can
+rewrite, which is the behaviour that needs no explaining: it would be strange to
+lose the ability to talk to an agent while keeping the ability to hand it
+credentials.
+
+**Rejected: a second scoped list** (`mayGrantReachTo: string[]`). More
+expressive — it would let someone rewrite a staging agent while dispatching only
+production ones — and it is exactly the asymmetric-grant drift
+`a-grant-names-an-agent-per-plane` warns about: two lists that must agree, where
+disagreement is silent and permission starts depending on which door the work
+arrived through.
+
+### Acts that name no station
+
+Minting an enrollment token brings a machine into the fleet. It has no station to
+match a pattern against, so the composition rule above has nothing to bite on.
+
+**A fleet-level act requires `mayGrantReach` and a dispatch value whose node half
+is `*`.** You may grow a fleet only if your authority already spans it. The
+alternative — the boolean alone — would let a principal scoped to one node add
+machines indefinitely, which is the "register an agent" half of Decision 4's
+threat restated.
+
+## What is reach-granting
+
+`packages/contract/src/station.ts:2` defines a closed enum of ten capabilities.
+Each is classified, and because `cleanup` covers both a read and a destructive
+write under one word, the check takes the capability **and** the route's effect,
+firing only when both say so:
+
+| capability | reach-bearing | routes | outcome |
+|---|---|---|---|
+| `fs.write` | yes | write, mkdir, move, delete | all four checked |
+| `terminal` | yes | WS attach | checked |
+| `cleanup` | yes | `plan` (read), `apply` (deletes) | `apply` checked, `plan` open |
+| `changeset` | no | `status`, `diff` | both read |
+| `lifecycle` | no | start/stop | operating an agent, not widening it |
+| `acp` | no | sessions | dispatch — `mayDispatch` already guards it |
+| `inventory` `health` `logs` `fs.read` | no | reads | open |
+
+Plus one non-station site: `POST /api/enrollment-tokens`, under the fleet-wide
+rule above.
+
+**`lifecycle` on the dispatch side is a judgement call, recorded as one.**
+Starting and stopping grants an agent no capability it did not have. The argument
+against: restarting an agent to pick up a config someone else wrote is a
+laundering path. It is weak while `fs.write` is itself guarded — whoever wrote
+the config needed reach to write it.
+
+## Where the check lives
+
+`services/control-pair.ts`, beside `isControlPairEnforced` and
+`ControlPairDenied`, so the pair stays in one file and the denial shape, the 403
+and the log line come out identical to a dispatch refusal.
+
+```ts
+type Effect = "read" | "mutate";
+
+/** Exhaustive by type: a new Capability member breaks the build until classified. */
+const REACH_BEARING: Record<Capability, boolean> = { "fs.write": true, terminal: true,
+  cleanup: true, changeset: false, lifecycle: false, acp: false, inventory: false,
+  health: false, logs: false, "fs.read": false };
+
+/** Station-scoped acts. Throws ControlPairDenied. */
+export function requireGrantReach(
+  userId: string, station: StationRef, cap: Capability, effect: Effect
+): Promise<void>
+
+/** Acts that name no station — enrollment today, the credential broker later. */
+export function requireFleetGrantReach(userId: string): Promise<void>
+```
+
+The scope half is not new code: `patternMatchesStation(pattern, { nodeName,
+stationKey })` in `services/grants.ts` already answers "does this grant cover this
+station", and is what `acp.createSession` calls. `requireGrantReach` reuses it
+verbatim, so dispatch and reach can never disagree about what a pattern means.
+`requireFleetGrantReach` asks the narrower question — does any `agentpod:` value
+have `*` as its node half (`agentpod:*/…`) — which is a string test on the same
+values, not a second grammar.
+
+The `Record<Capability, boolean>` **is** the fails-when-unclassified guarantee:
+add an eleventh capability to the contract enum and the hub stops compiling until
+someone classifies it. A test asserts the table's keys equal `Capability.options`,
+so widening the type later cannot silently reopen the hole. This is the pattern
+`db/tenant-scope.ts` already uses for tables.
+
+**Called beside `gateCapability`, never folded into it.** Two of that function's
+five callers are reads (`changeset`, `cleanup/plan`); a check inside it would
+refuse someone permission to read a diff, which is nobody's idea of granting
+reach.
+
+## Behaviour
+
+- **HTTP routes: 403**, carrying `ControlPairDenied` — the shape settled in #342.
+- **Terminal WS: close 1008** with a reason frame, matching the capability gate
+  beside it.
+- **A refusal is audited, not only logged.** The terminal route already calls
+  `recordAudit` on success; an attempt refused and recorded nowhere is
+  indistinguishable from an attempt nobody made.
+- **The console greys the control and says why.** It reads `mayGrantReach` from
+  its own token via `/api/auth/token` — the mechanism kaambaan's web app already
+  uses (kaambaan#43 option A). No new endpoint. `GrantDialog` stops saying "not
+  yet enforced anywhere" and names what the switch gates.
+
+## Rollout
+
+**The same `ENFORCE_CONTROL_PAIR` switch as dispatch.** Two switches means a hub
+where half the pair is live and half is not — the state that makes dispatch
+control decorative in the first place — and a boot warning that would have to
+describe four combinations instead of two.
+
+Shipping is going live: production has enforcement on, one principal, whose grant
+already carries `mayGrantReach: true` and fleet-wide dispatch values. The change
+is a no-op there on day one, and binding for every principal added after.
+
+**Lockout is recoverable, and the docs must say so.** `/api/admin/grants` is
+guarded by *admin*, not by the pair, so an admin can always restore their own
+grant from the console. "The control locked me out of the control" is the failure
+that gets a control disabled permanently.
+
+## Testing
+
+Integration per call site, because the claim under test is that each site is
+wired — a single helper test would pass with four routes unguarded:
+
+- `fs.write` (all four verbs) refused without `mayGrantReach`; permitted with it.
+- Terminal WS closed 1008 without it.
+- `cleanup/apply` refused, `cleanup/plan` unaffected.
+- `changeset` and `lifecycle` unaffected — the negative cases are the ones that
+  catch an over-broad classification.
+- Enrollment token refused with a node-scoped grant, permitted with a fleet-wide
+  one.
+- Scope composition: `mayGrantReach: true` plus a grant that does not match this
+  station is still a refusal.
+- Regression: the kaambaan bridge is untouched. It calls
+  `acpSessions.createSession` as a service and never crosses these routes.
+- Unit: the classification table is exhaustive over `Capability.options`.
+
+## Verification against production
+
+Same shape as the dispatch pass on 2026-08-15, and in this order:
+
+1. Confirm nothing changed: open a terminal, write a file.
+2. Set your own `mayGrantReach` to false. Confirm the terminal closes 1008 and a
+   write answers 403, with both visible in the audit trail.
+3. Restore it. Confirm recovery.
+
+## Where this ends
+
+**The credential broker** (`charter` → `strategy/2026-08-12-layer-reference.md`,
+P3) makes granting reach a first-class act instead of an inference from file
+writes, and the Capability Registry invariant means the ten capabilities here are
+an early sample, not the set. What this design must earn is that the migration is
+a *move*: the classification table gains the broker's verb, the check stays where
+it is, and no call site is rewritten.
+
+## What this design will not do
+
+- **Introduce a policy engine.** One boolean, one scope list, both failing closed.
+- **Guard reads.** Observation is not reach; a console that refused to show logs
+  would be routed around within a day.
+- **Cover cross-plane reach.** kaambaan granting an agent a tool or a credential
+  is its own boundary, on its own plane.


### PR DESCRIPTION
Design for #345, the last open item of the issuer-driven Organization layer. **Spec only — nothing implemented.**

`mayGrantReach` is minted into every token, stored, and now editable in Admin → Grants, and **read by nothing**. That leaves the dispatch half guarding the front door of a building with no walls: a principal denied one agent can open a terminal on an agent they *are* allowed to dispatch and write credentials into it.

## The decisions this records

- **The line.** `mayDispatch` = may I ask this agent to work. `mayGrantReach` = may I change what this agent is. Reads, observation and chat stay on the dispatch side.
- **Composition.** The boolean rides the existing dispatch scope — act on station X needs `mayGrantReach` **and** a `mayDispatch` value matching X. A second scoped list was rejected: two lists that must agree is the asymmetric-grant drift `a-grant-names-an-agent-per-plane` warns about.
- **Classification is a type, not a document.** `Record<Capability, boolean>` over the contract's closed enum — an eleventh capability stops the build until someone classifies it, the way `db/tenant-scope.ts` already does for tables. `cleanup` forced the check to take the route's *effect* too, since `plan` reads and `apply` destroys under one capability word.
- **Same `ENFORCE_CONTROL_PAIR` switch.** Two switches means a hub where half the pair is live, which is the state that makes the other half decorative.

## Two things the charter changed

- Decision 4 counts **registering** an agent as granting reach ("they build the agent they want"), so minting an enrollment token is in scope — and having no station to scope against, it requires a dispatch value that already spans the fleet (`agentpod:*/…`). I had wrongly set enrollment aside as fleet-growth.
- The **Capability Registry** invariant and the P3 **credential broker** mean today's ten capabilities are an early sample. The design is judged on whether that migration is a *move* — table gains a verb, call sites untouched.

## Rollout reality

Production has enforcement on, one principal, whose grant already carries `mayGrantReach: true` and fleet-wide values — so this is a no-op there on day one and binding for everyone added after. Lockout is recoverable because `/api/admin/grants` is guarded by admin, not by the pair; the spec requires that be documented, since "the control locked me out of the control" is how controls get disabled permanently.

Next step after review: `writing-plans` → implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW