### PR TITLE
fix: an agent gets its face when it has none, not only when it is new

### DIFF
--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -90,6 +90,13 @@ export interface MatrixClient {
   removeSpaceChild(creator: string, spaceRoomId: string, childRoomId: string): Promise<void>;
   /** Set a user's avatar. Optional for an agent; uniform across harnesses. */
   setAvatar(userId: string, mxcUrl: string): Promise<void>;
+  /**
+   * What the identity's avatar is now, or null when it has none.
+   *
+   * The homeserver is asked rather than a local flag consulted, so an avatar
+   * that was never uploaded is retried and one that exists is left alone.
+   */
+  getAvatar(userId: string): Promise<string | null>;
   /** Upload an image and return its mxc:// URL. */
   uploadImage(userId: string, bytes: Uint8Array, contentType: string): Promise<string | null>;
 }
@@ -329,6 +336,19 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
       if (!res.ok) return null;
       const body = (await res.json()) as { content_uri?: string };
       return body.content_uri ?? null;
+    },
+
+    async getAvatar(userId) {
+      const res = await call(
+        `/_matrix/client/v3/profile/${encodeURIComponent(userId)}/avatar_url`,
+        { method: "GET", userId }
+      );
+      // A profile with no avatar answers 404 M_NOT_FOUND on some homeservers and
+      // an empty body on others; both mean the same thing and neither is an
+      // error worth throwing over.
+      if (res.status === 404) return null;
+      const url = res.body.avatar_url;
+      return typeof url === "string" && url !== "" ? url : null;
     },
 
     async setAvatar(userId, mxcUrl) {

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -53,6 +53,8 @@ export interface ProvisionDeps {
       contentType: string
     ): Promise<string | null>;
     setAvatar?(userId: string, mxcUrl: string): Promise<void>;
+    /** The identity's current avatar, or null. Absent in tests that don't care. */
+    getAvatar?(userId: string): Promise<string | null>;
   };
   /**
    * Read a file from the station's workspace, or null when it is not there.
@@ -134,13 +136,20 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
     await deps.client.ensureUser(bridgeLocalpart(s.nodeName, s.stationKey), displayName);
   }
 
-  // An agent's face, if it has one — read once, when the station is first
-  // provisioned. Provisioning runs at every boot, and re-reading and re-uploading
-  // an image per station per restart is a cost with no benefit: the picture has
-  // not changed. A face added later lands the next time the identity is
-  // explicitly re-provisioned.
-  const firstProvision = !s.roomId;
-  if (bridged && firstProvision && deps.readWorkspaceFile && deps.client.uploadImage) {
+  // An agent's face, if it has one.
+  //
+  // Gated on the identity NOT ALREADY HAVING ONE, asked of the homeserver,
+  // rather than on this being the station's first provision. The first-provision
+  // gate shipped in #359 and gave 0 of 32 agents a face: every room already
+  // existed by the time that code deployed, so the read never ran for a single
+  // one of them, and nothing short of deleting a room could make it run. Asking
+  // costs one profile GET per station per boot and makes this self-healing — an
+  // agent that gains a `pfp.png` next month gets its face at the next restart,
+  // and one that already has a face is never re-read or re-uploaded.
+  const hasFace = deps.client.getAvatar
+    ? await deps.client.getAvatar(speaker).catch(() => null)
+    : s.roomId; // no way to ask: fall back to "only on first provision"
+  if (bridged && !hasFace && deps.readWorkspaceFile && deps.client.uploadImage) {
     const found = await pickAvatar({
       read: (path) => deps.readWorkspaceFile!(s.stationId, path),
     }).catch(() => null);

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -33,6 +33,8 @@ let invites: Array<{ roomId: string; invitee: string }> = [];
 let roomCounter = 0;
 let uploaded: Array<{ bytes: number; contentType: string }> = [];
 let avatars: Array<{ userId: string; mxcUrl: string }> = [];
+/** The homeserver's side of it: which identity has a face right now. */
+let faces: Record<string, string> = {};
 let workspaceFiles: Record<string, { bytes: Uint8Array; contentType: string } | null> = {};
 
 function deps() {
@@ -58,7 +60,9 @@ function deps() {
       },
       setAvatar: async (userId: string, mxcUrl: string) => {
         avatars.push({ userId, mxcUrl });
+        faces[userId] = mxcUrl;
       },
+      getAvatar: async (userId: string) => faces[userId] ?? null,
     },
     readWorkspaceFile: async (_stationId: string, path: string) =>
       workspaceFiles[path] ?? null,
@@ -109,6 +113,7 @@ beforeEach(async () => {
   invites = [];
   uploaded = [];
   avatars = [];
+  faces = {};
   workspaceFiles = {};
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
   await rawSql`
@@ -343,6 +348,8 @@ describe("an agent's face, if it has one", () => {
   test("does not re-upload an agent's face on every boot", async () => {
     // Provisioning runs at every restart. Reading and uploading an image per
     // station per boot is a cost with no benefit — the picture has not changed.
+    // The gate is "does this identity already have a face", asked of the
+    // homeserver.
     workspaceFiles["pfp.png"] = {
       bytes: new Uint8Array([137, 80, 78, 71]),
       contentType: "image/png",
@@ -354,5 +361,25 @@ describe("an agent's face, if it has one", () => {
     await provisionStation(OPENCLAW, deps());
 
     expect(uploaded).toHaveLength(0);
+  });
+});
+
+describe("an agent that has not got its face yet", () => {
+  test("gets one at the next provision, not only at its first", async () => {
+    // 0 of 32 agents had a face after #359 shipped: the read was gated on the
+    // station's FIRST provision, and every room already existed by the time
+    // that code deployed, so it never ran once. Nothing short of deleting a
+    // room could make it run. The gate is now the identity's own avatar, so an
+    // agent that gains a `pfp.png` later gets its face at the next restart.
+    await provisionStation(OPENCLAW, deps()); // no image in the workspace yet
+    expect(avatars).toHaveLength(0);
+
+    workspaceFiles["pfp.png"] = {
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      contentType: "image/png",
+    };
+    await provisionStation(OPENCLAW, deps());
+
+    expect(avatars).toHaveLength(1);
   });
 });


### PR DESCRIPTION
**0 of 32** agents on the live fleet had an avatar after #359 shipped. The images were fine; the gate was wrong.

The workspace read ran only on a station's *first* provision, and every room already existed by the time that code deployed — so it never ran once, and nothing short of deleting a room could make it run.

The gate is now **the identity's own avatar, asked of the homeserver**. One profile GET per station per boot buys a rule that self-heals:

- an agent that gains a `pfp.png` next month gets its face at the next restart
- one that already has a face is never re-read or re-uploaded
- a wiped database does not silently cost 32 agents their pictures

Verified on the hosts: all 14 hermes profiles on molt-bot carry `pfp.png`, and the `workspace_path` the hub records for those stations **is** the profile directory — the file is exactly where `pickAvatar` looks. openclaw agent directories contain no image, which stays what it always was: not a broken agent, just a letter.

hub: 1364 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW