### PR TITLE
fix: try an agent's face again once its node is actually reachable

### DIFF
--- a/apps/hub/src/routes/gateway.ts
+++ b/apps/hub/src/routes/gateway.ts
@@ -20,7 +20,7 @@ import { handleNodeMessage, dropNode } from "../services/broker";
 import { upgradeWebSocket } from "../ws";
 import { autoAdoptProvisionedHarness } from "../services/runtime-autoadopt";
 import { completeRuntimeStartForNode } from "../services/runtimes";
-import { refreshAdoptedCapabilities } from "../services/station-registry";
+import { refreshAdoptedCapabilities, announceStationsForNode } from "../services/station-registry";
 import { recordHealth, clearNode } from "../services/health-cache";
 
 // Node connects with `Authorization: Bearer <nodeId>:<nodeSecret>`.
@@ -109,6 +109,22 @@ export const gatewayRoutes = new Hono().get(
             } catch {
               // autoAdoptProvisionedHarness never throws, but guard anyway.
             }
+          }
+        })();
+
+        // Tell the Matrix bridge to look at this node's stations again, now
+        // that the node can actually be reached. Provisioning at boot runs
+        // while every node is still offline (the hub resets them all and the
+        // agents dial back seconds later), so the one part that needs the node
+        // — reading an agent's picture out of its workspace — never succeeds
+        // there. 32 agents had rooms and none had a face because of it.
+        // Fire-and-forget, like its neighbours, and idempotent downstream.
+        void (async () => {
+          if (!(await sleep(3000))) return;
+          try {
+            await announceStationsForNode(nodeId);
+          } catch {
+            // announceStationsForNode never throws, but guard anyway.
           }
         })();
 

--- a/apps/hub/src/services/station-registry.ts
+++ b/apps/hub/src/services/station-registry.ts
@@ -265,3 +265,35 @@ export async function refreshAdoptedCapabilities(
     return 0;
   }
 }
+
+/**
+ * Tell the Matrix bridge to look at this node's stations again.
+ *
+ * Provisioning runs at hub boot, and at boot **no node is connected yet** —
+ * the hub resets every node to offline and the agents dial back in seconds
+ * later. Everything provisioning does against the homeserver works anyway;
+ * the one part that needs the node does not, because it reads a file from the
+ * station's workspace. That is why 32 agents had rooms and none had a face:
+ * the read was attempted while every node was offline, and a failed read is
+ * silent by design — an agent's picture is never worth failing provisioning
+ * over.
+ *
+ * So the bridge is told again when the node is actually reachable. Everything
+ * downstream is idempotent: a station that has its room, its space and its
+ * face costs one profile GET and nothing else.
+ *
+ * Never throws: it runs from the gateway's connect path.
+ */
+export async function announceStationsForNode(nodeId: string): Promise<number> {
+  try {
+    const rows = await db
+      .select({ id: stations.id })
+      .from(stations)
+      .where(eq(stations.nodeId, nodeId));
+    if (rows.length === 0) return 0;
+    notifyStationsAdopted(rows.map((r) => r.id));
+    return rows.length;
+  } catch {
+    return 0;
+  }
+}

--- a/apps/hub/tests/integration/matrix-adoption-hook.test.ts
+++ b/apps/hub/tests/integration/matrix-adoption-hook.test.ts
@@ -3,7 +3,7 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
-import { adoptStations } from "../../src/services/station-registry";
+import { adoptStations, announceStationsForNode } from "../../src/services/station-registry";
 import { onStationsAdopted } from "../../src/services/matrix-as/hooks";
 
 /**
@@ -98,5 +98,37 @@ describe("adopting a station", () => {
     const rows = await adoptStations(USER, NODE, ["openclaw:three"], [detected("openclaw:three")]);
 
     expect(rows).toHaveLength(1);
+  });
+});
+
+describe("a node that has just reconnected", () => {
+  test("announces its stations, so the bridge tries again with the node reachable", async () => {
+    // Provisioning at boot runs while every node is still offline — the hub
+    // resets them all and the agents dial back seconds later. Everything it
+    // does against the homeserver works anyway; reading an agent's picture out
+    // of its workspace does not, and a failed read is silent by design. That is
+    // why 32 agents had rooms and not one had a face.
+    await adoptStations(USER, NODE, ["openclaw:one"], [detected("openclaw:one")]);
+    announced = [];
+    onStationsAdopted(async (ids) => {
+      announced.push(ids);
+    });
+
+    const count = await announceStationsForNode(NODE);
+
+    expect(count).toBe(1);
+    expect(announced).toHaveLength(1);
+  });
+
+  test("says nothing about a node with no stations", async () => {
+    // Every reconnect runs this, and most nodes are quiet. An empty
+    // announcement would make the bridge walk an empty list on every network
+    // blip in the fleet.
+    onStationsAdopted(async (ids) => {
+      announced.push(ids);
+    });
+
+    expect(await announceStationsForNode("node_that_has_none")).toBe(0);
+    expect(announced).toEqual([]);
   });
 });


### PR DESCRIPTION
Every station has a room; not one had a face. The images were never the problem — all 14 hermes profiles carry `pfp.png` at exactly the path the bridge reads.

**Provisioning runs at hub boot, and at boot no node is connected.** The hub resets every node to offline and the agents dial back in seconds later. Everything provisioning does against the homeserver succeeds; the one part that needs the node — reading a picture out of the station's workspace — fails every single time. And a failed read is silent by design, because an agent's picture is never worth failing provisioning over. So it failed 32 times without a word.

From the live log, one boot:

```
13:08:28  Reset 3 orphaned online node(s) to offline
13:08:32  matrix bridge ready — provisioned 32, failed 0
```

A node that connects now announces its stations three seconds in, on the same fire-and-forget path that already re-reads capabilities after an update. Everything downstream is idempotent: a station that has its room, its space and its face costs one profile GET and nothing else.

Two tests: a reconnected node announces its stations, and a node with none announces nothing (every reconnect in the fleet runs this, and most nodes are quiet).

hub: 1369 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW