### PR TITLE
fix: write a space's child edges as the space's creator

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0051_purpose_space_creator.sql
+++ b/apps/hub/src/db/drizzle-migrations/0051_purpose_space_creator.sql
@@ -1,0 +1,13 @@
+-- Who writes a space's child edges.
+--
+-- `m.space.child` state lives ON THE SPACE, so only somebody in the space can
+-- write it. Filing used to be done as the room's OWN agent, which is a member
+-- of its room and of nothing else — so the homeserver accepted the first edge
+-- (written by the agent that happened to create the space) and refused the
+-- other nine. Ten rooms were recorded as filed; one of them was.
+--
+-- Nullable because the rows that already exist were written before anything
+-- recorded this, and there is no value to invent for them. A space whose
+-- creator is unknown is skipped with a warning rather than filed as somebody
+-- who cannot file — the deployment's two rows are backfilled by hand.
+ALTER TABLE matrix_purpose_spaces ADD COLUMN creator text;

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1786687169202,
       "tag": "0050_purpose_spaces",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1786687170202,
+      "tag": "0051_purpose_space_creator",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -87,6 +87,14 @@ export const matrixPurposeSpaces = pgTable(
       .references(() => tenants.id, { onDelete: "restrict" }),
     purpose: text("purpose").notNull(),
     roomId: text("room_id").notNull(),
+    /**
+     * The agent that created the space, and therefore the only one that can
+     * write its `m.space.child` state — child edges live on the space, and a
+     * room's own agent is a member of its room and of nothing else.
+     *
+     * Null only for rows written before this was recorded.
+     */
+    creator: text("creator"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   (t) => [primaryKey({ columns: [t.tenantId, t.purpose] })]

--- a/apps/hub/src/routes/missions.ts
+++ b/apps/hub/src/routes/missions.ts
@@ -26,6 +26,7 @@ import {
   ensurePurposeSpace,
   ensureSpaceRecord,
   GENERAL_MISSIONS_KEY,
+  type Space,
 } from "../services/matrix-as/purpose-spaces";
 import { createLogger } from "../utils/logger";
 import type { AuthUser } from "../auth/middleware";
@@ -57,7 +58,7 @@ async function missionsSpace(
   speaker: string,
   owner: string | null,
   deps: MissionDeps
-): Promise<string | null> {
+): Promise<Space | null> {
   return ensureSpaceRecord(
     tenantId,
     GENERAL_MISSIONS_KEY,
@@ -178,7 +179,7 @@ export function createMissionRoutes(deps: MissionDeps) {
     const shared =
       purposes.size === 1 && members[0]!.purpose !== null ? members[0]!.purpose : null;
 
-    const spaceRoomId = shared
+    const space = shared
       ? await ensurePurposeSpace(
           tenantId,
           shared,
@@ -187,8 +188,13 @@ export function createMissionRoutes(deps: MissionDeps) {
           deps
         )
       : await missionsSpace(tenantId, speaker, identity?.externalId ?? null, deps);
-    if (spaceRoomId) {
-      await deps.client.addSpaceChild(speaker, spaceRoomId, roomId).catch(() => {});
+
+    // As the SPACE's creator, never as this mission's speaker: `m.space.child`
+    // state lives on the space, and a user who merely made one of its rooms is
+    // not in it. Doing this as the speaker is what shipped for agent rooms and
+    // had the homeserver refuse every edge but the first.
+    if (space?.creator) {
+      await deps.client.addSpaceChild(space.creator, space.roomId, roomId).catch(() => {});
     }
 
     const id = `msn_${crypto.randomUUID()}`;
@@ -199,7 +205,7 @@ export function createMissionRoutes(deps: MissionDeps) {
       name,
       roomId,
       alias,
-      spaceRoomId: spaceRoomId ?? null,
+      spaceRoomId: space?.roomId ?? null,
     });
     await db.insert(matrixMissionMembers).values(
       members.map((m) => ({ missionId: id, stationId: m.id, tenantId: m.tenantId }))
@@ -215,6 +221,6 @@ export function createMissionRoutes(deps: MissionDeps) {
 
     log.info("mission created", { id, name, members: members.length });
 
-    return c.json({ id, roomId, alias, spaceRoomId });
+    return c.json({ id, roomId, alias, spaceRoomId: space?.roomId ?? null });
   });
 }

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -237,7 +237,7 @@ async function fileByPurpose(
       )
     : null;
 
-  await fileRoomUnderSpace(room.roomId, desired, room.spaceRoomId, speaker, spaceDeps);
+  await fileRoomUnderSpace(room.roomId, desired, room.spaceRoomId, spaceDeps);
 }
 
 /**

--- a/apps/hub/src/services/matrix-as/purpose-spaces.ts
+++ b/apps/hub/src/services/matrix-as/purpose-spaces.ts
@@ -81,8 +81,23 @@ export async function ensurePurposeSpace(
   creator: string,
   owner: string | null,
   deps: SpaceCreateDeps
-): Promise<string | null> {
+): Promise<Space | null> {
   return ensureSpaceRecord(tenantId, purpose, spaceNameFor(purpose), creator, owner, deps);
+}
+
+/**
+ * A space and the user that can write its child edges.
+ *
+ * The pair travels together because filing needs both, and the actor is the
+ * half that is easy to get wrong: `m.space.child` state lives on the SPACE, so
+ * only somebody in the space can write it. Filing as the room's own agent —
+ * which is a member of its room and of nothing else — is what shipped, and the
+ * homeserver refused every edge but the first.
+ */
+export interface Space {
+  roomId: string;
+  /** Null only for a space recorded before the creator was stored. */
+  creator: string | null;
 }
 
 /**
@@ -115,10 +130,13 @@ export async function ensureSpaceRecord(
   creator: string,
   owner: string | null,
   deps: SpaceCreateDeps
-): Promise<string | null> {
+): Promise<Space | null> {
   const purpose = key;
   const [existing] = await db
-    .select({ roomId: matrixPurposeSpaces.roomId })
+    .select({
+      roomId: matrixPurposeSpaces.roomId,
+      creator: matrixPurposeSpaces.creator,
+    })
     .from(matrixPurposeSpaces)
     .where(
       and(
@@ -126,7 +144,7 @@ export async function ensureSpaceRecord(
         eq(matrixPurposeSpaces.purpose, purpose)
       )
     );
-  if (existing) return existing.roomId;
+  if (existing) return existing;
 
   const roomId = await deps.client.createSpace({ creator, name }).catch(() => null);
   if (!roomId) {
@@ -136,51 +154,93 @@ export async function ensureSpaceRecord(
 
   await db
     .insert(matrixPurposeSpaces)
-    .values({ tenantId, purpose, roomId })
+    .values({ tenantId, purpose, roomId, creator })
     .onConflictDoNothing();
 
   // Without this the space exists and nobody can see it.
   if (owner) await deps.client.invite(creator, roomId, owner).catch(() => {});
 
-  log.info("made a space", { name, roomId });
-  return roomId;
+  log.info("made a space", { name, roomId, creator });
+  return { roomId, creator };
 }
 
 /**
  * Put `roomId` under the space its station's purpose calls for — and take it
  * out of the one it is under now, if that is a different one.
  *
- * `desiredSpaceRoomId` of null means "belongs under nothing", which is what an
- * unlabelled station wants and also what a station whose purpose was just
- * cleared wants. Both cases still have work to do: the old edge has to go.
+ * `desired` of null means "belongs under nothing", which is what an unlabelled
+ * station wants and also what a station whose purpose was just cleared wants.
+ * Both cases still have work to do: the old edge has to go.
+ *
+ * Every edge is written **as the space's own creator**, never as the room's
+ * agent — see [`Space`] for the production failure that rule comes from.
+ *
+ * Nothing is recorded unless the homeserver accepted it. A filing written on
+ * top of a refused edge is worse than no filing at all: the next run sees
+ * nothing to do, and the room stays outside the space for good.
  */
 export async function fileRoomUnderSpace(
   roomId: string,
-  desiredSpaceRoomId: string | null,
+  desired: Space | null,
   currentSpaceRoomId: string | null,
-  creator: string,
   deps: SpaceFileDeps
 ): Promise<void> {
-  if (desiredSpaceRoomId === currentSpaceRoomId) return;
+  if ((desired?.roomId ?? null) === currentSpaceRoomId) return;
 
   if (currentSpaceRoomId) {
-    await deps.client
-      .removeSpaceChild(creator, currentSpaceRoomId, roomId)
-      .catch(() => {});
+    const [current] = await db
+      .select({ creator: matrixPurposeSpaces.creator })
+      .from(matrixPurposeSpaces)
+      .where(eq(matrixPurposeSpaces.roomId, currentSpaceRoomId));
+
+    if (!current?.creator) {
+      log.warn("cannot unfile a room from a space with no known creator", {
+        roomId,
+        spaceRoomId: currentSpaceRoomId,
+      });
+      return;
+    }
+
+    try {
+      await deps.client.removeSpaceChild(current.creator, currentSpaceRoomId, roomId);
+    } catch (err) {
+      log.warn("could not take a room out of its space; leaving it where it is", {
+        roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
   }
 
-  if (desiredSpaceRoomId) {
-    await deps.client.addSpaceChild(creator, desiredSpaceRoomId, roomId).catch(() => {});
+  if (desired) {
+    if (!desired.creator) {
+      log.warn("cannot file a room into a space with no known creator", {
+        roomId,
+        spaceRoomId: desired.roomId,
+      });
+      return;
+    }
+    try {
+      await deps.client.addSpaceChild(desired.creator, desired.roomId, roomId);
+    } catch (err) {
+      // Left unrecorded on purpose, so the next provision tries again.
+      log.warn("could not file a room into its space", {
+        roomId,
+        spaceRoomId: desired.roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
   }
 
   await db
     .update(matrixRooms)
-    .set({ spaceRoomId: desiredSpaceRoomId })
+    .set({ spaceRoomId: desired?.roomId ?? null })
     .where(eq(matrixRooms.roomId, roomId));
 
   log.info("re-filed a room", {
     roomId,
     from: currentSpaceRoomId,
-    to: desiredSpaceRoomId,
+    to: desired?.roomId ?? null,
   });
 }

--- a/apps/hub/tests/integration/matrix-purpose-spaces.test.ts
+++ b/apps/hub/tests/integration/matrix-purpose-spaces.test.ts
@@ -27,9 +27,11 @@ const DOMAIN = "id.agentpod.dev";
 interface Edge {
   space: string;
   child: string;
+  creator?: string;
 }
 
 let created: Array<{ name: string; creator: string }> = [];
+let addFails = false;
 let added: Edge[] = [];
 let removed: Edge[] = [];
 let invited: Array<{ roomId: string; invitee: string }> = [];
@@ -49,8 +51,9 @@ function deps() {
         nextSpace += 1;
         return `!space${nextSpace}:${DOMAIN}`;
       },
-      addSpaceChild: async (_creator: string, space: string, child: string) => {
-        added.push({ space, child });
+      addSpaceChild: async (creator: string, space: string, child: string) => {
+        if (addFails) throw new Error("M_FORBIDDEN: not a member of the space");
+        added.push({ space, child, creator });
       },
       removeSpaceChild: async (_creator: string, space: string, child: string) => {
         removed.push({ space, child });
@@ -99,6 +102,7 @@ beforeEach(async () => {
   removed = [];
   invited = [];
   nextSpace = 0;
+  addFails = false;
   const tenant = await resolveTenantForUser(OWNER);
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${A}, ${B})`;
   await rawSql`DELETE FROM matrix_purpose_spaces WHERE tenant_id = ${tenant}`;
@@ -202,5 +206,49 @@ describe("filing a station's room by purpose", () => {
     expect(created).toEqual([]);
     expect(added).toEqual([]);
     expect(removed).toEqual([]);
+  });
+});
+
+describe("who writes the child edge", () => {
+  test("the space's creator, not the room's own agent", async () => {
+    // Found in production: `m.space.child` state lives ON THE SPACE, and an
+    // agent that merely owns one of the rooms is not a member of the space, so
+    // the homeserver refused every edge after the first. Ten rooms were
+    // recorded as filed and one of them was.
+    await setPurpose(A, "personal");
+    await provisionStation(A, deps());
+    const creatorOfSpace = created[0]!.creator;
+
+    await setPurpose(B, "personal");
+    await provisionStation(B, deps());
+
+    expect(added).toHaveLength(2);
+    expect(added[1]!.creator).toBe(creatorOfSpace);
+    // …which is emphatically not B's own agent, the actor that used to be used.
+    expect(added[1]!.creator).not.toBe(added[1]!.child);
+  });
+
+  test("a refused edge is not recorded as a filing", async () => {
+    // The other half of the same bug: the failure was caught and the room was
+    // marked as filed anyway, so the next run saw nothing to do and the room
+    // stayed outside the space forever.
+    await setPurpose(A, "personal");
+    addFails = true;
+
+    await provisionStation(A, deps());
+
+    expect(await spaceOf(A)).toBeNull();
+  });
+
+  test("and the next run tries again", async () => {
+    await setPurpose(A, "personal");
+    addFails = true;
+    await provisionStation(A, deps());
+
+    addFails = false;
+    await provisionStation(A, deps());
+
+    expect(added).toHaveLength(1);
+    expect(await spaceOf(A)).toBe(added[0]!.space);
   });
 });


### PR DESCRIPTION
Found by reading the live homeserver after #362 deployed: the **Personal** space held **one** `m.space.child` event while the database claimed **ten** rooms were filed under it.

`m.space.child` state lives on the space, so only somebody in the space can write it. Filing was done as the room's own agent — which is a member of its own room and of nothing else — so the homeserver accepted the edge from whichever agent happened to create the space and refused the other nine with `M_FORBIDDEN`.

Two independent faults:

- **The actor.** The creator is now recorded when the space is made (`matrix_purpose_spaces.creator`, migration `0051`) and writes every later edge. The mission route had the same bug — it filed as the mission's speaker.
- **The silence.** The refusal was caught and the filing recorded anyway, so the next provision saw nothing to do and the room stayed outside the space permanently. Nothing is recorded now unless the homeserver accepted it, which is what makes a retry possible.

The column is nullable: rows written before this exist and there is no value to invent for them. A space with no known creator is skipped with a warning that names it, rather than filed as somebody who cannot file. The deployment's two rows get backfilled by hand, and every `space_room_id` is cleared so provisioning re-files from scratch.

Three regression tests: the edge is written as the creator and not as the room's agent, a refused edge leaves the room unfiled, and the next run tries again.

hub: 1363 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW