### PR TITLE
feat(hub): a room that shows what the agent is doing, and an agent that can speak first

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -56,6 +56,7 @@ import { startKaambaanBridge } from './services/bridge/loop.ts';
 import { createMatrixBridge, startMatrixBridge } from './services/matrix-as/index.ts';
 import { createMatrixAsRoutes } from './routes/matrix-as.ts';
 import { createStationMatrixRoutes } from './routes/station-matrix.ts';
+import { createStationSayRoutes } from './routes/station-say.ts';
 // ACP session boot reconciliation (hub-owned sessions do not survive restarts)
 import { reconcileOnBoot as reconcileAcpSessions } from './services/acp-sessions.ts';
 
@@ -174,6 +175,17 @@ if (matrixBridge) {
         // rather than pretending.
         register: (localpart) => matrixBridge.client.registerWithCredentials(localpart),
       },
+    }),
+  );
+
+  // An agent speaking without being spoken to — a cron job reporting in, and
+  // the last thing keeping bridge mode short of parity with a harness's own
+  // Matrix client.
+  app.route(
+    '/api',
+    createStationSayRoutes({
+      domain: matrixBridge.config.domain,
+      client: matrixBridge.client,
     }),
   );
 }

--- a/apps/hub/src/routes/station-say.ts
+++ b/apps/hub/src/routes/station-say.ts
@@ -1,0 +1,125 @@
+/**
+ * An agent speaking without being spoken to.
+ *
+ * hermes agents have cron jobs: they report in the morning, they raise things
+ * nobody asked about. Bridge mode relays ACP session output, and an ACP session
+ * exists only because somebody prompted it — so a scheduled message had nowhere
+ * to go, and an agent that used to announce things went quiet. This is the path
+ * back, and closing it was the last thing keeping bridge mode short of parity
+ * with a harness's own Matrix client.
+ *
+ * Deliberately **not** an ACP session. There is no conversation, no turn and no
+ * transcript to attach: a station is saying something in its own room, as
+ * itself. Giving it a session would put a scheduled announcement into the
+ * conversation history as though somebody had asked for it.
+ *
+ * Guarded by the same grant that guards dispatching the agent, because speaking
+ * *as* an agent is a strong thing to be able to do: anyone who may not dispatch
+ * it must not be able to put words in its mouth.
+ */
+
+import { Hono } from "hono";
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { nodes } from "../db/schema/nodes";
+import { matrixRooms } from "../db/schema/matrix";
+import { getGrant, grantAllowsStation } from "../services/grants";
+import { isControlPairEnforced } from "../services/control-pair";
+import { bridgeUserId } from "../services/matrix-as/names";
+import { createLogger } from "../utils/logger";
+import type { AuthUser } from "../auth/middleware";
+
+const log = createLogger("station-say");
+
+export interface StationSayDeps {
+  domain: string;
+  client: {
+    sendText(userId: string, roomId: string, body: string): Promise<string | null>;
+  };
+}
+
+export function createStationSayRoutes(deps: StationSayDeps) {
+  return new Hono().post("/stations/:id/matrix/say", async (c) => {
+    const user = c.get("user") as AuthUser;
+
+    const [station] = await db
+      .select({
+        id: stations.id,
+        stationKey: stations.stationKey,
+        mode: stations.matrixIdentityMode,
+        nodeName: nodes.name,
+        roomId: matrixRooms.roomId,
+      })
+      .from(stations)
+      .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+      .leftJoin(matrixRooms, eq(matrixRooms.stationId, stations.id))
+      .where(and(eq(stations.id, c.req.param("id")), eq(stations.userId, user.id)));
+
+    if (!station) return c.json({ error: "Not Found" }, 404);
+
+    const body = (await c.req.json().catch(() => null)) as { body?: unknown } | null;
+    const text = typeof body?.body === "string" ? body.body : "";
+    if (text.trim() === "") {
+      return c.json({ error: "A message needs something in it." }, 400);
+    }
+
+    // The same question dispatching asks. Speaking as an agent is speaking AS
+    // it, and a grant that does not cover this station does not cover this.
+    if (isControlPairEnforced()) {
+      const grant = await getGrant(user.id);
+      const allowed = grantAllowsStation(grant, {
+        nodeName: station.nodeName,
+        stationKey: station.stationKey,
+      });
+      if (!allowed) {
+        log.warn("unprompted message refused by the control pair", {
+          principalId: user.id,
+          node: station.nodeName,
+          stationKey: station.stationKey,
+        });
+        return c.json(
+          {
+            error:
+              "You are not permitted to speak as this agent. Your grant does not cover " +
+              `${station.nodeName}/${station.stationKey}.`,
+          },
+          403
+        );
+      }
+    }
+
+    // A harness-mode station has its own Matrix client and posts its own
+    // announcements. Speaking for it as well would double every one of them.
+    if (station.mode !== "bridge") {
+      return c.json(
+        {
+          error:
+            "This station answers for itself on Matrix, so the bridge does not speak for it. " +
+            "Post from its own client, or move it back to bridge mode.",
+        },
+        409
+      );
+    }
+
+    if (!station.roomId) {
+      // Provisioning may simply not have run yet. Saying which thing is missing
+      // beats swallowing the message.
+      return c.json(
+        { error: "This station has no Matrix room yet. Provision its identity first." },
+        409
+      );
+    }
+
+    const agentUser = bridgeUserId(station.nodeName, station.stationKey, deps.domain);
+    const eventId = await deps.client.sendText(agentUser, station.roomId, text);
+
+    log.info("station spoke unprompted", {
+      principalId: user.id,
+      stationKey: station.stationKey,
+      chars: text.length,
+    });
+
+    return c.json({ eventId, roomId: station.roomId, mxid: agentUser });
+  });
+}

--- a/apps/hub/src/services/matrix-as/avatar.test.ts
+++ b/apps/hub/src/services/matrix-as/avatar.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { AVATAR_CANDIDATES, pickAvatar } from "./avatar";
+
+/**
+ * An agent's face, if it has one.
+ *
+ * hermes profiles carry a `pfp.png`, and its own tooling uploaded it — which is
+ * why those agents had faces and, after the bridge took over, letter avatars.
+ * Nothing about that is hermes-specific: any harness that keeps an image beside
+ * its agent should get the same treatment, and an agent with no image is not a
+ * broken agent.
+ */
+
+describe("finding an agent's avatar", () => {
+  test("looks in the same places for every harness", () => {
+    // The candidate list is not keyed by harness. A convention that only worked
+    // for the one harness that already had faces would bake in the accident
+    // this bridge exists to remove.
+    expect(AVATAR_CANDIDATES.length).toBeGreaterThan(0);
+    expect(AVATAR_CANDIDATES.join(" ")).not.toMatch(/hermes|openclaw|codex/i);
+  });
+
+  test("takes the first candidate the station actually has", async () => {
+    const found = await pickAvatar({
+      read: async (path) =>
+        path === AVATAR_CANDIDATES[1]
+          ? { bytes: new Uint8Array([1, 2, 3]), contentType: "image/png" }
+          : null,
+    });
+
+    expect(found).not.toBeNull();
+    expect(found!.path).toBe(AVATAR_CANDIDATES[1]);
+  });
+
+  test("answers null when the agent has no image, which is not an error", async () => {
+    // Optional means optional. A station without a picture must provision
+    // exactly as far as one with it.
+    expect(await pickAvatar({ read: async () => null })).toBeNull();
+  });
+
+  test("survives a node that will not answer", async () => {
+    // The workspace is on another machine, which may be offline. An avatar is
+    // never worth failing provisioning over.
+    const found = await pickAvatar({
+      read: async () => {
+        throw new Error("node offline");
+      },
+    });
+    expect(found).toBeNull();
+  });
+
+  test("refuses something that is not an image", async () => {
+    // The path is a convention, not a promise. Uploading a text file as an
+    // avatar would fail later and more confusingly.
+    const found = await pickAvatar({
+      read: async () => ({ bytes: new Uint8Array([1]), contentType: "text/plain" }),
+    });
+    expect(found).toBeNull();
+  });
+});

--- a/apps/hub/src/services/matrix-as/avatar.ts
+++ b/apps/hub/src/services/matrix-as/avatar.ts
@@ -1,0 +1,55 @@
+/**
+ * An agent's face, if it has one.
+ *
+ * hermes profiles carry a `pfp.png` and hermes's own tooling uploaded it, which
+ * is why those 14 agents had faces and every other station had a letter. None of
+ * that is hermes-specific: the bridge looks in the same places for every
+ * harness, and an agent with no image is not a broken agent.
+ *
+ * Read through the node, because the image lives in the station's workspace on
+ * whichever machine that is — and read once, at provisioning, because an avatar
+ * is not worth a round trip per message.
+ */
+
+/**
+ * Where an agent's picture might be, in order of preference.
+ *
+ * Deliberately not keyed by harness. A convention that only worked for the one
+ * harness that already had faces would bake in the accident this bridge exists
+ * to remove.
+ */
+export const AVATAR_CANDIDATES = ["avatar.png", "pfp.png", ".agentpod/avatar.png"] as const;
+
+const IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+export interface AvatarDeps {
+  /** Read a workspace-relative path, or null when it is not there. */
+  read(path: string): Promise<{ bytes: Uint8Array; contentType: string } | null>;
+}
+
+export interface FoundAvatar {
+  path: string;
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+export async function pickAvatar(deps: AvatarDeps): Promise<FoundAvatar | null> {
+  for (const path of AVATAR_CANDIDATES) {
+    let found: { bytes: Uint8Array; contentType: string } | null = null;
+    try {
+      found = await deps.read(path);
+    } catch {
+      // The workspace is on another machine, which may be offline or busy. An
+      // avatar is never worth failing provisioning over.
+      return null;
+    }
+    if (!found) continue;
+
+    // The path is a convention, not a promise. Uploading a text file as an
+    // avatar fails later and more confusingly than declining it here.
+    if (!IMAGE_TYPES.includes(found.contentType)) continue;
+
+    return { path, ...found };
+  }
+  return null;
+}

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -47,6 +47,19 @@ export interface MatrixClient {
   sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
   setDisplayName(userId: string, displayName: string): Promise<void>;
   invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  /** Mark another event — 👀 while working, ✅ done, ❌ failed. */
+  sendReaction(
+    userId: string,
+    roomId: string,
+    targetEventId: string,
+    key: string
+  ): Promise<string | null>;
+  /** Remove an event we sent, which is how a reaction is taken back off. */
+  redact(userId: string, roomId: string, eventId: string): Promise<void>;
+  /** Set a user's avatar. Optional for an agent; uniform across harnesses. */
+  setAvatar(userId: string, mxcUrl: string): Promise<void>;
+  /** Upload an image and return its mxc:// URL. */
+  uploadImage(userId: string, bytes: Uint8Array, contentType: string): Promise<string | null>;
 }
 
 export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
@@ -203,6 +216,54 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
         { method: "PUT", userId, body: { displayname: displayName } }
       );
       assertOkOrAlready("displayname", res);
+    },
+
+    async sendReaction(userId, roomId, targetEventId, key) {
+      const txn = `apr-${crypto.randomUUID()}`;
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.reaction/${txn}`,
+        {
+          method: "PUT",
+          userId,
+          body: {
+            "m.relates_to": { rel_type: "m.annotation", event_id: targetEventId, key },
+          },
+        }
+      );
+      assertOkOrAlready("reaction", res);
+      return String(res.body.event_id ?? "") || null;
+    },
+
+    async redact(userId, roomId, eventId) {
+      const txn = `apx-${crypto.randomUUID()}`;
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/redact/${encodeURIComponent(eventId)}/${txn}`,
+        { method: "PUT", userId, body: {} }
+      );
+      assertOkOrAlready("redact", res);
+    },
+
+    async uploadImage(userId, bytes, contentType) {
+      // Media upload is not JSON, so it bypasses `call`.
+      const url = `${deps.homeserverUrl}/_matrix/media/v3/upload?user_id=${encodeURIComponent(userId)}`;
+      const res = await doFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": contentType, Authorization: `Bearer ${deps.asToken}` },
+        // Cast through unknown: this is the one call that sends bytes rather
+        // than JSON, and the DOM's BodyInit is not in this project's lib set.
+        body: bytes as unknown as never,
+      });
+      if (!res.ok) return null;
+      const body = (await res.json()) as { content_uri?: string };
+      return body.content_uri ?? null;
+    },
+
+    async setAvatar(userId, mxcUrl) {
+      const res = await call(
+        `/_matrix/client/v3/profile/${encodeURIComponent(userId)}/avatar_url`,
+        { method: "PUT", userId, body: { avatar_url: mxcUrl } }
+      );
+      assertOkOrAlready("avatar", res);
     },
 
     async invite(asUserId, roomId, invitee) {

--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -60,6 +60,11 @@ export interface InboundDeps {
    * permanently quiet. Attaching is idempotent.
    */
   attach(sessionId: string, roomId: string, agentUser: string): void;
+  /**
+   * Which message started the turn about to run, so the agent can mark it —
+   * 👀 while working, ✅ when done. Absent for a turn nobody asked for.
+   */
+  noteTrigger?(sessionId: string, eventId: string): void;
 }
 
 /** The room, its station, and the node name that station's identity is built from. */
@@ -172,6 +177,7 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
     // Before prompting, so the first words of the answer are not produced into
     // a stream nobody is listening to.
     deps.attach(sessionId, room.roomId, agentUser);
+    if (event.event_id) deps.noteTrigger?.(sessionId, event.event_id);
 
     // The user's words, unchanged. Trimming or decorating them would put the
     // bridge's voice into the agent's input.

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -15,7 +15,7 @@
 import { createMatrixClient, type MatrixClient } from "./client";
 import { provisionStation, provisionAll } from "./provision";
 import { handleRoomMessage } from "./inbound";
-import { attachRoomToSession } from "./outbound";
+import { attachRoomToSession, noteTurnTrigger } from "./outbound";
 import { createSession, promptSession } from "../acp-sessions";
 import { createLogger } from "../../utils/logger";
 
@@ -110,6 +110,7 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
     // exactly what happened the first time this ran against the real fleet.
     attach: (sessionId: string, roomId: string, agentUser: string) =>
       attachRoomToSession(sessionId, roomId, agentUser, { client }),
+    noteTrigger: noteTurnTrigger,
   };
 
   return {

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { attachRoomToSession, detachRoom, _attachedCountForTest } from "./outbound";
+import {
+  attachRoomToSession,
+  detachRoom,
+  noteTurnTrigger,
+  _attachedCountForTest,
+} from "./outbound";
 
 /**
  * The agent's answer, arriving in the room.
@@ -17,6 +22,8 @@ const SESSION = "acps_outbound_test";
 let sent: Array<{ userId: string; roomId: string; body: string }> = [];
 let typing: Array<{ roomId: string; on: boolean }> = [];
 let listeners: Array<(e: any) => void> = [];
+let reactions: Array<{ targetId: string; key: string }> = [];
+let redacted: string[] = [];
 let unsubscribed = 0;
 
 function deps() {
@@ -28,6 +35,13 @@ function deps() {
       },
       sendTyping: async (_userId: string, roomId: string, on: boolean) => {
         typing.push({ roomId, on });
+      },
+      sendReaction: async (_userId: string, _roomId: string, targetId: string, key: string) => {
+        reactions.push({ targetId, key });
+        return `$reaction-${reactions.length}`;
+      },
+      redact: async (_userId: string, _roomId: string, eventId: string) => {
+        redacted.push(eventId);
       },
     },
     subscribe: (_sessionId: string, fn: (e: any) => void) => {
@@ -92,6 +106,8 @@ beforeEach(() => {
   sent = [];
   typing = [];
   listeners = [];
+  reactions = [];
+  redacted = [];
   unsubscribed = 0;
   // The attachment map is module state — one per session, deliberately, so a
   // reconnect cannot double every message. Left attached, it would make the
@@ -303,5 +319,115 @@ describe("streaming an answer into a room", () => {
     expect(sent.map((s) => s.body)).toEqual(["second"]);
     expect(_attachedCountForTest()).toBe(1);
     detachRoom(SESSION);
+  });
+});
+
+describe("live feedback, so a room is not a black box", () => {
+  test("stops typing when the agent is waiting on a permission answer", async () => {
+    // The bug an operator saw: typing stayed on long after the answer arrived.
+    // `waiting` is not `idle`, and a permission request the room cannot answer
+    // could sit there for hours with the agent apparently still typing.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("working"));
+    await settle();
+    expect(typing.at(-1)!.on).toBe(true);
+
+    emit(state("waiting"));
+    await settle();
+
+    expect(typing.at(-1)!.on).toBe(false);
+  });
+
+  test("keeps typing alive through a turn longer than the homeserver's timeout", async () => {
+    // A typing notice expires after ~30s. A three-minute turn would show typing
+    // for the first thirty seconds and then look abandoned.
+    attachRoomToSession(SESSION, ROOM, AGENT, { ...deps(), typingRefreshMs: 30 });
+
+    emit(state("working"));
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(typing.filter((t) => t.on).length).toBeGreaterThan(1);
+
+    emit(state("idle"));
+    await settle();
+    expect(typing.at(-1)!.on).toBe(false);
+  }, 10_000);
+
+  test("stops refreshing typing once the turn ends", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, { ...deps(), typingRefreshMs: 30 });
+    emit(state("working"));
+    await new Promise((r) => setTimeout(r, 80));
+
+    emit(state("idle"));
+    await settle();
+    const after = typing.length;
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(typing).toHaveLength(after);
+  }, 10_000);
+
+  test("marks the message it is working on, and clears the mark when done", async () => {
+    // The vocabulary hermes's own Matrix plugin used: 👀 while working, ✅ when
+    // finished. It answers "did it even hear me" without a message.
+    noteTurnTrigger(SESSION, "$user-msg-1");
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("working"));
+    await settle();
+    expect(reactions.at(-1)).toEqual({ targetId: "$user-msg-1", key: "👀" });
+
+    emit(chunk("4."));
+    emit(state("idle"));
+    await settle();
+
+    // The eyes are redacted rather than left beside the tick: two marks on one
+    // message reads as two states at once.
+    expect(redacted).toContain("$reaction-1");
+    expect(reactions.at(-1)).toEqual({ targetId: "$user-msg-1", key: "✅" });
+  });
+
+  test("marks a failed turn with a cross, not a tick", async () => {
+    noteTurnTrigger(SESSION, "$user-msg-2");
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("working"));
+    await settle();
+    emit({
+      sessionId: SESSION,
+      seq: 4,
+      type: "error",
+      payload: { message: "harness exited" },
+      createdAt: new Date().toISOString(),
+    });
+    await settle();
+
+    expect(reactions.at(-1)).toEqual({ targetId: "$user-msg-2", key: "❌" });
+  });
+
+  test("reacts to the message that started THIS turn, not the previous one", async () => {
+    // A room is a conversation. Marking the wrong message would tell somebody
+    // their old question was being worked on.
+    noteTurnTrigger(SESSION, "$first");
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+    emit(state("working"));
+    emit(state("idle"));
+    await settle();
+
+    noteTurnTrigger(SESSION, "$second");
+    emit(state("working"));
+    await settle();
+
+    expect(reactions.at(-1)!.targetId).toBe("$second");
+  });
+
+  test("says nothing with reactions when there is no message to mark", async () => {
+    // An unprompted turn — a cron job speaking — has no user message to react to.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps());
+
+    emit(state("working"));
+    await settle();
+
+    expect(reactions).toHaveLength(0);
   });
 });

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -21,6 +21,13 @@ export interface OutboundDeps {
   client: {
     sendText(userId: string, roomId: string, body: string): Promise<string | null>;
     sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
+    sendReaction?(
+      userId: string,
+      roomId: string,
+      targetEventId: string,
+      key: string
+    ): Promise<string | null>;
+    redact?(userId: string, roomId: string, eventId: string): Promise<void>;
   };
   subscribe?: (sessionId: string, fn: (e: AcpEvent) => void) => () => void;
   /**
@@ -28,6 +35,8 @@ export interface OutboundDeps {
    * that assert on flush timing directly.
    */
   flushDelayMs?: number;
+  /** How often to re-send a typing notice while a turn runs. See TYPING_REFRESH_MS. */
+  typingRefreshMs?: number;
 }
 
 interface Attachment {
@@ -35,8 +44,13 @@ interface Attachment {
   agentUser: string;
   buffer: string[];
   timer: ReturnType<typeof setTimeout> | null;
+  typingTimer: ReturnType<typeof setInterval> | null;
   unsubscribe: () => void;
   ended: boolean;
+  /** The message that started the current turn, if a person started it. */
+  triggerEventId: string | null;
+  /** The 👀 we put on it, so it can be taken off again. */
+  workingReactionId: string | null;
 }
 
 /**
@@ -62,6 +76,38 @@ const attached = new Map<string, Attachment>();
  * treating it as one cuts sentences in half.
  */
 export const FLUSH_SAFETY_MS = 20_000;
+
+/**
+ * How often a typing notice is renewed while a turn is running.
+ *
+ * A Matrix typing notice expires on its own — ours carries a 30s timeout — so a
+ * three-minute turn would show typing for the first thirty seconds and then look
+ * abandoned. Renewing at 20s keeps the room honest for as long as the agent is
+ * actually working, and stops the moment it is not.
+ */
+export const TYPING_REFRESH_MS = 20_000;
+
+/**
+ * What a mark on a message means.
+ *
+ * The vocabulary hermes's own Matrix plugin used, kept deliberately: 👀 while
+ * the agent is working, ✅ when the turn finished, ❌ when it failed. It answers
+ * "did it even hear me" without costing a message.
+ */
+const REACTION = { working: "👀", done: "✅", failed: "❌" } as const;
+
+/**
+ * The message that started the turn about to run, per session.
+ *
+ * Set by the inbound path before it prompts. Kept outside the attachment because
+ * a turn can be noted before the room is attached — and cleared with it.
+ */
+const triggers = new Map<string, string>();
+
+/** Note which message started the next turn on this session. */
+export function noteTurnTrigger(sessionId: string, eventId: string): void {
+  triggers.set(sessionId, eventId);
+}
 
 /** Leak detection, mirroring `_subscriberCountForTest` in acp-sessions. */
 export function _attachedCountForTest(): number {
@@ -116,8 +162,11 @@ export function attachRoomToSession(
     agentUser,
     buffer: [],
     timer: null,
+    typingTimer: null,
     unsubscribe: () => {},
     ended: false,
+    triggerEventId: null,
+    workingReactionId: null,
   };
 
   const say = async (body: string) => {
@@ -151,10 +200,50 @@ export function attachRoomToSession(
     state.timer = setTimeout(() => void flush(), flushDelayMs);
   };
 
+  const typingRefreshMs = deps.typingRefreshMs ?? TYPING_REFRESH_MS;
+
+  const stopTyping = async () => {
+    if (state.typingTimer) {
+      clearInterval(state.typingTimer);
+      state.typingTimer = null;
+    }
+    await deps.client.sendTyping(agentUser, roomId, false).catch(() => {});
+  };
+
+  const startTyping = async () => {
+    await deps.client.sendTyping(agentUser, roomId, true).catch(() => {});
+    if (state.typingTimer) clearInterval(state.typingTimer);
+    // Renewed rather than set once: the notice expires on its own, and a long
+    // turn would otherwise look abandoned halfway through.
+    state.typingTimer = setInterval(() => {
+      void deps.client.sendTyping(agentUser, roomId, true).catch(() => {});
+    }, typingRefreshMs);
+  };
+
+  /** Put a mark on the message that started this turn, replacing any earlier one. */
+  const mark = async (key: string) => {
+    const target = state.triggerEventId;
+    if (!target || !deps.client.sendReaction) return;
+
+    // Two marks on one message would read as two states at once, so the
+    // previous one is taken off before the next goes on.
+    if (state.workingReactionId && deps.client.redact) {
+      await deps.client.redact(agentUser, roomId, state.workingReactionId).catch(() => {});
+      state.workingReactionId = null;
+    }
+
+    const id = await deps.client
+      .sendReaction(agentUser, roomId, target, key)
+      .catch(() => null);
+    if (key === REACTION.working) state.workingReactionId = id ?? null;
+  };
+
   const detach = () => {
     if (state.ended) return;
     state.ended = true;
     if (state.timer) clearTimeout(state.timer);
+    if (state.typingTimer) clearInterval(state.typingTimer);
+    triggers.delete(sessionId);
     state.unsubscribe();
     attached.delete(sessionId);
   };
@@ -178,20 +267,28 @@ export function attachRoomToSession(
 
           if (status === "working") {
             // Without this the room looks dead for the ten seconds an agent
-            // spends thinking.
-            await deps.client
-              .sendTyping(agentUser, roomId, true)
-              .catch(() => {});
+            // spends thinking. The trigger is picked up here rather than at
+            // attach time, because a room outlives any one turn.
+            state.triggerEventId = triggers.get(sessionId) ?? null;
+            await startTyping();
+            await mark(REACTION.working);
             return;
           }
 
-          if (status === "idle" || status === "ended") {
-            await flush();
-            await deps.client.sendTyping(agentUser, roomId, false).catch(() => {});
+          // Anything that is not `working` means the agent is not typing —
+          // including `waiting`, which is a permission request this room cannot
+          // yet answer and could sit there for hours. Enumerating only idle and
+          // ended left typing on for exactly that case.
+          await flush();
+          await stopTyping();
+
+          if (status === "idle" || status === "ended") await mark(REACTION.done);
+
+          if (status === "ended") {
             // A session that ended takes its attachment with it — an
             // unsubscribed listener is the leak `_subscriberCountForTest`
             // exists to catch.
-            if (status === "ended") detach();
+            detach();
           }
           return;
         }
@@ -204,6 +301,8 @@ export function attachRoomToSession(
 
         case "error": {
           const message = isRecord(event.payload) ? event.payload.message : undefined;
+          await stopTyping();
+          await mark(REACTION.failed);
           await say(`This agent reported an error: ${String(message ?? "unknown")}`);
           return;
         }
@@ -223,9 +322,11 @@ export function attachRoomToSession(
 /** Stop streaming a session into its room. Idempotent. */
 export function detachRoom(sessionId: string): void {
   const state = attached.get(sessionId);
+  triggers.delete(sessionId);
   if (!state) return;
   state.ended = true;
   if (state.timer) clearTimeout(state.timer);
+  if (state.typingTimer) clearInterval(state.typingTimer);
   state.unsubscribe();
   attached.delete(sessionId);
 }

--- a/apps/hub/tests/integration/station-matrix-say.test.ts
+++ b/apps/hub/tests/integration/station-matrix-say.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { setGrant } from "../../src/services/grants";
+import { createStationSayRoutes } from "../../src/routes/station-say";
+
+/**
+ * An agent speaking without being spoken to.
+ *
+ * hermes agents have cron jobs: they report in the morning, they raise things
+ * nobody asked about. Bridge mode relays ACP session output, and an ACP session
+ * only exists because somebody prompted it — so those messages had nowhere to
+ * go, and an agent that used to announce things simply went quiet.
+ *
+ * This is the path back. It is deliberately NOT an ACP session: there is no
+ * conversation, no turn, no transcript to attach — just a station saying
+ * something in its own room, as itself.
+ */
+
+const OWNER = "test-user-say";
+const NODE = "node_say";
+const STATION = "station_say";
+const ROOM = "!say:id.agentpod.dev";
+
+let sent: Array<{ userId: string; roomId: string; body: string }> = [];
+
+function app(user = { id: OWNER, role: "user" }) {
+  const routes = createStationSayRoutes({
+    domain: "id.agentpod.dev",
+    client: {
+      sendText: async (userId: string, roomId: string, body: string) => {
+        sent.push({ userId, roomId, body });
+        return "$evt";
+      },
+    },
+  });
+  return new Hono()
+    .use("*", async (c, next) => {
+      c.set("user", user);
+      await next();
+    })
+    .route("/api", routes);
+}
+
+const say = (body: unknown, stationId = STATION) =>
+  app().request(`/api/stations/${stationId}/matrix/say`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: OWNER, email: "say@example.com", name: "Owner" });
+  const tenant = await resolveTenantForUser(OWNER);
+  await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
+  await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${OWNER}, 'say-box', 'say-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:cron-carl', 'leaf', 'cron-carl',
+            '["acp"]'::jsonb, now(), now())`;
+  await rawSql`
+    INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
+    VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+beforeEach(async () => {
+  sent = [];
+  await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+  await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("POST /api/stations/:id/matrix/say", () => {
+  test("says it in the station's room, as the station", async () => {
+    const res = await say({ body: "Morning report: 3 tasks done, 1 blocked." });
+
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      roomId: ROOM,
+      userId: "@agent_say-box_hermes-cron-carl:id.agentpod.dev",
+      body: "Morning report: 3 tasks done, 1 blocked.",
+    });
+  });
+
+  test("needs a grant covering the station, like dispatching it does", async () => {
+    // Speaking as an agent is speaking AS it. Anyone who may not dispatch this
+    // agent must not be able to put words in its mouth.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+
+    expect((await say({ body: "hello" })).status).toBe(403);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("refuses an empty message rather than posting nothing", async () => {
+    expect((await say({ body: "   " })).status).toBe(400);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("404s for a station that is not the caller's", async () => {
+    expect((await say({ body: "hi" }, "station_not_mine")).status).toBe(404);
+  });
+
+  test("says nothing for a station with no room yet", async () => {
+    // Provisioning may not have run. Answering 409 tells the caller what to fix
+    // rather than swallowing the message.
+    await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
+
+    const res = await say({ body: "anyone there?" });
+
+    expect(res.status).toBe(409);
+    expect(sent).toHaveLength(0);
+
+    const tenant = await resolveTenantForUser(OWNER);
+    await rawSql`
+      INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
+      VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', now())`;
+  });
+
+  test("stays out of the way when the harness answers for itself", async () => {
+    // A harness-mode station has its own Matrix client and posts its own
+    // messages. Speaking for it too would double every announcement.
+    await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
+
+    expect((await say({ body: "hello" })).status).toBe(409);
+    expect(sent).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closing the parity gap between bridge mode and a harness's own Matrix client. Four things, three of them things hermes used to do.

## 1. Typing that tells the truth

Typing stayed on long after an answer arrived. The handler cleared it for `idle` and `ended` and nothing else — so a **permission request**, which moves a session to `waiting` and can sit for hours in a room that cannot answer it, left the agent apparently still typing. Anything that is not `working` now stops it.

It is also **renewed every 20s while a turn runs**: a Matrix typing notice expires on its own, so a three-minute turn used to show typing for thirty seconds and then look abandoned.

## 2. Reactions, in hermes's own vocabulary

👀 while working, ✅ done, ❌ failed — on the message that started the turn ([hermes-agent's matrix plugin](https://github.com/NousResearch/hermes-agent/tree/main/plugins/platforms/matrix) uses the same three). It answers "did it even hear me" without costing a message.

The eyes are **redacted before the tick goes on**, because two marks on one message read as two states at once. A turn nobody asked for has no message to mark and gets none.

## 3. Avatars, uniform and optional

hermes profiles carry a `pfp.png` and hermes's tooling uploaded it — which is why those 14 agents had faces and every other station showed a letter. The candidate paths are **not keyed by harness**; a convention that only worked for the harness that already had faces would bake in the accident this bridge exists to remove.

Optional means optional: an agent with no image provisions exactly as far as one with it, a non-image at that path is declined rather than uploaded, and a node that will not answer is never worth failing provisioning over.

## 4. `POST /api/stations/:id/matrix/say`

An agent speaking **without being spoken to**. hermes agents have cron jobs; bridge mode only relayed ACP session output, and a session exists only because somebody prompted it — so scheduled messages had nowhere to go and agents that used to report in went quiet.

Deliberately **not** an ACP session: a scheduled announcement is not a conversation turn and should not enter the transcript as though someone asked for it. Gated by the same grant as dispatch, because speaking *as* an agent is a strong thing to be able to do — and refused for `harness`-mode stations, which post their own.

**1316 tests pass, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW