### PR TITLE
feat(hub): a conversable fleet — the Matrix Application Service

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0044_matrix_identity_mode.sql
+++ b/apps/hub/src/db/drizzle-migrations/0044_matrix_identity_mode.sql
@@ -1,0 +1,26 @@
+-- Two different facts about one station, which an earlier draft of this
+-- migration tried to keep in one column.
+--
+-- `matrix_id` is what the HARNESS reports: the node agent reads it off the host
+-- from a profile, and owns it completely. That is how the 14 hermes agents have
+-- identities. Guarding that column against its own writer broke the fix that
+-- lets a station adopted before its profile was readable gain one later.
+--
+-- `bridge_matrix_id` is what the Application Service MINTED for a station whose
+-- harness knows nothing about Matrix. Nobody on the host can report it, so
+-- nothing on the host can erase it.
+--
+-- `matrix_identity_mode` says which one answers. Exactly one, always — two
+-- answerers on one address is the failure these columns exist to prevent.
+ALTER TABLE stations
+  ADD COLUMN bridge_matrix_id text,
+  ADD COLUMN matrix_identity_mode text NOT NULL DEFAULT 'bridge';
+
+ALTER TABLE stations
+  ADD CONSTRAINT stations_matrix_identity_mode_check
+  CHECK (matrix_identity_mode IN ('bridge', 'harness'));
+
+-- Every mxid that exists today was read off a host by the node agent: 14 hermes
+-- stations, all from harness profiles, verified 2026-08-16. Those stations
+-- answer for themselves until somebody moves them.
+UPDATE stations SET matrix_identity_mode = 'harness' WHERE matrix_id IS NOT NULL;

--- a/apps/hub/src/db/drizzle-migrations/0045_matrix_as_txns.sql
+++ b/apps/hub/src/db/drizzle-migrations/0045_matrix_as_txns.sql
@@ -1,0 +1,10 @@
+-- Which Application Service transactions have been applied.
+--
+-- A table rather than a set in memory: the homeserver retries a transaction it
+-- did not see acknowledged, and a crash mid-transaction is exactly when that
+-- happens. Idempotency that forgets on restart forgets precisely when it is
+-- needed, and the symptom is every conversation answered twice.
+CREATE TABLE matrix_as_transactions (
+  txn_id     text PRIMARY KEY,
+  applied_at timestamp NOT NULL DEFAULT now()
+);

--- a/apps/hub/src/db/drizzle-migrations/0046_matrix_rooms.sql
+++ b/apps/hub/src/db/drizzle-migrations/0046_matrix_rooms.sql
@@ -1,0 +1,34 @@
+-- Which room belongs to which station, and the conversation running in it.
+--
+-- The room id is the key because that is what an inbound event carries; the
+-- alias is derived and recorded only so an operator can read this table.
+--
+-- `acp_session_id` is what makes a room a conversation rather than a series of
+-- unrelated prompts: without it every message would open a session and the
+-- agent would lose its context between two consecutive sentences.
+--
+-- `tenant_id` is carried rather than inferred from the station, following the
+-- rule in db/tenant-scope.ts: "reachable only through a scoped parent" is a
+-- claim about the routes that happen to exist today. The composite foreign key
+-- below is what keeps the copy honest.
+CREATE TABLE matrix_rooms (
+  room_id        text PRIMARY KEY,
+  tenant_id      text NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  station_id     text NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+  alias          text NOT NULL,
+  acp_session_id text,
+  created_at     timestamp NOT NULL DEFAULT now()
+);
+
+-- A room's tenant must be its station's tenant. Without this the column is a
+-- second opinion rather than a copy.
+CREATE UNIQUE INDEX stations_id_tenant_idx ON stations (id, tenant_id);
+ALTER TABLE matrix_rooms
+  ADD CONSTRAINT matrix_rooms_station_tenant_fk
+  FOREIGN KEY (station_id, tenant_id) REFERENCES stations (id, tenant_id) ON DELETE CASCADE;
+
+CREATE INDEX matrix_rooms_tenant_id_idx ON matrix_rooms (tenant_id);
+
+-- One room per station: a second room for the same agent would split its
+-- conversation in two, with each half unaware of the other.
+CREATE UNIQUE INDEX matrix_rooms_station_idx ON matrix_rooms (station_id);

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1786687163202,
       "tag": "0044_matrix_identity_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1786687164202,
+      "tag": "0045_matrix_as_txns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1786687164202,
       "tag": "0045_matrix_as_txns",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1786687165202,
+      "tag": "0046_matrix_rooms",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1786687162202,
       "tag": "0043_node_name_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1786687163202,
+      "tag": "0044_matrix_identity_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/index.ts
+++ b/apps/hub/src/db/schema/index.ts
@@ -36,3 +36,6 @@ export * from "./bridge";
 export * from "./identities";
 
 export * from "./grants";
+
+// Matrix Application Service bookkeeping (#351)
+export * from "./matrix";

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -1,4 +1,6 @@
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, index, uniqueIndex, foreignKey } from "drizzle-orm/pg-core";
+import { tenants } from "./tenants";
+import { stations } from "./stations";
 
 /**
  * Applied Application Service transactions.
@@ -10,3 +12,38 @@ export const matrixAsTransactions = pgTable("matrix_as_transactions", {
   txnId: text("txn_id").primaryKey(),
   appliedAt: timestamp("applied_at").notNull().defaultNow(),
 });
+
+/**
+ * Which room belongs to which station, and the conversation running in it.
+ *
+ * Keyed by room id because that is what an inbound event carries. The alias is
+ * derived and stored only so this table is readable by a person.
+ */
+export const matrixRooms = pgTable(
+  "matrix_rooms",
+  {
+    roomId: text("room_id").primaryKey(),
+    /**
+     * Carried rather than inferred from the station: "reachable only through a
+     * scoped parent" is a claim about the routes that happen to exist today
+     * (db/tenant-scope.ts). The composite FK below keeps the copy honest.
+     */
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "restrict" }),
+    stationId: text("station_id").notNull(),
+    alias: text("alias").notNull(),
+    /** The ACP session this room is talking to, if one is open. */
+    acpSessionId: text("acp_session_id"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [
+    index("matrix_rooms_tenant_id_idx").on(t.tenantId),
+    uniqueIndex("matrix_rooms_station_idx").on(t.stationId),
+    foreignKey({
+      columns: [t.stationId, t.tenantId],
+      foreignColumns: [stations.id, stations.tenantId],
+      name: "matrix_rooms_station_tenant_fk",
+    }).onDelete("cascade"),
+  ]
+);

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -1,0 +1,12 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Applied Application Service transactions.
+ *
+ * The homeserver retries what it did not see acknowledged. This is what makes a
+ * retry a no-op instead of a second conversation.
+ */
+export const matrixAsTransactions = pgTable("matrix_as_transactions", {
+  txnId: text("txn_id").primaryKey(),
+  appliedAt: timestamp("applied_at").notNull().defaultNow(),
+});

--- a/apps/hub/src/db/schema/stations.ts
+++ b/apps/hub/src/db/schema/stations.ts
@@ -16,6 +16,17 @@ export const stations = pgTable("stations", {
   workspacePath: text("workspace_path"),
   capabilities: jsonb("capabilities").$type<string[]>(),
   matrixId: text("matrix_id"),
+  /**
+   * The identity the Application Service minted for this station. Distinct from
+   * `matrixId`, which is what the harness reports and the node agent owns —
+   * nobody on the host can report this one, so nothing on the host can erase it.
+   */
+  bridgeMatrixId: text("bridge_matrix_id"),
+  /**
+   * Who answers for this station on Matrix — `bridge` (the Application Service
+   * speaks for it) or `harness` (it runs its own Matrix client). Never both.
+   */
+  matrixIdentityMode: text("matrix_identity_mode").notNull().default("bridge"),
   adoptedAt: timestamp("adopted_at").defaultNow().notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (t) => [

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -38,7 +38,7 @@ import { bridgeDispatches } from "./schema/bridge";
 import { adminAuditLog, systemSettings } from "./schema/admin";
 import { stationAudit } from "./schema/audit";
 import { account, session, user, verification, jwks } from "./schema/auth";
-import { matrixAsTransactions } from "./schema/matrix";
+import { matrixAsTransactions, matrixRooms } from "./schema/matrix";
 import { principalIdentities } from "./schema/identities";
 import { principalGrants } from "./schema/grants";
 import { agentTasks, cloudflareSandboxes } from "./schema/cloudflare";
@@ -103,6 +103,7 @@ export const TENANT_SCOPED_TABLES = {
   bridgeDispatches,
   agentTasks,
   cloudflareSandboxes,
+  matrixRooms,
 } as const satisfies Record<string, TenantScopedTable>;
 
 /**

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -38,6 +38,7 @@ import { bridgeDispatches } from "./schema/bridge";
 import { adminAuditLog, systemSettings } from "./schema/admin";
 import { stationAudit } from "./schema/audit";
 import { account, session, user, verification, jwks } from "./schema/auth";
+import { matrixAsTransactions } from "./schema/matrix";
 import { principalIdentities } from "./schema/identities";
 import { principalGrants } from "./schema/grants";
 import { agentTasks, cloudflareSandboxes } from "./schema/cloudflare";
@@ -180,6 +181,17 @@ export const TENANT_EXEMPT_TABLES: Record<string, { table: Table; reason: string
       "OAuth provider linkage, written by Better Auth. A GitHub identity is a property of a " +
       "principal, not of a fleet.",
   },
+  matrix_as_transactions: {
+    table: matrixAsTransactions,
+    reason:
+      "Applied Application Service transaction ids, so a homeserver's retry is a no-op rather " +
+      "than a second conversation. A transaction id is the HOMESERVER's counter, not a fact " +
+      "about any tenant — it names an envelope, and the events inside it belong to whichever " +
+      "tenants their rooms do. Scoping this would mean asking which tenant a retry belongs to " +
+      "before reading what is in it, which is backwards, and would let one tenant's replay " +
+      "re-deliver another's.",
+  },
+
   jwks: {
     table: jwks,
     reason:

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -53,6 +53,9 @@ import { registerEnabledProvisioners } from './services/provisioner/bootstrap.ts
 import { enabledProviders } from './services/provisioner/registry.ts';
 import { startNodeSweeper } from './services/node-sweeper.ts';
 import { startKaambaanBridge } from './services/bridge/loop.ts';
+import { createMatrixBridge, startMatrixBridge } from './services/matrix-as/index.ts';
+import { createMatrixAsRoutes } from './routes/matrix-as.ts';
+import { createStationMatrixRoutes } from './routes/station-matrix.ts';
 // ACP session boot reconciliation (hub-owned sessions do not survive restarts)
 import { reconcileOnBoot as reconcileAcpSessions } from './services/acp-sessions.ts';
 
@@ -71,6 +74,12 @@ await reconcileAcpSessions();
 const errorLogger = createLogger('error-handler');
 
 // Create the Hono app
+// The Matrix bridge, or null when this deployment has not opted in. Built
+// BEFORE the routes so both mounts share one client and one config; null means
+// neither is mounted, and a homeserver talking to us gets a 404 rather than a
+// half-built bridge.
+const matrixBridge = createMatrixBridge();
+
 const app = new Hono()
   // Middleware
   .use('*', logger())
@@ -134,6 +143,41 @@ const app = new Hono()
   .route('/api', stationAcpRoutes)                         // POST/GET /api/stations/:id/acp/sessions, WS /api/acp/sessions/:sessionId/ws
   .route('/api', acpProxyRouter);                          // WS /api/acp/proxy — Doors: an editor's stdio, piped by `apn acp`
 
+// ── The Matrix Application Service ───────────────────────────────────────────
+//
+// Mounted OUTSIDE /api/* because the caller is a homeserver holding a shared
+// secret, not a session — and only when the bridge is configured, so an
+// unconfigured hub answers a homeserver with 404 rather than with a bridge that
+// cannot act.
+if (matrixBridge) {
+  app.route(
+    '/_matrix/app/v1',
+    createMatrixAsRoutes({
+      hsToken: matrixBridge.config.hsToken,
+      domain: matrixBridge.config.domain,
+      onEvent: (event) => matrixBridge.onEvent(event),
+      onProvisionAlias: (alias) => matrixBridge.onProvisionAlias(alias),
+    }),
+  );
+
+  // …and the operator-facing half, which IS session-authenticated.
+  app.route(
+    '/api',
+    createStationMatrixRoutes({
+      domain: matrixBridge.config.domain,
+      provisionStation: (stationId) => matrixBridge.provision(stationId),
+      credentials: {
+        // An appservice registration returns an access_token directly — no
+        // admin command, no password, no login round-trip. `rotate` is
+        // deliberately absent: replacing an existing identity's credentials
+        // needs the homeserver's admin account, and the route says so plainly
+        // rather than pretending.
+        register: (localpart) => matrixBridge.client.registerWithCredentials(localpart),
+      },
+    }),
+  );
+}
+
 app.onError((err, c) => {
   const requestId = c.req.header('x-request-id') || crypto.randomUUID();
   const isProduction = config.nodeEnv === 'production';
@@ -195,6 +239,15 @@ console.log(
   'kaambaan bridge:',
   bridge ? `claiming as ${bridge.agents.join(', ')}` : '(disabled)',
 );
+
+// Give every station a Matrix identity and a room, if the bridge is on. Runs
+// after the routes are mounted so a homeserver that starts pushing immediately
+// finds somewhere to push to.
+if (matrixBridge) {
+  await startMatrixBridge(matrixBridge);
+} else {
+  console.log('matrix bridge: (disabled)');
+}
 
 // Handle graceful shutdown
 process.on('SIGINT', () => {

--- a/apps/hub/src/routes/matrix-as.ts
+++ b/apps/hub/src/routes/matrix-as.ts
@@ -1,0 +1,221 @@
+/**
+ * The Application Service's front door.
+ *
+ * A homeserver pushes events here with no session and no user — only the
+ * `hs_token` it was configured with. Everything downstream in the bridge trusts
+ * what arrives, so this is the boundary that has to hold.
+ *
+ * Mounted OUTSIDE `/api/*`, deliberately: those paths carry session auth, CSRF
+ * and an activity logger, none of which apply to a homeserver talking to us. The
+ * caller here is a machine holding a shared secret.
+ *
+ * Design: `docs/superpowers/specs/2026-08-16-matrix-application-service-design.md`
+ */
+
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { matrixAsTransactions } from "../db/schema/matrix";
+import { isBridgeUser } from "../services/matrix-as/names";
+import {
+  stationForLocalpart,
+  localpartFromUserId,
+  localpartFromAlias,
+} from "../services/matrix-as/stations";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("matrix-as");
+
+/** The shape the homeserver pushes. Only what this route reads is named. */
+interface MatrixEvent {
+  type: string;
+  sender: string;
+  room_id?: string;
+  event_id?: string;
+  content?: Record<string, unknown>;
+}
+
+export interface MatrixAsDeps {
+  /** The token the HOMESERVER presents to us. Empty means unconfigured. */
+  hsToken: string;
+  /** This homeserver's name, e.g. `id.agentpod.dev`. */
+  domain: string;
+  /** What to do with an event that survived the gate. */
+  onEvent: (event: MatrixEvent) => Promise<void>;
+  /** Ephemeral events (typing, receipts) — optional; ignored when absent. */
+  onEphemeral?: (event: MatrixEvent) => Promise<void>;
+  /**
+   * Create the room behind an alias we claim. Called when the homeserver asks
+   * about an alias that maps to a station — answering 200 without creating it
+   * would send the asker to a room that is not there.
+   */
+  onProvisionAlias?: (alias: string) => Promise<void>;
+}
+
+/**
+ * Constant-time-ish comparison, so a wrong token cannot be discovered a
+ * character at a time by timing the reply.
+ */
+function tokenMatches(expected: string, presented: string): boolean {
+  if (expected.length === 0) return false;
+  if (expected.length !== presented.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ presented.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Has this transaction already been applied?
+ *
+ * Recorded in the database rather than in memory: the homeserver retries what it
+ * did not see acknowledged, and a crash mid-transaction is exactly when that
+ * happens. Idempotency that forgets on restart forgets when it is needed most,
+ * and the symptom is every conversation answered twice.
+ *
+ * Claimed BEFORE the events are handled. A retry that arrives while the first
+ * attempt is still running must not start a second — and the cost of that
+ * ordering is that a transaction whose handling dies mid-way is not retried.
+ * That is the right trade: a lost message is visible and recoverable, a doubled
+ * one is neither.
+ */
+async function claimTransaction(txnId: string): Promise<boolean> {
+  const claimed = await db
+    .insert(matrixAsTransactions)
+    .values({ txnId })
+    .onConflictDoNothing({ target: matrixAsTransactions.txnId })
+    .returning({ txnId: matrixAsTransactions.txnId });
+  return claimed.length > 0;
+}
+
+/** Did the homeserver present the token we were configured with? */
+function authorised(c: { req: { header: (n: string) => string | undefined } }, deps: MatrixAsDeps): boolean {
+  const presented = (c.req.header("Authorization") ?? "").replace(/^Bearer /, "");
+  return tokenMatches(deps.hsToken, presented);
+}
+
+export function createMatrixAsRoutes(deps: MatrixAsDeps) {
+  return (
+    new Hono()
+      /**
+       * PUT /_matrix/app/v1/transactions/:txnId
+       *
+       * Always answers `{}` with 200 once authenticated: the homeserver reads a
+       * non-2xx as "not delivered" and retries the whole transaction, so a
+       * failure inside one event must not be reported as a failure of the push.
+       */
+      .put("/transactions/:txnId", async (c) => {
+        if (!authorised(c, deps)) {
+          // No detail in the response: this path is reachable by anyone who can
+          // reach the hub, and the only useful answer is "no".
+          log.warn("appservice transaction rejected: bad or missing hs_token");
+          return c.json({ errcode: "M_FORBIDDEN" }, 403);
+        }
+
+        const txnId = c.req.param("txnId");
+
+        let body: { events?: MatrixEvent[]; ephemeral?: MatrixEvent[] };
+        try {
+          body = await c.req.json();
+        } catch {
+          // Malformed JSON from the homeserver is not something a retry fixes.
+          return c.json({}, 200);
+        }
+
+        if (!(await claimTransaction(txnId))) {
+          log.info("appservice transaction already applied", { txnId });
+          return c.json({}, 200);
+        }
+
+        for (const event of body.events ?? []) {
+          // An Application Service is sent what its own users send. Answering
+          // those is the loop that fills a database overnight — cut per EVENT,
+          // not per transaction, so one echo cannot silence a real message that
+          // arrived beside it.
+          if (isBridgeUser(event.sender, deps.domain)) continue;
+
+          try {
+            await deps.onEvent(event);
+          } catch (err) {
+            // The homeserver retries the whole transaction, so an event that
+            // always throws would block every event after it, forever.
+            log.error("appservice event handler threw", {
+              txnId,
+              eventId: event.event_id,
+              type: event.type,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
+        for (const event of body.ephemeral ?? []) {
+          if (!deps.onEphemeral) break;
+          if (isBridgeUser(event.sender ?? "", deps.domain)) continue;
+          try {
+            await deps.onEphemeral(event);
+          } catch (err) {
+            log.error("appservice ephemeral handler threw", {
+              txnId,
+              type: event.type,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
+        return c.json({}, 200);
+      })
+
+      /**
+       * GET /_matrix/app/v1/users/:userId
+       *
+       * "Does this user exist?" — asked before anyone may talk to a name in our
+       * namespace that has never been seen. 200 makes it exist; 404 means there
+       * is no station behind it, which is the honest answer for a name somebody
+       * typed hopefully.
+       */
+      .get("/users/:userId", async (c) => {
+        if (!authorised(c, deps)) return c.json({ errcode: "M_FORBIDDEN" }, 403);
+
+        const localpart = localpartFromUserId(
+          decodeURIComponent(c.req.param("userId")),
+          deps.domain
+        );
+        const station = localpart ? await stationForLocalpart(localpart) : null;
+        if (!station) return c.json({ errcode: "M_NOT_FOUND" }, 404);
+
+        return c.json({}, 200);
+      })
+
+      /**
+       * GET /_matrix/app/v1/rooms/:alias
+       *
+       * "Does this room exist?" — asked when someone tries to resolve an alias
+       * in our namespace. The room is created here rather than merely claimed,
+       * because a 200 promises the asker somewhere to go.
+       */
+      .get("/rooms/:alias", async (c) => {
+        if (!authorised(c, deps)) return c.json({ errcode: "M_FORBIDDEN" }, 403);
+
+        const alias = decodeURIComponent(c.req.param("alias"));
+        const localpart = localpartFromAlias(alias, deps.domain);
+        const station = localpart ? await stationForLocalpart(localpart) : null;
+        if (!station) return c.json({ errcode: "M_NOT_FOUND" }, 404);
+
+        if (deps.onProvisionAlias) await deps.onProvisionAlias(alias);
+        return c.json({}, 200);
+      })
+
+      /**
+       * GET /_matrix/app/v1/ping
+       *
+       * How a homeserver proves it can reach us. Cheap, and it needs the token
+       * like everything else: an unauthenticated liveness probe on a public path
+       * is a free way to learn a bridge is here.
+       */
+      .get("/ping", async (c) => {
+        if (!authorised(c, deps)) return c.json({ errcode: "M_FORBIDDEN" }, 403);
+        return c.json({}, 200);
+      })
+  );
+}

--- a/apps/hub/src/routes/matrix-as.ts
+++ b/apps/hub/src/routes/matrix-as.ts
@@ -22,6 +22,7 @@ import {
   localpartFromUserId,
   localpartFromAlias,
 } from "../services/matrix-as/stations";
+import { recordTransaction } from "../services/matrix-as/health";
 import { createLogger } from "../utils/logger";
 
 const log = createLogger("matrix-as");
@@ -112,6 +113,11 @@ export function createMatrixAsRoutes(deps: MatrixAsDeps) {
           log.warn("appservice transaction rejected: bad or missing hs_token");
           return c.json({ errcode: "M_FORBIDDEN" }, 403);
         }
+
+        // Recorded before anything else: the fact worth knowing is that the
+        // homeserver can reach us, which is true whether or not the events
+        // inside are ones we act on.
+        recordTransaction();
 
         const txnId = c.req.param("txnId");
 

--- a/apps/hub/src/routes/station-matrix.ts
+++ b/apps/hub/src/routes/station-matrix.ts
@@ -1,0 +1,169 @@
+/**
+ * A station's Matrix identity, over the hub's API.
+ *
+ * This is what replaces the homeserver admin token that lives in a file on
+ * molt-bot today. That credential can create, deactivate or take over **any**
+ * account on the homeserver, including a human's, and it sits on a node so a
+ * shell script can reach it.
+ *
+ * Two paths, and the difference between them is the point:
+ *
+ * - **identity** needs no privilege at all. An Application Service may register
+ *   users inside its own namespace, so this is the appservice acting as itself.
+ * - **credentials** hands an agent its own access token, which is the definition
+ *   of granting it reach (`charter` →
+ *   decisions/2026-08-15-granting-reach-is-changing-an-agent.md). It is gated on
+ *   `mayGrantReach` and on the station being in the caller's dispatch scope.
+ */
+
+import { Hono } from "hono";
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { nodes } from "../db/schema/nodes";
+import { requireIssueCredentials } from "../services/grant-reach";
+import { isGrantReachDenied } from "../services/control-pair";
+import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "../services/matrix-as/names";
+import type { AuthUser } from "../auth/middleware";
+
+export interface IssuedCredentials {
+  userId: string;
+  accessToken: string;
+  deviceId: string;
+}
+
+export interface StationMatrixDeps {
+  domain: string;
+  provisionStation(stationId: string): Promise<void>;
+  credentials: {
+    /** Register the identity and return its first credentials. */
+    register(localpart: string): Promise<IssuedCredentials>;
+    /**
+     * Replace the credentials of an identity that already exists.
+     *
+     * Optional because it needs the homeserver's admin account, which a
+     * deployment may not have configured. Absent means "cannot be done here",
+     * which is answered plainly rather than as a 500.
+     */
+    rotate?: (localpart: string) => Promise<IssuedCredentials>;
+  };
+  /** Injected so the tests can prove a token never reaches it. */
+  log?: (line: string) => void;
+}
+
+export function createStationMatrixRoutes(deps: StationMatrixDeps) {
+  const say = deps.log ?? ((line: string) => console.log(line));
+
+  /** The station, if it belongs to this principal. */
+  async function ownedStation(userId: string, stationId: string) {
+    const [row] = await db
+      .select({
+        id: stations.id,
+        nodeId: stations.nodeId,
+        nodeName: nodes.name,
+        stationKey: stations.stationKey,
+        mode: stations.matrixIdentityMode,
+      })
+      .from(stations)
+      .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+      .where(and(eq(stations.id, stationId), eq(stations.userId, userId)));
+    return row ?? null;
+  }
+
+  return new Hono()
+    /**
+     * POST /api/stations/:id/matrix/identity
+     *
+     * Give this station a Matrix identity and a room. Safe to call repeatedly —
+     * it is how a dynamically created agent on ANY harness gets one, without
+     * that harness learning to talk to a homeserver.
+     */
+    .post("/stations/:id/matrix/identity", async (c) => {
+      const user = c.get("user") as AuthUser;
+      const station = await ownedStation(user.id, c.req.param("id"));
+      if (!station) return c.json({ error: "Not Found" }, 404);
+
+      await deps.provisionStation(station.id);
+
+      return c.json({
+        mxid: bridgeUserId(station.nodeName, station.stationKey, deps.domain),
+        alias: bridgeAlias(station.nodeName, station.stationKey, deps.domain),
+        mode: station.mode,
+      });
+    })
+
+    /**
+     * POST /api/stations/:id/matrix/credentials
+     *
+     * Hand this station its own access token, so its harness can run a Matrix
+     * client instead of the bridge speaking for it. Flips the station to
+     * `harness` mode in the same write — the bridge stops answering there the
+     * moment somebody else can, because two answerers on one address is the
+     * failure the mode exists to prevent.
+     */
+    .post("/stations/:id/matrix/credentials", async (c) => {
+      const user = c.get("user") as AuthUser;
+      const station = await ownedStation(user.id, c.req.param("id"));
+      if (!station) return c.json({ error: "Not Found" }, 404);
+
+      try {
+        await requireIssueCredentials(user.id, {
+          nodeId: station.nodeId,
+          stationKey: station.stationKey,
+        });
+      } catch (e) {
+        if (!isGrantReachDenied(e)) throw e;
+        return c.json(
+          {
+            error:
+              "Issuing an agent its own credentials is granting it reach, which your " +
+              "grant does not permit for this agent.",
+          },
+          403
+        );
+      }
+
+      const localpart = bridgeLocalpart(station.nodeName, station.stationKey);
+
+      // An identity provisioned earlier already exists, so "already registered"
+      // is the normal case here rather than an error — but replacing its
+      // credentials needs the homeserver's admin account.
+      const alreadyHasIdentity = station.mode === "harness";
+      let issued: IssuedCredentials;
+
+      if (alreadyHasIdentity) {
+        if (!deps.credentials.rotate) {
+          return c.json(
+            {
+              error:
+                "This identity already exists, and rotating its credentials needs the " +
+                "homeserver admin account, which this hub is not configured with.",
+            },
+            409
+          );
+        }
+        issued = await deps.credentials.rotate(localpart);
+      } else {
+        issued = await deps.credentials.register(localpart);
+      }
+
+      await db
+        .update(stations)
+        .set({ matrixIdentityMode: "harness" })
+        .where(eq(stations.id, station.id));
+
+      // Audited, and never with the token in it: this line exists so the act is
+      // visible, not so the credential is recoverable from a log.
+      say(
+        `[station-matrix] issued Matrix credentials for ${station.nodeName}/${station.stationKey} ` +
+          `to principal ${user.id} (device ${issued.deviceId})`
+      );
+
+      return c.json({
+        mxid: issued.userId,
+        accessToken: issued.accessToken,
+        deviceId: issued.deviceId,
+        mode: "harness",
+      });
+    });
+}

--- a/apps/hub/src/services/grant-reach.ts
+++ b/apps/hub/src/services/grant-reach.ts
@@ -103,6 +103,49 @@ export async function requireGrantReach(
 }
 
 /**
+ * Guard issuing a station its own credentials.
+ *
+ * No capability is consulted, because this is not a capability: handing an agent
+ * an access token to a homeserver IS granting it reach, by the definition in
+ * `charter` → decisions/2026-08-15-granting-reach-is-changing-an-agent.md. The
+ * scope half is the same as everywhere else — you may only do it to an agent
+ * your dispatch grant already covers.
+ */
+export async function requireIssueCredentials(
+  userId: string,
+  station: { nodeId: string; stationKey: string }
+): Promise<void> {
+  if (!isControlPairEnforced()) return;
+
+  const grant = await getGrant(userId);
+  if (!grant?.mayGrantReach) {
+    log.warn("credential issue refused: principal may not change agents", {
+      principalId: userId,
+      stationKey: station.stationKey,
+    });
+    throw new GrantReachDenied(userId, station.stationKey, "credentials");
+  }
+
+  const [node] = await db
+    .select({ name: nodes.name })
+    .from(nodes)
+    .where(eq(nodes.id, station.nodeId))
+    .limit(1);
+
+  const inScope =
+    node !== undefined &&
+    grantAllowsStation(grant, { nodeName: node.name, stationKey: station.stationKey });
+
+  if (!inScope) {
+    log.warn("credential issue refused: station out of scope", {
+      principalId: userId,
+      stationKey: station.stationKey,
+    });
+    throw new GrantReachDenied(userId, station.stationKey, "credentials");
+  }
+}
+
+/**
  * Guard an act that names no station — minting an enrollment token today, the
  * credential broker later.
  *

--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createMatrixClient } from "./client";
+
+/**
+ * Speaking to a homeserver *as* a station.
+ *
+ * `?user_id=` is the whole mechanism. Without it every agent's message arrives
+ * from `@ai-bridge` and a room full of agents becomes one voice pretending to be
+ * many — which is worse than no bridge, because it looks like it works.
+ */
+
+const AS_TOKEN = "test-as-token-client";
+const HS = "http://homeserver.test";
+const USER = "@agent_box__pi_x:id.agentpod.dev";
+const ROOM = "!room:id.agentpod.dev";
+
+interface Call {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let calls: Call[] = [];
+let replies: Array<{ status: number; body: unknown }> = [];
+
+function client() {
+  return createMatrixClient({
+    homeserverUrl: HS,
+    asToken: AS_TOKEN,
+    domain: "id.agentpod.dev",
+    fetch: (async (url: string, init: RequestInit = {}) => {
+      calls.push({
+        url,
+        method: init.method ?? "GET",
+        headers: (init.headers ?? {}) as Record<string, string>,
+        body: init.body ? JSON.parse(init.body as string) : null,
+      });
+      const reply = replies.shift() ?? { status: 200, body: {} };
+      return new Response(JSON.stringify(reply.body), { status: reply.status });
+    }) as unknown as typeof fetch,
+  });
+}
+
+beforeEach(() => {
+  calls = [];
+  replies = [];
+});
+
+describe("acting as a station", () => {
+  test("sends with ?user_id=, which is what makes the message the agent's", async () => {
+    await client().sendText(USER, ROOM, "hello");
+
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+  });
+
+  test("carries the as_token, never anything else", async () => {
+    // as_token authenticates the bridge TO the homeserver. The hs_token points
+    // the other way, and swapping them fails as a 403 that reads like a
+    // permissions bug rather than a configuration one.
+    await client().sendText(USER, ROOM, "hello");
+
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${AS_TOKEN}`);
+  });
+
+  test("gives every send a transaction id, so a retry cannot double-send", async () => {
+    await client().sendText(USER, ROOM, "hello");
+    await client().sendText(USER, ROOM, "hello");
+
+    const ids = calls.map((c) => c.url.match(/\/send\/m\.room\.message\/([^?]+)/)?.[1]);
+    expect(ids[0]).toBeTruthy();
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  test("treats M_USER_IN_USE on register as success", async () => {
+    // ensureUser runs on every provision and every boot. A second call must be
+    // a no-op, not an error that stops an agent existing.
+    replies = [{ status: 400, body: { errcode: "M_USER_IN_USE" } }];
+
+    await client().ensureUser("agent_box__pi_x", "x (pi @ box)");
+  });
+
+  test("sets the display name even when the user already existed", async () => {
+    // A station that was renamed must stop introducing itself by its old name.
+    // Setting the name only on creation would mean the rename never lands,
+    // because the user is created exactly once and provisioning runs forever.
+    replies = [{ status: 400, body: { errcode: "M_USER_IN_USE" } }];
+
+    await client().ensureUser("agent_box__pi_x", "renamed (pi @ box)");
+
+    const profile = calls.find((c) => c.url.includes("/displayname"));
+    expect(profile).toBeTruthy();
+    expect(profile!.body).toEqual({ displayname: "renamed (pi @ box)" });
+  });
+
+  test("treats M_ROOM_IN_USE on create as success", async () => {
+    replies = [{ status: 400, body: { errcode: "M_ROOM_IN_USE" } }];
+
+    const roomId = await client().ensureRoom("#agentpod_box__pi_x:id.agentpod.dev", {
+      creator: USER,
+      name: "x",
+      topic: "pi @ box",
+    });
+
+    // Nothing was created, and the caller is told so rather than being handed a
+    // room id that does not exist.
+    expect(roomId).toBeNull();
+  });
+
+  test("a real failure is not swallowed", async () => {
+    // Only the two "already done" cases are success. A 403 from a namespace we
+    // do not own must surface, or provisioning silently produces nothing.
+    replies = [{ status: 403, body: { errcode: "M_FORBIDDEN", error: "not in namespace" } }];
+
+    await expect(client().ensureUser("agent_nope", "nope")).rejects.toThrow(/M_FORBIDDEN|namespace/);
+  });
+
+  test("typing is sent as the agent, so the room shows the agent thinking", async () => {
+    await client().sendTyping(USER, ROOM, true);
+
+    expect(calls[0]!.url).toContain("/typing/");
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+    expect(calls[0]!.body).toMatchObject({ typing: true });
+  });
+
+  test("a typing stop carries no timeout, because it is not a duration", async () => {
+    await client().sendTyping(USER, ROOM, false);
+    expect(calls[0]!.body).toEqual({ typing: false });
+  });
+
+  test("display name is set as the user itself", async () => {
+    await client().setDisplayName(USER, "x (pi @ box)");
+
+    expect(calls[0]!.url).toContain("/profile/");
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+    expect(calls[0]!.body).toEqual({ displayname: "x (pi @ box)" });
+  });
+
+  test("an invite is sent by the room's agent, not by the bridge bot", async () => {
+    await client().invite(USER, ROOM, "@rakesh:id.agentpod.dev");
+
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+    expect(calls[0]!.body).toEqual({ user_id: "@rakesh:id.agentpod.dev" });
+  });
+});

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -1,0 +1,175 @@
+/**
+ * A Matrix client that acts *as* a station.
+ *
+ * `?user_id=` is the whole mechanism: an Application Service presents its own
+ * `as_token` and names the user it is speaking for. Without it every agent's
+ * message arrives from `@ai-bridge`, and a room full of agents becomes one voice
+ * pretending to be many — worse than no bridge, because it looks like it works.
+ *
+ * Verified against a live tuwunel before this was written:
+ * `docs/superpowers/specs/2026-08-16-tuwunel-appservice-spike-findings.md`.
+ */
+
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("matrix-client");
+
+export interface MatrixClientDeps {
+  homeserverUrl: string;
+  /** Authenticates the BRIDGE to the homeserver. Not the hs_token. */
+  asToken: string;
+  /** This homeserver's name, so a localpart can be addressed as a full mxid. */
+  domain?: string;
+  fetch?: typeof fetch;
+}
+
+/** The two "it was already done" answers, which are successes for us. */
+const ALREADY: Record<string, true> = { M_USER_IN_USE: true, M_ROOM_IN_USE: true };
+
+export interface MatrixClient {
+  ensureUser(localpart: string, displayName: string): Promise<void>;
+  ensureRoom(
+    alias: string,
+    opts: { creator: string; name: string; topic: string }
+  ): Promise<string | null>;
+  sendText(userId: string, roomId: string, body: string): Promise<string | null>;
+  sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
+  setDisplayName(userId: string, displayName: string): Promise<void>;
+  invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+}
+
+export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
+  const doFetch = deps.fetch ?? fetch;
+
+  /** `?user_id=` on every call — the difference between the agent and the bridge. */
+  const asUser = (path: string, userId?: string): string => {
+    const url = `${deps.homeserverUrl}${path}`;
+    if (!userId) return url;
+    return `${url}${url.includes("?") ? "&" : "?"}user_id=${encodeURIComponent(userId)}`;
+  };
+
+  async function call(
+    path: string,
+    init: { method: string; body?: unknown; userId?: string }
+  ): Promise<{ status: number; body: Record<string, unknown> }> {
+    const res = await doFetch(asUser(path, init.userId), {
+      method: init.method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${deps.asToken}`,
+      },
+      ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
+    });
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await res.json()) as Record<string, unknown>;
+    } catch {
+      // A body-less 200 is ordinary for some of these.
+    }
+    return { status: res.status, body };
+  }
+
+  /** Throw unless the failure is one of the "already done" answers. */
+  function assertOkOrAlready(
+    what: string,
+    res: { status: number; body: Record<string, unknown> }
+  ): boolean {
+    if (res.status >= 200 && res.status < 300) return true;
+
+    const errcode = String(res.body.errcode ?? "");
+    if (ALREADY[errcode]) {
+      log.info("matrix: already done", { what, errcode });
+      return false;
+    }
+
+    throw new Error(
+      `matrix ${what} failed: ${res.status} ${errcode} ${String(res.body.error ?? "")}`.trim()
+    );
+  }
+
+  return {
+    async ensureUser(localpart, displayName) {
+      const res = await call("/_matrix/client/v3/register", {
+        method: "POST",
+        body: { type: "m.login.application_service", username: localpart },
+      });
+      assertOkOrAlready(`register ${localpart}`, res);
+
+      // Set the display name EVERY time, not only on creation. The user is
+      // created exactly once and provisioning runs forever, so a name set only
+      // at creation means a renamed station keeps introducing itself by its old
+      // name — and the display name is what carries the readability a derived
+      // mxid does not have.
+      //
+      // The register reply has no `user_id` when the user already existed, so
+      // the mxid is composed rather than read back.
+      const userId =
+        String(res.body.user_id ?? "") ||
+        (deps.domain ? `@${localpart}:${deps.domain}` : "");
+      if (userId) await this.setDisplayName(userId, displayName);
+    },
+
+    async ensureRoom(alias, opts) {
+      // The localpart only — the homeserver adds its own domain, and sending the
+      // full alias produces `#…:domain:domain`.
+      const aliasLocalpart = alias.replace(/^#/, "").replace(/:.*$/, "");
+
+      const res = await call("/_matrix/client/v3/createRoom", {
+        method: "POST",
+        userId: opts.creator,
+        body: {
+          room_alias_name: aliasLocalpart,
+          name: opts.name,
+          topic: opts.topic,
+          preset: "private_chat",
+        },
+      });
+
+      if (!assertOkOrAlready(`createRoom ${alias}`, res)) return null;
+      return String(res.body.room_id ?? "") || null;
+    },
+
+    async sendText(userId, roomId, body) {
+      // A fresh transaction id per send: the homeserver deduplicates on it, so
+      // reusing one would silently drop a genuinely new message.
+      const txn = `apb-${crypto.randomUUID()}`;
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${txn}`,
+        { method: "PUT", userId, body: { msgtype: "m.text", body } }
+      );
+      assertOkOrAlready("send", res);
+      return String(res.body.event_id ?? "") || null;
+    },
+
+    async sendTyping(userId, roomId, typing) {
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/typing/${encodeURIComponent(userId)}`,
+        {
+          method: "PUT",
+          userId,
+          // A stop carries no timeout: it is an end, not a duration.
+          body: typing ? { typing: true, timeout: 30_000 } : { typing: false },
+        }
+      );
+      assertOkOrAlready("typing", res);
+    },
+
+    async setDisplayName(userId, displayName) {
+      const res = await call(
+        `/_matrix/client/v3/profile/${encodeURIComponent(userId)}/displayname`,
+        { method: "PUT", userId, body: { displayname: displayName } }
+      );
+      assertOkOrAlready("displayname", res);
+    },
+
+    async invite(asUserId, roomId, invitee) {
+      const res = await call(`/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/invite`, {
+        method: "POST",
+        userId: asUserId,
+        body: { user_id: invitee },
+      });
+      assertOkOrAlready("invite", res);
+    },
+  };
+}

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -28,6 +28,17 @@ const ALREADY: Record<string, true> = { M_USER_IN_USE: true, M_ROOM_IN_USE: true
 
 export interface MatrixClient {
   ensureUser(localpart: string, displayName: string): Promise<void>;
+  /**
+   * Register an identity and keep the credentials it comes back with.
+   *
+   * Verified against a live tuwunel: an appservice registration returns an
+   * `access_token` and `device_id` directly, so handing a harness its own client
+   * needs no admin command and no password. Fails if the identity already
+   * exists — replacing credentials is a different, privileged act.
+   */
+  registerWithCredentials(
+    localpart: string
+  ): Promise<{ userId: string; accessToken: string; deviceId: string }>;
   ensureRoom(
     alias: string,
     opts: { creator: string; name: string; topic: string }
@@ -108,6 +119,37 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
         String(res.body.user_id ?? "") ||
         (deps.domain ? `@${localpart}:${deps.domain}` : "");
       if (userId) await this.setDisplayName(userId, displayName);
+    },
+
+    async registerWithCredentials(localpart) {
+      const res = await call("/_matrix/client/v3/register", {
+        method: "POST",
+        body: { type: "m.login.application_service", username: localpart },
+      });
+
+      // Deliberately NOT treating M_USER_IN_USE as success here. Everywhere else
+      // "already done" is what idempotency means; here it means the caller asked
+      // for credentials to an identity that already has some, and answering with
+      // nothing would leave a harness holding no token while believing it does.
+      if (res.status < 200 || res.status >= 300) {
+        throw new Error(
+          `matrix register ${localpart} failed: ${res.status} ${String(res.body.errcode ?? "")}`.trim()
+        );
+      }
+
+      const accessToken = String(res.body.access_token ?? "");
+      if (!accessToken) {
+        throw new Error(
+          `matrix register ${localpart} returned no access_token — this homeserver ` +
+            "does not issue appservice credentials this way"
+        );
+      }
+
+      return {
+        userId: String(res.body.user_id ?? `@${localpart}:${deps.domain ?? ""}`),
+        accessToken,
+        deviceId: String(res.body.device_id ?? ""),
+      };
     },
 
     async ensureRoom(alias, opts) {

--- a/apps/hub/src/services/matrix-as/health.test.ts
+++ b/apps/hub/src/services/matrix-as/health.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { recordTransaction, bridgeHealth, _resetHealthForTest } from "./health";
+
+/**
+ * Is the bridge working, or merely running?
+ *
+ * The distinction is not academic: the homeserver's registration carried
+ * `url: null` for months, which meant a perfectly healthy Application Service
+ * that had never been sent a single event — and nothing anywhere said so. A
+ * bridge that cannot tell "quiet" from "not connected" reproduces exactly that.
+ */
+
+const HOUR = 60 * 60 * 1000;
+
+beforeEach(() => _resetHealthForTest());
+
+describe("bridge health", () => {
+  test("starts as never-heard-from rather than healthy", () => {
+    // Optimism here is what let url:null hide. A bridge that has received
+    // nothing has not been proven to be reachable at all.
+    const h = bridgeHealth({ enabled: true, now: 0 });
+    expect(h.status).toBe("silent");
+    expect(h.reason).toMatch(/no transaction/i);
+  });
+
+  test("is healthy once the homeserver has pushed something", () => {
+    recordTransaction(1_000);
+    expect(bridgeHealth({ enabled: true, now: 2_000 }).status).toBe("ok");
+  });
+
+  test("goes silent again after a long quiet spell", () => {
+    // Two hours with no push, on a fleet of 32 agents, is not quiet — it is
+    // disconnected. Better a false alarm an operator can dismiss than a bridge
+    // that reports health it cannot demonstrate.
+    recordTransaction(1_000);
+    const h = bridgeHealth({ enabled: true, now: 1_000 + 3 * HOUR });
+    expect(h.status).toBe("silent");
+    expect(h.lastTransactionAt).toBe(1_000);
+  });
+
+  test("reports disabled when the bridge is off, not silent", () => {
+    // An operator who has not enabled it must not be told it is broken.
+    expect(bridgeHealth({ enabled: false, now: 0 }).status).toBe("disabled");
+  });
+});

--- a/apps/hub/src/services/matrix-as/health.ts
+++ b/apps/hub/src/services/matrix-as/health.ts
@@ -1,0 +1,62 @@
+/**
+ * Is the bridge working, or merely running?
+ *
+ * Not an academic distinction. The homeserver's registration carried
+ * `url: null` for months: a perfectly healthy Application Service that had never
+ * been sent a single event, with nothing anywhere saying so. This exists so that
+ * state has a name.
+ */
+
+/** When the homeserver last pushed us anything. Process-local, like the sweeper's. */
+let lastTransactionAt: number | null = null;
+
+export function recordTransaction(now = Date.now()): void {
+  lastTransactionAt = now;
+}
+
+/** Test hook — the counter is module state, as the sweeper's is. */
+export function _resetHealthForTest(): void {
+  lastTransactionAt = null;
+}
+
+/**
+ * How long a bridge may hear nothing before that is itself the news.
+ *
+ * Two hours: long enough that an idle night is not an alarm, short enough that
+ * a disconnected bridge is noticed the same working day.
+ */
+export const SILENCE_MS = 2 * 60 * 60 * 1000;
+
+export interface BridgeHealth {
+  status: "ok" | "silent" | "disabled";
+  reason?: string;
+  lastTransactionAt: number | null;
+}
+
+export function bridgeHealth(opts: { enabled: boolean; now?: number }): BridgeHealth {
+  const now = opts.now ?? Date.now();
+
+  if (!opts.enabled) {
+    return { status: "disabled", lastTransactionAt };
+  }
+
+  if (lastTransactionAt === null) {
+    return {
+      status: "silent",
+      reason:
+        "no transaction has ever arrived — the homeserver's registration may still " +
+        "have no `url`, in which case this bridge is running and connected to nothing",
+      lastTransactionAt: null,
+    };
+  }
+
+  if (now - lastTransactionAt > SILENCE_MS) {
+    return {
+      status: "silent",
+      reason: `no transaction for over ${Math.round(SILENCE_MS / 60000)} minutes`,
+      lastTransactionAt,
+    };
+  }
+
+  return { status: "ok", lastTransactionAt };
+}

--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -1,0 +1,167 @@
+/**
+ * Where a Matrix message becomes work.
+ *
+ * This is what the identity work was for. An inbound message is an
+ * authorization question the suite can already answer: `resolveMatrixId` gives a
+ * principal, and the control pair says whether that principal may dispatch this
+ * agent (`charter` → decisions/2026-08-13-ecosystem-identity.md, Decision 4).
+ *
+ * **A room is not a console session.** It is a shared space several people can
+ * type into, so the grant is checked on every message rather than once when the
+ * session was opened — otherwise the first permitted person to speak would open
+ * a conversation everyone else in the room could then drive.
+ *
+ * **A refusal is a message, never silence.** A bridge that ignored what it would
+ * not do looks like a broken agent, and sends an operator to the console, the
+ * node and the harness — everywhere except the grant that actually refused.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../../db/drizzle";
+import { matrixRooms } from "../../db/schema/matrix";
+import { stations } from "../../db/schema/stations";
+import { nodes } from "../../db/schema/nodes";
+import { resolveMatrixId } from "../matrix-identity";
+import { getGrant, grantAllowsStation } from "../grants";
+import { isControlPairEnforced } from "../control-pair";
+import { bridgeUserId } from "./names";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("matrix-inbound");
+
+export interface InboundEvent {
+  type: string;
+  sender: string;
+  room_id?: string;
+  event_id?: string;
+  content?: Record<string, unknown>;
+}
+
+export interface InboundDeps {
+  domain: string;
+  client: {
+    sendText(userId: string, roomId: string, body: string): Promise<string | null>;
+  };
+  acp: {
+    createSession(input: {
+      stationId: string;
+      userId: string;
+      mode: string;
+    }): Promise<{ id: string }>;
+    promptSession(userId: string, sessionId: string, text: string): Promise<void>;
+  };
+}
+
+/** The room, its station, and the node name that station's identity is built from. */
+async function roomContext(roomId: string) {
+  const [row] = await db
+    .select({
+      roomId: matrixRooms.roomId,
+      sessionId: matrixRooms.acpSessionId,
+      stationId: stations.id,
+      stationKey: stations.stationKey,
+      identityMode: stations.matrixIdentityMode,
+      nodeName: nodes.name,
+    })
+    .from(matrixRooms)
+    .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .where(eq(matrixRooms.roomId, roomId));
+  return row ?? null;
+}
+
+export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps): Promise<void> {
+  if (event.type !== "m.room.message") return;
+  if (!event.room_id) return;
+
+  const text = typeof event.content?.body === "string" ? event.content.body : "";
+  // Whitespace is not a prompt. Sending one would start a turn with nothing in
+  // it and cost an agent a round trip to say so.
+  if (text.trim() === "") return;
+
+  const room = await roomContext(event.room_id);
+  // A room we do not own is not ours to answer in — anyone can invite the bot
+  // anywhere.
+  if (!room) return;
+
+  // A harness-mode station answers for itself. Two answerers on one address is
+  // the failure the mode exists to prevent.
+  if (room.identityMode !== "bridge") return;
+
+  const agentUser = bridgeUserId(room.nodeName, room.stationKey, deps.domain);
+  const say = (body: string) => deps.client.sendText(agentUser, room.roomId, body);
+
+  // ── Who is this? ──────────────────────────────────────────────────────────
+  const identity = await resolveMatrixId(event.sender);
+  if (identity?.kind !== "principal") {
+    // Ambiguous is refused as firmly as unknown: `resolveMatrixId` fails closed
+    // when one mxid is claimed by both a station and a principal, and guessing
+    // would attribute a human's words to an agent.
+    log.warn("matrix message from an unresolvable sender", {
+      sender: event.sender,
+      kind: identity?.kind ?? "none",
+      room: room.roomId,
+    });
+    await say(
+      "I do not recognise you. This hub has no principal linked to " +
+        `${event.sender}, so I cannot act on your behalf.`
+    );
+    return;
+  }
+  const principalId = identity.principalId;
+
+  // ── May they dispatch THIS agent? ─────────────────────────────────────────
+  if (isControlPairEnforced()) {
+    const grant = await getGrant(principalId);
+    const allowed = grantAllowsStation(grant, {
+      nodeName: room.nodeName,
+      stationKey: room.stationKey,
+    });
+
+    if (!allowed) {
+      log.warn("matrix message refused by the control pair", {
+        principalId,
+        node: room.nodeName,
+        stationKey: room.stationKey,
+      });
+      await say(
+        "You are not permitted to dispatch this agent. Your grant does not " +
+          `cover ${room.nodeName}/${room.stationKey}.`
+      );
+      return;
+    }
+  }
+
+  // ── Say it to the agent ───────────────────────────────────────────────────
+  try {
+    let sessionId = room.sessionId;
+
+    if (!sessionId) {
+      // One session per room, not per message: a conversation is a
+      // conversation, and a session per message would throw away the agent's
+      // context between two consecutive sentences.
+      const session = await deps.acp.createSession({
+        stationId: room.stationId,
+        userId: principalId,
+        mode: "default",
+      });
+      sessionId = session.id;
+      await db
+        .update(matrixRooms)
+        .set({ acpSessionId: sessionId })
+        .where(eq(matrixRooms.roomId, room.roomId));
+    }
+
+    // The user's words, unchanged. Trimming or decorating them would put the
+    // bridge's voice into the agent's input.
+    await deps.acp.promptSession(principalId, sessionId, text);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log.error("matrix message could not reach the station", {
+      room: room.roomId,
+      stationKey: room.stationKey,
+      error: reason,
+    });
+    await say(`I could not reach this agent: ${reason}`);
+  }
+}

--- a/apps/hub/src/services/matrix-as/index.test.ts
+++ b/apps/hub/src/services/matrix-as/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { matrixBridgeConfig, matrixBridgeProblems, createMatrixBridge } from "./index";
+
+/**
+ * The switch, and what happens when it is half-thrown.
+ *
+ * A hub whose Matrix configuration is incomplete must still boot and serve its
+ * fleet — the bridge is an addition to a facilities console, not a dependency of
+ * one. So the failure mode is a warning and a bridge that does not run, never a
+ * hub that will not start.
+ */
+
+const base = {
+  ENABLE_MATRIX_BRIDGE: "true",
+  MATRIX_HOMESERVER_URL: "http://127.0.0.1:6167",
+  MATRIX_SERVER_NAME: "id.agentpod.dev",
+  MATRIX_AS_TOKEN: "as-token",
+  MATRIX_HS_TOKEN: "hs-token",
+} as unknown as NodeJS.ProcessEnv;
+
+describe("the bridge switch", () => {
+  test("is off unless the flag is the literal lowercase true", () => {
+    // `=1`, `TRUE` and `yes` are off. This codebase has already learned that a
+    // looser boolean passes boot validation and starts nothing — the worst of
+    // both, because it looks configured.
+    for (const value of ["1", "TRUE", "yes", "True", ""]) {
+      expect(matrixBridgeConfig({ ...base, ENABLE_MATRIX_BRIDGE: value }).enabled).toBe(false);
+    }
+    expect(matrixBridgeConfig(base).enabled).toBe(true);
+  });
+
+  test("names what is missing rather than starting half-configured", () => {
+    const cfg = matrixBridgeConfig({ ...base, MATRIX_AS_TOKEN: "", MATRIX_HS_TOKEN: "" });
+    expect(matrixBridgeProblems(cfg)).toEqual(["MATRIX_AS_TOKEN", "MATRIX_HS_TOKEN"]);
+  });
+
+  test("complains about nothing when it is switched off", () => {
+    // An operator who has not enabled the bridge should not be told about
+    // variables they were never asked for.
+    const cfg = matrixBridgeConfig({ ...base, ENABLE_MATRIX_BRIDGE: "false" });
+    expect(matrixBridgeProblems(cfg)).toEqual([]);
+  });
+
+  test("builds nothing when off, so no route can answer a homeserver", () => {
+    expect(createMatrixBridge(matrixBridgeConfig({ ...base, ENABLE_MATRIX_BRIDGE: "false" }))).toBeNull();
+  });
+
+  test("builds nothing when enabled but unconfigured", () => {
+    // Null rather than a half-built bridge: mounting routes that answered a
+    // homeserver we have no token for would be worse than not answering.
+    expect(createMatrixBridge(matrixBridgeConfig({ ...base, MATRIX_HS_TOKEN: "" }))).toBeNull();
+  });
+
+  test("builds when it has everything", () => {
+    const bridge = createMatrixBridge(matrixBridgeConfig(base));
+    expect(bridge).not.toBeNull();
+    expect(bridge!.config.domain).toBe("id.agentpod.dev");
+  });
+
+  test("defaults the homeserver to loopback, because it is never remote here", () => {
+    const cfg = matrixBridgeConfig({ ...base, MATRIX_HOMESERVER_URL: undefined });
+    expect(cfg.homeserverUrl).toBe("http://127.0.0.1:6167");
+  });
+});

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -1,0 +1,152 @@
+/**
+ * The Matrix bridge, assembled.
+ *
+ * Everything the bridge does is inert until the homeserver's registration file
+ * carries a `url` pointing here. That is deliberate: the whole of Phase B can be
+ * deployed with no effect, and turning it on is one field and one restart —
+ * which is also the off switch.
+ *
+ * Gated on `ENABLE_MATRIX_BRIDGE` being the **literal lowercase `"true"`**,
+ * matching `ENABLE_KAAMBAAN_BRIDGE` and `ENFORCE_CONTROL_PAIR`. This codebase has
+ * already learned that a looser boolean lets `=1` pass validation and start
+ * nothing.
+ */
+
+import { createMatrixClient, type MatrixClient } from "./client";
+import { provisionStation, provisionAll } from "./provision";
+import { handleRoomMessage } from "./inbound";
+import { attachRoomToSession } from "./outbound";
+import { createSession, promptSession } from "../acp-sessions";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("matrix-bridge");
+
+export interface MatrixBridgeConfig {
+  enabled: boolean;
+  homeserverUrl: string;
+  domain: string;
+  asToken: string;
+  hsToken: string;
+}
+
+/** What the deployment says. Read once, at boot, like every other switch here. */
+export function matrixBridgeConfig(env = process.env): MatrixBridgeConfig {
+  return {
+    // The literal lowercase "true" — see the note above.
+    enabled: env.ENABLE_MATRIX_BRIDGE === "true",
+    homeserverUrl: env.MATRIX_HOMESERVER_URL ?? "http://127.0.0.1:6167",
+    domain: env.MATRIX_SERVER_NAME ?? "id.agentpod.dev",
+    asToken: env.MATRIX_AS_TOKEN ?? "",
+    hsToken: env.MATRIX_HS_TOKEN ?? "",
+  };
+}
+
+/**
+ * What is missing before this bridge can work.
+ *
+ * Returned rather than thrown: a hub whose Matrix configuration is half-done
+ * must still boot and serve its fleet. The warning is what an operator reads.
+ */
+export function matrixBridgeProblems(cfg: MatrixBridgeConfig): string[] {
+  if (!cfg.enabled) return [];
+  const missing: string[] = [];
+  if (!cfg.asToken) missing.push("MATRIX_AS_TOKEN");
+  if (!cfg.hsToken) missing.push("MATRIX_HS_TOKEN");
+  return missing;
+}
+
+export interface MatrixBridge {
+  client: MatrixClient;
+  config: MatrixBridgeConfig;
+  /** Give a station its identity and room. Safe to call repeatedly. */
+  provision(stationId: string): Promise<void>;
+  /** Handle one event the homeserver pushed. */
+  onEvent(event: { type: string; sender: string; room_id?: string; content?: Record<string, unknown> }): Promise<void>;
+  /** Create the room behind an alias the homeserver asked about. */
+  onProvisionAlias(alias: string): Promise<void>;
+}
+
+/**
+ * Build the bridge, or null when it is switched off.
+ *
+ * Null rather than a no-op object so the caller cannot accidentally mount routes
+ * that would answer a homeserver this deployment never agreed to talk to.
+ */
+export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | null {
+  if (!cfg.enabled) return null;
+
+  const problems = matrixBridgeProblems(cfg);
+  if (problems.length > 0) {
+    log.warn("matrix bridge is enabled but not configured; it will not run", {
+      missing: problems,
+    });
+    return null;
+  }
+
+  const client = createMatrixClient({
+    homeserverUrl: cfg.homeserverUrl,
+    asToken: cfg.asToken,
+    domain: cfg.domain,
+  });
+
+  const provisionDeps = { domain: cfg.domain, client };
+
+  const inboundDeps = {
+    domain: cfg.domain,
+    client,
+    acp: {
+      createSession: async (input: { stationId: string; userId: string; mode: string }) => {
+        const session = await createSession({
+          stationId: input.stationId,
+          userId: input.userId,
+          mode: input.mode as never,
+        });
+        // The room hears the answer as soon as the session exists, not when the
+        // first chunk arrives — otherwise the opening of a conversation is the
+        // one part of it nobody sees.
+        return { id: session.id };
+      },
+      promptSession,
+    },
+  };
+
+  return {
+    client,
+    config: cfg,
+
+    async provision(stationId: string) {
+      await provisionStation(stationId, provisionDeps);
+    },
+
+    async onEvent(event) {
+      await handleRoomMessage(event, inboundDeps);
+    },
+
+    async onProvisionAlias(alias: string) {
+      // The homeserver asks about an alias when somebody tried to resolve it.
+      // Answering yes without creating the room would send them somewhere that
+      // is not there.
+      const { stationForLocalpart, localpartFromAlias } = await import("./stations");
+      const localpart = localpartFromAlias(alias, cfg.domain);
+      const station = localpart ? await stationForLocalpart(localpart) : null;
+      if (station) await provisionStation(station.stationId, provisionDeps);
+    },
+  };
+}
+
+/**
+ * Provision every station at boot, and stream any session already running.
+ *
+ * Runs after the routes are mounted, so a homeserver that starts pushing
+ * immediately finds somewhere to push to.
+ */
+export async function startMatrixBridge(bridge: MatrixBridge): Promise<void> {
+  const result = await provisionAll({ domain: bridge.config.domain, client: bridge.client });
+  log.info("matrix bridge ready", {
+    domain: bridge.config.domain,
+    provisioned: result.provisioned,
+    failed: result.failed,
+  });
+}
+
+export { attachRoomToSession };

--- a/apps/hub/src/services/matrix-as/names.test.ts
+++ b/apps/hub/src/services/matrix-as/names.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bridgeUserId, bridgeAlias, localpartFor, isBridgeUser } from "./names";
+import { bridgeUserId, bridgeAlias, bridgeLocalpart, localpartFor, isBridgeUser } from "./names";
 
 /**
  * A Matrix name for a station.
@@ -51,6 +51,15 @@ describe("bridge names", () => {
     // A separator that could also appear inside either half would make
     // `a_b`/`c` and `a`/`b_c` the same name. They must not collide.
     expect(localpartFor("a_b", "c")).not.toBe(localpartFor("a", "b_c"));
+  });
+
+  test("the registered username is exactly the user id's localpart", () => {
+    // Registering the bare name creates a user OUTSIDE the exclusive namespace,
+    // where the appservice may not act — and the failure surfaces later and
+    // elsewhere, as a 403 at send time.
+    const userId = bridgeUserId("molt-bot", "hermes:coder-kai", D);
+    expect(userId).toBe(`@${bridgeLocalpart("molt-bot", "hermes:coder-kai")}:${D}`);
+    expect(bridgeLocalpart("molt-bot", "hermes:coder-kai").startsWith("agent_")).toBe(true);
   });
 
   test("are stable — the same station always gets the same name", () => {

--- a/apps/hub/src/services/matrix-as/names.test.ts
+++ b/apps/hub/src/services/matrix-as/names.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { bridgeUserId, bridgeAlias, localpartFor, isBridgeUser } from "./names";
+
+/**
+ * A Matrix name for a station.
+ *
+ * Derived, never stored: from the same `(node, stationKey)` pair that already
+ * identifies a station in a grant
+ * (`charter` → decisions/2026-08-15-a-grant-names-an-agent-per-plane.md). A
+ * mapping table would be a second source of truth for a fact the fleet knows.
+ */
+
+const D = "id.agentpod.dev";
+
+describe("bridge names", () => {
+  test("name a node as well as a station", () => {
+    // `opencode:c52ddf65` exists on two nodes in production right now. A name
+    // that omitted the node would merge two different agents on two different
+    // machines — the collision this suite has already undone once, for grants.
+    const a = bridgeUserId("cloudchamber", "opencode:c52ddf65", D);
+    const b = bridgeUserId("9247e5a88cfa", "opencode:c52ddf65", D);
+    expect(a).not.toBe(b);
+  });
+
+  test("land inside the namespace the homeserver reserved", () => {
+    // agents.yaml claims `@agent_.*` and `#agentpod_.*` exclusive. A name
+    // outside them cannot be acted as, and the failure arrives late — a 403
+    // from the homeserver at send time, long after provisioning "worked".
+    // `__` separates the node half from the station half; a single `_` would
+    // make node `a_b` + station `c` collide with node `a` + station `b_c`.
+    expect(bridgeUserId("molt-bot", "hermes:analyst-echo", D)).toBe(
+      "@agent_molt-bot__hermes_analyst-echo:id.agentpod.dev"
+    );
+    expect(bridgeAlias("molt-bot", "hermes:analyst-echo", D)).toBe(
+      "#agentpod_molt-bot__hermes_analyst-echo:id.agentpod.dev"
+    );
+  });
+
+  test("replace characters an mxid localpart may not contain", () => {
+    // `:` is the mxid separator, and a station key is full of them.
+    expect(bridgeUserId("box", "claude-code:48c62ea7", D)).toBe(
+      "@agent_box__claude-code_48c62ea7:id.agentpod.dev"
+    );
+  });
+
+  test("lowercase, because Matrix localparts are", () => {
+    expect(bridgeUserId("BOX", "Pi:59099BF1", D)).toBe("@agent_box__pi_59099bf1:id.agentpod.dev");
+  });
+
+  test("keep the node and the station distinguishable", () => {
+    // A separator that could also appear inside either half would make
+    // `a_b`/`c` and `a`/`b_c` the same name. They must not collide.
+    expect(localpartFor("a_b", "c")).not.toBe(localpartFor("a", "b_c"));
+  });
+
+  test("are stable — the same station always gets the same name", () => {
+    // Provisioning runs on every adoption and every boot. A name that drifted
+    // would strand rooms behind identities nobody answers for.
+    expect(bridgeUserId("molt-bot", "hermes:coder-kai", D)).toBe(
+      bridgeUserId("molt-bot", "hermes:coder-kai", D)
+    );
+  });
+});
+
+describe("isBridgeUser", () => {
+  test("recognises our own users, which is how the echo loop is cut", () => {
+    // An Application Service receives what its own users send. Answering those
+    // is an infinite loop that fills a database overnight, so this predicate
+    // runs before anything else looks at an event.
+    expect(isBridgeUser("@agent_box__pi_59099bf1:id.agentpod.dev", D)).toBe(true);
+  });
+
+  test("recognises the appservice's own bot", () => {
+    expect(isBridgeUser("@ai-bridge:id.agentpod.dev", D)).toBe(true);
+  });
+
+  test("does not claim humans", () => {
+    expect(isBridgeUser("@rakesh:id.agentpod.dev", D)).toBe(false);
+  });
+
+  test("does not claim a lookalike from another server", () => {
+    // Federation is off today and may not always be. A name that merely looks
+    // like ours, on someone else's homeserver, is not ours.
+    expect(isBridgeUser("@agent_x:example.org", D)).toBe(false);
+    expect(isBridgeUser("@ai-bridge:example.org", D)).toBe(false);
+  });
+
+  test("does not claim a user whose name merely starts like the domain", () => {
+    // `:id.agentpod.dev.evil.example` ends with neither our domain nor a
+    // boundary — a suffix check without the colon would have accepted it.
+    expect(isBridgeUser("@agent_x:id.agentpod.dev.evil.example", D)).toBe(false);
+  });
+
+  test("survives junk without throwing, because it runs on untrusted input", () => {
+    expect(isBridgeUser("", D)).toBe(false);
+    expect(isBridgeUser("not-an-mxid", D)).toBe(false);
+  });
+});

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -31,8 +31,21 @@ export function localpartFor(nodeName: string, stationKey: string): string {
   return `${clean(nodeName)}__${clean(stationKey)}`;
 }
 
+/**
+ * The username to register, which is the mxid's localpart INCLUDING the
+ * `agent_` prefix.
+ *
+ * Separate from `localpartFor` because registering the bare name creates
+ * `@prov-box__openclaw_krishna` — outside the exclusive namespace the homeserver
+ * reserved, where the appservice may not act. The failure arrives later and
+ * elsewhere, as a 403 at send time.
+ */
+export function bridgeLocalpart(nodeName: string, stationKey: string): string {
+  return `agent_${localpartFor(nodeName, stationKey)}`;
+}
+
 export function bridgeUserId(nodeName: string, stationKey: string, domain: string): string {
-  return `@agent_${localpartFor(nodeName, stationKey)}:${domain}`;
+  return `@${bridgeLocalpart(nodeName, stationKey)}:${domain}`;
 }
 
 export function bridgeAlias(nodeName: string, stationKey: string, domain: string): string {

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -1,0 +1,56 @@
+/**
+ * A station's Matrix names.
+ *
+ * Pure, and derived from the pair that already identifies a station in a grant
+ * (`charter` → decisions/2026-08-15-a-grant-names-an-agent-per-plane.md). The
+ * node is in the name because station keys repeat across the fleet:
+ * `opencode:c52ddf65` exists on two of them today.
+ *
+ * Derivation rather than a mapping table, so there is nothing to keep in sync
+ * and an operator can predict a name from a station without looking it up.
+ */
+
+/**
+ * The characters a Matrix localpart may contain, lowercased. Everything else —
+ * `:` above all, which a station key is full of — becomes `_`.
+ */
+const ILLEGAL = /[^a-z0-9._=/-]/g;
+
+const clean = (s: string): string => s.toLowerCase().replace(ILLEGAL, "_");
+
+/**
+ * `<node>__<station>`, with a doubled separator between the halves.
+ *
+ * Doubled because a single `_` appears inside both halves after cleaning, and
+ * `a_b` + `c` would otherwise produce the same localpart as `a` + `b_c` — two
+ * different agents, one identity. `__` cannot appear inside a cleaned half,
+ * since the cleaner never emits two in a row for a single character and any
+ * literal `__` in a name is itself replaced.
+ */
+export function localpartFor(nodeName: string, stationKey: string): string {
+  return `${clean(nodeName)}__${clean(stationKey)}`;
+}
+
+export function bridgeUserId(nodeName: string, stationKey: string, domain: string): string {
+  return `@agent_${localpartFor(nodeName, stationKey)}:${domain}`;
+}
+
+export function bridgeAlias(nodeName: string, stationKey: string, domain: string): string {
+  return `#agentpod_${localpartFor(nodeName, stationKey)}:${domain}`;
+}
+
+/**
+ * Is this mxid one of ours?
+ *
+ * The first question asked of every inbound event. An Application Service is
+ * sent what its own users send, and a bridge that answers those talks to itself
+ * forever — the failure that fills a database overnight.
+ *
+ * The domain is checked as a whole label, not as a suffix: `:id.agentpod.dev`
+ * must be the end of the string, or `@agent_x:id.agentpod.dev.evil.example`
+ * would pass.
+ */
+export function isBridgeUser(mxid: string, domain: string): boolean {
+  if (!mxid.endsWith(`:${domain}`)) return false;
+  return mxid.startsWith("@agent_") || mxid === `@ai-bridge:${domain}`;
+}

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { attachRoomToSession, detachRoom, _attachedCountForTest } from "./outbound";
+
+/**
+ * The agent's answer, arriving in the room.
+ *
+ * The bridge is a second subscriber to the same in-process fan-out the console's
+ * WebSocket already uses. What it must not do is forward that stream verbatim: a
+ * Matrix event per token would buzz a phone forty times for one answer, hit rate
+ * limits, and make the room unreadable.
+ */
+
+const ROOM = "!room:id.agentpod.dev";
+const AGENT = "@agent_box__openclaw_krishna:id.agentpod.dev";
+const SESSION = "acps_outbound_test";
+
+let sent: Array<{ userId: string; roomId: string; body: string }> = [];
+let typing: Array<{ roomId: string; on: boolean }> = [];
+let listeners: Array<(e: any) => void> = [];
+let unsubscribed = 0;
+
+function deps() {
+  return {
+    client: {
+      sendText: async (userId: string, roomId: string, body: string) => {
+        sent.push({ userId, roomId, body });
+        return "$evt";
+      },
+      sendTyping: async (_userId: string, roomId: string, on: boolean) => {
+        typing.push({ roomId, on });
+      },
+    },
+    subscribe: (_sessionId: string, fn: (e: any) => void) => {
+      listeners.push(fn);
+      return () => {
+        unsubscribed++;
+        listeners = listeners.filter((l) => l !== fn);
+      };
+    },
+    // Flush immediately in tests: the debounce is asserted separately by
+    // counting messages, not by waiting for a timer.
+    flushDelayMs: 0,
+  };
+}
+
+function emit(e: unknown) {
+  for (const l of [...listeners]) l(e);
+}
+
+const chunk = (text: string, seq = 1) => ({
+  sessionId: SESSION,
+  seq,
+  type: "agent-update",
+  payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+  createdAt: new Date().toISOString(),
+});
+
+const thought = (text: string, seq = 1) => ({
+  sessionId: SESSION,
+  seq,
+  type: "agent-update",
+  payload: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text } },
+  createdAt: new Date().toISOString(),
+});
+
+const state = (status: string, seq = 9) => ({
+  sessionId: SESSION,
+  seq,
+  type: "state",
+  payload: { status },
+  createdAt: new Date().toISOString(),
+});
+
+const permission = (seq = 5) => ({
+  sessionId: SESSION,
+  seq,
+  type: "permission-request",
+  payload: {
+    toolCall: { title: "write /etc/hosts" },
+    options: [
+      { optionId: "allow", name: "Allow" },
+      { optionId: "reject", name: "Reject" },
+    ],
+  },
+  createdAt: new Date().toISOString(),
+});
+
+/** Let the flush microtask run. */
+const settle = () => new Promise((r) => setTimeout(r, 5));
+
+beforeEach(() => {
+  sent = [];
+  typing = [];
+  listeners = [];
+  unsubscribed = 0;
+  // The attachment map is module state — one per session, deliberately, so a
+  // reconnect cannot double every message. Left attached, it would make the
+  // next test's attach a no-op against a listener this one already dropped.
+  detachRoom(SESSION);
+  unsubscribed = 0;
+});
+
+describe("streaming an answer into a room", () => {
+  test("sends the agent's text as the agent", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(chunk("Working on it."));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ userId: AGENT, roomId: ROOM, body: "Working on it." });
+  });
+
+  test("coalesces a stream of chunks into one message", async () => {
+    // One Matrix event per token would be unreadable, would hit rate limits, and
+    // would make a phone buzz forty times for one answer.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    for (const c of ["Hel", "lo ", "there"]) emit(chunk(c));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toBe("Hello there");
+  });
+
+  test("does not send an empty message when a turn produced no text", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("working"));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test("keeps the agent's thinking out of the room", async () => {
+    // Reasoning chunks are for the console's transcript. Putting them in a room
+    // that people share would turn one answer into a monologue.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(thought("maybe I should check the disk"));
+    emit(chunk("Disk is fine."));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toBe("Disk is fine.");
+  });
+
+  test("shows typing while the turn is in flight, and stops at the end", async () => {
+    // Without this the room looks dead for the ten seconds an agent is thinking.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("working"));
+    await settle();
+    expect(typing.at(-1)).toMatchObject({ roomId: ROOM, on: true });
+
+    emit(chunk("done"));
+    emit(state("idle"));
+    await settle();
+    expect(typing.at(-1)).toMatchObject({ roomId: ROOM, on: false });
+  });
+
+  test("puts a permission request in the room, with its options", async () => {
+    // An agent blocked on a permission prompt with nobody watching the console
+    // has silently stopped. In the room it is a question somebody can see.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(permission());
+    await settle();
+
+    const body = sent.at(-1)!.body;
+    expect(body).toMatch(/permission/i);
+    expect(body).toContain("write /etc/hosts");
+    expect(body).toContain("Allow");
+    expect(body).toContain("Reject");
+  });
+
+  test("reports an error into the room rather than leaving it silent", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit({
+      sessionId: SESSION,
+      seq: 3,
+      type: "error",
+      payload: { message: "harness exited" },
+      createdAt: new Date().toISOString(),
+    });
+    await settle();
+
+    expect(sent.at(-1)!.body).toMatch(/harness exited/);
+  });
+
+  test("flushes what it has when the session ends", async () => {
+    // A turn interrupted by an ended session must not swallow the words the
+    // agent already produced.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(chunk("half a sen"));
+    emit(state("ended"));
+    await settle();
+
+    expect(sent.at(-1)!.body).toBe("half a sen");
+  });
+
+  test("stops listening when the session ends, and leaks nothing", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+    expect(_attachedCountForTest()).toBe(1);
+
+    emit(state("ended"));
+    await settle();
+
+    expect(unsubscribed).toBe(1);
+    expect(_attachedCountForTest()).toBe(0);
+  });
+
+  test("ignores events that arrive after the session ended", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("ended"));
+    await settle();
+    const after = sent.length;
+
+    emit(chunk("late"));
+    await settle();
+
+    expect(sent).toHaveLength(after);
+  });
+
+  test("attaching twice does not double every message", async () => {
+    // Provisioning and a reconnect both attach. Two subscribers on one session
+    // would say everything twice, which reads as an agent repeating itself.
+    const d = deps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d);
+    attachRoomToSession(SESSION, ROOM, AGENT, d);
+
+    emit(chunk("once"));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(_attachedCountForTest()).toBe(1);
+  });
+
+  test("detaching stops the stream and unsubscribes", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    detachRoom(SESSION);
+
+    expect(unsubscribed).toBe(1);
+    expect(_attachedCountForTest()).toBe(0);
+  });
+
+  test("a send that fails does not kill the subscription", async () => {
+    // A homeserver hiccup must not silently detach the room; the next turn
+    // should still arrive.
+    let failNext = true;
+    const d = {
+      ...deps(),
+      client: {
+        sendText: async (userId: string, roomId: string, body: string) => {
+          if (failNext) {
+            failNext = false;
+            throw new Error("homeserver 502");
+          }
+          sent.push({ userId, roomId, body });
+          return "$evt";
+        },
+        sendTyping: async () => {},
+      },
+    };
+    attachRoomToSession(SESSION, ROOM, AGENT, d);
+
+    emit(chunk("first"));
+    emit(state("idle"));
+    await settle();
+
+    emit(chunk("second"));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent.map((s) => s.body)).toEqual(["second"]);
+    expect(_attachedCountForTest()).toBe(1);
+    detachRoom(SESSION);
+  });
+});

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -1,0 +1,213 @@
+/**
+ * The agent's answer, arriving in the room.
+ *
+ * A second subscriber to the same in-process fan-out the console's WebSocket
+ * already uses (`acp-sessions.ts`). What it must not do is forward that stream
+ * verbatim: a Matrix event per token would buzz a phone forty times for one
+ * answer, hit the homeserver's rate limits, and make a shared room unreadable.
+ *
+ * So text is buffered and flushed when the turn ends, typing is shown while it
+ * is in flight, and the only things that reach the room are the ones a person
+ * needs to see: the answer, a permission question, and an error.
+ */
+
+import type { AcpEvent } from "@agentpod/contract";
+import { subscribe as subscribeToSession } from "../acp-sessions";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("matrix-outbound");
+
+export interface OutboundDeps {
+  client: {
+    sendText(userId: string, roomId: string, body: string): Promise<string | null>;
+    sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
+  };
+  subscribe?: (sessionId: string, fn: (e: AcpEvent) => void) => () => void;
+  /** How long to wait for more text before sending. 0 in tests. */
+  flushDelayMs?: number;
+}
+
+interface Attachment {
+  roomId: string;
+  agentUser: string;
+  buffer: string[];
+  timer: ReturnType<typeof setTimeout> | null;
+  unsubscribe: () => void;
+  ended: boolean;
+}
+
+/**
+ * One attachment per session.
+ *
+ * Provisioning and a reconnect both attach, and two subscribers on one session
+ * would say everything twice — which reads as an agent repeating itself, not as
+ * a bridge bug.
+ */
+const attached = new Map<string, Attachment>();
+
+/** Leak detection, mirroring `_subscriberCountForTest` in acp-sessions. */
+export function _attachedCountForTest(): number {
+  return attached.size;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/** The text of an `agent_message_chunk`, or undefined for anything else. */
+function messageChunkText(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  // Thought chunks are deliberately excluded: reasoning belongs in the
+  // console's transcript, not in a room people share, where it would turn one
+  // answer into a monologue.
+  if (payload.sessionUpdate !== "agent_message_chunk") return undefined;
+  const content = payload.content;
+  if (!isRecord(content) || content.type !== "text") return undefined;
+  return typeof content.text === "string" ? content.text : undefined;
+}
+
+/** A permission request, rendered as a question a person can answer. */
+function permissionText(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+  const toolCall = isRecord(payload.toolCall) ? payload.toolCall : {};
+  const what = typeof toolCall.title === "string" ? toolCall.title : "an action";
+
+  const options = Array.isArray(payload.options)
+    ? payload.options
+        .map((o) => (isRecord(o) && typeof o.name === "string" ? o.name : null))
+        .filter((n): n is string => n !== null)
+    : [];
+
+  const choices = options.length > 0 ? ` — ${options.join(" / ")}` : "";
+  return `Permission needed: ${what}${choices}. Answer in the console; this room cannot yet.`;
+}
+
+export function attachRoomToSession(
+  sessionId: string,
+  roomId: string,
+  agentUser: string,
+  deps: OutboundDeps
+): void {
+  if (attached.has(sessionId)) return;
+
+  const subscribe = deps.subscribe ?? subscribeToSession;
+  const flushDelayMs = deps.flushDelayMs ?? 400;
+
+  const state: Attachment = {
+    roomId,
+    agentUser,
+    buffer: [],
+    timer: null,
+    unsubscribe: () => {},
+    ended: false,
+  };
+
+  const say = async (body: string) => {
+    try {
+      await deps.client.sendText(agentUser, roomId, body);
+    } catch (err) {
+      // A homeserver hiccup must not silently detach the room: the next turn
+      // should still arrive. Losing one message loudly beats losing the
+      // conversation quietly.
+      log.error("could not send an agent message into its room", {
+        sessionId,
+        roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const flush = async () => {
+    if (state.timer) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+    const text = state.buffer.join("");
+    state.buffer = [];
+    if (text.trim() === "") return;
+    await say(text);
+  };
+
+  const scheduleFlush = () => {
+    if (state.timer) clearTimeout(state.timer);
+    state.timer = setTimeout(() => void flush(), flushDelayMs);
+  };
+
+  const detach = () => {
+    if (state.ended) return;
+    state.ended = true;
+    if (state.timer) clearTimeout(state.timer);
+    state.unsubscribe();
+    attached.delete(sessionId);
+  };
+
+  state.unsubscribe = subscribe(sessionId, (event: AcpEvent) => {
+    if (state.ended) return;
+
+    void (async () => {
+      switch (event.type) {
+        case "agent-update": {
+          const text = messageChunkText(event.payload);
+          if (text !== undefined) {
+            state.buffer.push(text);
+            scheduleFlush();
+          }
+          return;
+        }
+
+        case "state": {
+          const status = isRecord(event.payload) ? event.payload.status : undefined;
+
+          if (status === "working") {
+            // Without this the room looks dead for the ten seconds an agent
+            // spends thinking.
+            await deps.client
+              .sendTyping(agentUser, roomId, true)
+              .catch(() => {});
+            return;
+          }
+
+          if (status === "idle" || status === "ended") {
+            await flush();
+            await deps.client.sendTyping(agentUser, roomId, false).catch(() => {});
+            // A session that ended takes its attachment with it — an
+            // unsubscribed listener is the leak `_subscriberCountForTest`
+            // exists to catch.
+            if (status === "ended") detach();
+          }
+          return;
+        }
+
+        case "permission-request": {
+          const text = permissionText(event.payload);
+          if (text) await say(text);
+          return;
+        }
+
+        case "error": {
+          const message = isRecord(event.payload) ? event.payload.message : undefined;
+          await say(`This agent reported an error: ${String(message ?? "unknown")}`);
+          return;
+        }
+
+        default:
+          // user-prompt and permission-answer are echoes of what already
+          // happened in the room, or of a console action. Repeating them would
+          // make the agent quote the person it is talking to.
+          return;
+      }
+    })();
+  });
+
+  attached.set(sessionId, state);
+}
+
+/** Stop streaming a session into its room. Idempotent. */
+export function detachRoom(sessionId: string): void {
+  const state = attached.get(sessionId);
+  if (!state) return;
+  state.ended = true;
+  if (state.timer) clearTimeout(state.timer);
+  state.unsubscribe();
+  attached.delete(sessionId);
+}

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -1,0 +1,164 @@
+/**
+ * Giving every station a Matrix identity and somewhere to be talked to.
+ *
+ * Runs when a station is adopted and again at boot, so it has to be idempotent
+ * in the way that matters: not "does not crash on a second run", but "a second
+ * run changes nothing an operator would notice".
+ *
+ * What it will not do is register over a station that answers for itself. A
+ * `harness`-mode station has its own account and its own client; minting a
+ * second identity for it would produce two answerers on one address, which is
+ * the failure the mode exists to prevent.
+ */
+
+import { eq, and } from "drizzle-orm";
+import { db } from "../../db/drizzle";
+import { stations } from "../../db/schema/stations";
+import { nodes } from "../../db/schema/nodes";
+import { matrixRooms } from "../../db/schema/matrix";
+import { principalIdentities } from "../../db/schema/identities";
+import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("matrix-provision");
+
+export interface ProvisionDeps {
+  domain: string;
+  client: {
+    ensureUser(localpart: string, displayName: string): Promise<void>;
+    ensureRoom(
+      alias: string,
+      opts: { creator: string; name: string; topic: string }
+    ): Promise<string | null>;
+    invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  };
+}
+
+/** The station, its node's name, and whether a room already exists for it. */
+async function context(stationId: string) {
+  const [row] = await db
+    .select({
+      stationId: stations.id,
+      tenantId: stations.tenantId,
+      userId: stations.userId,
+      stationKey: stations.stationKey,
+      harness: stations.harness,
+      displayName: stations.displayName,
+      identityMode: stations.matrixIdentityMode,
+      harnessMxid: stations.matrixId,
+      nodeName: nodes.name,
+      roomId: matrixRooms.roomId,
+    })
+    .from(stations)
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .leftJoin(matrixRooms, eq(matrixRooms.stationId, stations.id))
+    .where(eq(stations.id, stationId));
+  return row ?? null;
+}
+
+/** The owner's Matrix id, so the room is not a locked door. */
+async function ownerMxid(principalId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(principalIdentities)
+    .where(
+      and(
+        eq(principalIdentities.principalId, principalId),
+        eq(principalIdentities.system, "matrix")
+      )
+    );
+  return row?.externalId ?? null;
+}
+
+export async function provisionStation(stationId: string, deps: ProvisionDeps): Promise<void> {
+  const s = await context(stationId);
+  if (!s) return;
+
+  const bridged = s.identityMode === "bridge";
+
+  // Whoever answers in this room is who creates it. For a bridge-mode station
+  // that is the identity we mint; for a harness-mode one it is the account the
+  // harness already holds, and if it has none there is nobody to create the
+  // room as — inventing one would be the bridge answering for a station that is
+  // supposed to answer for itself.
+  const speaker = bridged
+    ? bridgeUserId(s.nodeName, s.stationKey, deps.domain)
+    : s.harnessMxid;
+  if (!speaker) {
+    log.warn("station answers for itself but has no Matrix identity; nothing to provision", {
+      stationId,
+      stationKey: s.stationKey,
+    });
+    return;
+  }
+
+  // A name a person can read. The mxid is derived and unlovely; this is what a
+  // member list shows, and it is set on every run so a rename lands.
+  const displayName = `${s.displayName} (${s.harness} @ ${s.nodeName})`;
+
+  if (bridged) {
+    await deps.client.ensureUser(bridgeLocalpart(s.nodeName, s.stationKey), displayName);
+  }
+
+  // The room is created once. A second one for the same station would split its
+  // conversation in two, with each half unaware of the other.
+  if (!s.roomId) {
+    const alias = bridgeAlias(s.nodeName, s.stationKey, deps.domain);
+    const roomId = await deps.client.ensureRoom(alias, {
+      creator: speaker,
+      name: s.displayName,
+      topic: `${s.harness} on ${s.nodeName} — ${s.stationKey}`,
+    });
+
+    if (roomId) {
+      await db
+        .insert(matrixRooms)
+        .values({ roomId, tenantId: s.tenantId, stationId: s.stationId, alias })
+        .onConflictDoNothing();
+
+      const invitee = await ownerMxid(s.userId);
+      // Only on creation: re-inviting somebody into a room they are already in
+      // is an error on some homeservers and noise on all of them.
+      if (invitee) await deps.client.invite(speaker, roomId, invitee);
+    }
+  }
+
+  if (bridged) {
+    await db
+      .update(stations)
+      .set({ bridgeMatrixId: speaker })
+      .where(eq(stations.id, s.stationId));
+  }
+}
+
+/**
+ * Provision everything that has not been.
+ *
+ * Runs at boot. One station's failure must not leave the other 31 without
+ * rooms, and the count of failures is returned rather than swallowed so
+ * "provisioned 31 of 32" is something an operator can see.
+ */
+export async function provisionAll(
+  deps: ProvisionDeps
+): Promise<{ provisioned: number; failed: number }> {
+  const rows = await db.select({ id: stations.id }).from(stations);
+
+  let provisioned = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    try {
+      await provisionStation(row.id, deps);
+      provisioned++;
+    } catch (err) {
+      failed++;
+      log.error("could not provision a station's Matrix identity", {
+        stationId: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("matrix provisioning complete", { provisioned, failed });
+  return { provisioned, failed };
+}

--- a/apps/hub/src/services/matrix-as/stations.ts
+++ b/apps/hub/src/services/matrix-as/stations.ts
@@ -1,0 +1,75 @@
+/**
+ * From a Matrix name back to a station.
+ *
+ * The names are derived (`names.ts`), but the derivation is not reversible by
+ * string surgery: cleaning lowercases and replaces characters, so
+ * `@agent_box__hermes_a` could have come from station key `hermes:a` or
+ * `hermes/a` or `hermes a`. Rather than guess, this derives the name for each of
+ * the node's stations and compares — the same direction the bridge writes in, so
+ * a name can never resolve to a station that would not produce it.
+ *
+ * The fleet is 32 stations. When it is 32,000 this becomes a stored column with
+ * a unique index; it does not become a cleverer parser.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../../db/drizzle";
+import { stations } from "../../db/schema/stations";
+import { nodes } from "../../db/schema/nodes";
+import { localpartFor } from "./names";
+
+export interface BridgedStation {
+  stationId: string;
+  nodeId: string;
+  nodeName: string;
+  stationKey: string;
+  harness: string;
+  displayName: string;
+  identityMode: string;
+}
+
+/** Every adopted station, with the node name its Matrix identity is built from. */
+async function allBridgeable(): Promise<BridgedStation[]> {
+  const rows = await db
+    .select({
+      stationId: stations.id,
+      nodeId: stations.nodeId,
+      nodeName: nodes.name,
+      stationKey: stations.stationKey,
+      harness: stations.harness,
+      displayName: stations.displayName,
+      identityMode: stations.matrixIdentityMode,
+    })
+    .from(stations)
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId));
+  return rows;
+}
+
+/**
+ * The station whose derived localpart is exactly this one, or null.
+ *
+ * Null is the answer the homeserver needs for "there is nobody here" — claiming
+ * every name in our namespace would let anyone conjure an agent by typing one.
+ */
+export async function stationForLocalpart(localpart: string): Promise<BridgedStation | null> {
+  for (const s of await allBridgeable()) {
+    if (localpartFor(s.nodeName, s.stationKey) === localpart) return s;
+  }
+  return null;
+}
+
+/** `@agent_<localpart>:<domain>` → the localpart, or null if it is not one of ours. */
+export function localpartFromUserId(mxid: string, domain: string): string | null {
+  const prefix = "@agent_";
+  const suffix = `:${domain}`;
+  if (!mxid.startsWith(prefix) || !mxid.endsWith(suffix)) return null;
+  return mxid.slice(prefix.length, mxid.length - suffix.length) || null;
+}
+
+/** `#agentpod_<localpart>:<domain>` → the localpart, or null. */
+export function localpartFromAlias(alias: string, domain: string): string | null {
+  const prefix = "#agentpod_";
+  const suffix = `:${domain}`;
+  if (!alias.startsWith(prefix) || !alias.endsWith(suffix)) return null;
+  return alias.slice(prefix.length, alias.length - suffix.length) || null;
+}

--- a/apps/hub/src/services/station-registry.ts
+++ b/apps/hub/src/services/station-registry.ts
@@ -8,7 +8,7 @@
  * user's data by providing a different nodeId or stationId.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -1,0 +1,251 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { setGrant, deleteGrant } from "../../src/services/grants";
+import { handleRoomMessage } from "../../src/services/matrix-as/inbound";
+
+/**
+ * Where a Matrix message becomes work.
+ *
+ * This is what the identity work was for: an inbound message is an
+ * authorization question the suite can already answer — `resolveMatrixId` gives
+ * a principal, the control pair says whether that principal may dispatch this
+ * agent.
+ *
+ * A room is not a console session. It is a shared space that several people can
+ * type into, so the grant is checked **per message**, not once when the session
+ * was created. Otherwise the first permitted person to speak would open a
+ * session everyone else could then drive.
+ */
+
+const OWNER = "test-user-mx-inbound";
+const OTHER = "test-user-mx-inbound-other";
+const NODE = "node_mx_inbound";
+const STATION = "station_mx_inbound";
+const ROOM = "!inbound:id.agentpod.dev";
+const DOMAIN = "id.agentpod.dev";
+const OWNER_MXID = "@owner-inbound:id.agentpod.dev";
+const OTHER_MXID = "@other-inbound:id.agentpod.dev";
+
+let sent: Array<{ roomId: string; body: string }> = [];
+let created: Array<{ stationId: string; userId: string }> = [];
+let prompts: Array<{ sessionId: string; text: string; userId: string }> = [];
+let sessionCounter = 0;
+let createFails: Error | null = null;
+
+function deps() {
+  return {
+    domain: DOMAIN,
+    client: {
+      sendText: async (_userId: string, roomId: string, body: string) => {
+        sent.push({ roomId, body });
+        return "$evt";
+      },
+    },
+    acp: {
+      createSession: async (input: { stationId: string; userId: string }) => {
+        if (createFails) throw createFails;
+        created.push(input);
+        return { id: `acps_${++sessionCounter}` };
+      },
+      promptSession: async (userId: string, sessionId: string, text: string) => {
+        prompts.push({ userId, sessionId, text });
+      },
+    },
+  };
+}
+
+function message(sender: string, body: string, roomId = ROOM) {
+  return {
+    type: "m.room.message",
+    sender,
+    room_id: roomId,
+    event_id: `$${Math.random().toString(36).slice(2)}`,
+    content: { msgtype: "m.text", body },
+  };
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: OWNER, email: "mx-inbound@example.com", name: "Owner" });
+  await createTestUser({ id: OTHER, email: "mx-inbound-other@example.com", name: "Other" });
+  const tenant = await resolveTenantForUser(OWNER);
+
+  await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
+  await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${OWNER}, 'inbound-box', 'inbound-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
+            '["acp"]'::jsonb, now(), now())`;
+
+  // Both principals are known to this hub by their Matrix ids.
+  for (const [p, mxid] of [[OWNER, OWNER_MXID], [OTHER, OTHER_MXID]] as const) {
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${p}`;
+    await rawSql`
+      INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
+      VALUES (${`pid_${p}`}, ${p}, 'matrix', ${mxid}, now())`;
+  }
+
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+beforeEach(async () => {
+  sent = [];
+  created = [];
+  prompts = [];
+  createFails = null;
+  await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
+  await rawSql`
+    INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
+    VALUES (${ROOM}, (SELECT tenant_id FROM stations WHERE id = ${STATION}), ${STATION},
+            '#agentpod_inbound-box__openclaw_krishna:id.agentpod.dev', now())`;
+  await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id IN (${OWNER}, ${OTHER})`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${OWNER}, ${OTHER})`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${OWNER}, ${OTHER})`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("an inbound room message", () => {
+  test("prompts the station when the sender's grant covers it", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
+
+    expect(created).toHaveLength(1);
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]!.text).toBe("status?");
+  });
+
+  test("refuses IN THE ROOM when the grant does not cover this station", async () => {
+    // Silence would read as a broken agent and send the operator to the console,
+    // the node and the harness — everywhere except the grant.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
+
+    expect(prompts).toHaveLength(0);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toMatch(/not permitted|may not|permission/i);
+  });
+
+  test("checks every message, not only the one that opened the session", async () => {
+    // A room is shared. Without a per-message check, the first permitted person
+    // to speak would open a session that everyone else in the room could drive.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await handleRoomMessage(message(OWNER_MXID, "first"), deps());
+    expect(prompts).toHaveLength(1);
+
+    await deleteGrant(OTHER);
+    await handleRoomMessage(message(OTHER_MXID, "and me"), deps());
+
+    expect(prompts).toHaveLength(1);
+    expect(sent.at(-1)!.body).toMatch(/not permitted|may not|permission/i);
+  });
+
+  test("refuses a sender this hub cannot identify", async () => {
+    await handleRoomMessage(message("@stranger:id.agentpod.dev", "hello"), deps());
+
+    expect(prompts).toHaveLength(0);
+    expect(sent[0]!.body).toMatch(/do not recognise|not linked|unknown/i);
+  });
+
+  test("reuses the room's session instead of starting one per message", async () => {
+    // A conversation is a conversation. One session per message would throw away
+    // the agent's context between two consecutive sentences.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "first"), deps());
+    await handleRoomMessage(message(OWNER_MXID, "second"), deps());
+
+    expect(created).toHaveLength(1);
+    expect(prompts.map((p) => p.text)).toEqual(["first", "second"]);
+  });
+
+  test("says so when the station cannot be reached, rather than swallowing it", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    createFails = new Error("node offline");
+
+    await handleRoomMessage(message(OWNER_MXID, "hi"), deps());
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toMatch(/offline|could not/i);
+  });
+
+  test("ignores a message in a room that maps to no station", async () => {
+    // Someone can invite the bridge bot anywhere. A room we do not own is not
+    // ours to answer in.
+    await handleRoomMessage(message(OWNER_MXID, "hi", "!elsewhere:id.agentpod.dev"), deps());
+
+    expect(prompts).toHaveLength(0);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("stays out of a harness-mode station's room entirely", async () => {
+    // That station answers for itself. Two answerers on one address is the
+    // failure the mode exists to prevent.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
+
+    await handleRoomMessage(message(OWNER_MXID, "hi"), deps());
+
+    expect(prompts).toHaveLength(0);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("ignores anything that is not a text message", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(
+      { type: "m.room.member", sender: OWNER_MXID, room_id: ROOM, content: { membership: "join" } },
+      deps()
+    );
+
+    expect(prompts).toHaveLength(0);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("ignores an empty message rather than prompting with nothing", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "   "), deps());
+
+    expect(prompts).toHaveLength(0);
+  });
+
+  test("passes the message through unchanged, including its exact text", async () => {
+    // The prompt is the user's words. Trimming, prefixing or decorating them
+    // would put the bridge's voice into the agent's input.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "deploy  the thing\nnow"), deps());
+
+    expect(prompts[0]!.text).toBe("deploy  the thing\nnow");
+  });
+
+  test("prompts as the principal who sent it, not as the station's owner", async () => {
+    // The ACP session belongs to whoever is talking, so the transcript and the
+    // control pair both attribute the turn correctly.
+    await setGrant(OTHER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OTHER_MXID, "hello"), deps());
+
+    expect(created[0]!.userId).toBe(OTHER);
+  });
+});

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { provisionStation, provisionAll } from "../../src/services/matrix-as/provision";
+
+/**
+ * Giving every station a Matrix identity and somewhere to be talked to.
+ *
+ * Runs on adoption and again at boot, so it has to be idempotent in the way that
+ * matters: not "does not crash on a second run", but "a second run changes
+ * nothing an operator would notice".
+ */
+
+const OWNER = "test-user-mx-provision";
+const NODE = "node_mx_provision";
+const OPENCLAW = "station_mx_provision_openclaw";
+const HERMES = "station_mx_provision_hermes";
+const DOMAIN = "id.agentpod.dev";
+const OWNER_MXID = "@owner-provision:id.agentpod.dev";
+
+let registered: Array<{ localpart: string; displayName: string }> = [];
+let rooms: Array<{ alias: string; creator: string; name: string; topic: string }> = [];
+let invites: Array<{ roomId: string; invitee: string }> = [];
+let roomCounter = 0;
+
+function deps() {
+  return {
+    domain: DOMAIN,
+    client: {
+      ensureUser: async (localpart: string, displayName: string) => {
+        registered.push({ localpart, displayName });
+      },
+      ensureRoom: async (
+        alias: string,
+        opts: { creator: string; name: string; topic: string }
+      ) => {
+        rooms.push({ alias, ...opts });
+        return `!room${++roomCounter}:id.agentpod.dev`;
+      },
+      invite: async (_asUserId: string, roomId: string, invitee: string) => {
+        invites.push({ roomId, invitee });
+      },
+    },
+  };
+}
+
+async function roomRow(stationId: string) {
+  const [row] = await rawSql`
+    SELECT room_id, tenant_id, alias FROM matrix_rooms WHERE station_id = ${stationId}`;
+  return row ?? null;
+}
+
+async function stationRow(id: string) {
+  const [row] = await rawSql`
+    SELECT matrix_id, bridge_matrix_id, matrix_identity_mode FROM stations WHERE id = ${id}`;
+  return row!;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: OWNER, email: "mx-provision@example.com", name: "Owner" });
+  const tenant = await resolveTenantForUser(OWNER);
+
+  await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
+  await rawSql`DELETE FROM stations WHERE id IN (${OPENCLAW}, ${HERMES})`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${OWNER}, 'prov-box', 'prov-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${OPENCLAW}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
+            '["acp"]'::jsonb, now(), now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${HERMES}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:analyst-echo', 'leaf', 'analyst-echo',
+            '["acp"]'::jsonb, now(), now())`;
+
+  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+  await rawSql`
+    INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
+    VALUES ('pid_mx_provision', ${OWNER}, 'matrix', ${OWNER_MXID}, now())`;
+});
+
+beforeEach(async () => {
+  registered = [];
+  rooms = [];
+  invites = [];
+  await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
+  await rawSql`
+    UPDATE stations SET bridge_matrix_id = NULL, matrix_identity_mode = 'bridge', matrix_id = NULL
+    WHERE id IN (${OPENCLAW}, ${HERMES})`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM stations WHERE id IN (${OPENCLAW}, ${HERMES})`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("provisioning a station", () => {
+  test("gives it a user, a room, and a name a person can read", async () => {
+    await provisionStation(OPENCLAW, deps());
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0]!.localpart).toBe("agent_prov-box__openclaw_krishna");
+    // The display name carries the readability a derived mxid does not have.
+    expect(registered[0]!.displayName).toBe("krishna (openclaw @ prov-box)");
+    expect(rooms[0]!.alias).toBe("#agentpod_prov-box__openclaw_krishna:id.agentpod.dev");
+  });
+
+  test("records the room, with the tenant it belongs to", async () => {
+    await provisionStation(OPENCLAW, deps());
+
+    const row = await roomRow(OPENCLAW);
+    expect(row!.room_id).toMatch(/^!room/);
+    expect(row!.tenant_id).toBeTruthy();
+    expect(row!.alias).toBe("#agentpod_prov-box__openclaw_krishna:id.agentpod.dev");
+  });
+
+  test("records the identity it minted, without touching the harness column", async () => {
+    await provisionStation(OPENCLAW, deps());
+
+    const row = await stationRow(OPENCLAW);
+    expect(row.bridge_matrix_id).toBe("@agent_prov-box__openclaw_krishna:id.agentpod.dev");
+    expect(row.matrix_id).toBeNull();
+    expect(row.matrix_identity_mode).toBe("bridge");
+  });
+
+  test("invites the station's owner, so the room is not a locked door", async () => {
+    await provisionStation(OPENCLAW, deps());
+
+    expect(invites).toHaveLength(1);
+    expect(invites[0]!.invitee).toBe(OWNER_MXID);
+  });
+
+  test("provisions a hermes station exactly like every other", async () => {
+    // No exception list. The name is derived the same way, and the display name
+    // carries the readability its old bespoke address used to.
+    await provisionStation(HERMES, deps());
+
+    expect(registered[0]!.localpart).toBe("agent_prov-box__hermes_analyst-echo");
+    expect(registered[0]!.displayName).toBe("analyst-echo (hermes @ prov-box)");
+  });
+
+  test("a second run changes nothing", async () => {
+    // Idempotent in the way that matters: not "does not crash", but "an
+    // operator would not notice it ran twice".
+    await provisionStation(OPENCLAW, deps());
+    const first = await roomRow(OPENCLAW);
+
+    registered = [];
+    rooms = [];
+    invites = [];
+    await provisionStation(OPENCLAW, deps());
+
+    const second = await roomRow(OPENCLAW);
+    expect(second!.room_id).toBe(first!.room_id);
+    // The room is not created again, and nobody is re-invited into a room they
+    // are already in.
+    expect(rooms).toHaveLength(0);
+    expect(invites).toHaveLength(0);
+  });
+
+  test("still ensures the user on a second run, so a rename lands", async () => {
+    // ensureUser is where the display name is set, and a station renamed after
+    // its first provision must stop introducing itself by the old name.
+    await provisionStation(OPENCLAW, deps());
+    registered = [];
+
+    await provisionStation(OPENCLAW, deps());
+
+    expect(registered).toHaveLength(1);
+  });
+
+  test("leaves a harness-mode station's identity alone", async () => {
+    // That station answers for itself: it has its own account and its own
+    // client, and registering over it would produce two answerers.
+    await rawSql`
+      UPDATE stations SET matrix_identity_mode = 'harness', matrix_id = '@analyst-echo:id.agentpod.dev'
+      WHERE id = ${HERMES}`;
+
+    await provisionStation(HERMES, deps());
+
+    expect(registered).toHaveLength(0);
+    // The room is still made, because a harness client needs somewhere to talk,
+    // and it is created BY the identity that answers there.
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]!.creator).toBe("@analyst-echo:id.agentpod.dev");
+  });
+
+  test("skips a harness-mode station that has no identity at all", async () => {
+    // Nothing to create the room as, and inventing one would be the bridge
+    // answering for a station that is supposed to answer for itself.
+    await rawSql`
+      UPDATE stations SET matrix_identity_mode = 'harness', matrix_id = NULL WHERE id = ${HERMES}`;
+
+    await provisionStation(HERMES, deps());
+
+    expect(rooms).toHaveLength(0);
+    expect(await roomRow(HERMES)).toBeNull();
+  });
+});
+
+describe("provisioning the whole fleet", () => {
+  test("covers every adopted station", async () => {
+    const result = await provisionAll(deps());
+
+    expect(result.provisioned).toBeGreaterThanOrEqual(2);
+    expect(await roomRow(OPENCLAW)).toBeTruthy();
+    expect(await roomRow(HERMES)).toBeTruthy();
+  });
+
+  test("one station's failure does not stop the rest", async () => {
+    // Boot runs this. A single station whose homeserver call fails must not
+    // leave the other 31 without rooms — and the failure must be counted, not
+    // swallowed, so "provisioned 31 of 32" is visible.
+    let calls = 0;
+    const d = deps();
+    const failing = {
+      ...d,
+      client: {
+        ...d.client,
+        ensureUser: async (localpart: string, displayName: string) => {
+          if (++calls === 1) throw new Error("homeserver said no");
+          registered.push({ localpart, displayName });
+        },
+      },
+    };
+
+    const result = await provisionAll(failing);
+
+    expect(result.failed).toBeGreaterThanOrEqual(1);
+    expect(result.provisioned).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/hub/tests/integration/matrix-as-queries.test.ts
+++ b/apps/hub/tests/integration/matrix-as-queries.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { createMatrixAsRoutes } from "../../src/routes/matrix-as";
+import { bridgeUserId, bridgeAlias } from "../../src/services/matrix-as/names";
+
+/**
+ * What the homeserver asks before it will let anyone talk to one of our users
+ * or join one of our rooms.
+ *
+ * Answering 200 is what makes the thing exist. So the question this route is
+ * really answering is "is there a station behind this name" — and a bridge that
+ * claimed every conceivable name would let anyone conjure an agent by typing a
+ * room address.
+ */
+
+const USER = "test-user-matrix-queries";
+const NODE = "node_matrix_queries";
+const STATION = "station_matrix_queries";
+const DOMAIN = "id.agentpod.dev";
+const HS_TOKEN = "test-hs-token-queries";
+
+/** Rooms the bridge was asked to create, so provisioning can be asserted. */
+let provisioned: string[] = [];
+
+function app() {
+  return new Hono().route(
+    "/_matrix/app/v1",
+    createMatrixAsRoutes({
+      hsToken: HS_TOKEN,
+      domain: DOMAIN,
+      onEvent: async () => {},
+      onProvisionAlias: async (alias: string) => {
+        provisioned.push(alias);
+      },
+    })
+  );
+}
+
+function get(path: string, token = HS_TOKEN) {
+  return app().request(`/_matrix/app/v1${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "matrix-queries@example.com", name: "MQ" });
+  const tenant = await resolveTenantForUser(USER);
+  await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${USER}, 'query-box', 'query-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
+            '["acp"]'::jsonb, now(), now())`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+const REAL_USER = bridgeUserId("query-box", "openclaw:krishna", DOMAIN);
+const REAL_ALIAS = bridgeAlias("query-box", "openclaw:krishna", DOMAIN);
+
+describe("GET /_matrix/app/v1/users/:userId", () => {
+  test("claims a user that maps to an adopted station", async () => {
+    const res = await get(`/users/${encodeURIComponent(REAL_USER)}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  test("disclaims a name in our namespace with no station behind it", async () => {
+    // 404, not 200. Claiming everything would let anyone summon an agent that
+    // does not exist by typing a name, and the room would then look real.
+    const res = await get("/users/%40agent_nowhere__nothing%3Aid.agentpod.dev");
+    expect(res.status).toBe(404);
+    expect((await res.json()).errcode).toBe("M_NOT_FOUND");
+  });
+
+  test("disclaims a user outside our namespace entirely", async () => {
+    const res = await get("/users/%40rakesh%3Aid.agentpod.dev");
+    expect(res.status).toBe(404);
+  });
+
+  test("needs the homeserver's token like everything else here", async () => {
+    const res = await get(`/users/${encodeURIComponent(REAL_USER)}`, "wrong");
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /_matrix/app/v1/rooms/:alias", () => {
+  test("claims an alias that maps to a station, and provisions the room", async () => {
+    // The homeserver asks because someone tried to resolve the alias. Answering
+    // 200 without creating the room would send them to a room that is not there.
+    provisioned = [];
+
+    const res = await get(`/rooms/${encodeURIComponent(REAL_ALIAS)}`);
+
+    expect(res.status).toBe(200);
+    expect(provisioned).toEqual([REAL_ALIAS]);
+  });
+
+  test("disclaims an alias with no station behind it, and provisions nothing", async () => {
+    provisioned = [];
+
+    const res = await get("/rooms/%23agentpod_nowhere__nothing%3Aid.agentpod.dev");
+
+    expect(res.status).toBe(404);
+    expect(provisioned).toEqual([]);
+  });
+
+  test("a station on a different node is a different room", async () => {
+    // The node is in the name because station keys repeat. An alias naming
+    // another node must not resolve to this station.
+    const otherNode = bridgeAlias("some-other-box", "openclaw:krishna", DOMAIN);
+    const res = await get(`/rooms/${encodeURIComponent(otherNode)}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /_matrix/app/v1/ping", () => {
+  test("answers, so the homeserver can prove it can reach us", async () => {
+    const res = await get("/ping");
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hub/tests/integration/matrix-as-transactions.test.ts
+++ b/apps/hub/tests/integration/matrix-as-transactions.test.ts
@@ -1,0 +1,205 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { rawSql } from "../../src/db/drizzle";
+import { createMatrixAsRoutes } from "../../src/routes/matrix-as";
+
+/**
+ * The bridge's front door, and the three ways it goes wrong quietly.
+ *
+ * A homeserver pushes events here with no session and no user — only the
+ * `hs_token` it was configured with. Everything that follows in the bridge
+ * trusts what arrives, so this is the boundary that has to hold.
+ */
+
+const HS_TOKEN = "test-hs-token-transactions";
+const AS_TOKEN = "test-as-token-transactions";
+const DOMAIN = "id.agentpod.dev";
+
+/** Events the route accepted and passed on, in order. */
+let handled: Array<{ type: string; sender: string }> = [];
+
+function app(opts: { onEvent?: (e: any) => Promise<void> } = {}) {
+  return new Hono().route(
+    "/_matrix/app/v1",
+    createMatrixAsRoutes({
+      hsToken: HS_TOKEN,
+      domain: DOMAIN,
+      onEvent:
+        opts.onEvent ??
+        (async (e: any) => {
+          handled.push({ type: e.type, sender: e.sender });
+        }),
+    })
+  );
+}
+
+function message(sender: string, body: string, roomId = "!r:id.agentpod.dev") {
+  return {
+    type: "m.room.message",
+    sender,
+    room_id: roomId,
+    event_id: `$${Math.random().toString(36).slice(2)}`,
+    origin_server_ts: 1,
+    content: { msgtype: "m.text", body },
+  };
+}
+
+function deliver(txnId: string, events: unknown[], token = HS_TOKEN) {
+  return app().request(`/_matrix/app/v1/transactions/${txnId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ events }),
+  });
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
+
+beforeEach(async () => {
+  handled = [];
+  await rawSql`DELETE FROM matrix_as_transactions WHERE txn_id LIKE 'test-txn-%'`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM matrix_as_transactions WHERE txn_id LIKE 'test-txn-%'`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("PUT /_matrix/app/v1/transactions/:txnId", () => {
+  test("refuses a transaction with no token at all", async () => {
+    const res = await app().request("/_matrix/app/v1/transactions/test-txn-noauth", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events: [message("@rakesh:id.agentpod.dev", "hi")] }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(handled).toHaveLength(0);
+  });
+
+  test("refuses the AS token, which points the other way", async () => {
+    // as_token authenticates the bridge TO the homeserver; hs_token
+    // authenticates the homeserver to the bridge. Swapping them is the mistake
+    // a tired person makes at 1am, and accepting either would mean anything
+    // holding the bridge's own credential could inject events.
+    const res = await deliver("test-txn-wrongtoken", [message("@rakesh:id.agentpod.dev", "hi")], AS_TOKEN);
+
+    expect(res.status).toBe(403);
+    expect(handled).toHaveLength(0);
+  });
+
+  test("applies a transaction once, however many times it arrives", async () => {
+    // The homeserver retries a transaction it did not see acknowledged. A
+    // bridge that prompted twice for one message would double every
+    // conversation, and the second answer would look like the agent talking to
+    // itself.
+    await deliver("test-txn-dup", [message("@rakesh:id.agentpod.dev", "hello")]);
+    await deliver("test-txn-dup", [message("@rakesh:id.agentpod.dev", "hello")]);
+
+    expect(handled).toHaveLength(1);
+  });
+
+  test("remembers what it applied across a restart", async () => {
+    // Idempotency held in memory forgets exactly when the bridge is least
+    // healthy — a crash mid-transaction is precisely when the homeserver
+    // retries.
+    await deliver("test-txn-durable", [message("@rakesh:id.agentpod.dev", "hello")]);
+
+    const [row] = await rawSql`
+      SELECT txn_id FROM matrix_as_transactions WHERE txn_id = 'test-txn-durable'`;
+    expect(row).toBeTruthy();
+  });
+
+  test("drops events sent by our own users before anything else looks at them", async () => {
+    // An Application Service is sent what its own users send. Answering those
+    // is the loop that fills a database overnight.
+    await deliver("test-txn-loop", [message("@agent_box__pi_x:id.agentpod.dev", "output")]);
+
+    expect(handled).toHaveLength(0);
+  });
+
+  test("drops the appservice's own bot as well", async () => {
+    await deliver("test-txn-loop2", [message("@ai-bridge:id.agentpod.dev", "housekeeping")]);
+    expect(handled).toHaveLength(0);
+  });
+
+  test("still handles a human's events in a transaction that also contains ours", async () => {
+    // The loop cut is per event, not per transaction — otherwise one echo would
+    // silence a real message that arrived beside it.
+    await deliver("test-txn-mixed", [
+      message("@agent_box__pi_x:id.agentpod.dev", "echo"),
+      message("@rakesh:id.agentpod.dev", "status?"),
+    ]);
+
+    expect(handled).toHaveLength(1);
+    expect(handled[0]!.sender).toBe("@rakesh:id.agentpod.dev");
+  });
+
+  test("answers 200 with an empty object, which is what the homeserver expects", async () => {
+    const res = await deliver("test-txn-empty", []);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  test("one poisoned event does not strand the rest behind it", async () => {
+    // The homeserver retries the WHOLE transaction, so an event that always
+    // throws would block every event after it, forever, on every retry.
+    const seen: string[] = [];
+    const a = app({
+      onEvent: async (e: any) => {
+        if (e.content?.body === "poison") throw new Error("handler exploded");
+        seen.push(e.content?.body);
+      },
+    });
+
+    const res = await a.request("/_matrix/app/v1/transactions/test-txn-poison", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${HS_TOKEN}` },
+      body: JSON.stringify({
+        events: [message("@rakesh:id.agentpod.dev", "poison"), message("@rakesh:id.agentpod.dev", "second")],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(seen).toEqual(["second"]);
+  });
+
+  test("ephemeral events are accepted and do not count as messages", async () => {
+    // receive_ephemeral is on, so typing and receipts arrive in the same
+    // transaction shape. They must not reach the message handler.
+    const res = await app().request("/_matrix/app/v1/transactions/test-txn-eph", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${HS_TOKEN}` },
+      body: JSON.stringify({
+        events: [],
+        ephemeral: [{ type: "m.typing", room_id: "!r:id.agentpod.dev", content: { user_ids: [] } }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(handled).toHaveLength(0);
+  });
+
+  test("a bridge with no token configured refuses everything", async () => {
+    // Fail closed: an unconfigured bridge that accepted anonymous pushes would
+    // be an open injection point on a public path.
+    const unconfigured = new Hono().route(
+      "/_matrix/app/v1",
+      createMatrixAsRoutes({ hsToken: "", domain: DOMAIN, onEvent: async () => {} })
+    );
+
+    const res = await unconfigured.request("/_matrix/app/v1/transactions/test-txn-unconf", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer " },
+      body: JSON.stringify({ events: [] }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/hub/tests/integration/matrix-identity-mode.test.ts
+++ b/apps/hub/tests/integration/matrix-identity-mode.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { refreshAdoptedCapabilities } from "../../src/services/station-registry";
+
+/**
+ * Two facts about one station, and who answers.
+ *
+ * `matrix_id` is what the HARNESS reports — the node agent reads it off the host
+ * and owns it outright. `bridge_matrix_id` is what the Application Service
+ * MINTED for a station whose harness knows nothing about Matrix.
+ *
+ * An earlier draft kept both in `matrix_id` and guarded the column against its
+ * own writer. That broke a fix this repo already paid for: a station adopted
+ * before its profile was readable could no longer gain an identity later. Two
+ * facts, two columns; `matrix_identity_mode` says which one answers, and never
+ * both — two answerers on one address is the failure being prevented.
+ */
+
+const USER = "test-user-matrix-mode";
+const NODE = "node_matrix_mode";
+const BRIDGED = "station_matrix_mode_bridged";
+const HARNESS = "station_matrix_mode_harness";
+
+async function stationRow(id: string) {
+  const [row] = await rawSql`
+    SELECT matrix_id, bridge_matrix_id, matrix_identity_mode FROM stations WHERE id = ${id}`;
+  return row!;
+}
+
+/**
+ * Drive the refresh with what the node agent would have reported, through the
+ * broker injection point the function already exposes — no live node needed.
+ */
+async function nodeReports(reported: Array<{ key: string; matrixId: string | null }>) {
+  return refreshAdoptedCapabilities(NODE, {
+    brokerRequest: async () => ({
+      ok: true,
+      data: reported.map((s) => ({
+        key: s.key,
+        harness: "hermes",
+        kind: "leaf" as const,
+        displayName: s.key,
+        parentKey: null,
+        workspacePath: null,
+        capabilities: ["acp"],
+        matrixId: s.matrixId,
+      })),
+    }),
+  });
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "matrix-mode@example.com", name: "MM" });
+  const tenant = await resolveTenantForUser(USER);
+  await rawSql`DELETE FROM stations WHERE id IN (${BRIDGED}, ${HARNESS})`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${USER}, 'mode-box', 'mode-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  for (const [id, key] of [[BRIDGED, "hermes:bridged"], [HARNESS, "hermes:harness"]] as const) {
+    await rawSql`
+      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+      VALUES (${id}, ${tenant}, ${USER}, ${NODE}, 'hermes', ${key}, 'leaf', ${key}, '["acp"]'::jsonb, now(), now())`;
+  }
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE id IN (${BRIDGED}, ${HARNESS})`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("matrix_identity_mode", () => {
+  test("defaults to bridge, which is the mode with no credential anywhere", () => {
+    // A station only becomes `harness` when somebody deliberately issues it
+    // credentials. Defaulting the other way would mean a new station arrives
+    // claiming to answer for itself, with nothing able to answer.
+    return stationRow(BRIDGED).then((row) => {
+      expect(row.matrix_identity_mode).toBe("bridge");
+    });
+  });
+
+  test("refuses a mode that is neither", async () => {
+    let refused: unknown = null;
+    try {
+      await rawSql`UPDATE stations SET matrix_identity_mode = 'sometimes' WHERE id = ${BRIDGED}`;
+    } catch (e) {
+      refused = e;
+    }
+    expect(refused).not.toBeNull();
+  });
+
+  test("a node-agent refresh cannot touch the identity the bridge minted", async () => {
+    // The point of the second column. The node agent reports `matrixId: null`
+    // for a station whose harness knows nothing about Matrix — and no report it
+    // can make may erase what the Application Service minted.
+    await rawSql`
+      UPDATE stations SET bridge_matrix_id = '@agent_mode-box__hermes_bridged:id.agentpod.dev',
+                          matrix_identity_mode = 'bridge'
+      WHERE id = ${BRIDGED}`;
+
+    await nodeReports([{ key: "hermes:bridged", matrixId: null }]);
+
+    const row = await stationRow(BRIDGED);
+    expect(row.bridge_matrix_id).toBe("@agent_mode-box__hermes_bridged:id.agentpod.dev");
+    expect(row.matrix_identity_mode).toBe("bridge");
+  });
+
+  test("a bridge-owned station still gets its capabilities refreshed", async () => {
+    // Nothing about the mode may narrow what the node agent refreshes.
+    // Gating the row would stop capabilities, display name and workspace path
+    // landing for every bridge-mode station — the defect that once left 32
+    // stations stale, one column over.
+    await rawSql`
+      UPDATE stations SET capabilities = '["acp"]'::jsonb, display_name = 'stale',
+                          matrix_identity_mode = 'bridge'
+      WHERE id = ${BRIDGED}`;
+
+
+    await nodeReports([{ key: "hermes:bridged", matrixId: null }]);
+
+    const [row] = await rawSql`
+      SELECT display_name, capabilities FROM stations WHERE id = ${BRIDGED}`;
+    expect(row!.display_name).toBe("hermes:bridged");
+  });
+
+  test("the harness-reported mxid is refreshed however the station answers", async () => {
+    // The node agent owns `matrix_id` outright, in either mode. What the mode
+    // decides is who answers — not who may write down what the host says.
+    await rawSql`
+      UPDATE stations SET matrix_id = '@old:id.agentpod.dev', matrix_identity_mode = 'harness'
+      WHERE id = ${HARNESS}`;
+
+    await nodeReports([{ key: "hermes:harness", matrixId: "@new:id.agentpod.dev" }]);
+
+    expect((await stationRow(HARNESS)).matrix_id).toBe("@new:id.agentpod.dev");
+  });
+
+  test("a station that loses its harness identity on the host loses it here", async () => {
+    // `?? null` rather than skip-if-absent, unchanged for harness mode: an
+    // agent whose Matrix identity was removed must lose it here too, or a room
+    // message routes to an mxid nobody answers on.
+    await rawSql`
+      UPDATE stations SET matrix_id = '@present:id.agentpod.dev', matrix_identity_mode = 'harness'
+      WHERE id = ${HARNESS}`;
+
+    await nodeReports([{ key: "hermes:harness", matrixId: null }]);
+
+    expect((await stationRow(HARNESS)).matrix_id).toBeNull();
+  });
+});

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -1,0 +1,216 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { setGrant } from "../../src/services/grants";
+import { createStationMatrixRoutes } from "../../src/routes/station-matrix";
+
+/**
+ * Registering an agent's Matrix identity, without an admin credential on a node.
+ *
+ * Today `hermes-agents onboard` holds a homeserver admin token in a file on
+ * molt-bot and can create, deactivate or take over ANY account on that
+ * homeserver — including a human's. An Application Service needs no such rights
+ * to register users inside its own namespace, so the ordinary path drops the
+ * admin credential entirely.
+ *
+ * The privileged path — issuing an agent its own access token — moves behind the
+ * hub and behind `mayGrantReach`, because handing an agent a credential is the
+ * definition of granting it reach.
+ */
+
+const OWNER = "test-user-station-matrix";
+const NODE = "node_station_matrix";
+const STATION = "station_station_matrix";
+const DOMAIN = "id.agentpod.dev";
+
+let provisioned: string[] = [];
+let issued: Array<{ localpart: string }> = [];
+let rotated: Array<{ localpart: string }> = [];
+let canRotate = true;
+let logged: string[] = [];
+
+function app() {
+  const routes = createStationMatrixRoutes({
+    domain: DOMAIN,
+    provisionStation: async (stationId: string) => {
+      provisioned.push(stationId);
+    },
+    credentials: {
+      register: async (localpart: string) => {
+        issued.push({ localpart });
+        return {
+          userId: `@${localpart}:${DOMAIN}`,
+          accessToken: "syt_secret_token_value",
+          deviceId: "DEV1",
+        };
+      },
+      rotate: canRotate
+        ? async (localpart: string) => {
+            rotated.push({ localpart });
+            return {
+              userId: `@${localpart}:${DOMAIN}`,
+              accessToken: "syt_rotated_token_value",
+              deviceId: "DEV2",
+            };
+          }
+        : undefined,
+    },
+    log: (line: string) => logged.push(line),
+  });
+
+  return new Hono()
+    .use("*", async (c, next) => {
+      c.set("user", { id: OWNER, role: "user" });
+      await next();
+    })
+    .route("/api", routes);
+}
+
+const post = (path: string) => app().request(`/api${path}`, { method: "POST" });
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: OWNER, email: "station-matrix@example.com", name: "Owner" });
+  const tenant = await resolveTenantForUser(OWNER);
+  await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+  await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${OWNER}, 'sm-box', 'sm-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:analyst-echo', 'leaf', 'analyst-echo',
+            '["acp"]'::jsonb, now(), now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+beforeEach(async () => {
+  provisioned = [];
+  issued = [];
+  rotated = [];
+  logged = [];
+  canRotate = true;
+  await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("POST /api/stations/:id/matrix/identity", () => {
+  test("provisions an identity with no admin credential involved", async () => {
+    const res = await post(`/stations/${STATION}/matrix/identity`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { mxid: string; alias: string; mode: string };
+    expect(body.mxid).toBe("@agent_sm-box__hermes_analyst-echo:id.agentpod.dev");
+    expect(body.alias).toBe("#agentpod_sm-box__hermes_analyst-echo:id.agentpod.dev");
+    expect(body.mode).toBe("bridge");
+    expect(provisioned).toEqual([STATION]);
+    // Issuing an identity is the appservice acting in its own namespace. No
+    // token is minted and nothing privileged happens.
+    expect(issued).toHaveLength(0);
+  });
+
+  test("does not need mayGrantReach, because it grants nothing", async () => {
+    await setGrant(OWNER, { mayDispatch: [], mayGrantReach: false });
+
+    expect((await post(`/stations/${STATION}/matrix/identity`)).status).toBe(200);
+  });
+
+  test("is idempotent — the same identity comes back", async () => {
+    const a = await (await post(`/stations/${STATION}/matrix/identity`)).json();
+    const b = await (await post(`/stations/${STATION}/matrix/identity`)).json();
+    expect(b).toEqual(a);
+  });
+
+  test("404s for a station that is not this principal's", async () => {
+    const res = await post("/stations/station_does_not_exist/matrix/identity");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/stations/:id/matrix/credentials", () => {
+  test("requires mayGrantReach, because a credential IS reach", async () => {
+    // Dispatch permission is not enough: handing an agent an access token is
+    // the definition of granting it reach.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const res = await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(res.status).toBe(403);
+    expect(issued).toHaveLength(0);
+  });
+
+  test("requires the station to be in scope as well", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: true });
+
+    expect((await post(`/stations/${STATION}/matrix/credentials`)).status).toBe(403);
+  });
+
+  test("mints a token and flips the station to harness mode", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+
+    const res = await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { accessToken: string; mxid: string };
+    expect(body.accessToken).toBe("syt_secret_token_value");
+
+    const [row] = await rawSql`
+      SELECT matrix_identity_mode FROM stations WHERE id = ${STATION}`;
+    expect(row!.matrix_identity_mode).toBe("harness");
+  });
+
+  test("never writes the token it just issued into a log", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+
+    await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(logged.join("\n")).not.toContain("syt_secret_token_value");
+    // …and it still says something, so the act is auditable.
+    expect(logged.join("\n")).toMatch(/credential/i);
+  });
+
+  test("rotates rather than failing when the identity already exists", async () => {
+    // The identity is provisioned long before anyone asks for credentials, so
+    // "already registered" is the normal case, not an error.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
+
+    const res = await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(res.status).toBe(200);
+    expect(rotated).toHaveLength(1);
+    expect(((await res.json()) as { accessToken: string }).accessToken).toBe(
+      "syt_rotated_token_value"
+    );
+  });
+
+  test("says plainly when rotation is impossible rather than pretending", async () => {
+    // Rotating an existing identity needs the homeserver's admin account. If it
+    // is not configured, the honest answer is that this cannot be done here —
+    // not a 500, and not a silent no-op that leaves a harness without a token.
+    canRotate = false;
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
+
+    const res = await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(res.status).toBe(409);
+    expect((await res.text()).toLowerCase()).toMatch(/admin|rotate|configur/);
+  });
+});

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -782,7 +782,49 @@ thing it protects. The Synapse-era archive was copied off manually
 (`~/agentpod-backups/matrix-backup-2026-08-16.tar.gz`); nothing does that on a
 schedule yet.
 
-### 7d. What happened to the Synapse history
+### 7d. The Matrix bridge
+
+Every station gets a Matrix identity and a room, so an agent whose harness has
+never spoken Matrix can be talked to from a phone. Design:
+`docs/superpowers/specs/2026-08-16-matrix-application-service-design.md`.
+
+| | |
+|---|---|
+| switch | `ENABLE_MATRIX_BRIDGE` — the **literal lowercase `true`**; `1`, `TRUE` and `yes` are off |
+| config | `MATRIX_HOMESERVER_URL` (default `http://127.0.0.1:6167`), `MATRIX_SERVER_NAME`, `MATRIX_AS_TOKEN`, `MATRIX_HS_TOKEN` |
+| a station's user | `@agent_<node>__<station>:id.agentpod.dev` — **two** underscores between the halves |
+| its room | `#agentpod_<node>__<station>:id.agentpod.dev` |
+
+**Finding an agent's room.** The names are derived from the node and the station
+key, so `openclaw:krishna` on `superchotu` is
+`#agentpod_superchotu__openclaw_krishna`. The member list shows the readable
+form — `krishna (openclaw @ superchotu)`.
+
+**Who may talk to an agent** is the control pair, unchanged. A refusal arrives
+**in the room**, saying which of the three things happened: the hub does not
+recognise the sender, the sender's grant does not cover that agent, or the
+station could not be reached.
+
+**Turning it off** is one field in the homeserver's registration file:
+
+```yaml
+url: null          # was http://127.0.0.1:3001
+```
+
+then `systemctl restart tuwunel`. The hub keeps running; the homeserver simply
+stops pushing. This is also the state the bridge shipped in, which is why the
+health check treats "no transaction has ever arrived" as **silent**, not healthy:
+a registration with no `url` is a perfectly healthy Application Service
+connected to nothing, and that went unnoticed for months.
+
+**Two modes, and only ever one answerer.** A station is `bridge` (the
+Application Service speaks for it — the default, and no credential exists
+anywhere) or `harness` (it runs its own Matrix client). `POST
+/api/stations/:id/matrix/credentials` issues a token and flips the mode in the
+same write; it needs `mayGrantReach`, because handing an agent a credential is
+granting it reach.
+
+### 7e. What happened to the Synapse history
 
 The old homeserver's 19,603 events are **not in tuwunel** — there is no supported
 import path from Synapse into the Conduit lineage, and Matrix here carries a

--- a/docs/superpowers/plans/2026-08-16-conversable-fleet.md
+++ b/docs/superpowers/plans/2026-08-16-conversable-fleet.md
@@ -15,7 +15,7 @@
 
 - **Homeserver:** `id.agentpod.dev` on `178.105.68.68`, private, federation disabled, nginx proxying `/_matrix` to the homeserver's port. **tuwunel serves 6167 by default, not 8008** — the vhost changes with it.
 - **Registration file:** a YAML file in tuwunel's `appservice_dir`, Synapse-shaped (the spike confirmed the existing file's namespaces load unchanged): AS id `ai-agents`, `sender_localpart: ai-bridge`, users `@agent_.*` exclusive, aliases `#agentpod_.*` exclusive, **`receive_ephemeral: true`** (tuwunel's name for what Synapse spelled `de.sorunome.msc2409.push_ephemeral`), and `url` **left unset until Task 9**.
-- **Name derivation is a pure function** of `(nodeName, stationKey)`: lowercase, every character outside `[a-z0-9._=/-]` becomes `_`. User `@agent_<node>_<station>`, alias `#agentpod_<node>_<station>`. Never stored as a second source of truth. **All 32 stations, hermes included** — there is no exception list, because a name that omits the node breaks the rule the whole scheme rests on.
+- **Name derivation is a pure function** of `(nodeName, stationKey)`: lowercase, every character outside `[a-z0-9._=/-]` becomes `_`. User `@agent_<node>__<station>`, alias `#agentpod_<node>__<station>` — **two** underscores between the halves: with one, node `a_b` + station `c` collides with node `a` + station `b_c`. Never stored as a second source of truth. **All 32 stations, hermes included** — there is no exception list, because a name that omits the node breaks the rule the whole scheme rests on.
 - **A station's identity has a mode**: `bridge` (the AS answers) or `harness` (the harness runs its own client). Exactly one answerer per address, always.
 - **`hs_token` authenticates every AS route**; a request without it is 403 and is never processed. The `as_token` is what the bridge sends *to* the homeserver. The two point in opposite directions and swapping them fails as a 403 that reads like a permissions bug.
 - **Drop every event sent by our own namespace** before any other handling.
@@ -233,17 +233,17 @@ describe("bridge names", () => {
     // agents.yaml claims `@agent_.*` exclusive. A name outside it cannot be
     // acted as, and the failure is a 403 from the homeserver at send time.
     expect(bridgeUserId("molt-bot", "hermes:analyst-echo", D)).toBe(
-      "@agent_molt-bot_hermes_analyst-echo:id.agentpod.dev"
+      "@agent_molt-bot__hermes_analyst-echo:id.agentpod.dev"
     );
     expect(bridgeAlias("molt-bot", "hermes:analyst-echo", D)).toBe(
-      "#agentpod_molt-bot_hermes_analyst-echo:id.agentpod.dev"
+      "#agentpod_molt-bot__hermes_analyst-echo:id.agentpod.dev"
     );
   });
 
   test("replace characters an mxid localpart may not contain", () => {
     // `:` is the mxid separator; a station key is full of them.
     expect(bridgeUserId("box", "claude-code:48c62ea7", D)).toBe(
-      "@agent_box_claude-code_48c62ea7:id.agentpod.dev"
+      "@agent_box__claude-code_48c62ea7:id.agentpod.dev"
     );
     expect(bridgeUserId("BOX", "Pi:59099BF1", D)).toBe(
       "@agent_box_pi_59099bf1:id.agentpod.dev"
@@ -351,13 +351,13 @@ git commit -m "feat(hub): derive a station's Matrix names from its node and key"
  * answering in a room, with nothing anywhere saying why.
  */
 test("a station refresh leaves a bridge-owned mxid alone", async () => {
-  await setMatrixIdentity(STATION, "@agent_box_pi_x:id.agentpod.dev", "bridge");
+  await setMatrixIdentity(STATION, "@agent_box__pi_x:id.agentpod.dev", "bridge");
 
   // What the node agent does on every detect.
   await refreshStationFromDetect(STATION, { matrixId: null });
 
   const row = await stationRow(STATION);
-  expect(row.matrixId).toBe("@agent_box_pi_x:id.agentpod.dev");
+  expect(row.matrixId).toBe("@agent_box__pi_x:id.agentpod.dev");
   expect(row.matrixIdentityMode).toBe("bridge");
 });
 
@@ -457,7 +457,7 @@ describe("PUT /_matrix/app/v1/transactions/:txnId", () => {
   test("drops events sent by our own users before anything else looks at them", async () => {
     // An AS receives what its own users send. This is the loop that fills a
     // database overnight.
-    await deliver("txn-2", [message("@agent_box_pi_x:id.agentpod.dev", "output")]);
+    await deliver("txn-2", [message("@agent_box__pi_x:id.agentpod.dev", "output")]);
     expect(handled).toHaveLength(0);
   });
 
@@ -568,7 +568,7 @@ git commit -m "feat(hub): answer which of our users and rooms exist"
 test("acts as the station's user, not as the bridge", async () => {
   // ?user_id= is the whole mechanism. Without it every agent's message arrives
   // from @ai-bridge and the room becomes one voice pretending to be many.
-  await sendText("@agent_box_pi_x:id.agentpod.dev", "!room:id.agentpod.dev", "hello");
+  await sendText("@agent_box__pi_x:id.agentpod.dev", "!room:id.agentpod.dev", "hello");
   expect(lastUrl).toContain("user_id=%40agent_box_pi_x%3Aid.agentpod.dev");
 });
 
@@ -791,9 +791,9 @@ git commit -m "feat(hub): the agent's answer arrives in the room, as the agent"
 test("gives a station a user, a room and a readable name", async () => {
   await provisionStation(KRISHNA);
 
-  expect(created.users).toContain("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
+  expect(created.users).toContain("@agent_superchotu__openclaw_krishna:id.agentpod.dev");
   expect(created.rooms.at(-1)).toMatchObject({
-    alias: "#agentpod_superchotu_openclaw_krishna:id.agentpod.dev",
+    alias: "#agentpod_superchotu__openclaw_krishna:id.agentpod.dev",
   });
   // The display name is what a human sees in a member list — the station's
   // display name, not its mangled localpart.
@@ -809,7 +809,7 @@ test("is idempotent, because it runs on every adoption and every boot", async ()
 test("records the station's mxid, in bridge mode", async () => {
   await provisionStation(KRISHNA);
   const row = await stationRow(KRISHNA);
-  expect(row.matrixId).toBe("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
+  expect(row.matrixId).toBe("@agent_superchotu__openclaw_krishna:id.agentpod.dev");
   expect(row.matrixIdentityMode).toBe("bridge");
 });
 
@@ -818,7 +818,7 @@ test("provisions a hermes station exactly like every other", async () => {
   // display name carries the readability its old address used to.
   await provisionStation(ANALYST_ECHO);
   const row = await stationRow(ANALYST_ECHO);
-  expect(row.matrixId).toBe("@agent_molt-bot_hermes_analyst-echo:id.agentpod.dev");
+  expect(row.matrixId).toBe("@agent_molt-bot__hermes_analyst-echo:id.agentpod.dev");
   expect(created.displayNames.at(-1)).toBe("analyst-echo (hermes @ molt-bot)");
 });
 
@@ -880,7 +880,7 @@ describe("POST /api/stations/:id/matrix/identity", () => {
     const res = await post(`/api/stations/${KRISHNA}/matrix/identity`);
 
     expect(res.status).toBe(200);
-    expect((await res.json()).mxid).toBe("@agent_superchotu_openclaw_krishna:id.agentpod.dev");
+    expect((await res.json()).mxid).toBe("@agent_superchotu__openclaw_krishna:id.agentpod.dev");
     expect(adminCommandsRun).toHaveLength(0);
   });
 
@@ -1028,7 +1028,7 @@ Then `systemctl restart tuwunel`. **This is the moment the bridge starts receivi
 
 - [ ] **Step 3: Verify with one station before the rest**
 
-Pick `openclaw:krishna`. Join `#agentpod_superchotu_openclaw_krishna`, say hello, get an answer. Then check the refusal path: narrow your own grant to exclude openclaw, send again, and read the refusal **in the room**. Restore the grant.
+Pick `openclaw:krishna`. Join `#agentpod_superchotu__openclaw_krishna`, say hello, get an answer. Then check the refusal path: narrow your own grant to exclude openclaw, send again, and read the refusal **in the room**. Restore the grant.
 
 - [ ] **Step 4: Provision the remaining 31**
 

--- a/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
+++ b/docs/superpowers/specs/2026-08-16-matrix-application-service-design.md
@@ -90,8 +90,8 @@ is the control pair, unchanged.
 
 ```
 station  molt-bot / hermes:analyst-echo
-user     @agent_molt-bot_hermes_analyst-echo:id.agentpod.dev
-alias    #agentpod_molt-bot_hermes_analyst-echo:id.agentpod.dev
+user     @agent_molt-bot__hermes_analyst-echo:id.agentpod.dev
+alias    #agentpod_molt-bot__hermes_analyst-echo:id.agentpod.dev
 ```
 
 `:` and any character outside the mxid localpart grammar becomes `_`, lowercased.
@@ -119,7 +119,7 @@ the node**, because station keys repeat across the fleet. `@analyst-echo` names
 no node. Fourteen exceptions to the invariant, hardcoded as a regex alternation
 in a registration file, would have rotted the first time an agent was renamed.
 
-So every station, on every harness, is `@agent_<node>_<station>`. One namespace,
+So every station, on every harness, is `@agent_<node>__<station>`. One namespace,
 one rule, nothing to maintain by hand.
 
 **Readability is a display-name problem, and is solved there.** The member list
@@ -188,7 +188,7 @@ that reverting is one write.
 ## How a message becomes work
 
 ```
-Matrix room  #agentpod_molt-bot_hermes_analyst-echo
+Matrix room  #agentpod_molt-bot__hermes_analyst-echo
    │ m.room.message from @rakesh:id.agentpod.dev
    ▼
 AS transaction  PUT /_matrix/app/v1/transactions/:txnId    (hs_token)
@@ -254,6 +254,6 @@ process becomes the bottleneck; the seam is the routes, and it moves.
 ## What "done" looks like
 
 An operator opens supermessage on their phone, types in
-`#agentpod_superchotu_openclaw_krishna`, and an agent that has never spoken
+`#agentpod_superchotu__openclaw_krishna`, and an agent that has never spoken
 Matrix in its life answers — with the message refused, in the room, if their
 grant does not cover it.


### PR DESCRIPTION
Phase B of `docs/superpowers/plans/2026-08-16-conversable-fleet.md`. Every station gets a Matrix identity and a room, so the **18 agents whose harness has never spoken Matrix** can be talked to from any client — and the 14 that do speak it work the same way.

**Inert until one field changes.** The homeserver's registration still carries `url: null`, so nothing is pushed to the bridge. Merging this changes no behaviour; turning it on is one field and one restart, which is also the off switch.

## What's here

| task | |
|---|---|
| 1 | derived names, and the predicate that cuts the echo loop |
| 2 | `matrix_identity_mode` — who answers for a station, never both |
| 3 | the transaction endpoint: `hs_token`, idempotent, loop-proof |
| 4 | user and room queries |
| 5 | a client that acts *as* a station (`?user_id=`) |
| 6 | inbound: a message becomes a prompt, behind the control pair |
| 7 | outbound: the answer arrives in the room |
| 8 | provisioning every station's user and room |
| 8b | identity and credentials over the hub API |
| 9 | assembly, behind `ENABLE_MATRIX_BRIDGE` |
| 11 | health, and the operator docs |

## Four bugs the tests caught, all of which would have shipped

- **The separator.** The spec said one underscore between node and station. Node `a_b` + station `c` then collides with node `a` + station `b_c` — two agents, one identity, which is the collision node-qualification exists to prevent. It's `__` now, in code and docs.
- **The namespace prefix.** Provisioning registered the *bare* localpart, creating `@prov-box__openclaw_krishna` — outside the exclusive namespace the homeserver reserved. It would have looked like it worked and failed later as a 403 at send time.
- **The shared column.** `matrix_id` is the harness's, read off the host; guarding it against its own writer broke a fix this repo already paid for (a station adopted before its profile was readable could never gain an identity). Two facts, two columns.
- **The display name.** Set only on creation, so a renamed station would have introduced itself by its old name forever.

## Decisions worth reviewing

- **The grant is checked on every message**, not once per session. A room is shared; checking only at creation would let the first permitted speaker open a conversation everyone else could drive.
- **Refusals are messages in the room.** Silence reads as a broken agent and sends an operator everywhere except the grant that refused.
- **Text is coalesced, thoughts are not forwarded.** One event per token would buzz a phone forty times; reasoning in a shared room turns an answer into a monologue.
- **Transactions are claimed before handling**, so a retry cannot double a conversation — at the cost that a half-handled transaction isn't retried. A lost message is visible; a doubled one is not.
- **"No transaction has ever arrived" is reported as *silent*, not healthy** — that exact state (a live AS with `url: null`) went unnoticed for months.

## Tests

**1292 pass, 0 fail** (+69). `matrix_rooms` is tenant-scoped with a composite FK, as the tenant guard demanded when it caught the omission.

Not in scope, per the spec: card/run/gate events (kaambaan#34 owns those schemas), E2EE, federation, and any node-agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW