### PR TITLE
docs: a plan for a conversable fleet — tuwunel + the Matrix Application Service

### DIFF
--- a/deploy/tuwunel/tuwunel.service
+++ b/deploy/tuwunel/tuwunel.service
@@ -8,6 +8,11 @@
 #
 # It binds 127.0.0.1 only. nginx terminates TLS for id.agentpod.dev and proxies
 # /_matrix to it — the homeserver is never reachable from outside directly.
+#
+# Every path named in tuwunel.toml must be mounted here too, or the server
+# reports it as missing from inside the container while it exists on the host —
+# which is how `backup-database` first failed with "No such file or directory"
+# for a directory that was plainly there.
 Description=tuwunel Matrix homeserver
 Documentation=https://matrix-construct.github.io/tuwunel/
 After=docker.service network-online.target
@@ -24,6 +29,7 @@ ExecStartPre=-/usr/bin/docker rm -f tuwunel
 ExecStart=/usr/bin/docker run --rm --name tuwunel \
   --network host \
   -v /var/lib/tuwunel:/var/lib/tuwunel \
+  -v /var/backups/tuwunel:/var/backups/tuwunel \
   -v /etc/tuwunel/tuwunel.toml:/etc/tuwunel/tuwunel.toml:ro \
   -v /etc/tuwunel/appservices:/etc/tuwunel/appservices:ro \
   -e TUWUNEL_CONFIG=/etc/tuwunel/tuwunel.toml \

--- a/deploy/tuwunel/tuwunel.service
+++ b/deploy/tuwunel/tuwunel.service
@@ -1,0 +1,34 @@
+[Unit]
+# The Matrix homeserver for id.agentpod.dev.
+#
+# tuwunel (Apache-2.0) replaced Synapse (AGPLv3) on 2026-08-16. Run under Docker
+# rather than as a host binary because the project ships images and no Debian
+# package, and because the container is the same artefact the appservice spike
+# was verified against (docs/superpowers/specs/2026-08-16-tuwunel-appservice-spike-findings.md).
+#
+# It binds 127.0.0.1 only. nginx terminates TLS for id.agentpod.dev and proxies
+# /_matrix to it — the homeserver is never reachable from outside directly.
+Description=tuwunel Matrix homeserver
+Documentation=https://matrix-construct.github.io/tuwunel/
+After=docker.service network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+
+# Named container, removed on stop: a restart must never hit "name in use", and
+# a stopped unit must leave nothing behind holding port 6167.
+ExecStartPre=-/usr/bin/docker rm -f tuwunel
+ExecStart=/usr/bin/docker run --rm --name tuwunel \
+  --network host \
+  -v /var/lib/tuwunel:/var/lib/tuwunel \
+  -v /etc/tuwunel/tuwunel.toml:/etc/tuwunel/tuwunel.toml:ro \
+  -v /etc/tuwunel/appservices:/etc/tuwunel/appservices:ro \
+  -e TUWUNEL_CONFIG=/etc/tuwunel/tuwunel.toml \
+  ghcr.io/matrix-construct/tuwunel:latest
+ExecStop=/usr/bin/docker stop tuwunel
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -695,6 +695,103 @@ mobile navigation bar.
 
 Hermes stations that have a Matrix identity configured display the **Matrix ID** and a `matrix.to` deep-link in the station detail panel, so you can open a conversation with that agent identity directly from the console.
 
+### 7a. The homeserver
+
+`id.agentpod.dev` runs **tuwunel** (Apache-2.0), on the same host as the hub. It
+replaced Synapse (AGPLv3) on 2026-08-16; see
+`docs/superpowers/specs/2026-08-16-tuwunel-appservice-spike-findings.md` for why,
+and what was verified before the switch.
+
+| | |
+|---|---|
+| service | `tuwunel` (systemd → Docker, unit in `deploy/tuwunel/`) |
+| listens | `127.0.0.1:6167`, never exposed directly; nginx proxies `/_matrix` |
+| data | `/var/lib/tuwunel` (RocksDB, embedded — there is no separate database) |
+| config | `/etc/tuwunel/tuwunel.toml` |
+| appservice | `/etc/tuwunel/appservices/agentpod.yaml` — namespaces `@agent_.*`, `#agentpod_.*` |
+| backups | `/var/backups/tuwunel`, nightly at 04:17 via `/etc/cron.d/tuwunel-backup` |
+
+```sh
+systemctl status tuwunel
+journalctl -u tuwunel -f
+curl -s localhost:6167/_matrix/client/versions      # is it serving?
+```
+
+**Two log lines that look like faults and are not.** `ERROR … loopback/localhost
+listening address … will NOT work` is a false positive under `--network host`,
+where 127.0.0.1 *is* the host. `Error response from daemon: No such container:
+tuwunel` is the unit's `ExecStartPre=-docker rm -f`, which is why it carries a
+`-`.
+
+**Registration is closed** (`allow_registration = false`). Accounts are made
+deliberately: the appservice registers agents inside its own namespace, and a
+human needs the admin console.
+
+### 7b. Admin commands
+
+tuwunel has **no Synapse-style admin HTTP API**. Its admin surface is a room —
+`!94p3O40IPw164WyxHc:id.agentpod.dev`, which `@rakesh` is a member of. Send
+`!admin <command>` as an ordinary message:
+
+```
+!admin server help
+!admin users list-users
+!admin users create-user <name> [password]      # prints the password — see below
+!admin server backup-database
+```
+
+**`create-user` echoes the generated password** into whatever ran it. If that is
+a terminal or a transcript, follow with `!admin users reset-password <name>` and
+keep only the second one.
+
+When the server is stopped, the same commands run offline against the database
+with `--execute`, which is how the first admin was made:
+
+```sh
+systemctl stop tuwunel
+docker run --rm --network host -v /var/lib/tuwunel:/var/lib/tuwunel \
+  -v /etc/tuwunel/tuwunel.toml:/etc/tuwunel/tuwunel.toml:ro \
+  -e TUWUNEL_CONFIG=/etc/tuwunel/tuwunel.toml \
+  ghcr.io/matrix-construct/tuwunel:latest --execute 'users make-user-admin <name>'
+systemctl start tuwunel
+```
+
+Only one process may hold the RocksDB lock, which is why this needs the stop.
+
+### 7c. Backups, and restoring one
+
+`backup-database` writes a **RocksDB checkpoint while the server keeps running** —
+consistent by construction, unlike copying live files. `database_backups_to_keep`
+holds the last 3.
+
+```sh
+/usr/local/bin/tuwunel-backup.sh          # take one now
+ls /var/backups/tuwunel/
+```
+
+Restoring is a startup flag: `--restore-backup [<id>]` restores before opening
+the database, most recent when no id is given. `!admin server list-backups` lists
+them.
+
+> **Every path in `tuwunel.toml` must also be mounted in the unit.** The backup
+> path was configured before it was mounted, and `backup-database` failed with
+> "No such file or directory" for a directory that plainly existed on the host.
+
+**Off-site is still an open gap.** The nightly backup is on the same disk as the
+thing it protects. The Synapse-era archive was copied off manually
+(`~/agentpod-backups/matrix-backup-2026-08-16.tar.gz`); nothing does that on a
+schedule yet.
+
+### 7d. What happened to the Synapse history
+
+The old homeserver's 19,603 events are **not in tuwunel** — there is no supported
+import path from Synapse into the Conduit lineage, and Matrix here carries a
+projection rather than the truth (`acp_events` is the transcript of record). The
+SQLite database, its signing key and the appservice registration are preserved in
+`/root/matrix-backup-2026-08-16/` on the host and in
+`~/agentpod-backups/` off it. To read that history, run a throwaway Synapse
+against a *copy* — never against the original.
+
 ---
 
 ## 8. The kaambaan bridge

--- a/docs/superpowers/plans/2026-08-16-conversable-fleet.md
+++ b/docs/superpowers/plans/2026-08-16-conversable-fleet.md
@@ -15,7 +15,8 @@
 
 - **Homeserver:** `id.agentpod.dev` on `178.105.68.68`, private, federation disabled, nginx proxying `/_matrix` to the homeserver's port. **tuwunel serves 6167 by default, not 8008** — the vhost changes with it.
 - **Registration file:** a YAML file in tuwunel's `appservice_dir`, Synapse-shaped (the spike confirmed the existing file's namespaces load unchanged): AS id `ai-agents`, `sender_localpart: ai-bridge`, users `@agent_.*` exclusive, aliases `#agentpod_.*` exclusive, **`receive_ephemeral: true`** (tuwunel's name for what Synapse spelled `de.sorunome.msc2409.push_ephemeral`), and `url` **left unset until Task 9**.
-- **Name derivation is a pure function** of `(nodeName, stationKey)`: lowercase, every character outside `[a-z0-9._=/-]` becomes `_`. User `@agent_<node>_<station>`, alias `#agentpod_<node>_<station>`. Never stored as a second source of truth.
+- **Name derivation is a pure function** of `(nodeName, stationKey)`: lowercase, every character outside `[a-z0-9._=/-]` becomes `_`. User `@agent_<node>_<station>`, alias `#agentpod_<node>_<station>`. Never stored as a second source of truth. **All 32 stations, hermes included** — there is no exception list, because a name that omits the node breaks the rule the whole scheme rests on.
+- **A station's identity has a mode**: `bridge` (the AS answers) or `harness` (the harness runs its own client). Exactly one answerer per address, always.
 - **`hs_token` authenticates every AS route**; a request without it is 403 and is never processed. The `as_token` is what the bridge sends *to* the homeserver. The two point in opposite directions and swapping them fails as a 403 that reads like a permissions bug.
 - **Drop every event sent by our own namespace** before any other handling.
 - **Transactions are idempotent by `txnId`.**
@@ -86,13 +87,12 @@ receive_ephemeral: true
 rate_limited: false
 namespaces:
   users:
+    # One namespace for all 32. An earlier revision carried a second one listing
+    # the 14 hermes localparts verbatim, to preserve addresses whose rooms and
+    # history are being discarded anyway — fourteen hardcoded exceptions to the
+    # rule that a name must include its node.
     - exclusive: true
       regex: "@agent_.*"
-    # The 14 hermes addresses people already use, recreated on the new server by
-    # the bridge. Listed explicitly rather than by pattern: a broad regex here
-    # would claim human accounts on this homeserver.
-    - exclusive: true
-      regex: "@(analyst-echo|artistic-lyra|buddhimaan|cleaner-cody|coder-kai|controller-casey|onboarding-olivia|optimizer-ollie|predictor-paul|project-manager-pete|research-ray|strategy-sam|threat-hunter-theo|writer-quill):id\\.agentpod\\.dev"
   aliases:
     - exclusive: true
       regex: "#agentpod_.*"
@@ -306,17 +306,17 @@ git commit -m "feat(hub): derive a station's Matrix names from its node and key"
 
 ---
 
-### Task 2: Record who owns a station's Matrix id
+### Task 2: Record which mode a station's identity is in
 
 **Files:**
-- Create: `apps/hub/src/db/drizzle-migrations/0044_matrix_id_source.sql`
+- Create: `apps/hub/src/db/drizzle-migrations/0044_matrix_identity_mode.sql`
 - Modify: `apps/hub/src/db/drizzle-migrations/meta/_journal.json`
 - Modify: `apps/hub/src/db/schema/stations.ts`
 - Modify: `apps/hub/src/services/station-registry.ts` (the refresh path)
 - Test: `apps/hub/tests/integration/matrix-id-source.test.ts`
 
 **Interfaces:**
-- Produces: `stations.matrixIdSource: "harness" | "bridge"`, default `"harness"`.
+- Produces: `stations.matrixIdentityMode: "bridge" | "harness"`, default `"bridge"`.
 
 > **A migration without a `meta/_journal.json` entry never runs.** This repo has been bitten; add the entry in the same commit.
 
@@ -333,20 +333,20 @@ git commit -m "feat(hub): derive a station's Matrix names from its node and key"
  * answering in a room, with nothing anywhere saying why.
  */
 test("a station refresh leaves a bridge-owned mxid alone", async () => {
-  await setMatrixIdBySource(STATION, "@agent_box_pi_x:id.agentpod.dev", "bridge");
+  await setMatrixIdentity(STATION, "@agent_box_pi_x:id.agentpod.dev", "bridge");
 
   // What the node agent does on every detect.
   await refreshStationFromDetect(STATION, { matrixId: null });
 
   const row = await stationRow(STATION);
   expect(row.matrixId).toBe("@agent_box_pi_x:id.agentpod.dev");
-  expect(row.matrixIdSource).toBe("bridge");
+  expect(row.matrixIdentityMode).toBe("bridge");
 });
 
-test("a harness-owned mxid is still refreshed by the node agent", async () => {
-  // The existing behaviour must not regress: hermes reads its own identity off
-  // the host, and a profile change has to land.
-  await setMatrixIdBySource(STATION, "@old:id.agentpod.dev", "harness");
+test("a harness-mode mxid is still refreshed by the node agent", async () => {
+  // The existing behaviour must not regress: a harness that runs its own Matrix
+  // client reads its identity off the host, and a profile change has to land.
+  await setMatrixIdentity(STATION, "@old:id.agentpod.dev", "harness");
 
   await refreshStationFromDetect(STATION, { matrixId: "@new:id.agentpod.dev" });
 
@@ -359,23 +359,24 @@ test("a harness-owned mxid is still refreshed by the node agent", async () => {
 - [ ] **Step 3: Write the migration**
 
 ```sql
--- 0044_matrix_id_source.sql
+-- 0044_matrix_identity_mode.sql
 ALTER TABLE stations
-  ADD COLUMN matrix_id_source text NOT NULL DEFAULT 'harness';
+  ADD COLUMN matrix_identity_mode text NOT NULL DEFAULT 'bridge';
 
--- Every mxid that exists today was read off a host by the node agent.
--- The default is therefore correct for all 14 rows that have one, and the
--- bridge writes 'bridge' only where it takes ownership.
+-- 'bridge' is the safe default: the AS answers, and no credential exists
+-- anywhere for that identity. A station only becomes 'harness' when somebody
+-- deliberately issues it credentials (Task 8b), which is the act that could
+-- otherwise produce two answerers on one address.
 ALTER TABLE stations
-  ADD CONSTRAINT stations_matrix_id_source_check
-  CHECK (matrix_id_source IN ('harness', 'bridge'));
+  ADD CONSTRAINT stations_matrix_identity_mode_check
+  CHECK (matrix_identity_mode IN ('bridge', 'harness'));
 ```
 
 Add the journal entry. Classify the column in `db/tenant-scope.ts` if that file requires it for new columns.
 
 - [ ] **Step 4: Guard the refresh path**
 
-In `station-registry.ts`, the detect-refresh must not overwrite `matrix_id` when `matrix_id_source = 'bridge'`.
+In `station-registry.ts`, the detect-refresh must not overwrite `matrix_id` when `matrix_identity_mode = 'bridge'`.
 
 - [ ] **Step 5: Run the tests, then the full hub suite**
 
@@ -787,20 +788,28 @@ test("is idempotent, because it runs on every adoption and every boot", async ()
   expect(created.rooms).toHaveLength(1);
 });
 
-test("records the station's mxid as bridge-owned", async () => {
+test("records the station's mxid, in bridge mode", async () => {
   await provisionStation(KRISHNA);
   const row = await stationRow(KRISHNA);
   expect(row.matrixId).toBe("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
-  expect(row.matrixIdSource).toBe("bridge");
+  expect(row.matrixIdentityMode).toBe("bridge");
 });
 
-test("does not touch a harness-owned mxid", async () => {
-  // Task 10 migrates those deliberately, per agent, with the harness's own
-  // Matrix loop stopped first. Provisioning must not do it by accident.
+test("provisions a hermes station exactly like every other", async () => {
+  // No exception list. hermes gets the same derived name as openclaw, and the
+  // display name carries the readability its old address used to.
   await provisionStation(ANALYST_ECHO);
   const row = await stationRow(ANALYST_ECHO);
-  expect(row.matrixId).toBe("@analyst-echo:id.agentpod.dev");
-  expect(row.matrixIdSource).toBe("harness");
+  expect(row.matrixId).toBe("@agent_molt-bot_hermes_analyst-echo:id.agentpod.dev");
+  expect(created.displayNames.at(-1)).toBe("analyst-echo (hermes @ molt-bot)");
+});
+
+test("leaves a harness-mode station's conversations alone", async () => {
+  // The room is still provisioned — a harness client needs somewhere to talk —
+  // but the bridge must not answer for a station that answers for itself.
+  await setIdentityMode(ANALYST_ECHO, "harness");
+  await provisionStation(ANALYST_ECHO);
+  expect(subscribedSessionsFor(ANALYST_ECHO)).toHaveLength(0);
 });
 ```
 
@@ -824,7 +833,150 @@ git commit -m "feat(hub): every station gets a Matrix user and a room"
 
 ---
 
-### Task 9: Turn it on for the 18
+### Task 8b: Issue an identity, and optionally credentials, over the hub API
+
+**Files:**
+- Create: `apps/hub/src/routes/station-matrix.ts`
+- Create: `apps/hub/src/services/matrix-as/credentials.ts`
+- Test: `apps/hub/tests/integration/station-matrix-identity.test.ts`
+
+**Interfaces:**
+- Produces: `POST /api/stations/:id/matrix/identity` → `{ mxid, alias, roomId, mode }`; `POST /api/stations/:id/matrix/credentials` → `{ mxid, accessToken, deviceId }` and flips the station to `harness` mode.
+
+This is what replaces the Synapse admin token that lives on molt-bot today. It is also what makes **dynamically created agents** work: a new station on any harness gets an identity by asking the hub, rather than by each harness learning to talk to a homeserver.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/**
+ * Registering an agent identity, without an admin credential on a node.
+ *
+ * Today `hermes-agents onboard` holds a homeserver admin token in a file on
+ * molt-bot and can create, deactivate or take over ANY account on the
+ * homeserver — including a human's. An Application Service needs no such rights
+ * to register users inside its own namespace, so the ordinary path drops the
+ * admin credential entirely and the privileged path moves behind the hub.
+ */
+describe("POST /api/stations/:id/matrix/identity", () => {
+  test("provisions an identity with no admin credential involved", async () => {
+    const res = await post(`/api/stations/${KRISHNA}/matrix/identity`);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).mxid).toBe("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
+    expect(adminCommandsRun).toHaveLength(0);
+  });
+
+  test("is idempotent — a re-run returns the same identity", async () => {
+    const a = await (await post(`/api/stations/${KRISHNA}/matrix/identity`)).json();
+    const b = await (await post(`/api/stations/${KRISHNA}/matrix/identity`)).json();
+    expect(b).toEqual(a);
+  });
+});
+
+describe("POST /api/stations/:id/matrix/credentials", () => {
+  test("requires mayGrantReach, because a credential IS reach", async () => {
+    // Handing an agent an access token is the definition of granting it reach
+    // (charter → 2026-08-15-granting-reach-is-changing-an-agent). Dispatch
+    // permission is not enough.
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const res = await post(`/api/stations/${ANALYST_ECHO}/matrix/credentials`);
+    expect(res.status).toBe(403);
+  });
+
+  test("mints a token and flips the station to harness mode", async () => {
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+
+    const body = await (await post(`/api/stations/${ANALYST_ECHO}/matrix/credentials`)).json();
+
+    expect(body.accessToken).toBeTruthy();
+    expect((await stationRow(ANALYST_ECHO)).matrixIdentityMode).toBe("harness");
+  });
+
+  test("the bridge stops answering for that station the moment it does", async () => {
+    // The two-answerer failure, prevented by construction rather than by
+    // remembering to switch something off.
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await post(`/api/stations/${ANALYST_ECHO}/matrix/credentials`);
+
+    await handleMessage(message(PRINCIPAL_MXID, "hi"), ROOM_FOR_ANALYST_ECHO);
+    expect(prompts).toHaveLength(0);
+  });
+
+  test("never logs the token it just issued", async () => {
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    const body = await (await post(`/api/stations/${ANALYST_ECHO}/matrix/credentials`)).json();
+    expect(loggedLines.join("\n")).not.toContain(body.accessToken);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Implement**
+
+`identity` calls Task 8's provisioning. `credentials` additionally: generate a password, run `users reset-password` (or `create-user`) through the homeserver's **admin room** as the hub's own admin account, then log in as the station's user to obtain a device token. Return it once; store nothing but the mode.
+
+> tuwunel has no Synapse-shaped admin HTTP API. Its `users create-user` and `users reset-password` are admin-room commands, which a client with an admin account can send remotely — verified in the CLI surface (`--execute`, `!admin users …`).
+
+- [ ] **Step 4: Run the tests, then the full hub suite**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(hub): register an agent's Matrix identity, and issue credentials only behind mayGrantReach"
+```
+
+---
+
+### Task 8c: Port `hermes-agents onboard` onto the hub API
+
+**Files:**
+- Modify: `/root/maintenance/scripts/hermes-agents` on molt-bot (outside this repo)
+- Modify: `docs/OPERATING.md`
+
+Today's `cmd_onboard` does five Matrix things: checks the user through `/_synapse/admin/v2/users/…`, creates it with a generated password, logs in for a device token, creates a DM "home room", and writes `MATRIX_ACCESS_TOKEN` into the profile's env. **The first three break on tuwunel** — that admin API does not exist — and the fourth is what the bridge now does.
+
+- [ ] **Step 1: Prove the failure before changing anything**
+
+Run `hermes-agents onboard --homeserver <tuwunel> some-test-profile` against the new server and capture the error. A port that starts before the break is understood tends to preserve the wrong half.
+
+- [ ] **Step 2: Replace the Matrix section with two calls**
+
+```sh
+# was: curl -X PUT $hs/_synapse/admin/v2/users/$uid  (admin token on this box)
+# now: the hub owns identity, and the station is the thing that has one.
+station_id=$(hub_api GET "/api/stations?node=$(hostname)&key=hermes:$profile" | jq -r '.[0].id')
+creds=$(hub_api POST "/api/stations/$station_id/matrix/credentials")
+```
+
+The admin token file leaves molt-bot entirely.
+
+- [ ] **Step 3: Handle the ordering, which has inverted**
+
+Today the Matrix account exists before the agent runs. Now the **station must exist first** — the profile is created, the node agent detects it, the hub adopts it, and only then can it be given an identity. `onboard` waits for the station to appear (poll, with a timeout and a clear message naming what it is waiting for) rather than assuming.
+
+- [ ] **Step 4: Retire the home-room creation**
+
+The bridge provisions `#agentpod_<node>_hermes_<profile>` already. Keep marking it `m.direct` for the admin if that is what makes it land in a DM list.
+
+- [ ] **Step 5: Onboard a throwaway agent end to end**
+
+Create it, watch the station adopt, watch the identity provision, confirm the gateway starts and answers. Then remove it — including deactivating the Matrix user, which is now `users deactivate`.
+
+- [ ] **Step 6: Document, and delete the admin token**
+
+`docs/OPERATING.md`: how an agent is created now, and that no node holds homeserver admin rights any more. Then remove `/root/maintenance/.matrix-admin-token` from molt-bot and revoke it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "docs(ops): creating an agent no longer needs a homeserver admin token on a node"
+```
+
+---
+
+### Task 9: Turn it on
 
 **Files:**
 - Modify: `/etc/matrix-synapse/agents.yaml` (host — set `url`)
@@ -854,7 +1006,7 @@ Then `systemctl restart tuwunel`. **This is the moment the bridge starts receivi
 
 Pick `openclaw:krishna`. Join `#agentpod_superchotu_openclaw_krishna`, say hello, get an answer. Then check the refusal path: narrow your own grant to exclude openclaw, send again, and read the refusal **in the room**. Restore the grant.
 
-- [ ] **Step 4: Provision the remaining 17**
+- [ ] **Step 4: Provision the remaining 31**
 
 - [ ] **Step 5: Document**
 
@@ -868,48 +1020,48 @@ git commit -m "docs(deploy): running the Matrix bridge"
 
 ---
 
-### Task 10: Turn off hermes's native Matrix client
+### Task 10: Decide, per hermes agent, who answers
 
-On a fresh homeserver there is no adoption dance: the bridge already registered
-all 32 identities in Task 8, including the 14 hermes addresses, and hermes was
-never given credentials on the new server. This task is the cleanup that makes
-that true rather than accidental — and the honest conversation about what hermes
-loses.
+The old plan retired hermes's Matrix client wholesale. With identity modes that
+is no longer forced: hermes agents can keep their own clients under the same
+`@agent_*` identity, or hand the conversation to the bridge. What must never
+happen is both.
 
 **Files:**
-- Modify: hermes's own configuration on `molt-bot` (host, outside this repo)
+- Modify: hermes profile configuration on molt-bot (outside this repo)
 - Modify: `docs/OPERATING.md`
 
-- [ ] **Step 1: Confirm no hermes agent can log in**
+- [ ] **Step 1: Start all 14 in `bridge` mode**
 
-Its Matrix credentials point at a server that no longer exists, and its
-localparts are inside an exclusive namespace the bridge owns. Verify rather than
-assume: attempt a login as one of them with hermes's stored password and
-confirm it fails.
+They arrive that way — it is the column default and Task 8 provisions them like
+any other station. Their old credentials pointed at a homeserver that no longer
+exists, so nothing of theirs can log in. Verify rather than assume: attempt a
+login with a stored hermes token and confirm it fails.
 
-- [ ] **Step 2: Disable the Matrix loop in hermes's config**
+- [ ] **Step 2: Live with it for a week**
 
-Leaving it enabled means every agent retries a login it can never complete,
-forever, and fills a log with it.
+The question "what did hermes's own Matrix client do that ACP does not" is
+answered by absence, not by reading code. A week of ordinary use will surface
+anything that mattered — rooms it joined itself, DMs with humans, presence.
 
-- [ ] **Step 3: Confirm each of the 14 answers through the bridge**
+- [ ] **Step 3: For anything that mattered, switch that agent to `harness` mode**
 
-Message `#agentpod_molt-bot_hermes_analyst-echo` and get a reply whose transcript
-lands in `acp_events`. That is the proof the identity moved rather than merely
-stopped.
+`POST /api/stations/:id/matrix/credentials` (Task 8b) issues the token and flips
+the mode; the bridge stops answering for it in the same write. Per agent, and
+only where the absence was felt.
 
-- [ ] **Step 4: Write down what hermes lost**
+- [ ] **Step 4: Write down what each mode costs**
 
-In `docs/OPERATING.md`: hermes agents no longer speak Matrix natively; anything
-they did over Matrix that never went through ACP — agent-to-agent chatter, rooms
-they joined themselves — is gone with the old server, and comes back only as ACP
-conversation through the bridge.
+In `docs/OPERATING.md`: a `bridge` agent gains the control pair, an `acp_events`
+transcript and no credential on any host; a `harness` agent gains its own client
+and keeps its own Matrix behaviour, at the cost of a token existing and the
+control pair not seeing those conversations.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add docs/OPERATING.md
-git commit -m "docs(ops): hermes reaches Matrix through the bridge, like everything else"
+git commit -m "docs(ops): who answers for an agent, and what each mode costs"
 ```
 
 ---
@@ -952,7 +1104,7 @@ git commit -m "docs(ops): the Matrix bridge, and how to tell it is working"
 
 ## Self-review
 
-**Spec coverage.** Derived names (T1), ownership column (T2), transactions with auth/idempotency/loop-cut (T3), user and room queries (T4), acting as a station (T5), inbound with the control pair (T6), outbound streaming, typing and permissions (T7), provisioning all stations (T8), going live (T9), retiring hermes's native client (T10), operability (T11). Phase A replaces the homeserver rather than migrating its database, and closes #329.
+**Spec coverage.** Derived names, uniform across all 32 (T1), identity mode (T2), transactions with auth/idempotency/loop-cut (T3), user and room queries (T4), acting as a station (T5), inbound with the control pair (T6), outbound streaming, typing and permissions (T7), provisioning (T8), identity and credential registration over the hub API (T8b), porting `hermes-agents onboard` off the Synapse admin token (T8c), going live (T9), deciding who answers per hermes agent (T10), operability (T11). Phase A replaces the homeserver rather than migrating its database, and closes #329.
 
 **Deliberately not covered**, and named in the spec: kaambaan card/run/gate events (kaambaan#34 owns those schemas), E2EE, federation, and any node-agent change.
 

--- a/docs/superpowers/plans/2026-08-16-conversable-fleet.md
+++ b/docs/superpowers/plans/2026-08-16-conversable-fleet.md
@@ -1,0 +1,903 @@
+# A Conversable Fleet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every station in the fleet is reachable from any Matrix client — the 18 whose harness has never spoken Matrix, and the 14 whose harness does, through one mechanism.
+
+**Architecture:** Synapse moves to Postgres first, on its own. Then an Application Service inside the hub receives transactions at `/_matrix/app/v1/*`, owns a virtual `@agent_*` user and a room per station, maps inbound messages onto ACP sessions after checking the control pair, and streams the agent's output back by subscribing to the same in-process fan-out the console's WebSocket uses.
+
+**Tech Stack:** Synapse 1.x + Postgres 16 (`LC_COLLATE=C`), Bun + Hono + Drizzle (hub), the Matrix Application Service API r0/v1, MSC2409 ephemeral events.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-matrix-application-service-design.md`
+
+## Global Constraints
+
+- **Homeserver:** `id.agentpod.dev` on `178.105.68.68`, private, federation disabled, nginx proxying `/_matrix` and `/_synapse` to `127.0.0.1:8008`.
+- **Registration file:** `/etc/matrix-synapse/agents.yaml`, AS id `ai-agents`, `sender_localpart: ai-bridge`, users `@agent_.*` exclusive, aliases `#agentpod_.*` exclusive, `de.sorunome.msc2409.push_ephemeral: true`, `url: null` **until Task 9**.
+- **Name derivation is a pure function** of `(nodeName, stationKey)`: lowercase, every character outside `[a-z0-9._=/-]` becomes `_`. User `@agent_<node>_<station>`, alias `#agentpod_<node>_<station>`. Never stored as a second source of truth.
+- **`hs_token` authenticates every AS route**; a request without it is 403 and is never processed. The `as_token` is what the bridge sends *to* Synapse.
+- **Drop every event sent by our own namespace** before any other handling.
+- **Transactions are idempotent by `txnId`.**
+- **Refusals are messages in the room**, never silence.
+- Hub tests need `DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod"` and pgvector Postgres on :5434. Console tests need Node 22.
+- **TDD:** failing test first, every task. Regression test for every bug fixed.
+
+### Secrets, and where they are not
+
+`as_token` and `hs_token` live in `/etc/matrix-synapse/agents.yaml` and in the hub's environment as `MATRIX_AS_TOKEN` / `MATRIX_HS_TOKEN`. **Neither goes in the repository, in a test fixture, or in a log line.** The bridge logs mxids and room ids, never tokens.
+
+---
+
+## Phase A — Synapse on Postgres (#329)
+
+The migration plan is already written: `docs/superpowers/plans/2026-08-15-synapse-postgres-migration.md` on branch `docs/synapse-postgres-plan` (PR #329). Execute it as written. It is not restated here; these are the only additions this program makes to it.
+
+### Task A1: Execute the migration, with the AS in mind
+
+**Files:**
+- Follow: `docs/superpowers/plans/2026-08-15-synapse-postgres-migration.md`
+- Modify: `/etc/matrix-synapse/conf.d/database.yaml` (on the host)
+
+- [ ] **Step 1: Take the backups the plan requires**
+
+`sqlite3 .backup` of `homeserver.db`, plus `homeserver.signing.key` and `agents.yaml`, copied **off the box** and restored once into a scratch path to prove they open. The signing key cannot be regenerated: losing it loses the server's identity permanently.
+
+> The host has **no `sqlite3` CLI** (checked 2026-08-16). Install it first — `apt-get install -y sqlite3` — or the plan's very first command fails.
+
+- [ ] **Step 2: Create the database with C collation**
+
+```sql
+CREATE ROLE synapse_user LOGIN PASSWORD '<generated>';
+CREATE DATABASE synapse ENCODING 'UTF8' LC_COLLATE='C' LC_CTYPE='C'
+  template=template0 OWNER synapse_user;
+```
+
+`synapse_port_db` refuses to run without `C` collation, and fixing it afterwards means doing the migration again.
+
+- [ ] **Step 3: Run the port with Synapse stopped**
+
+Per the plan. 82 MB, ~19,400 events — minutes, not hours.
+
+- [ ] **Step 4: Raise `cp_max` for the bridge**
+
+The migration plan flags this as a follow-up; do it now rather than discovering it under load. In the Postgres stanza:
+
+```yaml
+database:
+  name: psycopg2
+  args:
+    cp_min: 5
+    cp_max: 15
+```
+
+An AS multiplies both connection demand and background work — the reason to leave SQLite in the first place.
+
+- [ ] **Step 5: Verify, then keep the SQLite file**
+
+`/health` on the hub is unrelated; verify Synapse itself: log in as an existing agent, read a room, send a message, and confirm `SELECT count(*) FROM events` in Postgres matches the SQLite count recorded in Step 1. Keep `homeserver.db` on disk, renamed `.migrated`, until Phase B is finished.
+
+- [ ] **Step 6: Write the backup schedule that has never existed**
+
+A nightly `pg_dump` of **both** databases (`agentpod`, `synapse`) plus the signing key, to somewhere off the box. The migration plan names this as the gap it does not close. Close it here — a homeserver with no backup is one disk away from every agent identity being unrecoverable.
+
+- [ ] **Step 7: Document it**
+
+`docs/OPERATING.md` has no homeserver section at all. Add one: where it runs, which database, how to restart it, where the registration lives, how to take and restore a backup.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/OPERATING.md
+git commit -m "docs(ops): the homeserver, its database, and its backups"
+```
+
+---
+
+## Phase B — The Application Service
+
+### Task 1: Derive names, and prove the collision case
+
+**Files:**
+- Create: `apps/hub/src/services/matrix-as/names.ts`
+- Test: `apps/hub/src/services/matrix-as/names.test.ts`
+
+**Interfaces:**
+- Produces: `bridgeUserId(nodeName, stationKey, domain)`, `bridgeAlias(nodeName, stationKey, domain)`, `localpartFor(nodeName, stationKey)`, `isBridgeUser(mxid, domain)`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { bridgeUserId, bridgeAlias, isBridgeUser } from "./names";
+
+const D = "id.agentpod.dev";
+
+/**
+ * A Matrix name for a station.
+ *
+ * Derived, never stored: the same `(node, stationKey)` pair that identifies a
+ * station in a grant. A mapping table would be a second source of truth for a
+ * fact the fleet already knows.
+ */
+describe("bridge names", () => {
+  test("name a node as well as a station", () => {
+    // `opencode:c52ddf65` exists on two nodes in production right now. A name
+    // that omitted the node would merge two different agents on two different
+    // machines — the collision this suite has already undone once.
+    const a = bridgeUserId("cloudchamber", "opencode:c52ddf65", D);
+    const b = bridgeUserId("9247e5a88cfa", "opencode:c52ddf65", D);
+    expect(a).not.toBe(b);
+  });
+
+  test("land inside the namespace the homeserver reserved", () => {
+    // agents.yaml claims `@agent_.*` exclusive. A name outside it cannot be
+    // acted as, and the failure is a 403 from Synapse at send time.
+    expect(bridgeUserId("molt-bot", "hermes:analyst-echo", D)).toBe(
+      "@agent_molt-bot_hermes_analyst-echo:id.agentpod.dev"
+    );
+    expect(bridgeAlias("molt-bot", "hermes:analyst-echo", D)).toBe(
+      "#agentpod_molt-bot_hermes_analyst-echo:id.agentpod.dev"
+    );
+  });
+
+  test("replace characters an mxid localpart may not contain", () => {
+    // `:` is the mxid separator; a station key is full of them.
+    expect(bridgeUserId("box", "claude-code:48c62ea7", D)).toBe(
+      "@agent_box_claude-code_48c62ea7:id.agentpod.dev"
+    );
+    expect(bridgeUserId("BOX", "Pi:59099BF1", D)).toBe(
+      "@agent_box_pi_59099bf1:id.agentpod.dev"
+    );
+  });
+
+  test("recognise our own users, which is how the loop is cut", () => {
+    // An AS receives what its own users send. Answering those is an infinite
+    // loop, so this predicate runs before anything else looks at an event.
+    expect(isBridgeUser("@agent_box_pi_59099bf1:id.agentpod.dev", D)).toBe(true);
+    expect(isBridgeUser("@rakesh:id.agentpod.dev", D)).toBe(false);
+    // The AS's own sender_localpart is ours too.
+    expect(isBridgeUser("@ai-bridge:id.agentpod.dev", D)).toBe(true);
+    // Another server's user that merely looks like ours is not ours.
+    expect(isBridgeUser("@agent_x:example.org", D)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" \
+  bun test src/services/matrix-as/names.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * A station's Matrix names.
+ *
+ * Pure, and derived from the pair that already identifies a station in a grant
+ * (`charter` → decisions/2026-08-15-a-grant-names-an-agent-per-plane.md). The
+ * node is in the name because station keys repeat across the fleet.
+ */
+
+/** The localpart grammar Matrix allows, lowercased. Everything else becomes `_`. */
+const ILLEGAL = /[^a-z0-9._=/-]/g;
+
+export function localpartFor(nodeName: string, stationKey: string): string {
+  const clean = (s: string) => s.toLowerCase().replace(ILLEGAL, "_");
+  return `${clean(nodeName)}_${clean(stationKey)}`;
+}
+
+export function bridgeUserId(nodeName: string, stationKey: string, domain: string): string {
+  return `@agent_${localpartFor(nodeName, stationKey)}:${domain}`;
+}
+
+export function bridgeAlias(nodeName: string, stationKey: string, domain: string): string {
+  return `#agentpod_${localpartFor(nodeName, stationKey)}:${domain}`;
+}
+
+/**
+ * Is this one of ours?
+ *
+ * The first question asked of every inbound event. An Application Service
+ * receives what its own users send, and a bridge that answers those talks to
+ * itself forever.
+ */
+export function isBridgeUser(mxid: string, domain: string): boolean {
+  return mxid.startsWith("@agent_") || mxid === `@ai-bridge:${domain}`
+    ? mxid.endsWith(`:${domain}`)
+    : false;
+}
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/services/matrix-as/
+git commit -m "feat(hub): derive a station's Matrix names from its node and key"
+```
+
+---
+
+### Task 2: Record who owns a station's Matrix id
+
+**Files:**
+- Create: `apps/hub/src/db/drizzle-migrations/0044_matrix_id_source.sql`
+- Modify: `apps/hub/src/db/drizzle-migrations/meta/_journal.json`
+- Modify: `apps/hub/src/db/schema/stations.ts`
+- Modify: `apps/hub/src/services/station-registry.ts` (the refresh path)
+- Test: `apps/hub/tests/integration/matrix-id-source.test.ts`
+
+**Interfaces:**
+- Produces: `stations.matrixIdSource: "harness" | "bridge"`, default `"harness"`.
+
+> **A migration without a `meta/_journal.json` entry never runs.** This repo has been bitten; add the entry in the same commit.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/**
+ * Two writers, one column.
+ *
+ * `stations.matrix_id` is read off the host by the node agent from a harness
+ * profile. The bridge writes it too, for stations whose harness has no Matrix
+ * identity of its own. Without a recorded owner the node agent's next refresh
+ * silently reverts the bridge — and the symptom is an agent that stops
+ * answering in a room, with nothing anywhere saying why.
+ */
+test("a station refresh leaves a bridge-owned mxid alone", async () => {
+  await setMatrixIdBySource(STATION, "@agent_box_pi_x:id.agentpod.dev", "bridge");
+
+  // What the node agent does on every detect.
+  await refreshStationFromDetect(STATION, { matrixId: null });
+
+  const row = await stationRow(STATION);
+  expect(row.matrixId).toBe("@agent_box_pi_x:id.agentpod.dev");
+  expect(row.matrixIdSource).toBe("bridge");
+});
+
+test("a harness-owned mxid is still refreshed by the node agent", async () => {
+  // The existing behaviour must not regress: hermes reads its own identity off
+  // the host, and a profile change has to land.
+  await setMatrixIdBySource(STATION, "@old:id.agentpod.dev", "harness");
+
+  await refreshStationFromDetect(STATION, { matrixId: "@new:id.agentpod.dev" });
+
+  expect((await stationRow(STATION)).matrixId).toBe("@new:id.agentpod.dev");
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- 0044_matrix_id_source.sql
+ALTER TABLE stations
+  ADD COLUMN matrix_id_source text NOT NULL DEFAULT 'harness';
+
+-- Every mxid that exists today was read off a host by the node agent.
+-- The default is therefore correct for all 14 rows that have one, and the
+-- bridge writes 'bridge' only where it takes ownership.
+ALTER TABLE stations
+  ADD CONSTRAINT stations_matrix_id_source_check
+  CHECK (matrix_id_source IN ('harness', 'bridge'));
+```
+
+Add the journal entry. Classify the column in `db/tenant-scope.ts` if that file requires it for new columns.
+
+- [ ] **Step 4: Guard the refresh path**
+
+In `station-registry.ts`, the detect-refresh must not overwrite `matrix_id` when `matrix_id_source = 'bridge'`.
+
+- [ ] **Step 5: Run the tests, then the full hub suite**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(hub): record whether a station's mxid comes from its harness or the bridge"
+```
+
+---
+
+### Task 3: The transaction endpoint — authenticated, idempotent, loop-proof
+
+**Files:**
+- Create: `apps/hub/src/routes/matrix-as.ts`
+- Create: `apps/hub/src/services/matrix-as/transactions.ts`
+- Create: `apps/hub/src/db/drizzle-migrations/0045_matrix_as_txns.sql` (+ journal)
+- Modify: `apps/hub/src/index.ts` (mount at `/_matrix/app/v1`)
+- Test: `apps/hub/tests/integration/matrix-as-transactions.test.ts`
+
+**Interfaces:**
+- Consumes: `isBridgeUser` (Task 1).
+- Produces: `PUT /_matrix/app/v1/transactions/:txnId` → `{}`; `applyTransaction(txnId, events)`.
+
+> The spec's routes are `PUT`, not `POST` — Synapse sends `PUT`. Mount **outside** the `/api/*` auth middleware: the caller is a homeserver with an `hs_token`, not a session.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/**
+ * The three ways a bridge's front door goes wrong, all of them quiet.
+ */
+describe("PUT /_matrix/app/v1/transactions/:txnId", () => {
+  test("refuses a transaction without the homeserver's token", async () => {
+    const res = await app().request("/_matrix/app/v1/transactions/1", {
+      method: "PUT",
+      body: JSON.stringify({ events: [message("@rakesh:id.agentpod.dev", "hi")] }),
+    });
+    expect(res.status).toBe(403);
+    expect(handled).toHaveLength(0);
+  });
+
+  test("refuses a transaction with the WRONG token", async () => {
+    // Including the as_token, which is the token pointing the other way and is
+    // the mistake a tired person makes at 1am.
+    const res = await withToken(AS_TOKEN).request(/* … */);
+    expect(res.status).toBe(403);
+  });
+
+  test("applies a transaction once, however many times it arrives", async () => {
+    // Synapse retries. A bridge that prompted twice for one message would
+    // double every conversation, and the second answer would look like the
+    // agent talking to itself.
+    await deliver("txn-1", [message("@rakesh:id.agentpod.dev", "hello")]);
+    await deliver("txn-1", [message("@rakesh:id.agentpod.dev", "hello")]);
+
+    expect(handled).toHaveLength(1);
+  });
+
+  test("drops events sent by our own users before anything else looks at them", async () => {
+    // An AS receives what its own users send. This is the loop that fills a
+    // database overnight.
+    await deliver("txn-2", [message("@agent_box_pi_x:id.agentpod.dev", "output")]);
+    expect(handled).toHaveLength(0);
+  });
+
+  test("answers 200 with an empty object, which is what the spec requires", async () => {
+    const res = await deliver("txn-3", []);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  test("a handler that throws does not lose the rest of the transaction", async () => {
+    // Synapse retries the WHOLE transaction; one poisoned event must not
+    // strand the others behind it forever.
+    await deliver("txn-4", [poison(), message("@rakesh:id.agentpod.dev", "second")]);
+    expect(handled).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Migration for applied transactions**
+
+```sql
+-- 0045_matrix_as_txns.sql
+CREATE TABLE matrix_as_transactions (
+  txn_id     text PRIMARY KEY,
+  applied_at timestamp NOT NULL DEFAULT now()
+);
+```
+
+A table rather than memory: idempotency that forgets on restart is idempotency that fails exactly when the bridge is least healthy. Add the journal entry.
+
+- [ ] **Step 4: Implement the route and `applyTransaction`**
+
+Constant-time compare on `hs_token`; insert-or-skip on `txn_id`; drop `isBridgeUser` senders; handle each event inside its own try/catch; always answer `{}`.
+
+- [ ] **Step 5: Run the tests, then the full hub suite**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(hub): receive Application Service transactions, once and only once"
+```
+
+---
+
+### Task 4: Answer the homeserver's questions about our users and rooms
+
+**Files:**
+- Modify: `apps/hub/src/routes/matrix-as.ts`
+- Test: `apps/hub/tests/integration/matrix-as-queries.test.ts`
+
+**Interfaces:**
+- Produces: `GET /_matrix/app/v1/users/:userId`, `GET /_matrix/app/v1/rooms/:alias`, `GET /_matrix/app/v1/ping`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("claims a user that maps to a real station", async () => {
+  // Synapse asks before it will let anyone talk to an unregistered user in our
+  // namespace. Answering 200 is what makes the user exist.
+  const res = await get(`/users/${encodeURIComponent(bridgeUserId("molt-bot", "hermes:analyst-echo", D))}`);
+  expect(res.status).toBe(200);
+});
+
+test("disclaims a user in our namespace that maps to no station", async () => {
+  // 404 rather than 200: claiming every conceivable name would let anyone
+  // conjure an agent that does not exist by typing a room address.
+  const res = await get("/users/%40agent_nowhere_nothing%3Aid.agentpod.dev");
+  expect(res.status).toBe(404);
+});
+
+test("claims an alias that maps to a real station and creates the room", async () => {
+  const res = await get(`/rooms/${encodeURIComponent(bridgeAlias("superchotu", "openclaw:krishna", D))}`);
+  expect(res.status).toBe(200);
+  expect(created.rooms).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Implement**
+
+Both queries resolve the localpart back to `(node, stationKey)` and look for an adopted station. Unknown → 404.
+
+- [ ] **Step 4: Run the tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(hub): answer which of our users and rooms exist"
+```
+
+---
+
+### Task 5: A client for acting as a station
+
+**Files:**
+- Create: `apps/hub/src/services/matrix-as/client.ts`
+- Test: `apps/hub/src/services/matrix-as/client.test.ts`
+
+**Interfaces:**
+- Produces: `ensureUser(localpart, displayName)`, `ensureRoom(alias, opts)`, `sendText(userId, roomId, body)`, `sendTyping(userId, roomId, on)`, `invite(roomId, mxid)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("acts as the station's user, not as the bridge", async () => {
+  // ?user_id= is the whole mechanism. Without it every agent's message arrives
+  // from @ai-bridge and the room becomes one voice pretending to be many.
+  await sendText("@agent_box_pi_x:id.agentpod.dev", "!room:id.agentpod.dev", "hello");
+  expect(lastUrl).toContain("user_id=%40agent_box_pi_x%3Aid.agentpod.dev");
+});
+
+test("carries the as_token, never the hs_token", async () => {
+  // The two tokens point in opposite directions and swapping them fails with a
+  // 403 that reads like a permissions bug.
+  expect(lastHeaders.Authorization).toBe(`Bearer ${AS_TOKEN}`);
+});
+
+test("treats M_USER_IN_USE on register as success", async () => {
+  // ensureUser runs on every message. The second call must be a no-op, not an
+  // error that stops an agent answering.
+  registerReplies(409, { errcode: "M_USER_IN_USE" });
+  await expect(ensureUser("agent_box_pi_x", "pi")).resolves.toBeUndefined();
+});
+
+test("gives a message a transaction id so a retry cannot double-send", async () => {
+  await sendText(USER, ROOM, "hello");
+  expect(lastUrl).toMatch(/\/send\/m\.room\.message\/[^/]+$/);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Implement**
+
+`fetch` against `MATRIX_HOMESERVER_URL` (default `http://127.0.0.1:8008`), `Authorization: Bearer <as_token>`, `?user_id=` on every call, a UUID txn id per send, `M_USER_IN_USE` and `M_ROOM_IN_USE` treated as success.
+
+- [ ] **Step 4: Run the tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(hub): a Matrix client that acts as a station"
+```
+
+---
+
+### Task 6: A message becomes a prompt — with the control pair in front of it
+
+**Files:**
+- Create: `apps/hub/src/services/matrix-as/inbound.ts`
+- Test: `apps/hub/tests/integration/matrix-as-inbound.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveMatrixId`, `requireGrantReach`'s sibling `grantAllowsStation` + `getGrant`, `acpSessions.createSession/promptSession`, Task 5's client.
+- Produces: `handleMessage(event, roomId)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/**
+ * Who may talk to an agent is the control pair, unchanged.
+ *
+ * This is the reason the identity work came first: an inbound Matrix message
+ * is an authorization question the suite can already answer.
+ */
+describe("an inbound message", () => {
+  test("prompts the station when the sender's grant covers it", async () => {
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleMessage(message(PRINCIPAL_MXID, "status?"), ROOM_FOR_KRISHNA);
+
+    expect(prompts).toHaveLength(1);
+  });
+
+  test("refuses in the room when the grant does not cover the station", async () => {
+    // Silence would read as a broken agent, and the operator would go looking
+    // in the wrong place — the console, the node, the harness.
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    await handleMessage(message(PRINCIPAL_MXID, "status?"), ROOM_FOR_KRISHNA);
+
+    expect(prompts).toHaveLength(0);
+    expect(sent.at(-1)!.body).toMatch(/not permitted|may not/i);
+  });
+
+  test("refuses a sender this hub cannot identify", async () => {
+    await handleMessage(message("@stranger:id.agentpod.dev", "hi"), ROOM_FOR_KRISHNA);
+    expect(prompts).toHaveLength(0);
+    expect(sent.at(-1)!.body).toMatch(/do not recognise|not linked/i);
+  });
+
+  test("refuses an ambiguous mxid rather than guessing", async () => {
+    // resolveMatrixId already fails closed here; the bridge must not "helpfully"
+    // pick one. A human's words attributed to an agent is unrecoverable.
+    await claimMxidAsBothStationAndPrincipal(AMBIGUOUS);
+    await handleMessage(message(AMBIGUOUS, "hi"), ROOM_FOR_KRISHNA);
+    expect(prompts).toHaveLength(0);
+  });
+
+  test("reuses the room's session instead of starting one per message", async () => {
+    await setGrant(PRINCIPAL, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleMessage(message(PRINCIPAL_MXID, "first"), ROOM_FOR_KRISHNA);
+    await handleMessage(message(PRINCIPAL_MXID, "second"), ROOM_FOR_KRISHNA);
+
+    // A conversation is a conversation. One session per message would throw
+    // away the agent's context between two consecutive sentences.
+    expect(createdSessions).toHaveLength(1);
+    expect(prompts).toHaveLength(2);
+  });
+
+  test("says so when the station is offline, rather than swallowing the message", async () => {
+    await nodeGoesOffline();
+    await handleMessage(message(PRINCIPAL_MXID, "hi"), ROOM_FOR_KRISHNA);
+    expect(sent.at(-1)!.body).toMatch(/offline/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Implement**
+
+Resolve room → station (by alias, stored on a `matrix_rooms` mapping written in Task 4/7), resolve sender → principal, check the grant, create-or-reuse a session keyed by room, prompt.
+
+- [ ] **Step 4: Run the tests, then the full hub suite**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(hub): a Matrix message is a prompt, if the sender may dispatch that agent"
+```
+
+---
+
+### Task 7: The agent answers in the room
+
+**Files:**
+- Create: `apps/hub/src/services/matrix-as/outbound.ts`
+- Test: `apps/hub/tests/integration/matrix-as-outbound.test.ts`
+
+**Interfaces:**
+- Consumes: the `acp-sessions` subscriber fan-out (the same one `station-acp.ts`'s WebSocket uses).
+- Produces: `attachRoomToSession(sessionId, roomId, userId)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("streams the agent's text into the room as the station's user", async () => {
+  attachRoomToSession(SESSION, ROOM, AGENT_USER);
+  emit(SESSION, agentText("Working on it."));
+  await settle();
+
+  expect(sent.at(-1)).toMatchObject({ userId: AGENT_USER, roomId: ROOM, body: "Working on it." });
+});
+
+test("coalesces a stream of chunks into a message, not a message per token", async () => {
+  // One Matrix event per token would be unreadable, would hit rate limits, and
+  // would make a phone buzz forty times for one answer.
+  attachRoomToSession(SESSION, ROOM, AGENT_USER);
+  for (const c of ["Hel", "lo ", "there"]) emit(SESSION, agentText(c));
+  await settle();
+
+  expect(sent).toHaveLength(1);
+  expect(sent[0]!.body).toBe("Hello there");
+});
+
+test("shows typing while a turn is in flight, and stops when it ends", async () => {
+  // MSC2409 is already enabled in agents.yaml. Without this the room looks
+  // dead during the ten seconds an agent is thinking.
+  attachRoomToSession(SESSION, ROOM, AGENT_USER);
+  emit(SESSION, turnStarted());
+  expect(typing.at(-1)).toMatchObject({ on: true });
+
+  emit(SESSION, turnEnded());
+  await settle();
+  expect(typing.at(-1)).toMatchObject({ on: false });
+});
+
+test("puts a permission request in the room as a question", async () => {
+  // An agent blocked on a permission prompt with nobody watching the console is
+  // an agent that has silently stopped.
+  emit(SESSION, permissionRequest({ options: ["allow", "deny"] }));
+  await settle();
+  expect(sent.at(-1)!.body).toMatch(/permission|allow/i);
+});
+
+test("stops sending when the session ends, and detaches", async () => {
+  attachRoomToSession(SESSION, ROOM, AGENT_USER);
+  emit(SESSION, sessionEnded());
+  emit(SESSION, agentText("late"));
+  await settle();
+
+  expect(sent.map((s) => s.body)).not.toContain("late");
+  expect(subscriberCountFor(SESSION)).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Implement**
+
+Subscribe per session; buffer text and flush on turn end or after a short idle; typing on turn start/end; unsubscribe on session end. **Leak check:** `_subscriberCountForTest` already exists for exactly this.
+
+- [ ] **Step 4: Run the tests, then the full hub suite**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(hub): the agent's answer arrives in the room, as the agent"
+```
+
+---
+
+### Task 8: Provision every station's user and room
+
+**Files:**
+- Create: `apps/hub/src/services/matrix-as/provision.ts`
+- Create: `apps/hub/src/db/drizzle-migrations/0046_matrix_rooms.sql` (+ journal)
+- Test: `apps/hub/tests/integration/matrix-as-provision.test.ts`
+
+**Interfaces:**
+- Produces: `provisionStation(stationId)`, `provisionAll()`; table `matrix_rooms(room_id, station_id, alias)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("gives a station a user, a room and a readable name", async () => {
+  await provisionStation(KRISHNA);
+
+  expect(created.users).toContain("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
+  expect(created.rooms.at(-1)).toMatchObject({
+    alias: "#agentpod_superchotu_openclaw_krishna:id.agentpod.dev",
+  });
+  // The display name is what a human sees in a member list — the station's
+  // display name, not its mangled localpart.
+  expect(created.displayNames.at(-1)).toBe("krishna (openclaw @ superchotu)");
+});
+
+test("is idempotent, because it runs on every adoption and every boot", async () => {
+  await provisionStation(KRISHNA);
+  await provisionStation(KRISHNA);
+  expect(created.rooms).toHaveLength(1);
+});
+
+test("records the station's mxid as bridge-owned", async () => {
+  await provisionStation(KRISHNA);
+  const row = await stationRow(KRISHNA);
+  expect(row.matrixId).toBe("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
+  expect(row.matrixIdSource).toBe("bridge");
+});
+
+test("does not touch a harness-owned mxid", async () => {
+  // Task 10 migrates those deliberately, per agent, with the harness's own
+  // Matrix loop stopped first. Provisioning must not do it by accident.
+  await provisionStation(ANALYST_ECHO);
+  const row = await stationRow(ANALYST_ECHO);
+  expect(row.matrixId).toBe("@analyst-echo:id.agentpod.dev");
+  expect(row.matrixIdSource).toBe("harness");
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+- [ ] **Step 3: Implement**
+
+`ensureUser` + display name, `ensureRoom` with the alias and a topic naming the station, invite the owning principal, upsert `matrix_rooms`, write `matrix_id`/`matrix_id_source` only when the source is not `harness`.
+
+- [ ] **Step 4: Call it where stations arrive**
+
+On adoption, and once at boot for anything missing. Gate the whole bridge on `ENABLE_MATRIX_BRIDGE === "true"` — the literal lowercase string, matching `ENABLE_KAAMBAAN_BRIDGE` and `ENFORCE_CONTROL_PAIR`.
+
+- [ ] **Step 5: Run the tests, then the full hub suite**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(hub): every station gets a Matrix user and a room"
+```
+
+---
+
+### Task 9: Turn it on for the 18
+
+**Files:**
+- Modify: `/etc/matrix-synapse/agents.yaml` (host — set `url`)
+- Modify: `/etc/agentpod/hub.env` (host)
+- Modify: `deploy/nginx/hub.agentpod.dev.conf` if the AS is reached over the network rather than `127.0.0.1`
+- Modify: `docs/DEPLOYMENT.md`
+
+- [ ] **Step 1: Configure the hub**
+
+```sh
+ENABLE_MATRIX_BRIDGE=true          # literal lowercase "true"
+MATRIX_HOMESERVER_URL=http://127.0.0.1:8008
+MATRIX_SERVER_NAME=id.agentpod.dev
+MATRIX_AS_TOKEN=<as_token from agents.yaml>
+MATRIX_HS_TOKEN=<hs_token from agents.yaml>
+```
+
+- [ ] **Step 2: Point the registration at the hub**
+
+```yaml
+url: "http://127.0.0.1:3001"    # was null
+```
+
+Then `systemctl restart matrix-synapse`. **This is the moment the bridge starts receiving traffic**; everything before it was inert.
+
+- [ ] **Step 3: Verify with one station before the rest**
+
+Pick `openclaw:krishna`. Join `#agentpod_superchotu_openclaw_krishna`, say hello, get an answer. Then check the refusal path: narrow your own grant to exclude openclaw, send again, and read the refusal **in the room**. Restore the grant.
+
+- [ ] **Step 4: Provision the remaining 17**
+
+- [ ] **Step 5: Document**
+
+`docs/DEPLOYMENT.md` gains a Matrix bridge section: the five variables, the `url` flip, how to tell whether Synapse is delivering (its `appservice` logs), and the fact that `url: null` disables the whole thing without touching the hub.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "docs(deploy): running the Matrix bridge"
+```
+
+---
+
+### Task 10: Migrate the 14 hermes agents, one at a time
+
+**Files:**
+- Modify: `/etc/matrix-synapse/agents.yaml` (host — second user namespace)
+- Create: `apps/hub/src/services/matrix-as/adopt-harness-mxid.ts`
+- Test: `apps/hub/tests/integration/matrix-as-adopt.test.ts`
+
+This is the riskiest task in the plan and the only one that touches something already working. **Nothing here is done in bulk.**
+
+- [ ] **Step 1: Widen the namespace**
+
+```yaml
+  users:
+    - regex: "@agent_.*"
+      exclusive: true
+    # The 14 hermes agents keep the addresses people already use. Listed
+    # explicitly rather than by pattern: a broad regex here would claim human
+    # accounts on this homeserver, and `exclusive: false` because these users
+    # already exist and were not registered by us.
+    - regex: "@(analyst-echo|artistic-lyra|buddhimaan|cleaner-cody|coder-kai|controller-casey|onboarding-olivia|optimizer-ollie|predictor-paul|project-manager-pete|research-ray|strategy-sam|threat-hunter-theo|writer-quill):id\\.agentpod\\.dev"
+      exclusive: false
+```
+
+Restart Synapse. The bridge can now act as them; nothing yet does.
+
+- [ ] **Step 2: Write the failing test for adoption**
+
+```ts
+test("adopting a harness mxid keeps the address and changes the owner", async () => {
+  await adoptHarnessMxid(ANALYST_ECHO);
+
+  const row = await stationRow(ANALYST_ECHO);
+  expect(row.matrixId).toBe("@analyst-echo:id.agentpod.dev");   // unchanged
+  expect(row.matrixIdSource).toBe("bridge");                     // changed
+});
+
+test("refuses to adopt while the harness's own Matrix loop is running", async () => {
+  // Two answerers on one address is the failure this ordering exists to
+  // prevent: the operator sees duplicate replies and cannot tell which is real.
+  await hermesLoopIsRunning(ANALYST_ECHO);
+  await expect(adoptHarnessMxid(ANALYST_ECHO)).rejects.toThrow(/still running|stop/i);
+});
+
+test("reverting is one row", async () => {
+  await adoptHarnessMxid(ANALYST_ECHO);
+  await revertHarnessMxid(ANALYST_ECHO);
+  expect((await stationRow(ANALYST_ECHO)).matrixIdSource).toBe("harness");
+});
+```
+
+- [ ] **Step 3: Implement, including the running-loop check**
+
+How "is hermes's Matrix loop running for this agent" is determined is a host question — read it through the node agent's health/config surface. If it cannot be determined, **refuse**: an unverifiable precondition on the one task that can produce two answerers is not a precondition worth having.
+
+- [ ] **Step 4: Cut over one agent**
+
+`hermes:analyst-echo` first — it is the least critical. Stop its Matrix loop on molt-bot, adopt, send a message in its existing room, confirm exactly one answer arrives and it came through ACP (check `acp_events`).
+
+- [ ] **Step 5: Wait a day, then do the remaining 13**
+
+Not ceremony: the failure mode here is *a duplicate answer nobody notices*, and it needs a day of ordinary use to surface.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(hub): adopt a harness-owned Matrix identity into the bridge"
+```
+
+---
+
+### Task 11: Operate it
+
+**Files:**
+- Modify: `docs/OPERATING.md`
+- Create: `apps/hub/src/services/matrix-as/health.ts`
+- Test: `apps/hub/tests/integration/matrix-as-health.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("reports a bridge that is configured but receiving nothing", async () => {
+  // The exact shape of the pre-existing bug: url: null meant a perfectly
+  // healthy AS that had never been sent a single event, and nothing said so.
+  await noTransactionsFor(2 * 60 * 60 * 1000);
+  const h = await bridgeHealth();
+  expect(h.status).toBe("silent");
+  expect(h.reason).toMatch(/no transaction/i);
+});
+```
+
+- [ ] **Step 2: Implement, and surface it**
+
+Last-transaction timestamp, rooms provisioned, sessions attached. Boot warning when `ENABLE_MATRIX_BRIDGE` is true and the tokens are missing — the same shape as the bridge and control-pair warnings.
+
+- [ ] **Step 3: Write the operator section**
+
+`docs/OPERATING.md`: what the bridge is, the room naming scheme, how to find an agent's room, what a refusal in a room means, how to turn it off (`url: null`, one restart), and how to read Synapse's appservice logs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "docs(ops): the Matrix bridge, and how to tell it is working"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Derived names (T1), ownership column (T2), transactions with auth/idempotency/loop-cut (T3), user and room queries (T4), acting as a station (T5), inbound with the control pair (T6), outbound streaming, typing and permissions (T7), provisioning all stations (T8), enabling for the 18 (T9), migrating the 14 (T10), operability (T11). The Postgres migration is Phase A and defers to the existing #329 plan.
+
+**Deliberately not covered**, and named in the spec: kaambaan card/run/gate events (kaambaan#34 owns those schemas), E2EE, federation, and any node-agent change.
+
+**Type consistency.** `bridgeUserId`/`bridgeAlias`/`isBridgeUser` (T1) are used with those signatures in T4, T5, T7 and T8; `matrixIdSource` is `"harness" | "bridge"` in T2, T8 and T10; `attachRoomToSession(sessionId, roomId, userId)` matches between T7's test and T8's provisioning.
+
+**The two riskiest steps, both flagged in place:** flipping `url` (T9 Step 2), which is when a quiet system becomes a live one, and adopting hermes identities (T10), which is the only task that can produce two answerers on one address — hence one agent at a time, a day of real use, and a one-row rollback.

--- a/docs/superpowers/plans/2026-08-16-conversable-fleet.md
+++ b/docs/superpowers/plans/2026-08-16-conversable-fleet.md
@@ -76,7 +76,19 @@ appservice_dir = "/etc/tuwunel/appservices"
 `allow_registration = false` from the first boot: the spike used open
 registration and tuwunel warned about it on every start, correctly.
 
-- [ ] **Step 3: Write the registration, and leave `url` out**
+> **Two log lines that look like faults and are not**, both seen on the real
+> deploy: `ERROR … loopback/localhost listening address … will NOT work` is a
+> false positive under `--network host`, where 127.0.0.1 *is* the host; and
+> `Error response from daemon: No such container: tuwunel` is the unit's
+> `ExecStartPre=-docker rm -f`, which is why it carries a `-`.
+
+- [ ] **Step 3: Write the registration with `url: null`**
+
+> **Corrected on 2026-08-16 while executing this step.** Synapse tolerates the
+> `url` key being absent; **tuwunel requires the field to be present** and aborts
+> its whole appservice service with `missing field \`url\`` when it is not —
+> which leaves the homeserver running and the appservice silently dead. `url:
+> null` is accepted and means the same thing: registered, receiving nothing.
 
 ```yaml
 id: ai-agents
@@ -120,9 +132,15 @@ git commit -m "deploy: the tuwunel unit and its configuration"
 
 - [ ] **Step 1: Register your own account on the new server**
 
-With `allow_registration = false`, use tuwunel's admin command or a one-shot
-registration token. Same localpart as before, so `@rakesh:id.agentpod.dev` is
-still you.
+With `allow_registration = false`, the admin console is the way in — and it needs
+the database, which the running server holds. So: stop the service, run the
+image once with `--execute "users create-user <name> <password>"`, start it again.
+
+> **`create-user` prints the password to stdout**, so it lands in whatever
+> terminal or transcript ran it. Either generate the password yourself and pass
+> it explicitly (still echoed), or follow with `users reset-password` and keep
+> only the second one. On this deploy the first password was echoed and was
+> rotated for exactly that reason.
 
 - [ ] **Step 2: Confirm the old client works against the new server**
 
@@ -917,7 +935,13 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
 
 `identity` calls Task 8's provisioning. `credentials` additionally: generate a password, run `users reset-password` (or `create-user`) through the homeserver's **admin room** as the hub's own admin account, then log in as the station's user to obtain a device token. Return it once; store nothing but the mode.
 
-> tuwunel has no Synapse-shaped admin HTTP API. Its `users create-user` and `users reset-password` are admin-room commands, which a client with an admin account can send remotely — verified in the CLI surface (`--execute`, `!admin users …`).
+> **Simpler than planned, verified on the real server:** an Application Service
+> registering a user through `POST /_matrix/client/v3/register` with
+> `m.login.application_service` gets back an **`access_token` and `device_id`
+> directly** — no admin command, no password, no login round-trip. The admin
+> path (`users create-user` / `users reset-password`, console-only since tuwunel
+> has no Synapse-shaped admin HTTP API) is only needed for accounts outside the
+> AS namespace, i.e. humans.
 
 - [ ] **Step 4: Run the tests, then the full hub suite**
 

--- a/docs/superpowers/plans/2026-08-16-conversable-fleet.md
+++ b/docs/superpowers/plans/2026-08-16-conversable-fleet.md
@@ -4,92 +4,174 @@
 
 **Goal:** Every station in the fleet is reachable from any Matrix client — the 18 whose harness has never spoken Matrix, and the 14 whose harness does, through one mechanism.
 
-**Architecture:** Synapse moves to Postgres first, on its own. Then an Application Service inside the hub receives transactions at `/_matrix/app/v1/*`, owns a virtual `@agent_*` user and a room per station, maps inbound messages onto ACP sessions after checking the control pair, and streams the agent's output back by subscribing to the same in-process fan-out the console's WebSocket uses.
+**Architecture:** The homeserver is replaced first — **tuwunel** (Apache-2.0) in place of Synapse (AGPLv3), starting empty. Then an Application Service inside the hub receives transactions at `/_matrix/app/v1/*`, owns a virtual user and a room per station, maps inbound messages onto ACP sessions after checking the control pair, and streams the agent's output back by subscribing to the same in-process fan-out the console's WebSocket uses.
 
-**Tech Stack:** Synapse 1.x + Postgres 16 (`LC_COLLATE=C`), Bun + Hono + Drizzle (hub), the Matrix Application Service API r0/v1, MSC2409 ephemeral events.
+**Tech Stack:** tuwunel 1.8.3 (RocksDB, embedded), Bun + Hono + Drizzle (hub), the Matrix Application Service API v1.
 
 **Spec:** `docs/superpowers/specs/2026-08-16-matrix-application-service-design.md`
+**Spike:** `docs/superpowers/specs/2026-08-16-tuwunel-appservice-spike-findings.md` — every AS feature below was verified against a running tuwunel before this plan was written.
 
 ## Global Constraints
 
-- **Homeserver:** `id.agentpod.dev` on `178.105.68.68`, private, federation disabled, nginx proxying `/_matrix` and `/_synapse` to `127.0.0.1:8008`.
-- **Registration file:** `/etc/matrix-synapse/agents.yaml`, AS id `ai-agents`, `sender_localpart: ai-bridge`, users `@agent_.*` exclusive, aliases `#agentpod_.*` exclusive, `de.sorunome.msc2409.push_ephemeral: true`, `url: null` **until Task 9**.
+- **Homeserver:** `id.agentpod.dev` on `178.105.68.68`, private, federation disabled, nginx proxying `/_matrix` to the homeserver's port. **tuwunel serves 6167 by default, not 8008** — the vhost changes with it.
+- **Registration file:** a YAML file in tuwunel's `appservice_dir`, Synapse-shaped (the spike confirmed the existing file's namespaces load unchanged): AS id `ai-agents`, `sender_localpart: ai-bridge`, users `@agent_.*` exclusive, aliases `#agentpod_.*` exclusive, **`receive_ephemeral: true`** (tuwunel's name for what Synapse spelled `de.sorunome.msc2409.push_ephemeral`), and `url` **left unset until Task 9**.
 - **Name derivation is a pure function** of `(nodeName, stationKey)`: lowercase, every character outside `[a-z0-9._=/-]` becomes `_`. User `@agent_<node>_<station>`, alias `#agentpod_<node>_<station>`. Never stored as a second source of truth.
-- **`hs_token` authenticates every AS route**; a request without it is 403 and is never processed. The `as_token` is what the bridge sends *to* Synapse.
+- **`hs_token` authenticates every AS route**; a request without it is 403 and is never processed. The `as_token` is what the bridge sends *to* the homeserver. The two point in opposite directions and swapping them fails as a 403 that reads like a permissions bug.
 - **Drop every event sent by our own namespace** before any other handling.
 - **Transactions are idempotent by `txnId`.**
 - **Refusals are messages in the room**, never silence.
-- Hub tests need `DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod"` and pgvector Postgres on :5434. Console tests need Node 22.
+- Hub tests need `DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod"` and pgvector Postgres on :5434 — that is the **hub's** database and is unrelated to the homeserver, which has none. Console tests need Node 22.
+- **A rejected registration is `M_EXCLUSIVE` with HTTP 400**, not 403 — the spec's code, and tuwunel's. Assert 400.
 - **TDD:** failing test first, every task. Regression test for every bug fixed.
 
 ### Secrets, and where they are not
 
-`as_token` and `hs_token` live in `/etc/matrix-synapse/agents.yaml` and in the hub's environment as `MATRIX_AS_TOKEN` / `MATRIX_HS_TOKEN`. **Neither goes in the repository, in a test fixture, or in a log line.** The bridge logs mxids and room ids, never tokens.
+`as_token` and `hs_token` live in `/etc/tuwunel/appservices/agentpod.yaml` and in the hub's environment as `MATRIX_AS_TOKEN` / `MATRIX_HS_TOKEN`. **Neither goes in the repository, in a test fixture, or in a log line.** The bridge logs mxids and room ids, never tokens.
 
 ---
 
-## Phase A — Synapse on Postgres (#329)
+## Phase A — Replace the homeserver
 
-The migration plan is already written: `docs/superpowers/plans/2026-08-15-synapse-postgres-migration.md` on branch `docs/synapse-postgres-plan` (PR #329). Execute it as written. It is not restated here; these are the only additions this program makes to it.
+**#329 is closed, not executed.** It existed because Synapse on SQLite has one
+writer, no safe hot backup, and a migration that only gets harder. tuwunel is
+RocksDB — embedded, concurrent, no separate database process — so every reason
+for that plan is answered by not running SQLite at all.
 
-### Task A1: Execute the migration, with the AS in mind
+**There is no migration path from Synapse.** The new homeserver starts empty.
+What survives is every address, because an mxid is localpart + domain and both
+are ours to recreate; what is lost is ~19,400 events of history, the room ids
+and any media. Accepted deliberately: `acp_events` is the authoritative
+transcript, Matrix carries a projection, and the bridge recreates every room.
+
+### Task A1: Stand tuwunel up beside Synapse
 
 **Files:**
-- Follow: `docs/superpowers/plans/2026-08-15-synapse-postgres-migration.md`
-- Modify: `/etc/matrix-synapse/conf.d/database.yaml` (on the host)
+- Create: `/etc/tuwunel/tuwunel.toml` (host)
+- Create: `/etc/tuwunel/appservices/agentpod.yaml` (host)
+- Create: `deploy/tuwunel/tuwunel.service` (repo — the unit, so it is not hand-rolled on the box)
 
-- [ ] **Step 1: Take the backups the plan requires**
+- [ ] **Step 1: Take the backups anyway**
 
-`sqlite3 .backup` of `homeserver.db`, plus `homeserver.signing.key` and `agents.yaml`, copied **off the box** and restored once into a scratch path to prove they open. The signing key cannot be regenerated: losing it loses the server's identity permanently.
+Synapse's `homeserver.db`, `homeserver.signing.key` and `agents.yaml`, copied off
+the box. Not for the migration — there isn't one — but because Task A4 turns the
+old server off, and a decision to discard history should be reversible for a
+month.
 
-> The host has **no `sqlite3` CLI** (checked 2026-08-16). Install it first — `apt-get install -y sqlite3` — or the plan's very first command fails.
+> The host has **no `sqlite3` CLI** (checked 2026-08-16). `apt-get install -y sqlite3` first, or use `VACUUM INTO`.
 
-- [ ] **Step 2: Create the database with C collation**
+- [ ] **Step 2: Write the config**
 
-```sql
-CREATE ROLE synapse_user LOGIN PASSWORD '<generated>';
-CREATE DATABASE synapse ENCODING 'UTF8' LC_COLLATE='C' LC_CTYPE='C'
-  template=template0 OWNER synapse_user;
+```toml
+[global]
+server_name = "id.agentpod.dev"
+database_path = "/var/lib/tuwunel"
+port = 6167
+address = "127.0.0.1"
+allow_registration = false          # the bridge registers agents; humans are made deliberately
+allow_federation = false
+appservice_dir = "/etc/tuwunel/appservices"
 ```
 
-`synapse_port_db` refuses to run without `C` collation, and fixing it afterwards means doing the migration again.
+`allow_registration = false` from the first boot: the spike used open
+registration and tuwunel warned about it on every start, correctly.
 
-- [ ] **Step 3: Run the port with Synapse stopped**
-
-Per the plan. 82 MB, ~19,400 events — minutes, not hours.
-
-- [ ] **Step 4: Raise `cp_max` for the bridge**
-
-The migration plan flags this as a follow-up; do it now rather than discovering it under load. In the Postgres stanza:
+- [ ] **Step 3: Write the registration, and leave `url` out**
 
 ```yaml
-database:
-  name: psycopg2
-  args:
-    cp_min: 5
-    cp_max: 15
+id: ai-agents
+as_token: <generate>
+hs_token: <generate>
+sender_localpart: ai-bridge
+receive_ephemeral: true
+rate_limited: false
+namespaces:
+  users:
+    - exclusive: true
+      regex: "@agent_.*"
+    # The 14 hermes addresses people already use, recreated on the new server by
+    # the bridge. Listed explicitly rather than by pattern: a broad regex here
+    # would claim human accounts on this homeserver.
+    - exclusive: true
+      regex: "@(analyst-echo|artistic-lyra|buddhimaan|cleaner-cody|coder-kai|controller-casey|onboarding-olivia|optimizer-ollie|predictor-paul|project-manager-pete|research-ray|strategy-sam|threat-hunter-theo|writer-quill):id\\.agentpod\\.dev"
+  aliases:
+    - exclusive: true
+      regex: "#agentpod_.*"
+  rooms: []
 ```
 
-An AS multiplies both connection demand and background work — the reason to leave SQLite in the first place.
+**New tokens, not Synapse's.** The old ones were valid for a server that is
+about to be switched off, and reusing a credential across a trust boundary
+change is how a stale token outlives the thing it authenticated.
 
-- [ ] **Step 5: Verify, then keep the SQLite file**
+- [ ] **Step 4: Run it on a port nothing points at yet**
 
-`/health` on the hub is unrelated; verify Synapse itself: log in as an existing agent, read a room, send a message, and confirm `SELECT count(*) FROM events` in Postgres matches the SQLite count recorded in Step 1. Keep `homeserver.db` on disk, renamed `.migrated`, until Phase B is finished.
+`systemctl enable --now tuwunel`, then confirm from the box:
+`curl -s localhost:6167/_matrix/client/versions`. Synapse is still serving
+`id.agentpod.dev`; nothing has moved.
 
-- [ ] **Step 6: Write the backup schedule that has never existed**
-
-A nightly `pg_dump` of **both** databases (`agentpod`, `synapse`) plus the signing key, to somewhere off the box. The migration plan names this as the gap it does not close. Close it here — a homeserver with no backup is one disk away from every agent identity being unrecoverable.
-
-- [ ] **Step 7: Document it**
-
-`docs/OPERATING.md` has no homeserver section at all. Add one: where it runs, which database, how to restart it, where the registration lives, how to take and restore a backup.
-
-- [ ] **Step 8: Commit**
+- [ ] **Step 5: Commit the unit and the config shape**
 
 ```bash
-git add docs/OPERATING.md
-git commit -m "docs(ops): the homeserver, its database, and its backups"
+git add deploy/tuwunel/
+git commit -m "deploy: the tuwunel unit and its configuration"
 ```
+
+### Task A2: Recreate the humans
+
+- [ ] **Step 1: Register your own account on the new server**
+
+With `allow_registration = false`, use tuwunel's admin command or a one-shot
+registration token. Same localpart as before, so `@rakesh:id.agentpod.dev` is
+still you.
+
+- [ ] **Step 2: Confirm the old client works against the new server**
+
+supermessage, logged in against `id.agentpod.dev` — it will need a fresh login,
+because the access token belonged to the other server.
+
+### Task A3: Cut the domain over
+
+- [ ] **Step 1: Stop Synapse**
+
+`systemctl stop matrix-synapse && systemctl disable matrix-synapse`. Leave the
+database on disk.
+
+- [ ] **Step 2: Point nginx at 6167**
+
+`deploy/nginx/agentpod.dev.conf`: `/\_matrix` → `127.0.0.1:6167`. The
+`/_synapse` location is Synapse-specific and goes away. Keep the
+`.well-known/matrix/*` files exactly as they are — the domain has not changed,
+only what serves it.
+
+- [ ] **Step 3: `nginx -t`, reload, and verify from off the box**
+
+`curl https://id.agentpod.dev/_matrix/client/versions` should now be tuwunel's.
+
+- [ ] **Step 4: Back up what there is to back up**
+
+A nightly copy of `/var/lib/tuwunel` (stop-copy-start, or a RocksDB checkpoint)
+plus `/etc/tuwunel/`, off the box. Synapse had **no backup schedule at all**;
+this is the gap #329 named and never closed.
+
+- [ ] **Step 5: Write the operator section**
+
+`docs/OPERATING.md` has no homeserver section. Add one: what runs, where its data
+is, how to restart it, where the registration lives, how to back it up and
+restore it, and that `allow_registration` is off by design.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/nginx/ docs/OPERATING.md
+git commit -m "deploy: serve id.agentpod.dev from tuwunel"
+```
+
+### Task A4: Close #329
+
+- [ ] **Step 1: Close it with the reason**
+
+The Postgres migration is unnecessary: the homeserver it applied to is no longer
+running. Link the spike findings so the reasoning survives.
 
 ---
 
@@ -131,7 +213,7 @@ describe("bridge names", () => {
 
   test("land inside the namespace the homeserver reserved", () => {
     // agents.yaml claims `@agent_.*` exclusive. A name outside it cannot be
-    // acted as, and the failure is a 403 from Synapse at send time.
+    // acted as, and the failure is a 403 from the homeserver at send time.
     expect(bridgeUserId("molt-bot", "hermes:analyst-echo", D)).toBe(
       "@agent_molt-bot_hermes_analyst-echo:id.agentpod.dev"
     );
@@ -318,7 +400,7 @@ git commit -m "feat(hub): record whether a station's mxid comes from its harness
 - Consumes: `isBridgeUser` (Task 1).
 - Produces: `PUT /_matrix/app/v1/transactions/:txnId` → `{}`; `applyTransaction(txnId, events)`.
 
-> The spec's routes are `PUT`, not `POST` — Synapse sends `PUT`. Mount **outside** the `/api/*` auth middleware: the caller is a homeserver with an `hs_token`, not a session.
+> The spec's routes are `PUT`, not `POST` — the homeserver sends `PUT`, as the spike observed. Mount **outside** the `/api/*` auth middleware: the caller is a homeserver with an `hs_token`, not a session.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -763,10 +845,10 @@ MATRIX_HS_TOKEN=<hs_token from agents.yaml>
 - [ ] **Step 2: Point the registration at the hub**
 
 ```yaml
-url: "http://127.0.0.1:3001"    # was null
+url: "http://127.0.0.1:3001"    # previously absent
 ```
 
-Then `systemctl restart matrix-synapse`. **This is the moment the bridge starts receiving traffic**; everything before it was inert.
+Then `systemctl restart tuwunel`. **This is the moment the bridge starts receiving traffic**; everything before it was inert. tuwunel also accepts registrations by admin-room command without a restart — use the file, so the configuration is on disk where an operator can find it.
 
 - [ ] **Step 3: Verify with one station before the rest**
 
@@ -776,7 +858,7 @@ Pick `openclaw:krishna`. Join `#agentpod_superchotu_openclaw_krishna`, say hello
 
 - [ ] **Step 5: Document**
 
-`docs/DEPLOYMENT.md` gains a Matrix bridge section: the five variables, the `url` flip, how to tell whether Synapse is delivering (its `appservice` logs), and the fact that `url: null` disables the whole thing without touching the hub.
+`docs/DEPLOYMENT.md` gains a Matrix bridge section: the five variables, the `url` flip, how to tell whether tuwunel is delivering (its appservice log lines), and the fact that removing `url` disables the whole thing without touching the hub.
 
 - [ ] **Step 6: Commit**
 
@@ -786,72 +868,48 @@ git commit -m "docs(deploy): running the Matrix bridge"
 
 ---
 
-### Task 10: Migrate the 14 hermes agents, one at a time
+### Task 10: Turn off hermes's native Matrix client
+
+On a fresh homeserver there is no adoption dance: the bridge already registered
+all 32 identities in Task 8, including the 14 hermes addresses, and hermes was
+never given credentials on the new server. This task is the cleanup that makes
+that true rather than accidental — and the honest conversation about what hermes
+loses.
 
 **Files:**
-- Modify: `/etc/matrix-synapse/agents.yaml` (host — second user namespace)
-- Create: `apps/hub/src/services/matrix-as/adopt-harness-mxid.ts`
-- Test: `apps/hub/tests/integration/matrix-as-adopt.test.ts`
+- Modify: hermes's own configuration on `molt-bot` (host, outside this repo)
+- Modify: `docs/OPERATING.md`
 
-This is the riskiest task in the plan and the only one that touches something already working. **Nothing here is done in bulk.**
+- [ ] **Step 1: Confirm no hermes agent can log in**
 
-- [ ] **Step 1: Widen the namespace**
+Its Matrix credentials point at a server that no longer exists, and its
+localparts are inside an exclusive namespace the bridge owns. Verify rather than
+assume: attempt a login as one of them with hermes's stored password and
+confirm it fails.
 
-```yaml
-  users:
-    - regex: "@agent_.*"
-      exclusive: true
-    # The 14 hermes agents keep the addresses people already use. Listed
-    # explicitly rather than by pattern: a broad regex here would claim human
-    # accounts on this homeserver, and `exclusive: false` because these users
-    # already exist and were not registered by us.
-    - regex: "@(analyst-echo|artistic-lyra|buddhimaan|cleaner-cody|coder-kai|controller-casey|onboarding-olivia|optimizer-ollie|predictor-paul|project-manager-pete|research-ray|strategy-sam|threat-hunter-theo|writer-quill):id\\.agentpod\\.dev"
-      exclusive: false
-```
+- [ ] **Step 2: Disable the Matrix loop in hermes's config**
 
-Restart Synapse. The bridge can now act as them; nothing yet does.
+Leaving it enabled means every agent retries a login it can never complete,
+forever, and fills a log with it.
 
-- [ ] **Step 2: Write the failing test for adoption**
+- [ ] **Step 3: Confirm each of the 14 answers through the bridge**
 
-```ts
-test("adopting a harness mxid keeps the address and changes the owner", async () => {
-  await adoptHarnessMxid(ANALYST_ECHO);
+Message `#agentpod_molt-bot_hermes_analyst-echo` and get a reply whose transcript
+lands in `acp_events`. That is the proof the identity moved rather than merely
+stopped.
 
-  const row = await stationRow(ANALYST_ECHO);
-  expect(row.matrixId).toBe("@analyst-echo:id.agentpod.dev");   // unchanged
-  expect(row.matrixIdSource).toBe("bridge");                     // changed
-});
+- [ ] **Step 4: Write down what hermes lost**
 
-test("refuses to adopt while the harness's own Matrix loop is running", async () => {
-  // Two answerers on one address is the failure this ordering exists to
-  // prevent: the operator sees duplicate replies and cannot tell which is real.
-  await hermesLoopIsRunning(ANALYST_ECHO);
-  await expect(adoptHarnessMxid(ANALYST_ECHO)).rejects.toThrow(/still running|stop/i);
-});
+In `docs/OPERATING.md`: hermes agents no longer speak Matrix natively; anything
+they did over Matrix that never went through ACP — agent-to-agent chatter, rooms
+they joined themselves — is gone with the old server, and comes back only as ACP
+conversation through the bridge.
 
-test("reverting is one row", async () => {
-  await adoptHarnessMxid(ANALYST_ECHO);
-  await revertHarnessMxid(ANALYST_ECHO);
-  expect((await stationRow(ANALYST_ECHO)).matrixIdSource).toBe("harness");
-});
-```
-
-- [ ] **Step 3: Implement, including the running-loop check**
-
-How "is hermes's Matrix loop running for this agent" is determined is a host question — read it through the node agent's health/config surface. If it cannot be determined, **refuse**: an unverifiable precondition on the one task that can produce two answerers is not a precondition worth having.
-
-- [ ] **Step 4: Cut over one agent**
-
-`hermes:analyst-echo` first — it is the least critical. Stop its Matrix loop on molt-bot, adopt, send a message in its existing room, confirm exactly one answer arrives and it came through ACP (check `acp_events`).
-
-- [ ] **Step 5: Wait a day, then do the remaining 13**
-
-Not ceremony: the failure mode here is *a duplicate answer nobody notices*, and it needs a day of ordinary use to surface.
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git commit -m "feat(hub): adopt a harness-owned Matrix identity into the bridge"
+git add docs/OPERATING.md
+git commit -m "docs(ops): hermes reaches Matrix through the bridge, like everything else"
 ```
 
 ---
@@ -894,10 +952,10 @@ git commit -m "docs(ops): the Matrix bridge, and how to tell it is working"
 
 ## Self-review
 
-**Spec coverage.** Derived names (T1), ownership column (T2), transactions with auth/idempotency/loop-cut (T3), user and room queries (T4), acting as a station (T5), inbound with the control pair (T6), outbound streaming, typing and permissions (T7), provisioning all stations (T8), enabling for the 18 (T9), migrating the 14 (T10), operability (T11). The Postgres migration is Phase A and defers to the existing #329 plan.
+**Spec coverage.** Derived names (T1), ownership column (T2), transactions with auth/idempotency/loop-cut (T3), user and room queries (T4), acting as a station (T5), inbound with the control pair (T6), outbound streaming, typing and permissions (T7), provisioning all stations (T8), going live (T9), retiring hermes's native client (T10), operability (T11). Phase A replaces the homeserver rather than migrating its database, and closes #329.
 
 **Deliberately not covered**, and named in the spec: kaambaan card/run/gate events (kaambaan#34 owns those schemas), E2EE, federation, and any node-agent change.
 
 **Type consistency.** `bridgeUserId`/`bridgeAlias`/`isBridgeUser` (T1) are used with those signatures in T4, T5, T7 and T8; `matrixIdSource` is `"harness" | "bridge"` in T2, T8 and T10; `attachRoomToSession(sessionId, roomId, userId)` matches between T7's test and T8's provisioning.
 
-**The two riskiest steps, both flagged in place:** flipping `url` (T9 Step 2), which is when a quiet system becomes a live one, and adopting hermes identities (T10), which is the only task that can produce two answerers on one address — hence one agent at a time, a day of real use, and a one-row rollback.
+**The riskiest steps, flagged in place:** cutting nginx over (A3), after which the old server is unreachable and its history is only in a backup; and flipping `url` (T9 Step 2), when a quiet system becomes a live one. The original plan's most dangerous task — adopting hermes's identities while its own Matrix loop could still answer — **no longer exists**, because a fresh homeserver never has two answerers for one address.

--- a/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
+++ b/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
@@ -105,36 +105,85 @@ exists on two nodes right now. A Matrix identity that named only the station key
 would merge two different agents on two different machines into one, which is
 the collision this suite has already undone once.
 
-### The 14 hermes agents keep their addresses, and the bridge creates them
+### All 32 names are uniform, hermes included
 
-They are `@analyst-echo:id.agentpod.dev` — outside `@agent_.*`, because hermes
-registered them itself on the old server.
+An earlier revision kept the hermes addresses — `@analyst-echo:id.agentpod.dev`
+— on the grounds that they live in people's rooms, history and muscle memory.
+**That reasoning does not survive the move to a new homeserver**, and it was
+wrong in a second way that matters more.
 
-Those addresses are in people's rooms and in their muscle memory, so they are
-**recreated verbatim on the new homeserver by the bridge**. The registration
-carries a second exclusive namespace listing those 14 localparts explicitly —
-explicitly rather than by pattern, because a broad regex here would claim human
-accounts on the same homeserver.
+The rooms and the history are being discarded anyway, so the only thing those
+addresses were protecting was habit, which a display name protects better. And
+keeping them would have broken this design's own central rule: **a name includes
+the node**, because station keys repeat across the fleet. `@analyst-echo` names
+no node. Fourteen exceptions to the invariant, hardcoded as a regex alternation
+in a registration file, would have rotted the first time an agent was renamed.
 
-**hermes's own Matrix loop is not given credentials on the new server.** This is
-the part to say out loud: hermes stops being a Matrix client and becomes an
-agent you reach the same way as every other — a room, the bridge, an ACP
-session. Conversation gains the control pair, an `acp_events` transcript, and
-one code path for all 32. What it loses is whatever hermes did with Matrix
-natively that never went through ACP.
+So every station, on every harness, is `@agent_<node>_<station>`. One namespace,
+one rule, nothing to maintain by hand.
 
-The reward for doing this on a fresh homeserver is that **no address is ever
-served by two answerers**. On Synapse this was an adoption dance per agent with a
-day of soak between; here it is the initial state.
+**Readability is a display-name problem, and is solved there.** The member list
+shows `analyst-echo (hermes @ molt-bot)`; the mxid is the machine's business.
+
+### Two identity modes, because some harnesses really are Matrix clients
+
+hermes is not merely reachable over Matrix — it *is* a Matrix client. Each agent
+has its own account, device, access token and gateway process, and a DM room with
+the admin. Retiring that wholesale would throw away working behaviour to make a
+diagram tidy.
+
+So a station's Matrix identity has a **mode**, recorded on the station:
+
+- **`bridge` (default, and what the 18 get).** The AS registers the user and
+  speaks for it. No password, no access token, no credential anywhere outside
+  the hub. The station need not know Matrix exists.
+- **`harness`.** The same `@agent_*` identity, plus real credentials issued to
+  the harness so it can run its own client. The bridge provisions the room and
+  then **stays out of that station's conversations** — one answerer per address,
+  always.
+
+The mode is a column, not a fork in the code: everything upstream of "who
+answers" is identical.
+
+### Identity registration is a hub API, not a homeserver admin token
+
+Today `hermes-agents onboard` creates an account by calling the **Synapse admin
+API** with a token stored in `/root/maintenance/.matrix-admin-token` on molt-bot,
+then logs in as the new user to mint a device token. tuwunel implements no such
+API — its equivalents are the admin-room commands `users create-user` and
+`users reset-password` — so that script breaks on migration whatever else
+changes.
+
+That break is an opportunity worth taking deliberately. **A shell script on a
+node currently holds a credential that can create, deactivate or take over any
+account on the homeserver, including a human's.** The bridge already registers
+identities without any admin credential at all, because an Application Service
+may register users inside its own namespace.
+
+So identity registration moves to the hub:
+
+```
+POST /api/stations/:id/matrix/identity     → provision the AS-owned identity + room
+POST /api/stations/:id/matrix/credentials  → additionally mint credentials (mode: harness)
+```
+
+The first needs no admin rights — it is the AS acting in its own namespace. Only
+the second does, and the admin account it uses lives in the hub, behind the
+control pair, instead of in a file on a node. `mayGrantReach` is the gate:
+issuing an agent a credential is the definition of granting it reach
+(`2026-08-15-granting-reach-is-changing-an-agent`).
 
 ### Ownership is still recorded, because the node agent still writes that column
 
 `stations.matrix_id` is written by the node agent from a harness profile — it
 reads hermes's configured mxid off the host and will keep doing so. The bridge
-must not fight it. A new column `stations.matrix_id_source`
-(`harness` | `bridge`, default `harness`) says who owns the address, and the
-node agent's refresh leaves `bridge` rows alone. `resolveMatrixId` is unchanged
-— it answers about an mxid, not about its provenance.
+must not fight it. A new column `stations.matrix_identity_mode`
+(`bridge` | `harness`, default `bridge`) says **who answers**, and the node
+agent's refresh leaves the mxid of a `bridge` row alone. `resolveMatrixId` is
+unchanged — it answers about an mxid, not about its provenance.
+
+The mode is what stops two answerers on one address, and it is one column so
+that reverting is one write.
 
 ## How a message becomes work
 

--- a/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
+++ b/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
@@ -1,0 +1,183 @@
+# A conversable fleet — the Matrix Application Service
+
+**Date:** 2026-08-16
+**Status:** Design. Unbuilt.
+**Phase:** charter → `strategy/2026-08-12-layer-reference.md` **P2 (Communication)**.
+**Depends on:** #329 (Synapse on Postgres), which ships first and separately.
+**Follows:** `charter/decisions/2026-08-14-supermessage-positioning.md`,
+`2026-08-13-ecosystem-identity.md` (Decision 4), `2026-08-15-granting-reach-is-changing-an-agent.md`.
+
+## The problem, stated as an operator sees it
+
+There are **32 adopted stations** in the fleet. **14** can be talked to from a
+phone; **18** cannot. The line between them is not capability — every one of
+them speaks ACP and holds a conversation in the console's Chat tab — it is
+*which harness happens to implement Matrix natively*. hermes does. openclaw,
+codex, claude-code, opencode and pi do not, and never will, because that is not
+their job.
+
+So the fleet's reachability is an accident of harness choice:
+
+| harness | stations | reachable from Matrix today |
+|---|---|---|
+| hermes | 14 | yes — each has its own account, e.g. `@analyst-echo:id.agentpod.dev` |
+| openclaw | 10 | no |
+| codex | 3 | no |
+| claude-code | 2 | no |
+| opencode | 2 | no |
+| pi | 1 | no |
+
+The console is not a substitute. It is a facilities console — the place you go
+to see a fleet, provision a runtime, read a log. Conversation belongs where
+conversation already happens, next to the people also in the room.
+
+## What already exists, and it is more than expected
+
+**The Application Service is registered.** `/etc/matrix-synapse/agents.yaml`
+declares an AS `ai-agents` with:
+
+- users `@agent_.*` — **exclusive**
+- aliases `#agentpod_.*` — **exclusive**
+- `de.sorunome.msc2409.push_ephemeral: true`
+- **`url: null`**
+
+`url: null` is the whole gap. The homeserver holds the namespaces and the
+tokens and pushes nothing, because there is nothing to push to. This design
+fills that hole; it does not invent the registration.
+
+**The authorization is built.** `resolveMatrixId(mxid)` already answers
+*principal*, *station*, *ambiguous* or *null* — and fails closed on ambiguity,
+because attributing a human's approval to an agent is the one mistake that
+cannot be walked back. The control pair then answers whether that principal may
+dispatch that station. An inbound Matrix message is therefore an *authorization
+question this suite can already answer*, which is why this is now a bridge and
+not a security project.
+
+**The conversation plumbing is built.** `acp-sessions.ts` owns sessions, a
+per-session subscriber fan-out, and an append-only `acp_events` transcript. The
+console's WebSocket route is one subscriber. The bridge is another.
+
+## The decision
+
+**Every station gets a Matrix identity owned by the bridge, and a room.** Not
+only the 18 — all 32, hermes included. One mechanism, uniform behaviour,
+one place to fix anything.
+
+A message in a station's room is a prompt to that station's ACP session. The
+agent's output comes back as messages from that station's user. Who may do this
+is the control pair, unchanged.
+
+### Names are derived, never stored twice
+
+```
+station  molt-bot / hermes:analyst-echo
+user     @agent_molt-bot_hermes_analyst-echo:id.agentpod.dev
+alias    #agentpod_molt-bot_hermes_analyst-echo:id.agentpod.dev
+```
+
+`:` and any character outside the mxid localpart grammar becomes `_`, lowercased.
+Derivation is a pure function of `(nodeName, stationKey)` — the same pair that
+already identifies a station in a grant
+(`2026-08-15-a-grant-names-an-agent-per-plane`). No mapping table, and a name
+an operator can read and predict.
+
+**Both names include the node**, for the reason grants do: `opencode:c52ddf65`
+exists on two nodes right now. A Matrix identity that named only the station key
+would merge two different agents on two different machines into one, which is
+the collision this suite has already undone once.
+
+### The 14 hermes agents keep their mxids and change owner
+
+They are `@analyst-echo:id.agentpod.dev` — **outside** `@agent_.*`, real
+accounts with their own logins, because hermes is a Matrix client.
+
+Renaming them to `@agent_molt-bot_hermes_analyst-echo` would be uniform and
+wrong: those addresses are in people's rooms, in their history, and in their
+muscle memory. **The registration gains a second, non-exclusive namespace
+listing those 14 localparts explicitly**, which is what lets the AS act as them.
+The mxid an operator knows does not change; what changes is who answers.
+
+The cost is real and is the riskiest part of this design: **hermes's own Matrix
+loop and the bridge would both answer the same address**. So the cutover is per
+agent, and it is a stop-then-start, never a dual-run in a room anyone uses:
+disable that agent's native Matrix loop on the host, then mark the station
+bridge-owned. Rollback is the same two steps reversed, and it is one row.
+
+### Ownership is recorded, because two things write that column
+
+`stations.matrix_id` is written by the node agent from a harness profile. The
+bridge must not fight it. A new column `stations.matrix_id_source`
+(`harness` | `bridge`, default `harness`) says who owns the address, and the
+node agent's refresh leaves `bridge` rows alone. `resolveMatrixId` is unchanged
+— it answers about an mxid, not about its provenance.
+
+## How a message becomes work
+
+```
+Matrix room  #agentpod_molt-bot_hermes_analyst-echo
+   │ m.room.message from @rakesh:id.agentpod.dev
+   ▼
+AS transaction  POST /_matrix/app/v1/transactions/:txnId   (hs_token)
+   │ resolveMatrixId(sender) → principal
+   │ control pair: may this principal dispatch this station?
+   ▼
+acpSessions.createSession / promptSession
+   │ subscriber fan-out (the same one the console's WS uses)
+   ▼
+messages sent as @agent_… ; typing while the turn is in flight
+```
+
+**Refusals are messages, not silence.** A sender with no principal mapping, an
+ambiguous mxid, or a grant that does not cover the station gets a reply in the
+room saying so. A bridge that ignored them would look broken, and an operator
+would conclude the agent was down.
+
+## What this design refuses to do
+
+- **No second state machine.** Matrix carries a *projection* of a conversation
+  that `acp_events` remains authoritative for, exactly as kaambaan#34 sets the
+  boundary for cards: *Matrix carries projections, never truth*.
+- **No card, run or gate events.** Those schemas are kaambaan's and are being
+  designed in the open (kaambaan#34). This bridge gives them a room to land in
+  and stops there.
+- **No E2EE.** Rooms are unencrypted. supermessage renders a placeholder for
+  encrypted rooms today, so encryption would make the fleet *less* reachable,
+  and MSC3202 device masquerading is a second project.
+- **No federation.** The homeserver is private and stays so.
+- **No new harness work.** The node agent is untouched: everything happens
+  between the homeserver and the hub.
+
+## The loop that eats a homeserver, and how it is avoided
+
+An AS receives the events its own users send. Reply to those and you have an
+infinite loop that bills nobody but fills a database. **Every event whose sender
+is inside the AS's user namespaces is dropped before anything else looks at it**
+— asserted by a test, because this is the failure that takes a homeserver down
+at 3am.
+
+Transactions are **idempotent by `txnId`**: Synapse retries a failed
+transaction, and a bridge that prompted an agent twice for one message would
+double every conversation. The last applied id is stored; a repeat is a 200 and
+no work.
+
+## Where it runs
+
+**In the hub**, as `services/matrix-as/` plus routes under `/_matrix/app/v1/*`,
+authenticated by `hs_token` rather than a session.
+
+The precedent is the kaambaan bridge, which lives there for the same reasons:
+it needs `acp-sessions`, `grants` and `resolveMatrixId` in-process, and every
+alternative is those three over HTTP with a second set of credentials. The
+console's own WebSocket already proves a second subscriber to the session
+fan-out is ordinary.
+
+A separate `apps/matrix-bridge` would be tidier on a diagram and would need the
+hub's database, its ACP service and its grant store anyway. Revisit if the hub
+process becomes the bottleneck; the seam is the routes, and it moves.
+
+## What "done" looks like
+
+An operator opens supermessage on their phone, types in
+`#agentpod_superchotu_openclaw_krishna`, and an agent that has never spoken
+Matrix in its life answers — with the message refused, in the room, if their
+grant does not cover it.

--- a/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
+++ b/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
@@ -3,7 +3,9 @@
 **Date:** 2026-08-16
 **Status:** Design. Unbuilt.
 **Phase:** charter → `strategy/2026-08-12-layer-reference.md` **P2 (Communication)**.
-**Depends on:** #329 (Synapse on Postgres), which ships first and separately.
+**Homeserver:** **tuwunel** (Apache-2.0), replacing Synapse (AGPLv3) — proven
+against this design in `2026-08-16-tuwunel-appservice-spike-findings.md`.
+**Replaces:** #329 (Synapse on Postgres), which this makes unnecessary.
 **Follows:** `charter/decisions/2026-08-14-supermessage-positioning.md`,
 `2026-08-13-ecosystem-identity.md` (Decision 4), `2026-08-15-granting-reach-is-changing-an-agent.md`.
 
@@ -31,19 +33,36 @@ The console is not a substitute. It is a facilities console — the place you go
 to see a fleet, provision a runtime, read a log. Conversation belongs where
 conversation already happens, next to the people also in the room.
 
-## What already exists, and it is more than expected
+## The homeserver changes underneath this
 
-**The Application Service is registered.** `/etc/matrix-synapse/agents.yaml`
-declares an AS `ai-agents` with:
+The operator requires an Apache- or MIT-licensed server. Synapse is AGPLv3;
+Dendrite followed it and is in maintenance mode. **tuwunel** (Apache-2.0, the
+official conduwuit successor) is the choice, and a spike proved every
+Application Service feature this design needs — masquerading via `?user_id=`,
+exclusive namespaces, `receive_ephemeral`, transaction push, and the room-alias
+query. Findings: `2026-08-16-tuwunel-appservice-spike-findings.md`.
 
-- users `@agent_.*` — **exclusive**
-- aliases `#agentpod_.*` — **exclusive**
-- `de.sorunome.msc2409.push_ephemeral: true`
-- **`url: null`**
+Three consequences shape everything below.
 
-`url: null` is the whole gap. The homeserver holds the namespaces and the
-tokens and pushes nothing, because there is nothing to push to. This design
-fills that hole; it does not invent the registration.
+**There is no migration from Synapse.** The new homeserver starts empty. That is
+affordable only because of what Matrix is here: `acp_events` holds the
+authoritative transcript, and Matrix carries a projection. What is lost is
+~19,400 events of history and the room ids; what survives is every **address**,
+because an mxid is localpart + domain and both are ours to recreate.
+
+**Every identity is created by the bridge, from nothing.** This removes the
+riskiest part of the original design. On Synapse the 14 hermes agents already
+held their own accounts and would have had to be *adopted* — a window in which
+the bridge and hermes's own Matrix loop could both answer one address. On a new
+server that window does not exist: the bridge registers all 32 identities before
+anything else logs in, and hermes's native Matrix integration is simply not
+given credentials.
+
+**The registration is a file, and it barely changes.** tuwunel reads Synapse-shaped
+YAML from `appservice_dir`; the spike ran the existing namespaces verbatim. Only
+one key differs — `receive_ephemeral: true` in place of the vendored
+`de.sorunome.msc2409.push_ephemeral`. The namespaces `@agent_.*` and
+`#agentpod_.*` carry over exactly.
 
 **The authorization is built.** `resolveMatrixId(mxid)` already answers
 *principal*, *station*, *ambiguous* or *null* — and fails closed on ambiguity,
@@ -86,27 +105,33 @@ exists on two nodes right now. A Matrix identity that named only the station key
 would merge two different agents on two different machines into one, which is
 the collision this suite has already undone once.
 
-### The 14 hermes agents keep their mxids and change owner
+### The 14 hermes agents keep their addresses, and the bridge creates them
 
-They are `@analyst-echo:id.agentpod.dev` — **outside** `@agent_.*`, real
-accounts with their own logins, because hermes is a Matrix client.
+They are `@analyst-echo:id.agentpod.dev` — outside `@agent_.*`, because hermes
+registered them itself on the old server.
 
-Renaming them to `@agent_molt-bot_hermes_analyst-echo` would be uniform and
-wrong: those addresses are in people's rooms, in their history, and in their
-muscle memory. **The registration gains a second, non-exclusive namespace
-listing those 14 localparts explicitly**, which is what lets the AS act as them.
-The mxid an operator knows does not change; what changes is who answers.
+Those addresses are in people's rooms and in their muscle memory, so they are
+**recreated verbatim on the new homeserver by the bridge**. The registration
+carries a second exclusive namespace listing those 14 localparts explicitly —
+explicitly rather than by pattern, because a broad regex here would claim human
+accounts on the same homeserver.
 
-The cost is real and is the riskiest part of this design: **hermes's own Matrix
-loop and the bridge would both answer the same address**. So the cutover is per
-agent, and it is a stop-then-start, never a dual-run in a room anyone uses:
-disable that agent's native Matrix loop on the host, then mark the station
-bridge-owned. Rollback is the same two steps reversed, and it is one row.
+**hermes's own Matrix loop is not given credentials on the new server.** This is
+the part to say out loud: hermes stops being a Matrix client and becomes an
+agent you reach the same way as every other — a room, the bridge, an ACP
+session. Conversation gains the control pair, an `acp_events` transcript, and
+one code path for all 32. What it loses is whatever hermes did with Matrix
+natively that never went through ACP.
 
-### Ownership is recorded, because two things write that column
+The reward for doing this on a fresh homeserver is that **no address is ever
+served by two answerers**. On Synapse this was an adoption dance per agent with a
+day of soak between; here it is the initial state.
 
-`stations.matrix_id` is written by the node agent from a harness profile. The
-bridge must not fight it. A new column `stations.matrix_id_source`
+### Ownership is still recorded, because the node agent still writes that column
+
+`stations.matrix_id` is written by the node agent from a harness profile — it
+reads hermes's configured mxid off the host and will keep doing so. The bridge
+must not fight it. A new column `stations.matrix_id_source`
 (`harness` | `bridge`, default `harness`) says who owns the address, and the
 node agent's refresh leaves `bridge` rows alone. `resolveMatrixId` is unchanged
 — it answers about an mxid, not about its provenance.
@@ -117,7 +142,7 @@ node agent's refresh leaves `bridge` rows alone. `resolveMatrixId` is unchanged
 Matrix room  #agentpod_molt-bot_hermes_analyst-echo
    │ m.room.message from @rakesh:id.agentpod.dev
    ▼
-AS transaction  POST /_matrix/app/v1/transactions/:txnId   (hs_token)
+AS transaction  PUT /_matrix/app/v1/transactions/:txnId    (hs_token)
    │ resolveMatrixId(sender) → principal
    │ control pair: may this principal dispatch this station?
    ▼
@@ -144,6 +169,8 @@ would conclude the agent was down.
   encrypted rooms today, so encryption would make the fleet *less* reachable,
   and MSC3202 device masquerading is a second project.
 - **No federation.** The homeserver is private and stays so.
+- **No history migration.** There is no supported path from Synapse, and
+  inventing one would mean writing another server's internals into RocksDB.
 - **No new harness work.** The node agent is untouched: everything happens
   between the homeserver and the hub.
 

--- a/docs/superpowers/specs/2026-08-16-tuwunel-appservice-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-16-tuwunel-appservice-spike-findings.md
@@ -1,0 +1,104 @@
+# Can an Apache-licensed homeserver carry the bridge? — spike findings
+
+**Date:** 2026-08-16
+**Question:** the conversable-fleet plan rests on Application Service features
+Synapse implements completely. Does **tuwunel** (Apache-2.0) implement them too?
+**Answer: yes — all of them, verified against a running server.**
+**Status:** spike complete, environment torn down. Nothing here is kept code.
+
+## Why this was asked
+
+The operator requires an Apache- or MIT-licensed homeserver. Synapse is AGPLv3
+since Element's 2023 relicense; Dendrite went with it *and* is in maintenance
+mode. That leaves the Conduit lineage — tuwunel, continuwuity, Conduit — all
+Apache-2.0.
+
+Switching a homeserver while writing your first appservice is two unknowns at
+once. This spike removes one of them **before** the plan is committed, because
+if masquerading did not work, no Apache-licensed server could carry the design
+and that is worth knowing on day zero rather than at task nine.
+
+## Method
+
+`ghcr.io/matrix-construct/tuwunel:latest` (**1.8.3**, RocksDB schema v17) in
+Docker, with a registration file in `appservice_dir` and a throwaway receiver on
+:29328 recording every push. Eleven assertions, each one a thing the plan does.
+
+The registration used **the ordinary Synapse YAML shape** — `namespaces.users`,
+`namespaces.aliases` — rather than the TOML-flavoured example in tuwunel's docs.
+It loaded and worked, which matters: our existing `agents.yaml` transfers nearly
+unchanged.
+
+## Results
+
+| # | Claim the plan makes | Result |
+|---|---|---|
+| 1 | a normal user can register (control) | **PASS** `@rakesh:spike.local` |
+| 2 | exclusive namespace refuses a human taking `@agent_*` | **PASS** `M_EXCLUSIVE`, HTTP 400 |
+| 3 | the appservice can register a virtual user | **PASS** `@agent_krishna:spike.local` |
+| 4 | the appservice can create a room as that user | **PASS** with an `#agentpod_*` alias |
+| 5 | **masquerading: `?user_id=` accepted on send** | **PASS** HTTP 200 |
+| 6 | the message's sender really is the virtual user | **PASS** `sender=@agent_krishna:spike.local` |
+| 7 | the virtual user can send a typing notice | **PASS** |
+| 8 | the homeserver pushes transactions to the appservice | **PASS** 7 transactions, 11 events |
+| 9 | a human's message arrives in a transaction | **PASS** |
+| 10 | `receive_ephemeral` delivers typing to the appservice | **PASS** 2 ephemeral events |
+| 11 | the room-alias query reaches the appservice | **PASS** `GET /_matrix/app/v1/rooms/#agentpod_unknown_station:…`, and the 404 was honoured |
+
+Zero errors or panics in the server log across the run.
+
+**#5 and #6 are the ones that mattered.** tuwunel's documentation never states
+that `?user_id=` masquerading is supported — it is alluded to once, in a sentence
+about rate limits. The entire bridge is built on that parameter, so it was
+tested first and directly rather than inferred from a claim of spec compliance.
+
+**#2 corrected an error in the test, not the server.** The assertion expected
+HTTP 403; the spec prescribes **400 with `M_EXCLUSIVE`**, which is exactly what
+tuwunel returned. Recorded because a future reader will otherwise re-litigate it.
+
+## What this changes, beyond the licence
+
+**The Postgres migration (#329) becomes unnecessary.** tuwunel is RocksDB —
+embedded, concurrent, no separate database process. Every reason #329 existed
+(SQLite's single writer, no safe hot backup, a migration that only gets harder)
+is answered by not running SQLite. That plan should be closed, not executed.
+
+**Backups change shape**: a data directory, not `pg_dump` and a collation trap.
+
+**There is no migration path from Synapse.** Conduit-family servers migrate
+between each other in place; from Synapse you start clean. For this fleet that
+is affordable and was accepted deliberately:
+
+- **the addresses survive** — an mxid is localpart + domain, and both are ours to
+  recreate, so `@analyst-echo:id.agentpod.dev` comes back as itself;
+- **Matrix is not the source of truth here** — `acp_events` is, per
+  `charter/decisions` and kaambaan#34's "Matrix carries projections, never truth";
+- the bridge recreates every room anyway;
+- there is no federation, so nothing remote is lost.
+
+What is genuinely lost: ~19,400 events of history, the room ids, and any media.
+The cost only grows with time, which is an argument for now rather than later.
+
+**One casualty worth naming:** the hermes onboarding tooling creates agent
+accounts through the *Synapse admin API*, which tuwunel does not implement. That
+work converges with the bridge — which registers identities itself — but it is
+real work, and it is not in the old plan.
+
+## What was NOT tested, and why
+
+- **E2EE appservices** (MSC3202/MSC4203, which tuwunel advertises). The plan
+  explicitly ships unencrypted rooms; supermessage renders a placeholder for
+  encrypted ones today.
+- **Federation.** Disabled by policy on both the old and new server.
+- **Scale.** Eleven events, not eleven thousand. This spike answers *can it*, not
+  *how fast*.
+- **continuwuity.** Not tested: tuwunel answered yes, and the two migrate between
+  each other in place, so the fallback is a data-directory move rather than a
+  decision to re-make now.
+
+## Recommendation
+
+**Adopt tuwunel.** Rewrite Phase A of the conversable-fleet plan from "migrate
+Synapse to Postgres" to "stand up tuwunel and recreate identities", close #329,
+and keep the rest of the design as it stands — every assumption it makes about
+the Application Service API held.


### PR DESCRIPTION
Design, spike findings and an implementation plan for charter **P2 (Communication)**. Docs only — nothing built.

**Supersedes #329**, which should be closed rather than executed.

## The problem in one table

| harness | stations | reachable from Matrix today |
|---|---|---|
| hermes | 14 | yes — native Matrix accounts |
| openclaw / codex / claude-code / opencode / pi | 18 | **no** |

The line is which harness happens to implement Matrix, not capability — all 32 hold a conversation over ACP in the console today.

## The homeserver changes: Synapse → tuwunel

You asked for an Apache- or MIT-licensed server. Synapse is AGPLv3; Dendrite followed it into AGPL **and** maintenance mode. That leaves the Conduit lineage, all Apache-2.0: **tuwunel** (official conduwuit successor), continuwuity, Conduit.

Switching a homeserver while writing your first appservice is two unknowns at once, so **the spike removed one before this plan was written**: 11 assertions against a running tuwunel 1.8.3, all passing —

- `?user_id=` masquerading accepted, **and the resulting event's sender really is the virtual user**
- exclusive namespaces enforced (`M_EXCLUSIVE`, HTTP 400 — the spec's code; my test asserted 403 and was wrong)
- virtual-user registration, room creation with an `#agentpod_*` alias, typing as the virtual user
- transaction push (7 transactions, 11 events), `receive_ephemeral` delivering typing
- the room-alias query reaching the appservice, and its 404 honoured

tuwunel's docs **never state that masquerading is supported** — it is alluded to once in a sentence about rate limits — and the entire bridge rests on it. So it was tested directly. Findings: `specs/2026-08-16-tuwunel-appservice-spike-findings.md`.

## Two consequences that shrink the plan

**#329 disappears.** It existed because Synapse on SQLite has one writer, no safe hot backup, and a migration that only gets harder. tuwunel is embedded RocksDB. Phase A becomes "stand a server up and cut the domain over", and finally adds the **backup schedule Synapse never had**.

**The most dangerous task disappears.** There is no migration path from Synapse, so the new homeserver starts empty and the bridge creates all 32 identities itself. The original plan's per-agent adoption dance — a window where the bridge and hermes's own Matrix loop could both answer one address — is gone: on a fresh server, no address is ever served by two answerers.

## What it costs, written down rather than glossed

- ~19,400 events of Matrix history, the room ids, and any media. Affordable because `acp_events` is the authoritative transcript and Matrix carries a projection (kaambaan#34's boundary, and this repo's).
- **Every address survives** — an mxid is localpart + domain, both ours to recreate, so `@analyst-echo:id.agentpod.dev` comes back as itself.
- **hermes stops being a Matrix client.** It becomes an agent you reach like every other: a room, the bridge, an ACP session — gaining the control pair and a transcript, losing whatever it did over Matrix that never went through ACP.
- The hermes onboarding tooling creates accounts through the **Synapse admin API**, which tuwunel does not implement. That converges with the bridge, but it is real work the plan now names.

## Unchanged from the previous revision

Derived names from `(node, stationKey)` — because `opencode:c52ddf65` exists on two nodes right now; the control pair in front of every inbound message; refusals as messages in the room, never silence; and the scope refusals (no card/run/gate events — kaambaan#34 owns those schemas; no E2EE; no federation; no node-agent change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW
