### PR TITLE
fix(hub): attach the room to the session, or the answer has nowhere to go

### DIFF
--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -50,6 +50,15 @@ export interface InboundDeps {
     }): Promise<{ id: string }>;
     promptSession(userId: string, sessionId: string, text: string): Promise<void>;
   };
+  /**
+   * Start streaming this session into this room.
+   *
+   * Called on every message, not only when a session is created: attachments
+   * live in memory, so after a hub restart the session row survives and the
+   * listener does not — and a room whose session predates the restart would go
+   * permanently quiet. Attaching is idempotent.
+   */
+  attach(sessionId: string, roomId: string, agentUser: string): void;
 }
 
 /** The room, its station, and the node name that station's identity is built from. */
@@ -151,6 +160,10 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
         .set({ acpSessionId: sessionId })
         .where(eq(matrixRooms.roomId, room.roomId));
     }
+
+    // Before prompting, so the first words of the answer are not produced into
+    // a stream nobody is listening to.
+    deps.attach(sessionId, room.roomId, agentUser);
 
     // The user's words, unchanged. Trimming or decorating them would put the
     // bridge's voice into the agent's input.

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -101,13 +101,15 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
           userId: input.userId,
           mode: input.mode as never,
         });
-        // The room hears the answer as soon as the session exists, not when the
-        // first chunk arrives — otherwise the opening of a conversation is the
-        // one part of it nobody sees.
         return { id: session.id };
       },
       promptSession,
     },
+    // The joint between inbound and outbound. Without it a session is created,
+    // prompted, and answers into a stream nobody is listening to — which is
+    // exactly what happened the first time this ran against the real fleet.
+    attach: (sessionId: string, roomId: string, agentUser: string) =>
+      attachRoomToSession(sessionId, roomId, agentUser, { client }),
   };
 
   return {

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -34,6 +34,7 @@ let created: Array<{ stationId: string; userId: string }> = [];
 let prompts: Array<{ sessionId: string; text: string; userId: string }> = [];
 let sessionCounter = 0;
 let createFails: Error | null = null;
+let attached: Array<{ sessionId: string; roomId: string; agentUser: string }> = [];
 
 function deps() {
   return {
@@ -53,6 +54,9 @@ function deps() {
       promptSession: async (userId: string, sessionId: string, text: string) => {
         prompts.push({ userId, sessionId, text });
       },
+    },
+    attach: (sessionId: string, roomId: string, agentUser: string) => {
+      attached.push({ sessionId, roomId, agentUser });
     },
   };
 }
@@ -99,6 +103,7 @@ beforeEach(async () => {
   sent = [];
   created = [];
   prompts = [];
+  attached = [];
   createFails = null;
   await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
   await rawSql`
@@ -131,6 +136,41 @@ describe("an inbound room message", () => {
     expect(created).toHaveLength(1);
     expect(prompts).toHaveLength(1);
     expect(prompts[0]!.text).toBe("status?");
+  });
+
+  test("attaches the room to the session, or the answer has nowhere to go", async () => {
+    // The gap that live verification found: a session was created and prompted
+    // and the agent answered into a stream nobody was listening to. Both halves
+    // had tests; the joint did not.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
+
+    expect(attached).toHaveLength(1);
+    expect(attached[0]!.roomId).toBe(ROOM);
+    expect(attached[0]!.agentUser).toBe("@agent_inbound-box__openclaw_krishna:id.agentpod.dev");
+    expect(attached[0]!.sessionId).toBe(prompts[0]!.sessionId);
+  });
+
+  test("attaches again when reusing an existing session, because a restart forgets", async () => {
+    // Attachments live in memory. After a hub restart the session row survives
+    // and the listener does not, so a room whose session predates the restart
+    // would go permanently quiet.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "first"), deps());
+    await handleRoomMessage(message(OWNER_MXID, "second"), deps());
+
+    expect(created).toHaveLength(1);
+    expect(attached).toHaveLength(2);
+  });
+
+  test("does not attach when the message was refused", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
+
+    expect(attached).toHaveLength(0);
   });
 
   test("refuses IN THE ROOM when the grant does not cover this station", async () => {


### PR DESCRIPTION
Found by flipping the bridge on against the real fleet.

A message arrived, `@rakesh` resolved to a principal, the control pair permitted it, an ACP session was created and prompted — and then nothing came back. The session sat `idle`, having answered into a stream nobody was listening to.

**Task 6 built the inbound path. Task 7 built the outbound streamer. The assembly never joined them.** Both halves had passing tests; the joint had none, because each side's tests used fakes for the other.

Two things this changes:

- Attachment happens **on every message**, not only when a session is created. Attachments live in memory, so after a hub restart the session row survives and the listener does not — a room whose session predates the restart would go permanently quiet, which is the same failure with a slower onset.
- It happens **before** the prompt, so the opening words of an answer aren't produced into a stream that isn't being read yet.

Three regression tests, including the restart case and "does not attach when the message was refused".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW