### PR TITLE
feat(hub): give an agent its face, whatever harness it runs

### DIFF
--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -2013,7 +2013,17 @@ function fakeObservableProvisioner(
 }
 
 /** An `online` runtime whose node stopped heartbeating `agoMs` ago. */
-async function seedUnobserved(id: string, agoMs = 10 * 60_000) {
+/**
+ * `agoMs` defaults to well past the grace window, not exactly to it.
+ *
+ * At exactly UNOBSERVED_GRACE_MS the row sits on the boundary the sweep
+ * compares against, and the two timestamps come from different clocks — the
+ * row's from Postgres, the cutoff from this process. A second of skew between
+ * them decides the test, which is how it failed in CI while passing locally.
+ * The boundary itself is covered by the grace-window test below, deliberately
+ * and from the safe side.
+ */
+async function seedUnobserved(id: string, agoMs = 45 * 60_000) {
   const nodeId = `node_unobs_${id}`;
   // Every seeded row is a candidate for every other test's sweep, so each test
   // starts from a clean slate rather than counting probes it did not cause.

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -12,6 +12,10 @@
  * nothing.
  */
 
+import { eq } from "drizzle-orm";
+import { db } from "../../db/drizzle";
+import { stations } from "../../db/schema/stations";
+import * as broker from "../broker";
 import { createMatrixClient, type MatrixClient } from "./client";
 import { provisionStation, provisionAll } from "./provision";
 import { handleRoomMessage } from "./inbound";
@@ -20,6 +24,15 @@ import { createSession, promptSession } from "../acp-sessions";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-bridge");
+
+/** The image types `avatar.ts` accepts, by extension. Anything else is declined there. */
+function contentTypeFor(path: string): string {
+  if (path.endsWith(".png")) return "image/png";
+  if (path.endsWith(".jpg") || path.endsWith(".jpeg")) return "image/jpeg";
+  if (path.endsWith(".gif")) return "image/gif";
+  if (path.endsWith(".webp")) return "image/webp";
+  return "application/octet-stream";
+}
 
 export interface MatrixBridgeConfig {
   enabled: boolean;
@@ -58,6 +71,8 @@ export function matrixBridgeProblems(cfg: MatrixBridgeConfig): string[] {
 export interface MatrixBridge {
   client: MatrixClient;
   config: MatrixBridgeConfig;
+  /** Everything provisioning needs, so boot and the API use the same deps. */
+  provisionDeps: Parameters<typeof provisionAll>[0];
   /** Give a station its identity and room. Safe to call repeatedly. */
   provision(stationId: string): Promise<void>;
   /** Handle one event the homeserver pushed. */
@@ -89,7 +104,43 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
     domain: cfg.domain,
   });
 
-  const provisionDeps = { domain: cfg.domain, client };
+  /**
+   * Read a file from a station's workspace, through its node.
+   *
+   * Used for one thing — an agent's avatar — so it is deliberately small: a
+   * short timeout, a size cap, and null for everything that is not a plain
+   * successful read. The image lives on whichever machine the station does, and
+   * that machine may be offline, busy, or simply not have the file.
+   */
+  const readWorkspaceFile = async (
+    stationId: string,
+    path: string
+  ): Promise<{ bytes: Uint8Array; contentType: string } | null> => {
+    const [station] = await db
+      .select({ nodeId: stations.nodeId, stationKey: stations.stationKey })
+      .from(stations)
+      .where(eq(stations.id, stationId));
+    if (!station) return null;
+
+    const res = await broker.request(
+      station.nodeId,
+      "fs.read",
+      { key: station.stationKey, path, maxBytes: 2 * 1024 * 1024 },
+      { timeoutMs: 5_000 }
+    );
+    if (!res.ok) return null;
+
+    const data = res.data as { content?: string; encoding?: string; truncated?: boolean };
+    // A truncated image is a corrupt image. Better no face than a broken one.
+    if (!data?.content || data.encoding !== "base64" || data.truncated) return null;
+
+    return {
+      bytes: Uint8Array.from(Buffer.from(data.content, "base64")),
+      contentType: contentTypeFor(path),
+    };
+  };
+
+  const provisionDeps = { domain: cfg.domain, client, readWorkspaceFile };
 
   const inboundDeps = {
     domain: cfg.domain,
@@ -116,6 +167,7 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
   return {
     client,
     config: cfg,
+    provisionDeps,
 
     async provision(stationId: string) {
       await provisionStation(stationId, provisionDeps);
@@ -144,7 +196,7 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
  * immediately finds somewhere to push to.
  */
 export async function startMatrixBridge(bridge: MatrixBridge): Promise<void> {
-  const result = await provisionAll({ domain: bridge.config.domain, client: bridge.client });
+  const result = await provisionAll(bridge.provisionDeps);
   log.info("matrix bridge ready", {
     domain: bridge.config.domain,
     provisioned: result.provisioned,

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -18,6 +18,7 @@ import { nodes } from "../../db/schema/nodes";
 import { matrixRooms } from "../../db/schema/matrix";
 import { principalIdentities } from "../../db/schema/identities";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
+import { pickAvatar } from "./avatar";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-provision");
@@ -37,7 +38,23 @@ export interface ProvisionDeps {
       }
     ): Promise<string | null>;
     invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+    uploadImage?(
+      userId: string,
+      bytes: Uint8Array,
+      contentType: string
+    ): Promise<string | null>;
+    setAvatar?(userId: string, mxcUrl: string): Promise<void>;
   };
+  /**
+   * Read a file from the station's workspace, or null when it is not there.
+   *
+   * Absent in deployments that cannot reach the node — an agent's face is never
+   * worth failing provisioning over.
+   */
+  readWorkspaceFile?(
+    stationId: string,
+    path: string
+  ): Promise<{ bytes: Uint8Array; contentType: string } | null>;
 }
 
 /** The station, its node's name, and whether a room already exists for it. */
@@ -104,6 +121,28 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
 
   if (bridged) {
     await deps.client.ensureUser(bridgeLocalpart(s.nodeName, s.stationKey), displayName);
+  }
+
+  // An agent's face, if it has one — read once, when the station is first
+  // provisioned. Provisioning runs at every boot, and re-reading and re-uploading
+  // an image per station per restart is a cost with no benefit: the picture has
+  // not changed. A face added later lands the next time the identity is
+  // explicitly re-provisioned.
+  const firstProvision = !s.roomId;
+  if (bridged && firstProvision && deps.readWorkspaceFile && deps.client.uploadImage) {
+    const found = await pickAvatar({
+      read: (path) => deps.readWorkspaceFile!(s.stationId, path),
+    }).catch(() => null);
+
+    if (found) {
+      const mxc = await deps.client
+        .uploadImage(speaker, found.bytes, found.contentType)
+        .catch(() => null);
+      if (mxc && deps.client.setAvatar) {
+        await deps.client.setAvatar(speaker, mxc).catch(() => {});
+        log.info("gave an agent its face", { stationId, path: found.path });
+      }
+    }
   }
 
   // The room is created once. A second one for the same station would split its

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -31,6 +31,9 @@ let rooms: Array<{
 }> = [];
 let invites: Array<{ roomId: string; invitee: string }> = [];
 let roomCounter = 0;
+let uploaded: Array<{ bytes: number; contentType: string }> = [];
+let avatars: Array<{ userId: string; mxcUrl: string }> = [];
+let workspaceFiles: Record<string, { bytes: Uint8Array; contentType: string } | null> = {};
 
 function deps() {
   return {
@@ -49,7 +52,16 @@ function deps() {
       invite: async (_asUserId: string, roomId: string, invitee: string) => {
         invites.push({ roomId, invitee });
       },
+      uploadImage: async (_userId: string, bytes: Uint8Array, contentType: string) => {
+        uploaded.push({ bytes: bytes.length, contentType });
+        return "mxc://id.agentpod.dev/abc123";
+      },
+      setAvatar: async (userId: string, mxcUrl: string) => {
+        avatars.push({ userId, mxcUrl });
+      },
     },
+    readWorkspaceFile: async (_stationId: string, path: string) =>
+      workspaceFiles[path] ?? null,
   };
 }
 
@@ -95,6 +107,9 @@ beforeEach(async () => {
   registered = [];
   rooms = [];
   invites = [];
+  uploaded = [];
+  avatars = [];
+  workspaceFiles = {};
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
   await rawSql`
     UPDATE stations SET bridge_matrix_id = NULL, matrix_identity_mode = 'bridge', matrix_id = NULL
@@ -276,5 +291,68 @@ describe("provisioning the whole fleet", () => {
 
     expect(result.failed).toBeGreaterThanOrEqual(1);
     expect(result.provisioned).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("an agent's face, if it has one", () => {
+  test("uploads the image it finds and puts it on the agent", async () => {
+    // hermes profiles carry a pfp.png and hermes's tooling uploaded it, which is
+    // why those agents had faces and everything else had a letter. The bridge
+    // looks in the same places whatever the harness is.
+    workspaceFiles["pfp.png"] = {
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      contentType: "image/png",
+    };
+
+    await provisionStation(OPENCLAW, deps());
+
+    expect(uploaded).toHaveLength(1);
+    expect(avatars.at(-1)).toMatchObject({
+      userId: "@agent_prov-box_openclaw-krishna:id.agentpod.dev",
+      mxcUrl: "mxc://id.agentpod.dev/abc123",
+    });
+  });
+
+  test("provisions exactly as far for an agent with no image", async () => {
+    // Optional means optional: no face is not a failure, and the room, the
+    // identity and the display name all still land.
+    await provisionStation(OPENCLAW, deps());
+
+    expect(avatars).toHaveLength(0);
+    expect(rooms).toHaveLength(1);
+    expect(registered).toHaveLength(1);
+  });
+
+  test("a node that will not answer costs the agent a face, not a room", async () => {
+    // The image lives on another machine, which may be offline. Provisioning
+    // must not depend on it.
+    const d = deps();
+    const failing = {
+      ...d,
+      readWorkspaceFile: async () => {
+        throw new Error("node offline");
+      },
+    };
+
+    await provisionStation(OPENCLAW, failing);
+
+    expect(avatars).toHaveLength(0);
+    expect(rooms).toHaveLength(1);
+  });
+
+  test("does not re-upload an agent's face on every boot", async () => {
+    // Provisioning runs at every restart. Reading and uploading an image per
+    // station per boot is a cost with no benefit — the picture has not changed.
+    workspaceFiles["pfp.png"] = {
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      contentType: "image/png",
+    };
+    await provisionStation(OPENCLAW, deps());
+    uploaded = [];
+    avatars = [];
+
+    await provisionStation(OPENCLAW, deps());
+
+    expect(uploaded).toHaveLength(0);
   });
 });


### PR DESCRIPTION
hermes profiles carry a `pfp.png` and hermes's own tooling uploaded it — which is why those 14 agents had faces and every other station shows a letter. The candidate paths here are **not keyed by harness**: a convention that only worked for the harness that already had faces would preserve exactly the accident this bridge exists to remove.

## Optional throughout

- No image is not a failure — the room, the identity and the display name all still land.
- A non-image at that path is declined rather than uploaded.
- A **truncated** read is treated as no image, because a truncated image is a corrupt one.
- A node that will not answer costs an agent its face, never its room.

## Read once, at first provision

Provisioning runs at every boot. Re-reading and re-uploading an image per station per restart is a cost with no benefit, since the picture has not changed. A face added later lands the next time that identity is explicitly re-provisioned.

## Also: a flaky test, fixed

`a substrate that cannot answer changes nothing, but says so` failed in CI and passed locally, twice. Its seed used **exactly** `UNOBSERVED_GRACE_MS`, so the row sat on the boundary the sweep compares against — and the two timestamps come from different clocks, the row's from Postgres and the cutoff from the hub process. A second of skew decided it. Seeded well past the window now; the boundary stays covered by the grace-window test, from the safe side.

**1322 tests pass, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW