### PR TITLE
feat(hub): rooms where several agents work together

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0048_matrix_missions.sql
+++ b/apps/hub/src/db/drizzle-migrations/0048_matrix_missions.sql
@@ -1,0 +1,37 @@
+-- Rooms where several agents work together.
+--
+-- A per-agent room is a DM: one correspondent, filed under People. A mission is
+-- the other shape — several stations and several people in one place — so it is
+-- an ordinary room, and it is what spaces group.
+--
+-- `space_room_id` is the Matrix space this mission's room hangs under. Nullable
+-- because a mission can exist before its space does, and because a deployment
+-- may not want the hierarchy at all.
+CREATE TABLE matrix_missions (
+  id            text PRIMARY KEY,
+  tenant_id     text NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  user_id       text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  name          text NOT NULL,
+  room_id       text,
+  alias         text NOT NULL,
+  space_room_id text,
+  created_at    timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX matrix_missions_alias_idx ON matrix_missions (alias);
+CREATE INDEX matrix_missions_tenant_id_idx ON matrix_missions (tenant_id);
+
+-- Which stations are in a mission.
+--
+-- A station may be in several missions at once: an agent is not consumed by the
+-- work it is doing, and the alternative — one mission per agent — is the DM we
+-- already have.
+CREATE TABLE matrix_mission_members (
+  mission_id text NOT NULL REFERENCES matrix_missions(id) ON DELETE CASCADE,
+  station_id text NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+  tenant_id  text NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  added_at   timestamp NOT NULL DEFAULT now(),
+  PRIMARY KEY (mission_id, station_id)
+);
+
+CREATE INDEX matrix_mission_members_tenant_id_idx ON matrix_mission_members (tenant_id);

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1786687166202,
       "tag": "0047_reset_identity_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1786687167202,
+      "tag": "0048_matrix_missions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -47,3 +47,49 @@ export const matrixRooms = pgTable(
     }).onDelete("cascade"),
   ]
 );
+
+/**
+ * A room where several agents work together.
+ *
+ * A per-agent room is a DM — one correspondent, filed under People. A mission is
+ * the other shape, and is an ordinary room precisely because it is not one-to-one.
+ */
+export const matrixMissions = pgTable(
+  "matrix_missions",
+  {
+    id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "restrict" }),
+    userId: text("user_id").notNull(),
+    name: text("name").notNull(),
+    roomId: text("room_id"),
+    alias: text("alias").notNull(),
+    /** The space this mission hangs under, once it has one. */
+    spaceRoomId: text("space_room_id"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [
+    index("matrix_missions_tenant_id_idx").on(t.tenantId),
+    uniqueIndex("matrix_missions_alias_idx").on(t.alias),
+  ]
+);
+
+/**
+ * Which stations are in a mission.
+ *
+ * A station may be in several at once: an agent is not consumed by the work it
+ * is doing, and one-mission-per-agent is the DM we already have.
+ */
+export const matrixMissionMembers = pgTable(
+  "matrix_mission_members",
+  {
+    missionId: text("mission_id").notNull(),
+    stationId: text("station_id").notNull(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "restrict" }),
+    addedAt: timestamp("added_at").notNull().defaultNow(),
+  },
+  (t) => [index("matrix_mission_members_tenant_id_idx").on(t.tenantId)]
+);

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -38,7 +38,12 @@ import { bridgeDispatches } from "./schema/bridge";
 import { adminAuditLog, systemSettings } from "./schema/admin";
 import { stationAudit } from "./schema/audit";
 import { account, session, user, verification, jwks } from "./schema/auth";
-import { matrixAsTransactions, matrixRooms } from "./schema/matrix";
+import {
+  matrixAsTransactions,
+  matrixRooms,
+  matrixMissions,
+  matrixMissionMembers,
+} from "./schema/matrix";
 import { principalIdentities } from "./schema/identities";
 import { principalGrants } from "./schema/grants";
 import { agentTasks, cloudflareSandboxes } from "./schema/cloudflare";
@@ -104,6 +109,8 @@ export const TENANT_SCOPED_TABLES = {
   agentTasks,
   cloudflareSandboxes,
   matrixRooms,
+  matrixMissions,
+  matrixMissionMembers,
 } as const satisfies Record<string, TenantScopedTable>;
 
 /**

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -57,6 +57,7 @@ import { createMatrixBridge, startMatrixBridge } from './services/matrix-as/inde
 import { createMatrixAsRoutes } from './routes/matrix-as.ts';
 import { createStationMatrixRoutes } from './routes/station-matrix.ts';
 import { createStationSayRoutes } from './routes/station-say.ts';
+import { createMissionRoutes } from './routes/missions.ts';
 // ACP session boot reconciliation (hub-owned sessions do not survive restarts)
 import { reconcileOnBoot as reconcileAcpSessions } from './services/acp-sessions.ts';
 
@@ -184,6 +185,17 @@ if (matrixBridge) {
   app.route(
     '/api',
     createStationSayRoutes({
+      domain: matrixBridge.config.domain,
+      client: matrixBridge.client,
+    }),
+  );
+
+  // Rooms where several agents work together. A per-agent room is a DM; a
+  // mission has several correspondents, so it is an ordinary room — and
+  // ordinary rooms are what a space can group.
+  app.route(
+    '/api',
+    createMissionRoutes({
       domain: matrixBridge.config.domain,
       client: matrixBridge.client,
     }),

--- a/apps/hub/src/routes/missions.ts
+++ b/apps/hub/src/routes/missions.ts
@@ -1,0 +1,195 @@
+/**
+ * Rooms where several agents work together.
+ *
+ * The other half of a split the operator drew: a **per-agent room is a DM**,
+ * because talking to one agent has exactly one correspondent and 32 of those in
+ * a Rooms list is a wall. A **mission has several** — agents and people — so it
+ * is an ordinary room. That is also what makes spaces useful here: ordinary
+ * rooms can be grouped, and DMs did not need it.
+ *
+ * `charter` → `strategy/2026-08-12-layer-reference.md` P2 calls these
+ * "mission/team rooms".
+ */
+
+import { Hono } from "hono";
+import { eq, and, inArray } from "drizzle-orm";
+import { db } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { nodes } from "../db/schema/nodes";
+import { matrixMissions, matrixMissionMembers } from "../db/schema/matrix";
+import { principalIdentities } from "../db/schema/identities";
+import { getGrant, grantAllowsStation } from "../services/grants";
+import { isControlPairEnforced } from "../services/control-pair";
+import { bridgeUserId } from "../services/matrix-as/names";
+import { missionAlias, spaceAlias } from "../services/matrix-as/missions";
+import { createLogger } from "../utils/logger";
+import type { AuthUser } from "../auth/middleware";
+
+const log = createLogger("missions");
+
+/** One space holds every mission. Per-node spaces would group the wrong axis:
+ *  a mission spans nodes by design, so filing it under one of them would lie. */
+const MISSIONS_SPACE = "missions";
+
+export interface MissionDeps {
+  domain: string;
+  client: {
+    ensureRoom(
+      alias: string,
+      opts: { creator: string; name: string; topic: string; invite?: string; isDirect?: boolean }
+    ): Promise<string | null>;
+    ensureSpace(alias: string, opts: { creator: string; name: string }): Promise<string | null>;
+    addSpaceChild(creator: string, spaceRoomId: string, childRoomId: string): Promise<void>;
+    invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  };
+}
+
+export function createMissionRoutes(deps: MissionDeps) {
+  return new Hono().post("/missions", async (c) => {
+    const user = c.get("user") as AuthUser;
+    const body = (await c.req.json().catch(() => null)) as
+      | { name?: unknown; stationIds?: unknown }
+      | null;
+
+    const name = typeof body?.name === "string" ? body.name.trim() : "";
+    const stationIds = Array.isArray(body?.stationIds)
+      ? body.stationIds.filter((s): s is string => typeof s === "string")
+      : [];
+
+    if (name === "") return c.json({ error: "A mission needs a name." }, 400);
+    if (stationIds.length === 0) {
+      // A room with no agents in it is a room, and this bridge is not a chat
+      // host.
+      return c.json({ error: "A mission needs at least one agent in it." }, 400);
+    }
+
+    const members = await db
+      .select({
+        id: stations.id,
+        tenantId: stations.tenantId,
+        stationKey: stations.stationKey,
+        nodeName: nodes.name,
+      })
+      .from(stations)
+      .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+      .where(and(eq(stations.userId, user.id), inArray(stations.id, stationIds)));
+
+    if (members.length !== stationIds.length) {
+      return c.json({ error: "Not Found" }, 404);
+    }
+
+    // In the order they were ASKED for, not the order Postgres happened to
+    // return. The first member creates the room and speaks for it, so leaving
+    // that to row order means the same request picks a different creator on a
+    // different day — and the room's creator is visible to everyone in it.
+    members.sort((a, b) => stationIds.indexOf(a.id) - stationIds.indexOf(b.id));
+
+    // Putting an agent in a room is putting it to work, so the grant that
+    // governs dispatching it governs this too — checked for EVERY member before
+    // anything is created, because a half-made mission is worse than none.
+    if (isControlPairEnforced()) {
+      const grant = await getGrant(user.id);
+      const refused = members.filter(
+        (m) => !grantAllowsStation(grant, { nodeName: m.nodeName, stationKey: m.stationKey })
+      );
+      if (refused.length > 0) {
+        log.warn("mission refused by the control pair", {
+          principalId: user.id,
+          refused: refused.map((m) => `${m.nodeName}/${m.stationKey}`),
+        });
+        return c.json(
+          {
+            error:
+              "You are not permitted to dispatch every agent in this mission: " +
+              refused.map((m) => `${m.nodeName}/${m.stationKey}`).join(", "),
+          },
+          403
+        );
+      }
+    }
+
+    const alias = missionAlias(name, deps.domain);
+
+    // A repeated name is the same mission. Somebody typing it twice means one
+    // room both times, and the unique index on alias is what says so.
+    const [existing] = await db
+      .select()
+      .from(matrixMissions)
+      .where(eq(matrixMissions.alias, alias));
+    if (existing) {
+      return c.json({ id: existing.id, roomId: existing.roomId, alias: existing.alias });
+    }
+
+    const tenantId = members[0]!.tenantId;
+    // The mission speaks as the first agent in it: an appservice must act as
+    // SOME user in its namespace, and a room created by one of its members reads
+    // better than one created by a nameless bot.
+    const speaker = bridgeUserId(members[0]!.nodeName, members[0]!.stationKey, deps.domain);
+
+    const roomId = await deps.client.ensureRoom(alias, {
+      creator: speaker,
+      name,
+      topic: `Mission: ${name}`,
+    });
+    if (!roomId) return c.json({ error: "Could not create the mission's room." }, 502);
+
+    // One space for every mission. A space per NODE would group the wrong axis —
+    // a mission spans nodes by design, so filing it under one would lie about
+    // where the work is.
+    //
+    // The id is remembered from the last mission rather than re-created:
+    // `ensureSpace` answers null for a space that already exists, which is
+    // correct for "did I create one" and would have meant every mission after
+    // the first was never hung in the space at all.
+    const [withSpace] = await db
+      .select({ spaceRoomId: matrixMissions.spaceRoomId })
+      .from(matrixMissions)
+      .where(eq(matrixMissions.tenantId, tenantId))
+      .limit(1);
+
+    const spaceRoomId =
+      withSpace?.spaceRoomId ??
+      (await deps.client.ensureSpace(spaceAlias(MISSIONS_SPACE, deps.domain), {
+        creator: speaker,
+        name: "Missions",
+      }));
+    if (spaceRoomId) {
+      await deps.client.addSpaceChild(speaker, spaceRoomId, roomId).catch(() => {});
+    }
+
+    const id = `msn_${crypto.randomUUID()}`;
+    await db.insert(matrixMissions).values({
+      id,
+      tenantId,
+      userId: user.id,
+      name,
+      roomId,
+      alias,
+      spaceRoomId: spaceRoomId ?? null,
+    });
+    await db.insert(matrixMissionMembers).values(
+      members.map((m) => ({ missionId: id, stationId: m.id, tenantId: m.tenantId }))
+    );
+
+    for (const m of members) {
+      const agent = bridgeUserId(m.nodeName, m.stationKey, deps.domain);
+      if (agent === speaker) continue; // already in the room, having made it
+      await deps.client.invite(speaker, roomId, agent).catch(() => {});
+    }
+
+    const [identity] = await db
+      .select({ externalId: principalIdentities.externalId })
+      .from(principalIdentities)
+      .where(
+        and(
+          eq(principalIdentities.principalId, user.id),
+          eq(principalIdentities.system, "matrix")
+        )
+      );
+    if (identity) await deps.client.invite(speaker, roomId, identity.externalId).catch(() => {});
+
+    log.info("mission created", { id, name, members: members.length });
+
+    return c.json({ id, roomId, alias, spaceRoomId });
+  });
+}

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -71,6 +71,10 @@ export interface MatrixClient {
   ): Promise<string | null>;
   /** Remove an event we sent, which is how a reaction is taken back off. */
   redact(userId: string, roomId: string, eventId: string): Promise<void>;
+  /** Create a space — a room whose type groups other rooms. */
+  ensureSpace(alias: string, opts: { creator: string; name: string }): Promise<string | null>;
+  /** Hang a room under a space, which is what makes a hierarchy. */
+  addSpaceChild(creator: string, spaceRoomId: string, childRoomId: string): Promise<void>;
   /** Set a user's avatar. Optional for an agent; uniform across harnesses. */
   setAvatar(userId: string, mxcUrl: string): Promise<void>;
   /** Upload an image and return its mxc:// URL. */
@@ -233,6 +237,37 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
         { method: "PUT", userId, body: { displayname: displayName } }
       );
       assertOkOrAlready("displayname", res);
+    },
+
+    async ensureSpace(alias, opts) {
+      const aliasLocalpart = alias.replace(/^#/, "").replace(/:.*$/, "");
+      const res = await call("/_matrix/client/v3/createRoom", {
+        method: "POST",
+        userId: opts.creator,
+        body: {
+          room_alias_name: aliasLocalpart,
+          name: opts.name,
+          preset: "private_chat",
+          // What makes a room a space rather than a conversation.
+          creation_content: { type: "m.space" },
+        },
+      });
+      if (!assertOkOrAlready(`createSpace ${alias}`, res)) return null;
+      return String(res.body.room_id ?? "") || null;
+    },
+
+    async addSpaceChild(creator, spaceRoomId, childRoomId) {
+      // The child event lives on the SPACE, which is what makes a space's claim
+      // about its children authoritative — a room claiming a parent is not.
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(spaceRoomId)}/state/m.space.child/${encodeURIComponent(childRoomId)}`,
+        {
+          method: "PUT",
+          userId: creator,
+          body: { via: [deps.domain ?? ""] },
+        }
+      );
+      assertOkOrAlready("space child", res);
     },
 
     async sendReaction(userId, roomId, targetEventId, key) {

--- a/apps/hub/src/services/matrix-as/missions.test.ts
+++ b/apps/hub/src/services/matrix-as/missions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { missionAlias, spaceAlias, missionLocalpart } from "./missions";
+
+/**
+ * Names for rooms where several agents work together.
+ *
+ * A mission is not an agent, so its name is not derived from a node and a
+ * station — it is a thing a person names, and the same cleaning rules apply for
+ * the same reason: `_` never survives, so it stays available as a separator.
+ */
+
+const D = "id.agentpod.dev";
+
+describe("mission names", () => {
+  test("land inside the alias namespace the homeserver reserved", () => {
+    // Same exclusive namespace as agent rooms: a name outside it cannot be
+    // created by the appservice at all.
+    expect(missionAlias("Q3 migration", D)).toBe("#agentpod_mission_q3-migration:id.agentpod.dev");
+  });
+
+  test("a space is named for what it groups", () => {
+    expect(spaceAlias("molt-bot", D)).toBe("#agentpod_space_molt-bot:id.agentpod.dev");
+  });
+
+  test("two missions that clean to the same name are the same mission", () => {
+    // Not a collision to guard against — a mission is named by a person, and
+    // "Q3 migration" and "Q3/migration" being one room is the honest reading of
+    // somebody typing the same name twice. The unique index on alias enforces it.
+    expect(missionLocalpart("Q3 migration")).toBe(missionLocalpart("Q3/migration"));
+  });
+
+  test("keeps a name a person can still read", () => {
+    expect(missionLocalpart("Rescue the Friday deploy")).toBe("rescue-the-friday-deploy");
+  });
+
+  test("survives a name made entirely of punctuation", () => {
+    // A room still needs an address. Falling back beats creating `#agentpod_mission_:`.
+    expect(missionLocalpart("!!!")).toMatch(/^[a-z0-9-]+$/);
+  });
+});

--- a/apps/hub/src/services/matrix-as/missions.ts
+++ b/apps/hub/src/services/matrix-as/missions.ts
@@ -1,0 +1,52 @@
+/**
+ * Names for rooms where several agents work together.
+ *
+ * A per-agent room is a DM, and its name is derived from the node and station it
+ * belongs to. A mission is the other shape: several stations and several people
+ * in one place, named by a person rather than by the fleet.
+ *
+ * The cleaning rules are the same as `names.ts` and for the same reason — `_`
+ * never survives, so it stays available as a separator between the kind prefix
+ * and the name.
+ */
+
+/**
+ * Narrower than `names.ts`: `/` is replaced here too.
+ *
+ * A station key is machine-shaped and never contains one. A mission name is free
+ * text somebody types, where `/` is ordinary — and an alias containing it is
+ * legal but has to be escaped in every URL that carries it, for no benefit.
+ */
+const ILLEGAL = /[^a-z0-9.=-]/g;
+
+/**
+ * A person's words, made addressable.
+ *
+ * Two names that clean to the same localpart are the same mission. That is not
+ * a collision to defend against: a mission is named by a person, and somebody
+ * typing "Q3 migration" and "Q3/migration" means one room both times. The unique
+ * index on `alias` is what enforces it.
+ */
+export function missionLocalpart(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(ILLEGAL, "-")
+    // Collapse runs and trim edges, so "Q3   migration!" is not
+    // "q3---migration-".
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  // A room still needs an address. A name made entirely of punctuation would
+  // otherwise produce `#agentpod_mission_:domain`.
+  return cleaned || "mission";
+}
+
+/** `#agentpod_mission_<name>` — an ordinary room, inside the reserved namespace. */
+export function missionAlias(name: string, domain: string): string {
+  return `#agentpod_mission_${missionLocalpart(name)}:${domain}`;
+}
+
+/** `#agentpod_space_<name>` — the space that groups missions. */
+export function spaceAlias(name: string, domain: string): string {
+  return `#agentpod_space_${missionLocalpart(name)}:${domain}`;
+}

--- a/apps/hub/tests/integration/matrix-missions.test.ts
+++ b/apps/hub/tests/integration/matrix-missions.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { resolveTenantForUser } from "../../src/auth/tenant";
+import { setGrant } from "../../src/services/grants";
+import { createMissionRoutes } from "../../src/routes/missions";
+
+/**
+ * Rooms where several agents work together.
+ *
+ * The other half of the split: a per-agent room is a DM, because talking to one
+ * agent has one correspondent. A mission has several, so it is an ordinary room
+ * — and ordinary rooms are what a space can group, which is the thing DMs did
+ * not need.
+ */
+
+const OWNER = "test-user-mission";
+const NODE = "node_mission";
+const A = "station_mission_a";
+const B = "station_mission_b";
+const OWNER_MXID = "@owner-mission:id.agentpod.dev";
+
+let rooms: Array<{ alias: string; name: string; invite?: string }> = [];
+let spaces: Array<{ alias: string; name: string }> = [];
+let children: Array<{ space: string; child: string }> = [];
+let invited: Array<{ roomId: string; invitee: string }> = [];
+
+function app() {
+  const routes = createMissionRoutes({
+    domain: "id.agentpod.dev",
+    client: {
+      ensureRoom: async (alias: string, opts: any) => {
+        rooms.push({ alias, name: opts.name, invite: opts.invite });
+        return `!mission${rooms.length}:id.agentpod.dev`;
+      },
+      ensureSpace: async (alias: string, opts: any) => {
+        spaces.push({ alias, name: opts.name });
+        return `!space${spaces.length}:id.agentpod.dev`;
+      },
+      addSpaceChild: async (_creator: string, space: string, child: string) => {
+        children.push({ space, child });
+      },
+      invite: async (_as: string, roomId: string, invitee: string) => {
+        invited.push({ roomId, invitee });
+      },
+    },
+  });
+  return new Hono()
+    .use("*", async (c, next) => {
+      c.set("user", { id: OWNER, role: "user" });
+      await next();
+    })
+    .route("/api", routes);
+}
+
+const post = (path: string, body: unknown) =>
+  app().request(`/api${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: OWNER, email: "mission@example.com", name: "Owner" });
+  const tenant = await resolveTenantForUser(OWNER);
+  await rawSql`DELETE FROM matrix_mission_members`;
+  await rawSql`DELETE FROM matrix_missions`;
+  await rawSql`DELETE FROM stations WHERE id IN (${A}, ${B})`;
+  await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${NODE}, ${tenant}, ${OWNER}, 'mission-box', 'mission-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  for (const [id, key] of [[A, "hermes:one"], [B, "openclaw:two"]] as const) {
+    await rawSql`
+      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+      VALUES (${id}, ${tenant}, ${OWNER}, ${NODE}, ${key.split(":")[0]}, ${key}, 'leaf', ${key},
+              '["acp"]'::jsonb, now(), now())`;
+  }
+  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+  await rawSql`
+    INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
+    VALUES ('pid_mission', ${OWNER}, 'matrix', ${OWNER_MXID}, now())`;
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+beforeEach(async () => {
+  rooms = [];
+  spaces = [];
+  children = [];
+  invited = [];
+  await rawSql`DELETE FROM matrix_mission_members`;
+  await rawSql`DELETE FROM matrix_missions`;
+  await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*", "agentpod:*/openclaw:*"], mayGrantReach: false });
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM matrix_mission_members`;
+    await rawSql`DELETE FROM matrix_missions`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM stations WHERE id IN (${A}, ${B})`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("POST /api/missions", () => {
+  test("makes an ordinary room, not a DM", async () => {
+    // Several agents and several people. `is_direct` would file it under
+    // People as though it were one correspondent.
+    const res = await post("/missions", { name: "Q3 migration", stationIds: [A, B] });
+
+    expect(res.status).toBe(200);
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]!.alias).toBe("#agentpod_mission_q3-migration:id.agentpod.dev");
+    expect((rooms[0] as any).isDirect).toBeUndefined();
+  });
+
+  test("invites the other agents and the person who made it", async () => {
+    // The room is created BY one of its members — an appservice must act as
+    // some user in its namespace, and a room made by a member reads better than
+    // one made by a nameless bot. That member is already in it, so inviting it
+    // would be an error on some homeservers and noise on all of them.
+    await post("/missions", { name: "Q3 migration", stationIds: [A, B] });
+
+    const invitees = invited.map((i) => i.invitee);
+    expect(invitees).toContain("@agent_mission-box_openclaw-two:id.agentpod.dev");
+    expect(invitees).toContain(OWNER_MXID);
+    expect(invitees).not.toContain("@agent_mission-box_hermes-one:id.agentpod.dev");
+  });
+
+  test("refuses a station the caller may not dispatch", async () => {
+    // Putting an agent in a room is putting it to work. The grant that governs
+    // dispatching it governs this too.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+
+    const res = await post("/missions", { name: "Half a mission", stationIds: [A, B] });
+
+    expect(res.status).toBe(403);
+    // Nothing half-made: no room for a mission that was refused.
+    expect(rooms).toHaveLength(0);
+  });
+
+  test("hangs the room under a space, which is what groups missions", async () => {
+    await post("/missions", { name: "Q3 migration", stationIds: [A] });
+
+    expect(spaces).toHaveLength(1);
+    expect(spaces[0]!.alias).toBe("#agentpod_space_missions:id.agentpod.dev");
+    expect(children).toHaveLength(1);
+    expect(children[0]!.child).toBe("!mission1:id.agentpod.dev");
+  });
+
+  test("reuses the space rather than making one per mission", async () => {
+    await post("/missions", { name: "First", stationIds: [A] });
+    spaces = [];
+
+    await post("/missions", { name: "Second", stationIds: [A] });
+
+    expect(spaces).toHaveLength(0);
+    expect(children).toHaveLength(2);
+  });
+
+  test("a station can be in several missions at once", async () => {
+    // An agent is not consumed by the work it is doing, and one mission per
+    // agent is the DM we already have.
+    await post("/missions", { name: "First", stationIds: [A] });
+    const res = await post("/missions", { name: "Second", stationIds: [A] });
+
+    expect(res.status).toBe(200);
+    const rows = await rawSql`SELECT count(*)::int AS n FROM matrix_mission_members WHERE station_id = ${A}`;
+    expect(rows[0]!.n).toBe(2);
+  });
+
+  test("refuses a mission with no agents in it", async () => {
+    // That is a room, not a mission, and the bridge is not a chat host.
+    expect((await post("/missions", { name: "Empty", stationIds: [] })).status).toBe(400);
+  });
+
+  test("a repeated name returns the same mission rather than a second room", async () => {
+    const first = await (await post("/missions", { name: "Q3 migration", stationIds: [A] })).json();
+    rooms = [];
+
+    const second = await (await post("/missions", { name: "Q3 migration", stationIds: [A] })).json();
+
+    expect((second as any).id).toBe((first as any).id);
+    expect(rooms).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Per the split you drew: **a per-agent room is a DM** (shipped in #358), **a mission is a room**. Talking to one agent has exactly one correspondent; a mission has several — agents and people — so it stays an ordinary room. That is also what makes spaces useful here at last: ordinary rooms can be grouped, and DMs did not need it.

`POST /api/missions {name, stationIds}` creates the room, invites every other member's agent and the person who asked, and hangs it under one `#agentpod_space_missions` space. One space, not one per node — a mission spans nodes by design, so filing it under one of them would lie about where the work is.

The grant that governs dispatching an agent governs putting it in a mission, checked for **every** member before anything is created. A half-made mission with two of three agents in it is worse than none.

Two bugs the tests caught rather than production:

- `ensureSpace` answers null when the space already exists — correct for "did I create one", and it would have meant every mission after the first was silently never hung in the space. The id is remembered from the previous mission instead.
- The member query returned rows in Postgres's order, and the first member creates the room and speaks for it. Which agent showed as the room's creator — visible to everyone in it — would have varied run to run.

Migration `0048_matrix_missions.sql`; both new tables are tenant-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW