### PR TITLE
fix(hub): one turn is one message, even when the agent pauses to think

### DIFF
--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -125,6 +125,25 @@ describe("streaming an answer into a room", () => {
     expect(sent[0]!.body).toBe("Hello there");
   });
 
+  test("does not split one answer because the agent paused mid-sentence", async () => {
+    // Observed in production: the console showed one message and the room showed
+    // two — "Hello! Analyst Echo" and " here, ready to turn your data into
+    // insights…". A debounce short enough to chunk on a pause is a debounce that
+    // cuts sentences in half, because an agent thinking mid-answer is ordinary.
+    // The turn's end is the flush; the timer is only a safety net for a turn
+    // that never ends.
+    attachRoomToSession(SESSION, ROOM, AGENT, { ...deps(), flushDelayMs: undefined });
+
+    emit(chunk("Hello! Analyst Echo"));
+    await new Promise((r) => setTimeout(r, 900));
+    emit(chunk(" here, ready to help."));
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toBe("Hello! Analyst Echo here, ready to help.");
+  }, 10_000);
+
   test("does not send an empty message when a turn produced no text", async () => {
     attachRoomToSession(SESSION, ROOM, AGENT, deps());
 

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -23,7 +23,10 @@ export interface OutboundDeps {
     sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
   };
   subscribe?: (sessionId: string, fn: (e: AcpEvent) => void) => () => void;
-  /** How long to wait for more text before sending. 0 in tests. */
+  /**
+   * A safety net, not a chunking strategy — see `FLUSH_SAFETY_MS`. 0 in tests
+   * that assert on flush timing directly.
+   */
   flushDelayMs?: number;
 }
 
@@ -44,6 +47,21 @@ interface Attachment {
  * a bridge bug.
  */
 const attached = new Map<string, Attachment>();
+
+/**
+ * How long buffered text may sit before it is sent without the turn having ended.
+ *
+ * **A safety net, not a chunking strategy.** The turn's end is what flushes; this
+ * only exists so a turn that never ends does not swallow what the agent already
+ * said.
+ *
+ * It was 400ms, which is short enough to fire on an ordinary mid-answer pause —
+ * and it did, in production: the console showed one message while the room showed
+ * "Hello! Analyst Echo" and " here, ready to turn your data into insights…" as
+ * two. An agent pausing to think mid-sentence is not the end of its turn, and
+ * treating it as one cuts sentences in half.
+ */
+export const FLUSH_SAFETY_MS = 20_000;
 
 /** Leak detection, mirroring `_subscriberCountForTest` in acp-sessions. */
 export function _attachedCountForTest(): number {
@@ -91,7 +109,7 @@ export function attachRoomToSession(
   if (attached.has(sessionId)) return;
 
   const subscribe = deps.subscribe ?? subscribeToSession;
-  const flushDelayMs = deps.flushDelayMs ?? 400;
+  const flushDelayMs = deps.flushDelayMs ?? FLUSH_SAFETY_MS;
 
   const state: Attachment = {
     roomId,


### PR DESCRIPTION
Two screenshots of the same exchange, side by side:

**Console:** `Hello! Analyst Echo here, ready to turn your data into insights. What would you like to analyze today?`

**Matrix room:** the same answer as **two** messages — `Hello! Analyst Echo` and ` here, ready to turn your data into insights…`

The flush timer was 400ms. That is short enough to fire on an ordinary mid-answer pause, and an agent thinking mid-sentence is not the end of its turn — treating it as one cuts sentences in half.

The turn's end is what flushes. The timer is now a **20s safety net** whose only job is to stop a turn that never ends from swallowing what the agent already said. Its name and comment say so, so nobody tunes it down again to "make messages arrive sooner".

Test pins a 900ms mid-answer pause producing one message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW