### PR TITLE
feat(hub): a one-to-one agent room is a DM

### DIFF
--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -41,7 +41,22 @@ export interface MatrixClient {
   ): Promise<{ userId: string; accessToken: string; deviceId: string }>;
   ensureRoom(
     alias: string,
-    opts: { creator: string; name: string; topic: string }
+    opts: {
+      creator: string;
+      name: string;
+      topic: string;
+      /** Invited at creation, because `isDirect` rides on the invite's member event. */
+      invite?: string;
+      /**
+       * Make this a DM for the invitee.
+       *
+       * The server stamps `is_direct` on the invite it sends, and a conformant
+       * client files the room under People itself. Deliberately not written into
+       * the human's own `m.direct` account data — that needs a human's access
+       * token, which is the credential this bridge exists to stop keeping.
+       */
+      isDirect?: boolean;
+    }
   ): Promise<string | null>;
   sendText(userId: string, roomId: string, body: string): Promise<string | null>;
   sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
@@ -178,6 +193,8 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
           name: opts.name,
           topic: opts.topic,
           preset: "private_chat",
+          ...(opts.invite ? { invite: [opts.invite] } : {}),
+          ...(opts.isDirect ? { is_direct: true } : {}),
         },
       });
 

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -28,7 +28,13 @@ export interface ProvisionDeps {
     ensureUser(localpart: string, displayName: string): Promise<void>;
     ensureRoom(
       alias: string,
-      opts: { creator: string; name: string; topic: string }
+      opts: {
+        creator: string;
+        name: string;
+        topic: string;
+        invite?: string;
+        isDirect?: boolean;
+      }
     ): Promise<string | null>;
     invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
   };
@@ -104,10 +110,22 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
   // conversation in two, with each half unaware of the other.
   if (!s.roomId) {
     const alias = bridgeAlias(s.nodeName, s.stationKey, deps.domain);
+
+    // The owner is invited AT creation rather than afterwards, because the flag
+    // that makes this a DM rides on the invite's own member event and can only
+    // be set there.
+    //
+    // A one-to-one agent room is a conversation with one correspondent, so it
+    // belongs under People — 32 agents in a Rooms list is a wall. Rooms where
+    // several agents work together are ordinary rooms, and are what spaces will
+    // group.
+    const invitee = await ownerMxid(s.userId);
+
     const roomId = await deps.client.ensureRoom(alias, {
       creator: speaker,
       name: s.displayName,
       topic: `${s.harness} on ${s.nodeName} — ${s.stationKey}`,
+      ...(invitee ? { invite: invitee, isDirect: true } : {}),
     });
 
     if (roomId) {
@@ -115,11 +133,6 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
         .insert(matrixRooms)
         .values({ roomId, tenantId: s.tenantId, stationId: s.stationId, alias })
         .onConflictDoNothing();
-
-      const invitee = await ownerMxid(s.userId);
-      // Only on creation: re-inviting somebody into a room they are already in
-      // is an error on some homeservers and noise on all of them.
-      if (invitee) await deps.client.invite(speaker, roomId, invitee);
     }
   }
 

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -21,7 +21,14 @@ const DOMAIN = "id.agentpod.dev";
 const OWNER_MXID = "@owner-provision:id.agentpod.dev";
 
 let registered: Array<{ localpart: string; displayName: string }> = [];
-let rooms: Array<{ alias: string; creator: string; name: string; topic: string }> = [];
+let rooms: Array<{
+  alias: string;
+  creator: string;
+  name: string;
+  topic: string;
+  invite?: string;
+  isDirect?: boolean;
+}> = [];
 let invites: Array<{ roomId: string; invitee: string }> = [];
 let roomCounter = 0;
 
@@ -34,9 +41,9 @@ function deps() {
       },
       ensureRoom: async (
         alias: string,
-        opts: { creator: string; name: string; topic: string }
+        opts: { creator: string; name: string; topic: string; invite?: string; isDirect?: boolean }
       ) => {
-        rooms.push({ alias, ...opts });
+        rooms.push({ alias, ...opts } as any);
         return `!room${++roomCounter}:id.agentpod.dev`;
       },
       invite: async (_asUserId: string, roomId: string, invitee: string) => {
@@ -138,8 +145,37 @@ describe("provisioning a station", () => {
   test("invites the station's owner, so the room is not a locked door", async () => {
     await provisionStation(OPENCLAW, deps());
 
-    expect(invites).toHaveLength(1);
-    expect(invites[0]!.invitee).toBe(OWNER_MXID);
+    // Invited at creation rather than afterwards: the flag that makes this a DM
+    // rides on the invite's member event, and can only be set there.
+    expect(rooms[0]!.invite).toBe(OWNER_MXID);
+  });
+
+  test("a one-to-one agent room is a DM, which is what hermes's rooms were", async () => {
+    // Talking to one agent is a conversation with one correspondent. Element
+    // files it under People, and 32 agents in a Rooms list is a wall.
+    //
+    // `is_direct` at creation rather than writing the human's m.direct: that is
+    // what hermes did, and it needed a human's access token — the credential
+    // this bridge exists to stop keeping. A conformant client files the DM
+    // itself when it sees the flag on its invite.
+    await provisionStation(OPENCLAW, deps());
+
+    expect(rooms[0]!.isDirect).toBe(true);
+  });
+
+  test("a station whose owner has no Matrix identity gets a room, not a DM", async () => {
+    // Nobody to be direct WITH. The room still exists so the agent has somewhere
+    // to be, and somebody can be invited later.
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+
+    await provisionStation(OPENCLAW, deps());
+
+    expect(rooms[0]!.isDirect).toBeFalsy();
+    expect(rooms[0]!.invite).toBeUndefined();
+
+    await rawSql`
+      INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
+      VALUES ('pid_mx_provision', ${OWNER}, 'matrix', ${OWNER_MXID}, now())`;
   });
 
   test("provisions a hermes station exactly like every other", async () => {


### PR DESCRIPTION
Talking to one agent is a conversation with one correspondent, and 32 of them in a Rooms list is a wall. Element files a DM under People — which is where hermes's agents lived before the bridge took over, and a difference nobody asked for when it changed.

## How, and why not the way hermes did it

The owner is invited **at room creation** rather than afterwards, because `is_direct` rides on the invite's own member event and can only be set there.

Deliberately **not** by writing the human's `m.direct` account data. That is how `hermes-agents onboard` did it (`mark_admin_direct_room`), and it needed a human's access token — the credential this bridge exists to stop keeping on a node. Setting `is_direct` on the invite is credential-free: a conformant client, including the rust-sdk supermessage uses, files the DM itself.

A station whose owner has no Matrix identity still gets a room, just not a DM — there is nobody to be direct with, and the agent still needs somewhere to be.

## What stays a room

Rooms where several agents work together. Those are the ones spaces will group, once mission rooms exist — `charter` → `strategy/2026-08-12-layer-reference.md` P2 calls them "mission/team rooms".

Verified on the live homeserver that tuwunel creates spaces, accepts `m.space.child` and answers `/hierarchy`, so that path is open when the feature is.

**1318 tests pass, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW