### PR TITLE
fix(hub): ask the substrate about a runtime whose node went quiet

### DIFF
--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -53,6 +53,7 @@ import {
   STOP_TIMEOUT_MS,
   sweepExpiringRuntimes,
   ROTATION_MARGIN_MS,
+  sweepUnobservedRuntimes,
 } from "../services/runtimes";
 import { enrollNode } from "../services/enrollment";
 import type { AuthUser } from "../auth/middleware";
@@ -1976,4 +1977,162 @@ test("a rotation the substrate refuses leaves the runtime in error, naming the c
   expect(after.status).toBe("error");
   expect(after.statusReason).toContain("no capacity");
   expect(after.statusReason).toMatch(/24|ceiling|lifetime/i);
+}, 30_000);
+
+// ─── The runtime nobody asked about (#347) ────────────────────────────────────
+
+/**
+ * A driver that answers about its container, and declares whether a stop can be
+ * undone. `stopSemantics` is the difference between "asleep" and "stopped" for
+ * an operator: on Cloudflare a stopped container wakes with its workspace
+ * restored from R2, and calling that `stopped` reads as "gone".
+ */
+function fakeObservableProvisioner(
+  answers: () => "running" | "stopped" | "unknown",
+  stopSemantics: "resumable" | "terminal" = "resumable",
+  opts: { withStatus?: boolean } = {}
+) {
+  const calls = { status: [] as string[] };
+  const driver: Record<string, unknown> = {
+    provider: "docker",
+    manifest: { provider: "docker", stopSemantics },
+    async provision(spec: ProvisionSpec) {
+      return { externalId: `fake-container-${spec.runtimeId}` };
+    },
+    async destroy() {},
+    async start() {},
+    async stop() {},
+  };
+  if (opts.withStatus !== false) {
+    driver.status = async (externalId: string) => {
+      calls.status.push(externalId);
+      return answers();
+    };
+  }
+  return { driver: driver as unknown as RuntimeProvisioner, calls };
+}
+
+/** An `online` runtime whose node stopped heartbeating `agoMs` ago. */
+async function seedUnobserved(id: string, agoMs = 10 * 60_000) {
+  const nodeId = `node_unobs_${id}`;
+  // Every seeded row is a candidate for every other test's sweep, so each test
+  // starts from a clean slate rather than counting probes it did not cause.
+  await rawSql`DELETE FROM provisioned_runtimes WHERE id LIKE 'rt_unobs_%'`;
+  await rawSql`DELETE FROM nodes WHERE id LIKE 'node_unobs_%'`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, last_seen_at, created_at)
+    VALUES (${nodeId}, (SELECT tenant_id FROM provisioned_runtimes LIMIT 1), ${TEST_USER},
+            ${id}, ${id}, 'linux', 'amd64', 2, 'offline', 'x',
+            now() - (${agoMs} || ' milliseconds')::interval, now())`;
+  await rawSql`
+    INSERT INTO provisioned_runtimes (id, tenant_id, user_id, provider, external_id, status, node_id, name, harness, created_at, updated_at)
+    VALUES (${id}, (SELECT tenant_id FROM nodes WHERE id = ${nodeId}), ${TEST_USER}, 'docker',
+            ${`fake-container-${id}`}, 'online', ${nodeId}, ${id}, 'none',
+            now() - (${agoMs} || ' milliseconds')::interval,
+            now() - (${agoMs} || ' milliseconds')::interval)`;
+  return { nodeId };
+}
+
+test("a runtime whose container the substrate says is gone stops claiming to be online", async () => {
+  // The live bug: cf-opencode read `online` for two days while its container was
+  // stopped. The substrate knew; nobody asked.
+  const { driver, calls } = fakeObservableProvisioner(() => "stopped", "resumable");
+  await withProvisioner(driver, async () => {
+    await seedUnobserved("rt_unobs_gone");
+
+    const swept = await sweepUnobservedRuntimes(Date.now());
+    expect(swept.reconciled).toContain("rt_unobs_gone");
+    expect(calls.status).toHaveLength(1);
+
+    const row = await rowOf("rt_unobs_gone");
+    // `asleep`, not `stopped`: this substrate's stop is resumable, and the
+    // difference is whether an operator thinks their work is gone.
+    expect(row.status).toBe("asleep");
+  });
+}, 30_000);
+
+test("a terminal substrate's stop is recorded as stopped, not asleep", async () => {
+  const { driver } = fakeObservableProvisioner(() => "stopped", "terminal");
+  await withProvisioner(driver, async () => {
+    await seedUnobserved("rt_unobs_terminal");
+
+    await sweepUnobservedRuntimes(Date.now());
+
+    expect((await rowOf("rt_unobs_terminal")).status).toBe("stopped");
+  });
+}, 30_000);
+
+test("a runtime the substrate still reports running is left alone", async () => {
+  // The case the evidence rule exists for: nodes drop off the network while
+  // their container runs, and bills. Absence of a node is not a stop.
+  const { driver } = fakeObservableProvisioner(() => "running");
+  await withProvisioner(driver, async () => {
+    await seedUnobserved("rt_unobs_running");
+
+    const swept = await sweepUnobservedRuntimes(Date.now());
+    expect(swept.reconciled).not.toContain("rt_unobs_running");
+
+    const row = await rowOf("rt_unobs_running");
+    expect(row.status).toBe("online");
+    expect(row.statusReason).toBeNull();
+  });
+}, 30_000);
+
+test("a substrate that cannot answer changes nothing, but says so", async () => {
+  // Never manufacture a state. An operator reading `online` with no explanation
+  // believes the hub checked; this tells them it could not.
+  const { driver } = fakeObservableProvisioner(() => "unknown");
+  await withProvisioner(driver, async () => {
+    await seedUnobserved("rt_unobs_unknown");
+
+    await sweepUnobservedRuntimes(Date.now());
+
+    const row = await rowOf("rt_unobs_unknown");
+    expect(row.status).toBe("online");
+    // Says which fact is missing, not just that something is wrong.
+    expect(row.statusReason).toMatch(/unseen/i);
+    expect(row.statusReason).toMatch(/did not answer|cannot report|no driver/i);
+  });
+}, 30_000);
+
+test("a driver with no status() is not guessed about either", async () => {
+  const { driver } = fakeObservableProvisioner(() => "stopped", "resumable", {
+    withStatus: false,
+  });
+  await withProvisioner(driver, async () => {
+    await seedUnobserved("rt_unobs_nostatus");
+
+    await sweepUnobservedRuntimes(Date.now());
+
+    const row = await rowOf("rt_unobs_nostatus");
+    expect(row.status).toBe("online");
+    expect(row.statusReason).toBeTruthy();
+  });
+}, 30_000);
+
+test("a node offline only briefly is inside the grace window and is not probed", async () => {
+  // A hub restart, a redeploy, a flaky minute — probing every one of those would
+  // turn a substrate API into a heartbeat.
+  const { driver, calls } = fakeObservableProvisioner(() => "stopped");
+  await withProvisioner(driver, async () => {
+    await seedUnobserved("rt_unobs_recent", 30_000);
+
+    await sweepUnobservedRuntimes(Date.now());
+
+    expect(calls.status).not.toContain("fake-container-rt_unobs_recent");
+    expect((await rowOf("rt_unobs_recent")).status).toBe("online");
+  });
+}, 30_000);
+
+test("runtimes whose node is online are never probed", async () => {
+  const { driver, calls } = fakeObservableProvisioner(() => "stopped");
+  await withProvisioner(driver, async () => {
+    const { nodeId } = await seedUnobserved("rt_unobs_healthy");
+    await rawSql`UPDATE nodes SET status = 'online', last_seen_at = now() WHERE id = ${nodeId}`;
+
+    await sweepUnobservedRuntimes(Date.now());
+
+    expect(calls.status).not.toContain("fake-container-rt_unobs_healthy");
+    expect((await rowOf("rt_unobs_healthy")).status).toBe("online");
+  });
 }, 30_000);

--- a/apps/hub/src/services/node-sweeper.ts
+++ b/apps/hub/src/services/node-sweeper.ts
@@ -17,6 +17,7 @@ import {
   sweepStalledRuntimeStarts,
   sweepStalledRuntimeStops,
   sweepExpiringRuntimes,
+  sweepUnobservedRuntimes,
 } from "./runtimes";
 
 export const SWEEP_INTERVAL_MS = 15_000;
@@ -48,12 +49,14 @@ export async function sweepStaleNodes(now: number = Date.now()): Promise<string[
 /**
  * Start the periodic sweeper. Returns a stop function.
  *
- * Four expiries share the tick because they are the same idea at four levels: a
+ * Five sweeps share the tick because they are the same idea at five levels: a
  * node that stopped talking, a runtime that was asked to run and never produced
  * a node at all (sweepStalledRuntimeStarts), a runtime that was asked to stop
- * and has not been seen to (sweepStalledRuntimeStops), and the one nobody asked
- * for — a runtime the SUBSTRATE is about to destroy for age while it is working
- * perfectly (sweepExpiringRuntimes).
+ * and has not been seen to (sweepStalledRuntimeStops), the one nobody asked for
+ * — a runtime the SUBSTRATE is about to destroy for age while it is working
+ * perfectly (sweepExpiringRuntimes) — and the one nobody was told about: a
+ * runtime whose container stopped without any of these paths hearing about it
+ * (sweepUnobservedRuntimes).
  */
 export function startNodeSweeper(): () => void {
   const timer = setInterval(() => {
@@ -76,6 +79,14 @@ export function startNodeSweeper(): () => void {
     // cost nothing here.
     void sweepExpiringRuntimes().catch((err) =>
       console.error("[sweeper] runtime rotation sweep failed:", err)
+    );
+    // And the one nobody was TOLD about. A substrate reports a stop only on the
+    // paths it knows to report — Cloudflare tells us when it idles a container
+    // out, and says nothing when one crashes, is evicted, or predates the
+    // callback feature. Absence of a node is still not evidence of a stop, so
+    // this asks the driver rather than assuming (#347).
+    void sweepUnobservedRuntimes().catch((err) =>
+      console.error("[sweeper] unobserved runtime sweep failed:", err)
     );
   }, SWEEP_INTERVAL_MS);
   return () => clearInterval(timer);

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -1133,3 +1133,142 @@ export async function sweepExpiringRuntimes(
 
 // Re-export for convenience (routes use this)
 export { enabledProviders, providerManifests };
+
+// ─── The runtime nobody asked about (#347) ────────────────────────────────────
+
+/**
+ * How long a node must have been unseen before its runtime is probed.
+ *
+ * The node sweeper already expires a node after 45s of silence, and most of
+ * those are nothing: a hub restart, a redeploy, a flaky minute of network.
+ * Probing every one would turn a substrate's API into a heartbeat and bill for
+ * the privilege. Ten minutes is long past any of that and still far short of the
+ * two days `cf-opencode` spent claiming to be online.
+ */
+export const UNOBSERVED_GRACE_MS = 10 * 60_000;
+
+/**
+ * Reconcile runtimes whose container stopped without anyone being told.
+ *
+ * The hub learns that a Cloudflare container stopped by being *told*
+ * (`onActivityExpired` → `notifyHub`). That covers exactly one path: the idle
+ * one, and only for sandboxes whose stored env carries the callback token. A
+ * container that crashes, is evicted, is restarted by the platform, or predates
+ * the callback feature says nothing at all — and until this sweep, nothing
+ * asked. `cf-opencode` read `online` for two days with its container stopped.
+ *
+ * The rule this obeys is unchanged and load-bearing: **the absence of a node is
+ * not evidence of a stop**, because nodes drop off the network while their
+ * container runs and bills. What changes is the response to that absence. It was
+ * "write nothing", which leaves a stale claim standing forever; it is now "go
+ * and get evidence" — the drivers have a `status()` that answers, and a claim
+ * the hub can check but does not is a claim it should not be making.
+ *
+ * Nothing here manufactures a state. A substrate that will not answer leaves the
+ * status alone and gets a `statusReason` saying so, because "online, unverified"
+ * and "online" are different facts and an operator is entitled to know which one
+ * they are reading.
+ */
+export async function sweepUnobservedRuntimes(
+  now: number = Date.now()
+): Promise<{ reconciled: string[]; unverified: string[] }> {
+  const cutoff = new Date(now - UNOBSERVED_GRACE_MS);
+
+  const candidates = await db
+    .select({
+      id: provisionedRuntimes.id,
+      provider: provisionedRuntimes.provider,
+      externalId: provisionedRuntimes.externalId,
+    })
+    .from(provisionedRuntimes)
+    .innerJoin(nodes, eq(nodes.id, provisionedRuntimes.nodeId))
+    .where(
+      and(
+        eq(provisionedRuntimes.status, "online"),
+        isNotNull(provisionedRuntimes.externalId),
+        eq(nodes.status, "offline"),
+        lt(nodes.lastSeenAt, cutoff)
+      )
+    );
+
+  const reconciled: string[] = [];
+  const unverified: string[] = [];
+
+  for (const row of candidates) {
+    const provisioner = getProvisionerUnguarded(row.provider);
+    const state = provisioner ? await probeState(provisioner, row.externalId!) : "unknown";
+
+    if (state === "running") {
+      // The case the evidence rule exists to protect: the node is unreachable
+      // and the container is fine. Nothing to write.
+      continue;
+    }
+
+    if (state === "stopped") {
+      // `asleep` where a stop can be undone, `stopped` where it cannot. On
+      // Cloudflare a stopped container wakes with the same node id and its
+      // workspace restored from R2, and telling an operator "stopped" for that
+      // reads as "gone" — which is the sentence that gets a runtime destroyed
+      // and its archive deleted with it.
+      const resumable = provisioner?.manifest?.stopSemantics === "resumable";
+
+      const flipped = await db
+        .update(provisionedRuntimes)
+        .set({
+          status: resumable ? "asleep" : "stopped",
+          statusReason: resumable
+            ? `its node stopped reporting and the ${row.provider} substrate confirms the ` +
+              `container is down — start it to wake it, do not reprovision (that discards ` +
+              `the workspace archive)`
+            : null,
+          updatedAt: new Date(now),
+        })
+        .where(
+          and(
+            eq(provisionedRuntimes.id, row.id),
+            // Guarded: a node that reconnected mid-sweep has already written a
+            // truer answer than this probe's.
+            eq(provisionedRuntimes.status, "online")
+          )
+        )
+        .returning({ id: provisionedRuntimes.id });
+
+      if (flipped.length > 0) {
+        reconciled.push(row.id);
+        console.log(
+          `[runtime-sweeper] ${row.id} online → ${resumable ? "asleep" : "stopped"} ` +
+            `(${row.provider} confirmed the container is down)`
+        );
+      }
+      continue;
+    }
+
+    // `unknown`, or no driver, or no status() to call. Say what is not known
+    // rather than inventing what is.
+    const why = !provisioner
+      ? `no driver is registered for ${row.provider} to ask`
+      : !provisioner.status
+        ? `the ${row.provider} driver cannot report container state`
+        : `the ${row.provider} substrate did not answer`;
+
+    const annotated = await db
+      .update(provisionedRuntimes)
+      .set({
+        statusReason:
+          `its node has been unseen for over ${humanMs(UNOBSERVED_GRACE_MS)} and ` +
+          `${why} — this runtime may not exist, and may still be billing`,
+        updatedAt: new Date(now),
+      })
+      .where(
+        and(
+          eq(provisionedRuntimes.id, row.id),
+          eq(provisionedRuntimes.status, "online")
+        )
+      )
+      .returning({ id: provisionedRuntimes.id });
+
+    if (annotated.length > 0) unverified.push(row.id);
+  }
+
+  return { reconciled, unverified };
+}


### PR DESCRIPTION
Closes #347. Found while answering "cf-opencode is online but cloudchamber is offline?" — they are the same machine, and the runtime row had been wrong for two days.

```
GET /sandbox/rt_e0abb94bb19147b7840c → {"state":"stopped"}
```

## Why it was wrong

The hub learns that a Cloudflare container stopped by being **told**: `onActivityExpired` → `notifyHub` → `POST /public/runtimes/:id/state`. Two holes:

1. **Only the idle path reports.** `onStop` records to DO storage and notifies nobody, so a crash, an eviction or a platform restart is silent.
2. **`notifyHub` needs env captured at creation.** `cf-opencode` was created 08-12 07:46; the sleep callback shipped 08-12 09:23 (602117b). It predates its own notifier and can never report anything.

And nothing polled: the three existing sweeps filter `starting`/`provisioning`, `stopping`, and the age cap. None asks whether an `online` runtime is still there.

## The fix

`sweepUnobservedRuntimes`, a fifth sweep on the same 15s tick. Candidates are `online` runtimes whose node is `offline` and unseen for more than 10 minutes — long past a hub restart or a flaky minute, and far short of two days.

- driver says **running** → leave it. This is the case the evidence rule exists to protect: nodes drop off the network while their container runs and bills.
- driver says **stopped** → `asleep` when `stopSemantics` is `resumable`, `stopped` when `terminal`. **First use of `stopSemantics` in this path**, and the distinction is the point: on Cloudflare a stopped container wakes with the same node id and its workspace restored from R2, so calling it `stopped` reads as "gone" — the sentence that gets a runtime destroyed and its R2 archive deleted with it. The `asleep` reason says explicitly: start it, do not reprovision.
- driver says **unknown**, has no `status()`, or is not registered → **change nothing**, write a `statusReason` naming what could not be confirmed. "Online" and "online, unverified" are different facts.

The rule is unchanged — absence of a node is still not evidence of a stop. What changes is that the hub now goes and gets evidence instead of leaving a stale claim standing.

## Tests

7 new (73 in the file, 1177 in the suite, 0 fail): substrate-confirmed stop → `asleep`; terminal substrate → `stopped`; still-running → untouched; unknown and no-`status()` → annotated, never guessed; inside the grace window → not probed; healthy node → not probed. The last two assert on *this* runtime's probe rather than a global count, so a sibling test's rows can't make them pass or fail by accident.

## Not in scope

Backfilling callback env into pre-602117b sandboxes — the sweep makes it unnecessary, said out loud so nobody writes that migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW