### PR TITLE
feat(hub): a station adopted now gets its room now, and onboarding stops holding an admin token

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -54,6 +54,7 @@ import { enabledProviders } from './services/provisioner/registry.ts';
 import { startNodeSweeper } from './services/node-sweeper.ts';
 import { startKaambaanBridge } from './services/bridge/loop.ts';
 import { createMatrixBridge, startMatrixBridge } from './services/matrix-as/index.ts';
+import { onStationsAdopted } from './services/matrix-as/hooks.ts';
 import { createMatrixAsRoutes } from './routes/matrix-as.ts';
 import { createStationMatrixRoutes } from './routes/station-matrix.ts';
 import { createStationSayRoutes } from './routes/station-say.ts';
@@ -256,6 +257,10 @@ console.log(
 // after the routes are mounted so a homeserver that starts pushing immediately
 // finds somewhere to push to.
 if (matrixBridge) {
+  // A station adopted at noon must not wait for a restart to get a room.
+  onStationsAdopted(async (stationIds) => {
+    for (const id of stationIds) await matrixBridge.provision(id);
+  });
   await startMatrixBridge(matrixBridge);
 } else {
   console.log('matrix bridge: (disabled)');

--- a/apps/hub/src/services/matrix-as/hooks.ts
+++ b/apps/hub/src/services/matrix-as/hooks.ts
@@ -1,0 +1,43 @@
+/**
+ * Telling the bridge that stations have arrived.
+ *
+ * Provisioning runs at boot, which is enough for a fleet that only changes when
+ * the hub restarts — and wrong for one that doesn't. A station adopted at noon
+ * would have no Matrix identity and no room until somebody restarted the hub,
+ * and the symptom is an agent that exists everywhere except the place you were
+ * told to talk to it.
+ *
+ * A hook rather than a direct call, so `station-registry` keeps knowing nothing
+ * about Matrix: adoption announces what happened, and whoever cares listens.
+ * Nobody listens when the bridge is off.
+ */
+
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("matrix-hooks");
+
+type Listener = (stationIds: string[]) => Promise<void>;
+
+let listener: Listener | null = null;
+
+/** Register the one listener. Replaces any previous — this is boot wiring. */
+export function onStationsAdopted(fn: Listener | null): void {
+  listener = fn;
+}
+
+/**
+ * Announce newly adopted stations.
+ *
+ * Never throws and never delays the caller: adoption succeeded, and a bridge
+ * that could not give an agent a room must not make it look as though the
+ * station was not adopted.
+ */
+export function notifyStationsAdopted(stationIds: string[]): void {
+  if (!listener || stationIds.length === 0) return;
+  void listener(stationIds).catch((err) => {
+    log.error("could not provision Matrix identities for newly adopted stations", {
+      count: stationIds.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}

--- a/apps/hub/src/services/station-registry.ts
+++ b/apps/hub/src/services/station-registry.ts
@@ -9,6 +9,7 @@
  */
 
 import { and, eq, sql } from "drizzle-orm";
+import { notifyStationsAdopted } from "./matrix-as/hooks";
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
@@ -119,7 +120,15 @@ export async function adoptStations(
     .from(stations)
     .where(and(eq(stations.userId, userId), eq(stations.nodeId, nodeId)));
 
-  return allAdopted.filter((r) => keys.includes(r.stationKey));
+  const adopted = allAdopted.filter((r) => keys.includes(r.stationKey));
+
+  // Announce, do not act: this module knows nothing about Matrix, and nobody
+  // listens when the bridge is off. Fire-and-forget, because adoption has
+  // already succeeded and a bridge that could not make a room must not make it
+  // look as though the station was not adopted.
+  notifyStationsAdopted(adopted.map((r) => r.id));
+
+  return adopted;
 }
 
 // ─── listAdopted ─────────────────────────────────────────────────────────────

--- a/apps/hub/tests/integration/matrix-adoption-hook.test.ts
+++ b/apps/hub/tests/integration/matrix-adoption-hook.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { adoptStations } from "../../src/services/station-registry";
+import { onStationsAdopted } from "../../src/services/matrix-as/hooks";
+
+/**
+ * A station adopted at noon should not wait for a restart to get a room.
+ *
+ * Provisioning ran only at boot, which is enough for a fleet that changes when
+ * the hub restarts and wrong for one that doesn't: the agent would exist
+ * everywhere except the place you had been told to talk to it.
+ */
+
+const USER = "test-user-adopt-hook";
+const NODE = "node_adopt_hook";
+
+let announced: string[][] = [];
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: USER, email: "adopt-hook@example.com", name: "AH" });
+  const tenant = await resolveTenantForUser(USER);
+  await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${USER}, 'adopt-box', 'adopt-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+});
+
+beforeEach(async () => {
+  announced = [];
+  await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
+});
+
+afterAll(async () => {
+  onStationsAdopted(null);
+  try {
+    await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+const detected = (key: string) => ({
+  key,
+  harness: "openclaw",
+  kind: "leaf" as const,
+  displayName: key,
+  parentKey: null,
+  workspacePath: null,
+  capabilities: ["acp"],
+  matrixId: null,
+});
+
+describe("adopting a station", () => {
+  test("announces it, so the bridge can give it a room", async () => {
+    onStationsAdopted(async (ids) => {
+      announced.push(ids);
+    });
+
+    const rows = await adoptStations(USER, NODE, ["openclaw:new"], [detected("openclaw:new")]);
+
+    expect(rows).toHaveLength(1);
+    expect(announced).toHaveLength(1);
+    expect(announced[0]).toEqual([rows[0]!.id]);
+  });
+
+  test("adoption still succeeds when the listener throws", async () => {
+    // The station IS adopted. A bridge that could not make a room must not make
+    // it look as though adoption failed.
+    onStationsAdopted(async () => {
+      throw new Error("homeserver unreachable");
+    });
+
+    const rows = await adoptStations(USER, NODE, ["openclaw:two"], [detected("openclaw:two")]);
+
+    expect(rows).toHaveLength(1);
+  });
+
+  test("says nothing when nothing was adopted", async () => {
+    onStationsAdopted(async (ids) => {
+      announced.push(ids);
+    });
+
+    await adoptStations(USER, NODE, [], []);
+
+    expect(announced).toHaveLength(0);
+  });
+
+  test("nobody listens when the bridge is off", async () => {
+    onStationsAdopted(null);
+
+    const rows = await adoptStations(USER, NODE, ["openclaw:three"], [detected("openclaw:three")]);
+
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/apps/hub/tests/unit/docs-claims.test.ts
+++ b/apps/hub/tests/unit/docs-claims.test.ts
@@ -68,6 +68,9 @@ const CODE_FILES = [
   "apps/hub/src/utils/validate-config.ts",
   "apps/console/vite.config.js",
   "apps/console/src/lib/api/client.ts",
+  // A shell script an operator runs is code that reads env vars, and the ones
+  // OPERATING.md §7e tells them to export are read here rather than by the hub.
+  "scripts/onboard-agent.sh",
 ] as const;
 
 /**

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -824,7 +824,34 @@ anywhere) or `harness` (it runs its own Matrix client). `POST
 same write; it needs `mayGrantReach`, because handing an agent a credential is
 granting it reach.
 
-### 7e. What happened to the Synapse history
+### 7e. Creating a new agent
+
+`hermes-agents onboard` created a Matrix account through the **Synapse admin
+API** with a token stored on molt-bot — a credential that could create,
+deactivate or take over any account on the homeserver, including a human's. That
+API does not exist on tuwunel, so the Matrix half of that command cannot work
+and must not be used.
+
+Use `scripts/onboard-agent.sh` on the host instead:
+
+```sh
+# 1. create the harness profile as usual (hermes-agents create-service, etc.)
+# 2. then, on that host:
+AGENTPOD_HUB_URL=https://hub.agentpod.dev \
+AGENTPOD_API_TOKEN=<hub token> \
+  ./onboard-agent.sh hermes:analyst-echo
+```
+
+It never talks to the homeserver. It waits for the node agent to detect the
+station, adopts it through the hub, and **adoption is what makes the bridge
+provision** an identity and a DM room. The credential it holds is a hub token,
+so everything it can do is something the control pair already governs.
+
+**The ordering inverted**, and it is the thing to remember: the old flow made the
+Matrix account first and the agent second; now the station must exist before it
+can have an identity.
+
+### 7f. What happened to the Synapse history
 
 The old homeserver's 19,603 events are **not in tuwunel** — there is no supported
 import path from Synapse into the Conduit lineage, and Matrix here carries a

--- a/scripts/onboard-agent.sh
+++ b/scripts/onboard-agent.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# onboard-agent.sh — give a newly created agent a place in the fleet.
+#
+# Run on the host where the agent's harness lives, AFTER its profile exists.
+# It adopts the station through the hub, and the hub gives it a Matrix identity
+# and a room on its own.
+#
+# ── Why this exists ──────────────────────────────────────────────────────────
+#
+# `hermes-agents onboard` used to do the Matrix half itself: it created the
+# account through the SYNAPSE ADMIN API, logged in as the new user to mint a
+# device token, and created a room — all with an admin token stored in a file on
+# the node. That token could create, deactivate or take over any account on the
+# homeserver, including a human's.
+#
+# Two things ended it. The homeserver is tuwunel now and implements no such
+# admin API, so that code cannot work. And an Application Service needs no
+# privilege to register users inside its own namespace, so the ordinary path
+# needs no admin credential at all.
+#
+# What this script holds instead is a HUB token. Everything it can do is
+# something the control pair already governs — it can adopt a station, and
+# adoption is what makes the hub provision an identity. It cannot touch the
+# homeserver, and it cannot act outside its own grant.
+#
+# ── The ordering inverted, and that is the trap ──────────────────────────────
+#
+# The old flow made the Matrix account first and the agent second. Now the
+# STATION must exist before it can have an identity: the harness creates the
+# profile, the node agent detects it, somebody adopts it, and the hub provisions.
+# So this script waits for the station to appear rather than assuming it has.
+#
+# Usage:
+#   AGENTPOD_HUB_URL=https://hub.agentpod.dev \
+#   AGENTPOD_API_TOKEN=<hub token> \
+#     ./onboard-agent.sh <station-key>
+#
+#   e.g. ./onboard-agent.sh hermes:analyst-echo
+set -eu
+
+STATION_KEY="${1:-}"
+HUB="${AGENTPOD_HUB_URL:-https://hub.agentpod.dev}"
+TOKEN="${AGENTPOD_API_TOKEN:-}"
+NODE_NAME="${AGENTPOD_NODE_NAME:-$(hostname)}"
+WAIT_SECONDS="${AGENTPOD_WAIT_SECONDS:-120}"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+say() { printf '%s\n' "$*"; }
+
+[ -n "$STATION_KEY" ] || die "usage: onboard-agent.sh <station-key>   e.g. hermes:analyst-echo"
+[ -n "$TOKEN" ] || die "AGENTPOD_API_TOKEN is not set. This script talks to the hub, not to the homeserver."
+
+api() {
+  _method="$1"; _path="$2"; _body="${3:-}"
+  if [ -n "$_body" ]; then
+    curl -sS -X "$_method" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+      -d "$_body" "$HUB$_path"
+  else
+    curl -sS -X "$_method" -H "Authorization: Bearer $TOKEN" "$HUB$_path"
+  fi
+}
+
+json_field() { python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('$1',''))" 2>/dev/null || true; }
+
+# ── 1. Which node is this? ───────────────────────────────────────────────────
+#
+# By NAME rather than hostname: enrolment suffixes a hostname collision
+# (`molt-bot`, `molt-bot-2`), and the name is what a grant and a Matrix room are
+# built from.
+say "Finding node '$NODE_NAME' in the fleet…"
+NODE_ID=$(api GET /api/nodes | python3 -c "
+import sys, json
+name = '$NODE_NAME'
+nodes = json.load(sys.stdin)
+match = [n for n in nodes if n.get('name') == name]
+print(match[0]['id'] if match else '')
+")
+[ -n "$NODE_ID" ] || die "No node named '$NODE_NAME' is enrolled. Set AGENTPOD_NODE_NAME if this host enrolled under a different name."
+say "  node: $NODE_ID"
+
+# ── 2. Wait for the harness to show the station ──────────────────────────────
+#
+# The profile was created a moment ago; the node agent detects on its own
+# schedule. Waiting with a deadline and a clear message beats failing on a race.
+say "Waiting for '$STATION_KEY' to be detected on this node…"
+DEADLINE=$(( $(date +%s) + WAIT_SECONDS ))
+while :; do
+  if api GET "/api/nodes/$NODE_ID/detected" | grep -q "\"$STATION_KEY\""; then
+    say "  detected"
+    break
+  fi
+  [ "$(date +%s)" -lt "$DEADLINE" ] || die "Timed out after ${WAIT_SECONDS}s waiting for '$STATION_KEY'. Is the harness profile created and the node agent running? (\`apn status\`)"
+  sleep 3
+done
+
+# ── 3. Adopt it ──────────────────────────────────────────────────────────────
+#
+# Adoption is the explicit act — the hub never adopts what it merely sees — and
+# it is what makes the bridge provision a Matrix identity and a room.
+say "Adopting…"
+ADOPTED=$(api POST "/api/nodes/$NODE_ID/stations/adopt" "{\"keys\":[\"$STATION_KEY\"]}")
+STATION_ID=$(printf '%s' "$ADOPTED" | python3 -c "
+import sys, json
+rows = json.load(sys.stdin)
+rows = rows if isinstance(rows, list) else []
+print(rows[0]['id'] if rows else '')
+")
+[ -n "$STATION_ID" ] || die "Adoption did not return a station. Response: $ADOPTED"
+say "  station: $STATION_ID"
+
+# ── 4. Read back where to talk to it ─────────────────────────────────────────
+#
+# Idempotent, and it does not create anything the adoption hook has not already
+# made — it is here so the operator ends with an address rather than an id.
+IDENTITY=$(api POST "/api/stations/$STATION_ID/matrix/identity" '{}')
+MXID=$(printf '%s' "$IDENTITY" | json_field mxid)
+ALIAS=$(printf '%s' "$IDENTITY" | json_field alias)
+
+say ""
+say "Done."
+say "  station : $STATION_KEY on $NODE_NAME"
+say "  matrix  : ${MXID:-（not provisioned — is ENABLE_MATRIX_BRIDGE set on the hub?）}"
+say "  room    : ${ALIAS:-—}"
+say ""
+say "The room is a DM: accept the invite in your client and talk to it there."
+say "If this agent should run its own Matrix client instead of being spoken for,"
+say "ask the hub for credentials — that needs mayGrantReach:"
+say "  curl -X POST -H \"Authorization: Bearer \$AGENTPOD_API_TOKEN\" \\"
+say "    $HUB/api/stations/$STATION_ID/matrix/credentials"


### PR DESCRIPTION
Two halves of the same problem: what happens when a new agent appears.

**Adoption provisions.** Provisioning ran at boot and on request, so a station adopted at 10am had no Matrix identity until somebody restarted the hub. `onStationsAdopted` fires from `station-registry.adoptStations`, and the bridge provisions on it — the room exists by the time the operator looks for it.

**Onboarding stops holding an admin token.** `hermes-agents onboard` created the Matrix account through the *Synapse admin API*, with a token stored in a file on molt-bot that could create, deactivate or take over any account on the homeserver — including a human's. That code cannot work now anyway: tuwunel implements no such API. `scripts/onboard-agent.sh` holds a hub token instead, and everything it can do is something the control pair already governs. It cannot reach the homeserver at all.

The ordering inverted, which is the trap the script exists to handle: the station must exist before it can have an identity, so it waits for detection rather than assuming it.

`docs/OPERATING.md` §7e is the operator-facing version.

Incidentally: the `AGENTPOD_*` variables §7e tells an operator to export are read by that script rather than by the hub, which the docs-claims check called dead. A shell script an operator runs is code that reads env vars, so the scanner now reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW