### PR TITLE
fix: reclaim a room alias left behind, instead of creating nothing quietly

### DIFF
--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -143,3 +143,74 @@ describe("acting as a station", () => {
     expect(calls[0]!.body).toEqual({ user_id: "@rakesh:id.agentpod.dev" });
   });
 });
+
+describe("an alias that is already taken", () => {
+  const ALIAS = "#agentpod_box_pi-x:id.agentpod.dev";
+  const OLD = "!old:id.agentpod.dev";
+  const NEW = "!new:id.agentpod.dev";
+
+  const inUse = { status: 409, body: { errcode: "M_ROOM_IN_USE" } };
+
+  test("hands back the existing room when the agent is still in it", async () => {
+    // The ordinary restart. Returning null here — what shipped — made
+    // provisioning create nothing and call it success.
+    replies = [
+      inUse,
+      { status: 200, body: { room_id: OLD } }, // directory lookup
+      { status: 200, body: { joined_rooms: [OLD] } }, // still a member
+    ];
+
+    const roomId = await client().ensureRoom(ALIAS, {
+      creator: USER,
+      name: "pi-x",
+      topic: "t",
+    });
+
+    expect(roomId).toBe(OLD);
+    expect(calls.map((c) => c.method)).toEqual(["POST", "GET", "GET"]);
+  });
+
+  test("reclaims the alias when the agent has left that room, and creates a fresh one", async () => {
+    // After a clean slate: the room is emptied and forgotten, but the alias
+    // still points at it, so `createRoom` fails forever and nothing else will
+    // ever release it. This is the case that made a rebuild produce 0 rooms
+    // while reporting 32 provisioned.
+    replies = [
+      inUse,
+      { status: 200, body: { room_id: OLD } },
+      { status: 200, body: { joined_rooms: [] } }, // no longer in it
+      { status: 200, body: {} }, // alias deleted
+      { status: 200, body: { room_id: NEW } }, // created at last
+    ];
+
+    const roomId = await client().ensureRoom(ALIAS, {
+      creator: USER,
+      name: "pi-x",
+      topic: "t",
+    });
+
+    expect(roomId).toBe(NEW);
+    const del = calls.find((c) => c.method === "DELETE")!;
+    expect(del.url).toContain("/directory/room/");
+    // As the agent that owns the alias — the bridge's own token is refused
+    // with a 403, which is what the live homeserver answered.
+    expect(del.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+  });
+
+  test("gives up rather than pretending when the alias cannot be released", async () => {
+    replies = [
+      inUse,
+      { status: 200, body: { room_id: OLD } },
+      { status: 200, body: { joined_rooms: [] } },
+      { status: 403, body: { errcode: "M_FORBIDDEN" } }, // delete refused
+    ];
+
+    const roomId = await client().ensureRoom(ALIAS, {
+      creator: USER,
+      name: "pi-x",
+      topic: "t",
+    });
+
+    expect(roomId).toBeNull();
+  });
+});

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -151,6 +151,24 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
     );
   }
 
+  /** The room an alias points at, or null when nothing does. */
+  async function resolveAlias(alias: string): Promise<string | null> {
+    const res = await call(
+      `/_matrix/client/v3/directory/room/${encodeURIComponent(alias)}`,
+      { method: "GET" }
+    );
+    if (res.status !== 200) return null;
+    return String(res.body.room_id ?? "") || null;
+  }
+
+  /** Whether `userId` is still in `roomId`. */
+  async function isJoined(userId: string, roomId: string): Promise<boolean> {
+    const res = await call("/_matrix/client/v3/joined_rooms", { method: "GET", userId });
+    if (res.status !== 200) return false;
+    const rooms = Array.isArray(res.body.joined_rooms) ? res.body.joined_rooms : [];
+    return rooms.some((r) => r === roomId);
+  }
+
   return {
     async ensureUser(localpart, displayName) {
       const res = await call("/_matrix/client/v3/register", {
@@ -222,8 +240,56 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
         },
       });
 
-      if (!assertOkOrAlready(`createRoom ${alias}`, res)) return null;
-      return String(res.body.room_id ?? "") || null;
+      if (assertOkOrAlready(`createRoom ${alias}`, res)) {
+        return String(res.body.room_id ?? "") || null;
+      }
+
+      // M_ROOM_IN_USE. The alias is taken, and by what decides everything:
+      //
+      //  - by a room this agent is still in — the ordinary restart. That room
+      //    IS the answer, so resolve the alias and hand it back. Returning null
+      //    here (what shipped) made provisioning create nothing and report
+      //    success.
+      //  - by a room it has left — an emptied room after a clean slate. The
+      //    alias outlives the room's usefulness and nothing else will ever
+      //    release it, so take it back and try once more.
+      const existing = await resolveAlias(alias);
+      if (!existing) return null;
+
+      if (await isJoined(opts.creator, existing)) return existing;
+
+      log.info("reclaiming an alias from a room this agent has left", {
+        alias,
+        roomId: existing,
+      });
+      const dropped = await call(
+        `/_matrix/client/v3/directory/room/${encodeURIComponent(alias)}`,
+        { method: "DELETE", userId: opts.creator }
+      );
+      if (dropped.status < 200 || dropped.status >= 300) {
+        log.warn("could not release a stale alias; the room cannot be recreated", {
+          alias,
+          status: dropped.status,
+        });
+        return null;
+      }
+
+      const retry = await call("/_matrix/client/v3/createRoom", {
+        method: "POST",
+        userId: opts.creator,
+        body: {
+          room_alias_name: aliasLocalpart,
+          name: opts.name,
+          topic: opts.topic,
+          preset: "private_chat",
+          ...(opts.invite ? { invite: [opts.invite] } : {}),
+          ...(opts.isDirect ? { is_direct: true } : {}),
+        },
+      });
+      if (!assertOkOrAlready(`createRoom ${alias} (after reclaiming its alias)`, retry)) {
+        return null;
+      }
+      return String(retry.body.room_id ?? "") || null;
     },
 
     async sendText(userId, roomId, body) {

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -187,12 +187,20 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
       ...(invitee ? { invite: invitee, isDirect: true } : {}),
     });
 
-    if (roomId) {
-      await db
-        .insert(matrixRooms)
-        .values({ roomId, tenantId: s.tenantId, stationId: s.stationId, alias })
-        .onConflictDoNothing();
+    if (!roomId) {
+      // Thrown, not logged and stepped over: `provisionAll` counts failures,
+      // and a station left with no room is exactly what that count is for.
+      // Swallowing it is how a rebuild reported "provisioned 32, failed 0"
+      // while creating nothing at all.
+      throw new Error(
+        `could not create a room for ${s.stationKey} at ${alias} — the homeserver refused, or its alias is held by a room this agent cannot reclaim`
+      );
     }
+
+    await db
+      .insert(matrixRooms)
+      .values({ roomId, tenantId: s.tenantId, stationId: s.stationId, alias })
+      .onConflictDoNothing();
   }
 
   if (bridged) {


### PR DESCRIPTION
The clean slate emptied all 32 agent rooms, and the rebuild reported **"provisioned 32, failed 0" while creating zero rooms**.

Leaving and forgetting a room does not release its alias. `#agentpod_<node>_<station>` still resolved to the dead room, `createRoom` answered `M_ROOM_IN_USE`, and `ensureRoom` returned null — which provisioning stepped over as though the room already existed. Nothing else ever releases such an alias, so those stations could never have got a room again.

`ensureRoom` now looks at what actually holds the alias:

| Holder | Answer |
|---|---|
| a room the agent is **still in** | that room *is* the answer — resolve and return it (the ordinary restart) |
| a room it has **left** | release the alias and create again |
| an alias it **cannot** release | return null, and let the caller fail loudly |

The delete is made **as the agent**, because the alias belongs to whoever created the room — the bridge's own token is refused with 403, which is exactly what the live homeserver answered when I tried this by hand.

Provisioning also stops counting a station with no room as provisioned: it throws, so `provisionAll`'s failure count means what it says. A number that cannot be wrong is the only reason to print one.

This makes a clean slate a one-step operation — empty the rooms, restart, and the bridge takes its own aliases back.

hub: 1367 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW