### PR TITLE
fix(hub): every station answers through the bridge after the homeserver swap

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0047_reset_identity_mode.sql
+++ b/apps/hub/src/db/drizzle-migrations/0047_reset_identity_mode.sql
@@ -1,0 +1,18 @@
+-- Every station answers through the bridge, because no harness identity survived
+-- the homeserver replacement.
+--
+-- 0044 backfilled `matrix_identity_mode = 'harness'` wherever a station had an
+-- mxid, on the reasoning that every one of those had been read off a host by the
+-- node agent. That was true, and it stopped being the whole truth on 2026-08-16
+-- when id.agentpod.dev moved from Synapse to tuwunel: those accounts existed on
+-- the old homeserver and do not exist on the new one. The stations kept pointing
+-- at identities nobody can log into and nothing can act as.
+--
+-- The symptom was precise: provisioning tried to create each room AS the
+-- harness's own identity and the homeserver answered
+-- `M_EXCLUSIVE: User is not in namespace` — 18 stations provisioned, 14 failed.
+--
+-- A station returns to `harness` only by being issued credentials
+-- (POST /api/stations/:id/matrix/credentials), which is an act somebody performs
+-- deliberately and which the control pair gates.
+UPDATE stations SET matrix_identity_mode = 'bridge';

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1786687165202,
       "tag": "0046_matrix_rooms",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1786687166202,
+      "tag": "0047_reset_identity_mode",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Found by turning the bridge on: **18 stations provisioned, 14 failed**, and 14 is exactly the hermes count.

```
matrix createRoom #agentpod_molt-bot__hermes_coder-kai:id.agentpod.dev
  failed: 400 M_EXCLUSIVE M_EXCLUSIVE: User is not in namespace.
```

Migration 0044 backfilled `matrix_identity_mode = 'harness'` wherever a station already had an mxid, reasoning that every one of those had been read off a host by the node agent. That was true — and it stopped being the whole truth when `id.agentpod.dev` moved from Synapse to tuwunel the same day. Those accounts existed on the old homeserver; they do not exist on the new one. So 14 stations were left claiming to answer for themselves through identities nobody can log into and the bridge may not act as.

This resets every station to `bridge`. A station returns to `harness` only by being issued credentials — an act somebody performs deliberately, gated on `mayGrantReach`.

**Worth noting:** the failure was visible only because `provisionAll` counts failures instead of swallowing them. Without that it would have been 14 rooms quietly missing, discovered whenever somebody first tried to talk to a hermes agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW