### PR TITLE
fix(hub): a room whose session ended starts a new one, and one underscore is enough

### DIFF
--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -11,7 +11,7 @@ import { createMatrixClient } from "./client";
 
 const AS_TOKEN = "test-as-token-client";
 const HS = "http://homeserver.test";
-const USER = "@agent_box__pi_x:id.agentpod.dev";
+const USER = "@agent_box_pi-x:id.agentpod.dev";
 const ROOM = "!room:id.agentpod.dev";
 
 interface Call {
@@ -77,7 +77,7 @@ describe("acting as a station", () => {
     // a no-op, not an error that stops an agent existing.
     replies = [{ status: 400, body: { errcode: "M_USER_IN_USE" } }];
 
-    await client().ensureUser("agent_box__pi_x", "x (pi @ box)");
+    await client().ensureUser("agent_box_pi-x", "x (pi @ box)");
   });
 
   test("sets the display name even when the user already existed", async () => {
@@ -86,7 +86,7 @@ describe("acting as a station", () => {
     // because the user is created exactly once and provisioning runs forever.
     replies = [{ status: 400, body: { errcode: "M_USER_IN_USE" } }];
 
-    await client().ensureUser("agent_box__pi_x", "renamed (pi @ box)");
+    await client().ensureUser("agent_box_pi-x", "renamed (pi @ box)");
 
     const profile = calls.find((c) => c.url.includes("/displayname"));
     expect(profile).toBeTruthy();
@@ -96,7 +96,7 @@ describe("acting as a station", () => {
   test("treats M_ROOM_IN_USE on create as success", async () => {
     replies = [{ status: 400, body: { errcode: "M_ROOM_IN_USE" } }];
 
-    const roomId = await client().ensureRoom("#agentpod_box__pi_x:id.agentpod.dev", {
+    const roomId = await client().ensureRoom("#agentpod_box_pi-x:id.agentpod.dev", {
       creator: USER,
       name: "x",
       topic: "pi @ box",

--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -19,6 +19,7 @@
 import { eq } from "drizzle-orm";
 import { db } from "../../db/drizzle";
 import { matrixRooms } from "../../db/schema/matrix";
+import { acpSessions } from "../../db/schema/acp";
 import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
 import { resolveMatrixId } from "../matrix-identity";
@@ -71,10 +72,12 @@ async function roomContext(roomId: string) {
       stationKey: stations.stationKey,
       identityMode: stations.matrixIdentityMode,
       nodeName: nodes.name,
+      sessionStatus: acpSessions.status,
     })
     .from(matrixRooms)
     .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
     .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .leftJoin(acpSessions, eq(acpSessions.id, matrixRooms.acpSessionId))
     .where(eq(matrixRooms.roomId, roomId));
   return row ?? null;
 }
@@ -143,7 +146,12 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
 
   // ── Say it to the agent ───────────────────────────────────────────────────
   try {
-    let sessionId = room.sessionId;
+    // A session the hub has already ended is not a session. Boot reconciliation
+    // ends every live one with "hub restarted", so without this check a room
+    // prompts a corpse forever and every bridged room dies permanently at the
+    // first restart — with "Session not found or not active" as the only clue.
+    const sessionUsable = room.sessionId !== null && room.sessionStatus !== null && room.sessionStatus !== "ended";
+    let sessionId = sessionUsable ? room.sessionId : null;
 
     if (!sessionId) {
       // One session per room, not per message: a conversation is a

--- a/apps/hub/src/services/matrix-as/names.test.ts
+++ b/apps/hub/src/services/matrix-as/names.test.ts
@@ -26,31 +26,39 @@ describe("bridge names", () => {
     // agents.yaml claims `@agent_.*` and `#agentpod_.*` exclusive. A name
     // outside them cannot be acted as, and the failure arrives late — a 403
     // from the homeserver at send time, long after provisioning "worked".
-    // `__` separates the node half from the station half; a single `_` would
-    // make node `a_b` + station `c` collide with node `a` + station `b_c`.
+    // One `_`, and it is unambiguous because `_` cannot survive cleaning:
+    // every underscore in a station key or node name becomes `-`.
     expect(bridgeUserId("molt-bot", "hermes:analyst-echo", D)).toBe(
-      "@agent_molt-bot__hermes_analyst-echo:id.agentpod.dev"
+      "@agent_molt-bot_hermes-analyst-echo:id.agentpod.dev"
     );
     expect(bridgeAlias("molt-bot", "hermes:analyst-echo", D)).toBe(
-      "#agentpod_molt-bot__hermes_analyst-echo:id.agentpod.dev"
+      "#agentpod_molt-bot_hermes-analyst-echo:id.agentpod.dev"
     );
   });
 
   test("replace characters an mxid localpart may not contain", () => {
     // `:` is the mxid separator, and a station key is full of them.
     expect(bridgeUserId("box", "claude-code:48c62ea7", D)).toBe(
-      "@agent_box__claude-code_48c62ea7:id.agentpod.dev"
+      "@agent_box_claude-code-48c62ea7:id.agentpod.dev"
     );
   });
 
   test("lowercase, because Matrix localparts are", () => {
-    expect(bridgeUserId("BOX", "Pi:59099BF1", D)).toBe("@agent_box__pi_59099bf1:id.agentpod.dev");
+    expect(bridgeUserId("BOX", "Pi:59099BF1", D)).toBe("@agent_box_pi-59099bf1:id.agentpod.dev");
   });
 
   test("keep the node and the station distinguishable", () => {
     // A separator that could also appear inside either half would make
     // `a_b`/`c` and `a`/`b_c` the same name. They must not collide.
     expect(localpartFor("a_b", "c")).not.toBe(localpartFor("a", "b_c"));
+  });
+
+  test("never emit the separator from a name's own characters", () => {
+    // This is what makes one underscore enough. Two illegal characters in a row
+    // used to produce `__` inside a half, which is how the doubled separator
+    // was safe in practice and not in principle.
+    expect(localpartFor("a::b", "c")).not.toContain("__");
+    expect(localpartFor("a_b", "c").split("_")).toHaveLength(2);
   });
 
   test("the registered username is exactly the user id's localpart", () => {
@@ -76,7 +84,7 @@ describe("isBridgeUser", () => {
     // An Application Service receives what its own users send. Answering those
     // is an infinite loop that fills a database overnight, so this predicate
     // runs before anything else looks at an event.
-    expect(isBridgeUser("@agent_box__pi_59099bf1:id.agentpod.dev", D)).toBe(true);
+    expect(isBridgeUser("@agent_box_pi-59099bf1:id.agentpod.dev", D)).toBe(true);
   });
 
   test("recognises the appservice's own bot", () => {

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -11,24 +11,30 @@
  */
 
 /**
- * The characters a Matrix localpart may contain, lowercased. Everything else —
- * `:` above all, which a station key is full of — becomes `_`.
+ * Everything that is not a safe localpart character becomes `-`, lowercased.
+ *
+ * `_` is deliberately NOT in the kept set and is never emitted, which is what
+ * makes it usable as a separator below. `:` — which every station key is full
+ * of — is the main casualty, along with anything else a hostname or a harness
+ * might contain.
  */
-const ILLEGAL = /[^a-z0-9._=/-]/g;
+const ILLEGAL = /[^a-z0-9.=/-]/g;
 
-const clean = (s: string): string => s.toLowerCase().replace(ILLEGAL, "_");
+const clean = (s: string): string => s.toLowerCase().replace(ILLEGAL, "-");
 
 /**
- * `<node>__<station>`, with a doubled separator between the halves.
+ * `<node>_<station>`.
  *
- * Doubled because a single `_` appears inside both halves after cleaning, and
- * `a_b` + `c` would otherwise produce the same localpart as `a` + `b_c` — two
- * different agents, one identity. `__` cannot appear inside a cleaned half,
- * since the cleaner never emits two in a row for a single character and any
- * literal `__` in a name is itself replaced.
+ * One underscore, and unambiguous **by construction**: `_` cannot survive
+ * cleaning, so the first one in a localpart is always the separator. An earlier
+ * version kept `_` inside the halves and doubled the separator to compensate,
+ * which made `a_b` + `c` and `a` + `b_c` distinct in practice but not in
+ * principle — two illegal characters in a row still produced `__` inside a half.
+ * Excluding `_` from the alphabet is the version that cannot collide, and it
+ * reads better: `molt-bot_hermes-analyst-echo`.
  */
 export function localpartFor(nodeName: string, stationKey: string): string {
-  return `${clean(nodeName)}__${clean(stationKey)}`;
+  return `${clean(nodeName)}_${clean(stationKey)}`;
 }
 
 /**

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -11,7 +11,7 @@ import { attachRoomToSession, detachRoom, _attachedCountForTest } from "./outbou
  */
 
 const ROOM = "!room:id.agentpod.dev";
-const AGENT = "@agent_box__openclaw_krishna:id.agentpod.dev";
+const AGENT = "@agent_box_openclaw-krishna:id.agentpod.dev";
 const SESSION = "acps_outbound_test";
 
 let sent: Array<{ userId: string; roomId: string; body: string }> = [];

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -49,7 +49,16 @@ function deps() {
       createSession: async (input: { stationId: string; userId: string }) => {
         if (createFails) throw createFails;
         created.push(input);
-        return { id: `acps_${++sessionCounter}` };
+        // A real createSession writes a row, and the bridge reads that row's
+        // status to decide whether the session is still usable. A fake that
+        // returned only an id would make every session look already-gone.
+        const id = `acps_mx_inbound_${++sessionCounter}`;
+        await rawSql`DELETE FROM acp_sessions WHERE id = ${id}`;
+        await rawSql`
+          INSERT INTO acp_sessions (id, tenant_id, station_id, user_id, mode, status, last_seq, created_at, last_event_at)
+          VALUES (${id}, (SELECT tenant_id FROM stations WHERE id = ${input.stationId}),
+                  ${input.stationId}, ${input.userId}, 'default', 'idle', 0, now(), now())`;
+        return { id };
       },
       promptSession: async (userId: string, sessionId: string, text: string) => {
         prompts.push({ userId, sessionId, text });
@@ -105,17 +114,19 @@ beforeEach(async () => {
   prompts = [];
   attached = [];
   createFails = null;
+  await rawSql`DELETE FROM acp_sessions WHERE id LIKE 'acps_mx_inbound_%'`;
   await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
   await rawSql`
     INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
     VALUES (${ROOM}, (SELECT tenant_id FROM stations WHERE id = ${STATION}), ${STATION},
-            '#agentpod_inbound-box__openclaw_krishna:id.agentpod.dev', now())`;
+            '#agentpod_inbound-box_openclaw-krishna:id.agentpod.dev', now())`;
   await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
 });
 
 afterAll(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
   try {
+    await rawSql`DELETE FROM acp_sessions WHERE id LIKE 'acps_mx_inbound_%'`;
     await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
     await rawSql`DELETE FROM principal_identities WHERE principal_id IN (${OWNER}, ${OTHER})`;
     await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${OWNER}, ${OTHER})`;
@@ -148,7 +159,7 @@ describe("an inbound room message", () => {
 
     expect(attached).toHaveLength(1);
     expect(attached[0]!.roomId).toBe(ROOM);
-    expect(attached[0]!.agentUser).toBe("@agent_inbound-box__openclaw_krishna:id.agentpod.dev");
+    expect(attached[0]!.agentUser).toBe("@agent_inbound-box_openclaw-krishna:id.agentpod.dev");
     expect(attached[0]!.sessionId).toBe(prompts[0]!.sessionId);
   });
 
@@ -216,6 +227,24 @@ describe("an inbound room message", () => {
 
     expect(created).toHaveLength(1);
     expect(prompts.map((p) => p.text)).toEqual(["first", "second"]);
+  });
+
+  test("starts a new session when the room's one has ended", async () => {
+    // Boot reconciliation ends every live session with 'hub restarted'. Without
+    // this the room keeps prompting a corpse and every bridged room dies
+    // permanently at the first restart — the agent simply stops answering, with
+    // 'Session not found or not active' as the only clue.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await handleRoomMessage(message(OWNER_MXID, "first"), deps());
+    const dead = prompts[0]!.sessionId;
+
+    await rawSql`
+      UPDATE acp_sessions SET status = 'ended', ended_reason = 'hub restarted' WHERE id = ${dead}`;
+
+    await handleRoomMessage(message(OWNER_MXID, "second"), deps());
+
+    expect(created).toHaveLength(2);
+    expect(prompts[1]!.sessionId).not.toBe(dead);
   });
 
   test("says so when the station cannot be reached, rather than swallowing it", async () => {

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -111,10 +111,10 @@ describe("provisioning a station", () => {
     await provisionStation(OPENCLAW, deps());
 
     expect(registered).toHaveLength(1);
-    expect(registered[0]!.localpart).toBe("agent_prov-box__openclaw_krishna");
+    expect(registered[0]!.localpart).toBe("agent_prov-box_openclaw-krishna");
     // The display name carries the readability a derived mxid does not have.
     expect(registered[0]!.displayName).toBe("krishna (openclaw @ prov-box)");
-    expect(rooms[0]!.alias).toBe("#agentpod_prov-box__openclaw_krishna:id.agentpod.dev");
+    expect(rooms[0]!.alias).toBe("#agentpod_prov-box_openclaw-krishna:id.agentpod.dev");
   });
 
   test("records the room, with the tenant it belongs to", async () => {
@@ -123,14 +123,14 @@ describe("provisioning a station", () => {
     const row = await roomRow(OPENCLAW);
     expect(row!.room_id).toMatch(/^!room/);
     expect(row!.tenant_id).toBeTruthy();
-    expect(row!.alias).toBe("#agentpod_prov-box__openclaw_krishna:id.agentpod.dev");
+    expect(row!.alias).toBe("#agentpod_prov-box_openclaw-krishna:id.agentpod.dev");
   });
 
   test("records the identity it minted, without touching the harness column", async () => {
     await provisionStation(OPENCLAW, deps());
 
     const row = await stationRow(OPENCLAW);
-    expect(row.bridge_matrix_id).toBe("@agent_prov-box__openclaw_krishna:id.agentpod.dev");
+    expect(row.bridge_matrix_id).toBe("@agent_prov-box_openclaw-krishna:id.agentpod.dev");
     expect(row.matrix_id).toBeNull();
     expect(row.matrix_identity_mode).toBe("bridge");
   });
@@ -147,7 +147,7 @@ describe("provisioning a station", () => {
     // carries the readability its old bespoke address used to.
     await provisionStation(HERMES, deps());
 
-    expect(registered[0]!.localpart).toBe("agent_prov-box__hermes_analyst-echo");
+    expect(registered[0]!.localpart).toBe("agent_prov-box_hermes-analyst-echo");
     expect(registered[0]!.displayName).toBe("analyst-echo (hermes @ prov-box)");
   });
 

--- a/apps/hub/tests/integration/matrix-as-transactions.test.ts
+++ b/apps/hub/tests/integration/matrix-as-transactions.test.ts
@@ -118,7 +118,7 @@ describe("PUT /_matrix/app/v1/transactions/:txnId", () => {
   test("drops events sent by our own users before anything else looks at them", async () => {
     // An Application Service is sent what its own users send. Answering those
     // is the loop that fills a database overnight.
-    await deliver("test-txn-loop", [message("@agent_box__pi_x:id.agentpod.dev", "output")]);
+    await deliver("test-txn-loop", [message("@agent_box_pi-x:id.agentpod.dev", "output")]);
 
     expect(handled).toHaveLength(0);
   });
@@ -132,7 +132,7 @@ describe("PUT /_matrix/app/v1/transactions/:txnId", () => {
     // The loop cut is per event, not per transaction — otherwise one echo would
     // silence a real message that arrived beside it.
     await deliver("test-txn-mixed", [
-      message("@agent_box__pi_x:id.agentpod.dev", "echo"),
+      message("@agent_box_pi-x:id.agentpod.dev", "echo"),
       message("@rakesh:id.agentpod.dev", "status?"),
     ]);
 

--- a/apps/hub/tests/integration/matrix-identity-mode.test.ts
+++ b/apps/hub/tests/integration/matrix-identity-mode.test.ts
@@ -103,14 +103,14 @@ describe("matrix_identity_mode", () => {
     // for a station whose harness knows nothing about Matrix — and no report it
     // can make may erase what the Application Service minted.
     await rawSql`
-      UPDATE stations SET bridge_matrix_id = '@agent_mode-box__hermes_bridged:id.agentpod.dev',
+      UPDATE stations SET bridge_matrix_id = '@agent_mode-box_hermes-bridged:id.agentpod.dev',
                           matrix_identity_mode = 'bridge'
       WHERE id = ${BRIDGED}`;
 
     await nodeReports([{ key: "hermes:bridged", matrixId: null }]);
 
     const row = await stationRow(BRIDGED);
-    expect(row.bridge_matrix_id).toBe("@agent_mode-box__hermes_bridged:id.agentpod.dev");
+    expect(row.bridge_matrix_id).toBe("@agent_mode-box_hermes-bridged:id.agentpod.dev");
     expect(row.matrix_identity_mode).toBe("bridge");
   });
 

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -116,8 +116,8 @@ describe("POST /api/stations/:id/matrix/identity", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { mxid: string; alias: string; mode: string };
-    expect(body.mxid).toBe("@agent_sm-box__hermes_analyst-echo:id.agentpod.dev");
-    expect(body.alias).toBe("#agentpod_sm-box__hermes_analyst-echo:id.agentpod.dev");
+    expect(body.mxid).toBe("@agent_sm-box_hermes-analyst-echo:id.agentpod.dev");
+    expect(body.alias).toBe("#agentpod_sm-box_hermes-analyst-echo:id.agentpod.dev");
     expect(body.mode).toBe("bridge");
     expect(provisioned).toEqual([STATION]);
     // Issuing an identity is the appservice acting in its own namespace. No


### PR DESCRIPTION
Both found by running the bridge against the real fleet.

## 1. Every bridged room died at the first hub restart

Boot reconciliation ends every live ACP session with `hub restarted`. The room kept its `acp_session_id` and went on prompting a corpse, so the agent simply stopped answering — with `Session not found or not active` in a log as the only clue.

An ended session is now treated as no session, and a new one is created. The test fake had to start writing real `acp_sessions` rows to catch this: a fake that returns only an id makes every session look already-gone, which is why the original tests passed.

## 2. One underscore, made safe by construction

`@agent_molt-bot__hermes_analyst-echo` was doubled because a single `_` let node `a_b` + station `c` collide with node `a` + station `b_c`. But doubling only made it safe *in practice*: two illegal characters in a row still produced `__` inside a half.

Excluding `_` from the alphabet — every illegal character becomes `-` — makes one underscore unambiguous **by construction**, with a test pinning that a name's own characters can never emit the separator. It also reads better:

```
@agent_molt-bot_hermes-analyst-echo:id.agentpod.dev
#agentpod_superchotu_openclaw-krishna:id.agentpod.dev
```

## ⚠️ Deploying #2 renames every room

The 32 users and rooms already provisioned carry the old names. Deploying this creates 32 new ones and orphans the old — including any invite already accepted. That is cheap today (one day old, one human member) and gets steadily less cheap.

**1297 tests pass, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW