### PR TITLE
fix(hub): refuse to 'update' a node whose binary comes from an image

### DIFF
--- a/.github/workflows/release-node-agent.yml
+++ b/.github/workflows/release-node-agent.yml
@@ -215,7 +215,7 @@ jobs:
       # steps.bump.outputs.changed: 0 when both files already pin $TAG, which is
       # what a re-run or a re-cut tag hits, and is a clean success — no branch,
       # no empty commit, no PR.
-      - name: Bump the ARG in both Fly Dockerfiles
+      - name: Bump the ARG in the Fly and Cloudflare Dockerfiles
         id: bump
         run: sh fly/node-image/bump-version-pin.sh --to "$TAG"
 
@@ -229,7 +229,7 @@ jobs:
 
           # Belt and braces: `changed=1` already means the files differ, but an
           # empty commit here would fail the job on an otherwise fine release.
-          if git diff --quiet -- fly/node-image/Dockerfile fly/node-image/Dockerfile.pi; then
+          if git diff --quiet -- fly/node-image/Dockerfile fly/node-image/Dockerfile.pi cloudflare/worker-v2/Dockerfile; then
             echo "nothing to commit despite changed=1 — leaving the pin alone" >&2
             exit 1
           fi
@@ -239,7 +239,7 @@ jobs:
           git checkout -b "$branch"
           git commit -m "chore(fly): pin the node-agent to $TAG" \
             -m "Opened by release-node-agent.yml when $TAG was released (#302)." \
-            -- fly/node-image/Dockerfile fly/node-image/Dockerfile.pi
+            -- fly/node-image/Dockerfile fly/node-image/Dockerfile.pi cloudflare/worker-v2/Dockerfile
           # Force: re-running the release for the same tag must reach the same
           # end state rather than failing on a branch left by the first run.
           git push --force origin "HEAD:refs/heads/$branch"

--- a/apps/hub/src/routes/nodes.ts
+++ b/apps/hub/src/routes/nodes.ts
@@ -3,6 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import { EnrollRequest } from "@agentpod/contract";
 import { enrollNode, verifyNodeCredential } from "../services/enrollment";
 import { listNodes } from "../services/node-registry";
+import { nodesWithFixedImage } from "../services/runtimes";
 import {
   executeRollout,
   planRollout,
@@ -76,9 +77,12 @@ export function createNodeRoutes(deps?: {
   request?: RequestFn;
   /** Replaces the database-backed node list so the rollout is unit-testable. */
   listNodesFn?: (userId: string) => Promise<RolloutNode[]>;
+  /** Replaces the runtime lookup that answers which nodes boot from an image. */
+  fixedImageNodesFn?: (userId: string) => Promise<Set<string>>;
 }) {
   const _request: RequestFn = deps?.request ?? brokerRequest;
   const _listNodes = deps?.listNodesFn ?? (listNodes as (u: string) => Promise<RolloutNode[]>);
+  const _fixedImageNodes = deps?.fixedImageNodesFn ?? nodesWithFixedImage;
 
   return (
     new Hono()
@@ -111,8 +115,17 @@ export function createNodeRoutes(deps?: {
           ? (body.only as unknown[]).filter((x): x is string => typeof x === "string")
           : undefined;
 
-        const nodes = await _listNodes(c.get("user").id);
-        const plan = planRollout(nodes, { force, only });
+        const userId = c.get("user").id;
+        const nodes = await _listNodes(userId);
+
+        // A node whose binary comes from an image is not updatable by RPC, and
+        // asking stops it. A rollout that did that to every container station
+        // would be far worse than one that updates nothing (#349).
+        const fixed = await _fixedImageNodes(userId);
+        const plan = planRollout(
+          nodes.map((n) => ({ ...n, imageFixed: fixed.has(n.id) })),
+          { force, only }
+        );
         const results = await executeRollout(plan, { request: _request, force });
 
         return c.json({
@@ -151,6 +164,25 @@ export function createNodeRoutes(deps?: {
       .post("/:id/update", async (c) => {
         const nodeId = c.req.param("id");
         const force = await readForce(c);
+
+        // Refused BEFORE the RPC, because sending it is what stops the station:
+        // the agent swaps its binary and exits for a supervisor that a
+        // container substrate does not have, onto a disk that will not keep the
+        // swap (#349). `force` does not apply — it cannot make this work.
+        if ((await _fixedImageNodes(c.get("user").id)).has(nodeId)) {
+          return c.json(
+            {
+              ok: false as const,
+              error:
+                "This node's binary comes from the substrate's image, so it cannot " +
+                "self-update — the attempt would stop the station and change nothing. " +
+                "Bump AGENTPOD_VERSION in that image, redeploy it, then restart the " +
+                "runtime; the workspace is restored from its archive.",
+            },
+            409
+          );
+        }
+
         const r = await _request(nodeId, "update", { force });
 
         // The RPC never reached the node, or the node rejected the frame.

--- a/apps/hub/src/services/rollout.ts
+++ b/apps/hub/src/services/rollout.ts
@@ -25,6 +25,16 @@ export interface RolloutNode {
   agentVersion: string | null;
   latestVersion: string | null;
   updateAvailable: boolean;
+  /**
+   * True when this node's binary comes from an image rather than from disk —
+   * the driver declares `imageBinding: "fixed"` (#349).
+   *
+   * Such a node cannot be moved forward by self-update **by construction**:
+   * the swap does not survive a restart from the image, and the exit that
+   * self-update performs to hand over to a supervisor is, on a container
+   * substrate with no supervisor, simply the station stopping.
+   */
+  imageFixed?: boolean;
 }
 
 export interface PlanItem {
@@ -78,6 +88,17 @@ export function planRollout(nodes: RolloutNode[], opts: PlanOptions): PlanItem[]
       // RPC. Calling this a failure would make every rollout report failures
       // for machines that are merely switched off.
       if (n.status !== "online") return skip(`the node is ${n.status || "offline"}`);
+
+      // Also not a policy choice, and checked BEFORE force for that reason:
+      // sending this node an update does not update it, it stops it. The
+      // binary is swapped into an ephemeral disk and the process exits looking
+      // for a supervisor that a container does not have.
+      if (n.imageFixed) {
+        return skip(
+          "its binary comes from the substrate's image — update it by bumping " +
+            "AGENTPOD_VERSION in that image, redeploying, and restarting the runtime"
+        );
+      }
 
       if (opts.force) return { nodeId: n.id, name: n.name, action: "update" };
 

--- a/apps/hub/src/services/runtimes.ts
+++ b/apps/hub/src/services/runtimes.ts
@@ -1272,3 +1272,42 @@ export async function sweepUnobservedRuntimes(
 
   return { reconciled, unverified };
 }
+
+/**
+ * Nodes whose binary comes from the substrate's image, not from their disk (#349).
+ *
+ * A node backed by a driver that declares `imageBinding: "fixed"` cannot be
+ * moved forward by self-update, and asking it to try is worse than refusing:
+ * `selfupdate.Apply` swaps the binary and the agent exits to hand over to a
+ * supervisor, which on a container substrate is simply the station stopping —
+ * and the swapped binary would not have survived the restart anyway, because
+ * the next start comes up from the image.
+ *
+ * Returns the set of node ids to leave alone. A set rather than a per-node
+ * question because both callers — the single-node route and the fleet rollout —
+ * want to decide before sending anything, and the fleet one would otherwise ask
+ * once per node.
+ */
+export async function nodesWithFixedImage(userId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({
+      nodeId: provisionedRuntimes.nodeId,
+      provider: provisionedRuntimes.provider,
+    })
+    .from(provisionedRuntimes)
+    .where(
+      and(
+        eq(provisionedRuntimes.userId, userId),
+        isNotNull(provisionedRuntimes.nodeId)
+      )
+    );
+
+  const fixed = new Set<string>();
+  for (const row of rows) {
+    const provisioner = getProvisionerUnguarded(row.provider);
+    // Unknown driver → not claimed as fixed. A refusal on a guess would block
+    // an update that might work; the node's own answer still has the last word.
+    if (provisioner?.manifest?.imageBinding === "fixed") fixed.add(row.nodeId!);
+  }
+  return fixed;
+}

--- a/apps/hub/tests/unit/nodes-update-all-route.test.ts
+++ b/apps/hub/tests/unit/nodes-update-all-route.test.ts
@@ -41,7 +41,10 @@ const fleet: RolloutNode[] = [
 ];
 
 /** Mounts the routes behind a stub that supplies the authenticated user. */
-function appWith(request: Parameters<typeof createNodeRoutes>[0]["request"]) {
+function appWith(
+  request: Parameters<typeof createNodeRoutes>[0]["request"],
+  fixedImage: Set<string> = new Set()
+) {
   const app = new Hono();
   app.use("*", async (c, next) => {
     c.set("user", { id: "user_1" });
@@ -49,7 +52,14 @@ function appWith(request: Parameters<typeof createNodeRoutes>[0]["request"]) {
   });
   app.route(
     "/api/nodes",
-    createNodeRoutes({ request, listNodesFn: async () => fleet })
+    // fixedImageNodesFn is injected like listNodesFn: without it the route asks
+    // the database which nodes boot from an image, and this file is a unit test
+    // of the wiring, with no schema behind it.
+    createNodeRoutes({
+      request,
+      listNodesFn: async () => fleet,
+      fixedImageNodesFn: async () => fixedImage,
+    })
   );
   return app;
 }
@@ -152,4 +162,31 @@ describe("POST /api/nodes/update-all (#295)", () => {
     const res = await app.request("/api/nodes/update-all", { method: "POST" });
     expect(res.status).toBe(200);
   });
+});
+
+/**
+ * A fleet rollout must not stop the stations it cannot update (#349).
+ *
+ * A node whose binary comes from the substrate's image cannot be moved forward
+ * by RPC — the agent swaps the binary, exits for a supervisor a container does
+ * not have, and the swap dies with the ephemeral disk. Asking it is not a failed
+ * update, it is an outage, and doing that to every container station at once is
+ * the worst outcome this route can produce.
+ */
+test("a node whose binary comes from an image is skipped, not asked", async () => {
+  const asked: string[] = [];
+  const app = appWith(async (nodeId) => {
+    asked.push(nodeId);
+    return { ok: true, data: { ok: true, updating: true, tag: "v0.1.27" } };
+  }, new Set(["n_behind"]));
+
+  const res = await post(app);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as {
+    results: Array<{ nodeId: string; action?: string; status?: string; reason?: string }>;
+  };
+
+  expect(asked).not.toContain("n_behind");
+  const row = body.results.find((r) => r.nodeId === "n_behind")!;
+  expect(JSON.stringify(row)).toMatch(/image/i);
 });

--- a/apps/hub/tests/unit/nodes-update-route.test.ts
+++ b/apps/hub/tests/unit/nodes-update-route.test.ts
@@ -45,7 +45,13 @@ type RequestFn = (
  * every request.
  */
 function makeTestApp(mockRequest: RequestFn) {
-  const routes = createNodeRoutes({ request: mockRequest });
+  // fixedImageNodesFn is injected for the same reason `request` is: this file
+  // has no database behind it, and without the injection the route asks one
+  // which nodes boot from a substrate image.
+  const routes = createNodeRoutes({
+    request: mockRequest,
+    fixedImageNodesFn: async () => new Set<string>(),
+  });
 
   return new Hono()
     .use("/api/nodes/*", async (c, next) => {

--- a/apps/hub/tests/unit/nodes-update-route.test.ts
+++ b/apps/hub/tests/unit/nodes-update-route.test.ts
@@ -233,3 +233,85 @@ test("POST /api/nodes/:id/update → a successful update is still a 200", async 
     expect(res.status).toBe(200);
   }
 });
+
+// ─── A node whose binary comes from an image (#349) ───────────────────────────
+
+/**
+ * `cf-opencode` was updated from the console and went offline, still on
+ * v0.1.22. Self-update swaps the binary and exits so a supervisor can restart
+ * it; a Cloudflare container has no supervisor, so the exit IS the stop — and
+ * the swap would not have survived the restart it never got, because the next
+ * start comes up from the image.
+ *
+ * So the refusal must happen BEFORE the RPC. A route that sent the verb and
+ * reported the failure afterwards would have already stopped the station.
+ */
+function appWithFixedImageNode(mockRequest: RequestFn) {
+  const routes = createNodeRoutes({
+    request: mockRequest,
+    fixedImageNodesFn: async () => new Set([TEST_NODE_ID]),
+  });
+  return new Hono()
+    .use("/api/nodes/*", async (c, next) => {
+      c.set("user", {
+        id: TEST_USER_ID,
+        authType: "api_key",
+        tenantId: "fleet_00000000000000000000",
+      } satisfies AuthUser);
+      return next();
+    })
+    .route("/api/nodes", routes);
+}
+
+test("a node that boots from an image is refused, and the RPC is never sent", async () => {
+  const { request, calls } = stubBroker({ ok: true, data: { ok: true, updating: true } });
+
+  const res = await appWithFixedImageNode(request).request(
+    `/api/nodes/${TEST_NODE_ID}/update`,
+    { method: "POST", headers: { "Content-Type": "application/json" } }
+  );
+
+  expect(res.status).toBe(409);
+  // Not sending it is the whole point: the send is what stops the station.
+  expect(calls).toHaveLength(0);
+});
+
+test("the refusal says how to update the node instead", async () => {
+  // A bare "unsupported" leaves an operator with a stale station and no next
+  // step, which is how people end up destroying a runtime to fix a version.
+  const { request } = stubBroker({ ok: true, data: { ok: true, updating: true } });
+
+  const res = await appWithFixedImageNode(request).request(
+    `/api/nodes/${TEST_NODE_ID}/update`,
+    { method: "POST", headers: { "Content-Type": "application/json" } }
+  );
+  const body = (await res.json()) as { ok: boolean; error: string };
+
+  expect(body.ok).toBe(false);
+  expect(body.error).toMatch(/image/i);
+  expect(body.error).toMatch(/AGENTPOD_VERSION|redeploy/i);
+});
+
+test("force does not override it, because force cannot make this work", async () => {
+  const { request, calls } = stubBroker({ ok: true, data: { ok: true, updating: true } });
+
+  const res = await appWithFixedImageNode(request).request(
+    `/api/nodes/${TEST_NODE_ID}/update?force=1`,
+    { method: "POST", headers: { "Content-Type": "application/json" } }
+  );
+
+  expect(res.status).toBe(409);
+  expect(calls).toHaveLength(0);
+});
+
+test("an ordinary node is unaffected", async () => {
+  const { request, calls } = stubBroker({
+    ok: true,
+    data: { ok: true, updating: true, tag: "v0.1.27" },
+  });
+
+  const res = await postUpdate(request);
+
+  expect(res.status).toBe(200);
+  expect(calls).toHaveLength(1);
+});

--- a/apps/hub/tests/unit/rollout.test.ts
+++ b/apps/hub/tests/unit/rollout.test.ts
@@ -200,3 +200,48 @@ describe("executeRollout", () => {
     expect(results[1]!.outcome).toBe("updated");
   });
 });
+
+// ─── A node whose binary comes from an image (#349) ───────────────────────────
+
+/**
+ * `cf-opencode` went offline when someone pressed Update, and stayed on
+ * v0.1.22. Self-update swaps a binary and exits, expecting a supervisor; a
+ * Cloudflare container has none, so the exit IS the stop. And the disk is
+ * ephemeral, so the swapped binary would not survive the restart it never got.
+ *
+ * A fleet rollout that did this to every Cloudflare station is a much worse
+ * outcome than one that updates nothing, so the planner has to know.
+ */
+describe("nodes whose image is a deployment artifact", () => {
+  test("are skipped, and the reason says how to update them instead", () => {
+    const [item] = planRollout([node({ imageFixed: true })], {});
+
+    expect(item!.action).toBe("skip");
+    // A bare "not supported" would leave an operator with a stale station and
+    // no next step. The path that works is naming the image.
+    expect(item!.reason).toMatch(/image/i);
+  });
+
+  test("are skipped even under force, because force cannot make this work", () => {
+    // force overrides policy choices. This is not one: the binary cannot
+    // persist and the attempt stops the station.
+    const [item] = planRollout([node({ imageFixed: true })], { force: true });
+
+    expect(item!.action).toBe("skip");
+  });
+
+  test("do not stop the rest of the fleet being updated", () => {
+    const plan = planRollout(
+      [node({ id: "n1", name: "alpha", imageFixed: true }), node({ id: "n2", name: "beta" })],
+      {}
+    );
+
+    expect(plan.find((p) => p.nodeId === "n1")!.action).toBe("skip");
+    expect(plan.find((p) => p.nodeId === "n2")!.action).toBe("update");
+  });
+
+  test("an ordinary node is untouched by this rule", () => {
+    expect(planRollout([node()], {})[0]!.action).toBe("update");
+    expect(planRollout([node({ imageFixed: false })], {})[0]!.action).toBe("update");
+  });
+});

--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -15,7 +15,7 @@
 # bun base (Debian) for opencode, matching Dockerfile.opencode.
 FROM oven/bun:1-slim
 
-ARG AGENTPOD_VERSION=v0.1.22
+ARG AGENTPOD_VERSION=v0.1.27
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git procps \

--- a/fly/node-image/bump-version-pin.sh
+++ b/fly/node-image/bump-version-pin.sh
@@ -76,7 +76,11 @@ done
 
 # Both Fly images by default: they are pinned together on purpose, so they are
 # bumped together too.
-[ -n "$FILES" ] || FILES="$HERE/Dockerfile $HERE/Dockerfile.pi"
+# The Cloudflare worker image is checked too. It is not a Fly file, but it
+# pins the node-agent the same way and is a deployment artifact its nodes
+# cannot self-update away from (#349) — while nothing checked it, it sat on
+# v0.1.22 for five releases and a station could not be moved forward at all.
+[ -n "$FILES" ] || FILES="$HERE/Dockerfile $HERE/Dockerfile.pi $HERE/../../cloudflare/worker-v2/Dockerfile"
 
 if [ -z "$TARGET" ]; then
   # shellcheck disable=SC2086 # deliberate word splitting of the file list

--- a/fly/node-image/check-version-pin.sh
+++ b/fly/node-image/check-version-pin.sh
@@ -157,7 +157,11 @@ done
 # Both Fly images by default. They are pinned together ON PURPOSE — two
 # stations on one substrate running different node-agent builds makes "it works
 # on the other one" mean nothing — so both are checked, and against each other.
-[ -n "$FILES" ] || FILES="$HERE/Dockerfile $HERE/Dockerfile.pi"
+# The Cloudflare worker image is checked too. It is not a Fly file, but it
+# pins the node-agent the same way and is a deployment artifact its nodes
+# cannot self-update away from (#349) — while nothing checked it, it sat on
+# v0.1.22 for five releases and a station could not be moved forward at all.
+[ -n "$FILES" ] || FILES="$HERE/Dockerfile $HERE/Dockerfile.pi $HERE/../../cloudflare/worker-v2/Dockerfile"
 
 if [ -z "$LATEST" ]; then
   # shellcheck disable=SC2086 # deliberate word splitting of the file list


### PR DESCRIPTION
Closes #349. Reported live: `cf-opencode` was started, its workspace came back from R2 correctly, and then **Update** from the console took it offline — still on v0.1.22.

## Why pressing Update stopped the station

1. `selfupdate.Apply` swaps the binary and reports `Updated: true`.
2. `updateHandler` therefore **exits on purpose** — "so that the system supervisor (e.g. systemd Restart=always) can start the new binary".
3. A Cloudflare container has no supervisor. The agent is the child of `snapshot-wrapper.sh`, whose `wait` returns, archives the workspace, and exits with the child's status — **PID 1 exits, the container stops**.
4. And the disk is ephemeral, so the swapped binary would not have survived the restart it never got. The next start comes up from the image, pinned at `v0.1.22`.

Self-defeating twice over, with a stopped station as the only visible result. The archive path did its job — no work was lost.

## The fix

The distinguishing property is already modelled: **`imageBinding: "fixed"`** (`cloudflare-sandbox.ts:136` — "its image is a deployment artifact"). Docker, Fly and Modal are `per-instance` and are unaffected.

- **Single node:** refused **before the RPC is sent**, since sending it is what stops the station. `409` with the path that works: bump `AGENTPOD_VERSION` in the image, redeploy, restart the runtime.
- **Fleet rollout:** these nodes are skipped with that same reason, checked *before* `force` — force overrides policy choices, and this is not one. A rollout that stopped every container station would be far worse than one that updates nothing.
- **Console:** unchanged code path; it already surfaces the hub's `error`, so the button now explains instead of breaking things.

## And the reason it was five releases behind

`check-version-pin.sh` and `bump-version-pin.sh` both defaulted to the two Fly Dockerfiles, so nothing ever checked the Cloudflare image. The one substrate whose nodes *cannot* self-update was the one substrate nothing kept pinned. Both scripts now cover it, the release job's bump PR includes it, and the image is moved to **v0.1.27**.

```
ok: fly/node-image/Dockerfile pins v0.1.27 (current release)
ok: fly/node-image/Dockerfile.pi pins v0.1.27 (current release)
ok: cloudflare/worker-v2/Dockerfile pins v0.1.27 (current release)
```

## Tests

1185 pass, 0 fail (8 new). The route tests assert the RPC is **not sent** — the refusal has to be the absence of a call, not a message after one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW