### PR TITLE
feat: approve an agent's action from the room it asked in

### DIFF
--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -26,6 +26,12 @@ import { resolveMatrixId } from "../matrix-identity";
 import { getGrant, grantAllowsStation } from "../grants";
 import { isControlPairEnforced } from "../control-pair";
 import { bridgeUserId } from "./names";
+import {
+  clearPendingPermission,
+  matchPermissionAnswer,
+  pendingPermissionFor,
+  unmatchedAnswerText,
+} from "./permissions";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-inbound");
@@ -50,6 +56,16 @@ export interface InboundDeps {
       mode: string;
     }): Promise<{ id: string }>;
     promptSession(userId: string, sessionId: string, text: string): Promise<void>;
+    /**
+     * Answer a permission request the agent is parked on. Optional so a
+     * deployment (or a test) that only relays messages still type-checks.
+     */
+    answerPermission?(
+      userId: string,
+      sessionId: string,
+      requestSeq: number,
+      optionId: string
+    ): Promise<void>;
   };
   /**
    * Start streaming this session into this room.
@@ -147,6 +163,57 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
       );
       return;
     }
+  }
+
+  // ── Is this an answer to a question the agent is waiting on? ─────────────
+  //
+  // Checked after the grant, deliberately: approving an action is dispatching
+  // the agent by another name, so somebody who may not dispatch it must not be
+  // able to approve its next tool call either.
+  //
+  // Checked before prompting, because while a permission is pending the
+  // session cannot take a prompt — it is parked. Treating the answer as a
+  // message would lose the answer AND fail the prompt.
+  const waiting = pendingPermissionFor(room.roomId);
+  if (waiting) {
+    const optionId = matchPermissionAnswer(text, waiting.options);
+    if (!optionId) {
+      // Not resolved to the nearest-looking option: approving a tool call the
+      // operator did not mean to approve is the one failure this must not
+      // have.
+      await say(unmatchedAnswerText(waiting.options));
+      return;
+    }
+
+    if (!deps.acp.answerPermission) {
+      await say("This hub cannot answer permission requests from a room yet.");
+      return;
+    }
+
+    try {
+      await deps.acp.answerPermission(
+        principalId,
+        waiting.sessionId,
+        waiting.requestSeq,
+        optionId
+      );
+      // Only after it was accepted: a cleared question plus a failed answer
+      // would leave the agent parked with nothing able to release it.
+      clearPendingPermission(room.roomId);
+      log.info("permission answered from a room", {
+        principalId,
+        room: room.roomId,
+        optionId,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      log.error("permission answer from a room was refused", {
+        room: room.roomId,
+        error: reason,
+      });
+      await say(`I could not record that answer: ${reason}`);
+    }
+    return;
   }
 
   // ── Say it to the agent ───────────────────────────────────────────────────

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -20,7 +20,8 @@ import { createMatrixClient, type MatrixClient } from "./client";
 import { provisionStation, provisionAll } from "./provision";
 import { handleRoomMessage } from "./inbound";
 import { attachRoomToSession, noteTurnTrigger } from "./outbound";
-import { createSession, promptSession } from "../acp-sessions";
+import { createSession, promptSession,
+  answerPermission } from "../acp-sessions";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-bridge");
@@ -155,6 +156,7 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
         return { id: session.id };
       },
       promptSession,
+      answerPermission,
     },
     // The joint between inbound and outbound. Without it a session is created,
     // prompted, and answers into a stream nobody is listening to — which is

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -13,6 +13,12 @@
 
 import type { AcpEvent } from "@agentpod/contract";
 import { subscribe as subscribeToSession } from "../acp-sessions";
+import {
+  clearPendingPermission,
+  notePendingPermission,
+  permissionPrompt,
+  type PermissionOption,
+} from "./permissions";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-outbound");
@@ -130,20 +136,28 @@ function messageChunkText(payload: unknown): string | undefined {
   return typeof content.text === "string" ? content.text : undefined;
 }
 
-/** A permission request, rendered as a question a person can answer. */
-function permissionText(payload: unknown): string | null {
+/** What an agent is asking to do, and the answers it will accept. */
+function permissionRequest(payload: unknown): {
+  title: string;
+  options: PermissionOption[];
+} | null {
   if (!isRecord(payload)) return null;
   const toolCall = isRecord(payload.toolCall) ? payload.toolCall : {};
-  const what = typeof toolCall.title === "string" ? toolCall.title : "an action";
+  const title = typeof toolCall.title === "string" ? toolCall.title : "an action";
 
+  // Both halves or neither: an option the room can name but not answer with
+  // would be worse than one it never showed.
   const options = Array.isArray(payload.options)
     ? payload.options
-        .map((o) => (isRecord(o) && typeof o.name === "string" ? o.name : null))
-        .filter((n): n is string => n !== null)
+        .map((o) =>
+          isRecord(o) && typeof o.name === "string" && typeof o.optionId === "string"
+            ? { optionId: o.optionId, name: o.name }
+            : null
+        )
+        .filter((o): o is PermissionOption => o !== null)
     : [];
 
-  const choices = options.length > 0 ? ` — ${options.join(" / ")}` : "";
-  return `Permission needed: ${what}${choices}. Answer in the console; this room cannot yet.`;
+  return { title, options };
 }
 
 export function attachRoomToSession(
@@ -241,6 +255,7 @@ export function attachRoomToSession(
   const detach = () => {
     if (state.ended) return;
     state.ended = true;
+    clearPendingPermission(roomId);
     if (state.timer) clearTimeout(state.timer);
     if (state.typingTimer) clearInterval(state.typingTimer);
     triggers.delete(sessionId);
@@ -275,6 +290,11 @@ export function attachRoomToSession(
             return;
           }
 
+          // A question only stands while the agent is waiting on it. A turn
+          // that moved on — answered in the console, cancelled, failed — must
+          // not leave the room able to "approve" something already decided.
+          if (status !== "waiting") clearPendingPermission(roomId);
+
           // Anything that is not `working` means the agent is not typing —
           // including `waiting`, which is a permission request this room cannot
           // yet answer and could sit there for hours. Enumerating only idle and
@@ -294,8 +314,25 @@ export function attachRoomToSession(
         }
 
         case "permission-request": {
-          const text = permissionText(event.payload);
-          if (text) await say(text);
+          const request = permissionRequest(event.payload);
+          if (!request) return;
+
+          // Remembered BEFORE the message is sent: an answer cannot arrive
+          // before the question, but a reply racing a slow homeserver would
+          // find nothing pending and be treated as an ordinary prompt.
+          //
+          // `event.seq` is the request's own sequence number, which is how
+          // `answerPermission` addresses it — the same address the console's
+          // WebSocket sends.
+          if (request.options.length > 0) {
+            notePendingPermission(roomId, {
+              sessionId,
+              requestSeq: event.seq,
+              options: request.options,
+            });
+          }
+
+          await say(permissionPrompt(request.title, request.options));
           return;
         }
 
@@ -324,6 +361,7 @@ export function detachRoom(sessionId: string): void {
   const state = attached.get(sessionId);
   triggers.delete(sessionId);
   if (!state) return;
+  clearPendingPermission(state.roomId);
   state.ended = true;
   if (state.timer) clearTimeout(state.timer);
   if (state.typingTimer) clearInterval(state.typingTimer);

--- a/apps/hub/src/services/matrix-as/permissions.test.ts
+++ b/apps/hub/src/services/matrix-as/permissions.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  matchPermissionAnswer,
+  permissionPrompt,
+  unmatchedAnswerText,
+  type PermissionOption,
+} from "./permissions";
+
+const OPTIONS: PermissionOption[] = [
+  { optionId: "allow_once", name: "Allow once" },
+  { optionId: "allow_always", name: "Allow always" },
+  { optionId: "reject", name: "Reject" },
+];
+
+describe("the question, as it arrives in the room", () => {
+  test("numbers the options and says how to answer", () => {
+    const text = permissionPrompt("Write src/main.ts", OPTIONS);
+
+    expect(text).toContain("Permission needed: Write src/main.ts");
+    expect(text).toContain("1. Allow once");
+    expect(text).toContain("3. Reject");
+    expect(text).toMatch(/reply with the number/i);
+  });
+
+  test("says plainly when there is nothing to choose between", () => {
+    // An empty numbered list waiting for an answer that cannot exist is worse
+    // than admitting the room cannot serve this one.
+    const text = permissionPrompt("Something", []);
+
+    expect(text).toMatch(/no options/i);
+    expect(text).not.toMatch(/reply with the number/i);
+  });
+});
+
+describe("matching a reply to an option", () => {
+  test("takes the number as printed, one-based", () => {
+    expect(matchPermissionAnswer("1", OPTIONS)).toBe("allow_once");
+    expect(matchPermissionAnswer("3", OPTIONS)).toBe("reject");
+    expect(matchPermissionAnswer(" 2 ", OPTIONS)).toBe("allow_always");
+  });
+
+  test("takes the option's name, however it was capitalised", () => {
+    expect(matchPermissionAnswer("Allow once", OPTIONS)).toBe("allow_once");
+    expect(matchPermissionAnswer("reject", OPTIONS)).toBe("reject");
+  });
+
+  test("takes the option id, which is what a scripted answer would send", () => {
+    expect(matchPermissionAnswer("allow_always", OPTIONS)).toBe("allow_always");
+  });
+
+  test("refuses a number outside the list rather than wrapping or clamping", () => {
+    expect(matchPermissionAnswer("0", OPTIONS)).toBeNull();
+    expect(matchPermissionAnswer("4", OPTIONS)).toBeNull();
+    expect(matchPermissionAnswer("99", OPTIONS)).toBeNull();
+  });
+
+  test("refuses anything that merely sounds like agreement", () => {
+    // The one failure this must never have is approving a tool call the
+    // operator did not mean to approve. Against options named "Allow once"
+    // and "Allow always", a bare "yes" does not say which — and "sure",
+    // "ok", "go ahead" say even less.
+    for (const reply of ["yes", "y", "sure", "ok", "go ahead", "do it", "allow"]) {
+      expect(matchPermissionAnswer(reply, OPTIONS)).toBeNull();
+    }
+  });
+
+  test("refuses an empty or whitespace reply", () => {
+    expect(matchPermissionAnswer("", OPTIONS)).toBeNull();
+    expect(matchPermissionAnswer("   ", OPTIONS)).toBeNull();
+  });
+
+  test("matches nothing when there is nothing to match", () => {
+    expect(matchPermissionAnswer("1", [])).toBeNull();
+  });
+});
+
+describe("when a reply matched nothing", () => {
+  test("shows the options again and says nothing was approved", () => {
+    // The operator has to know two things at once: that their message did not
+    // count, and what would.
+    const text = unmatchedAnswerText(OPTIONS);
+
+    expect(text).toMatch(/nothing has been approved/i);
+    expect(text).toContain("1. Allow once");
+  });
+});

--- a/apps/hub/src/services/matrix-as/permissions.ts
+++ b/apps/hub/src/services/matrix-as/permissions.ts
@@ -1,0 +1,117 @@
+/**
+ * Approving an agent's action from the room it asked in.
+ *
+ * The bridge used to post "Permission needed: … Answer in the console; this
+ * room cannot yet." — which is the whole product with the last step missing.
+ * An agent that asks for permission and can only be answered somewhere else
+ * has not moved the decision to where the operator is; it has added a
+ * notification.
+ *
+ * Two pieces live here, and both are pure so they can be tested without a
+ * homeserver: what the question looks like when it arrives in a room, and how
+ * a reply is matched back to one of the options. The state — which room is
+ * waiting on which request — is a map, because a room can hold at most one
+ * pending question at a time (the session parks until it is answered).
+ *
+ * **Nothing is guessed.** A reply that is not plainly one of the options is
+ * refused with the list again, rather than resolved to the nearest-looking
+ * one. Approving a tool call the operator did not mean to approve is the one
+ * failure this must never have, and "yes" against options named *Allow once*
+ * and *Allow always* is exactly the ambiguity that would cause it.
+ */
+
+export interface PermissionOption {
+  optionId: string;
+  name: string;
+}
+
+export interface PendingPermission {
+  sessionId: string;
+  /** The seq of the `permission-request` event, which is how the answer is addressed. */
+  requestSeq: number;
+  options: PermissionOption[];
+}
+
+/** Keyed by room: the operator answers where the question was asked. */
+const pending = new Map<string, PendingPermission>();
+
+export function notePendingPermission(roomId: string, permission: PendingPermission): void {
+  pending.set(roomId, permission);
+}
+
+export function pendingPermissionFor(roomId: string): PendingPermission | undefined {
+  return pending.get(roomId);
+}
+
+export function clearPendingPermission(roomId: string): void {
+  pending.delete(roomId);
+}
+
+/** Leak detection, mirroring `_attachedCountForTest` in `outbound.ts`. */
+export function _pendingCountForTest(): number {
+  return pending.size;
+}
+
+/**
+ * The question, as it arrives in the room.
+ *
+ * Numbered, because a number is the shortest thing a person can type on a
+ * phone and the only answer that cannot be misspelled. The names are shown
+ * too — the operator is approving an action, and "1" alone would make the
+ * transcript unreadable afterwards.
+ */
+export function permissionPrompt(title: string, options: PermissionOption[]): string {
+  if (options.length === 0) {
+    // Nothing to choose between. Say so rather than posting an empty list and
+    // waiting for an answer that cannot exist.
+    return `Permission needed: ${title}. There are no options to choose from — answer in the console.`;
+  }
+
+  const lines = options.map((option, index) => `${index + 1}. ${option.name}`);
+  return [
+    `Permission needed: ${title}`,
+    "",
+    ...lines,
+    "",
+    "Reply with the number, or the option's name.",
+  ].join("\n");
+}
+
+/**
+ * The option a reply selects, or null when it selects none.
+ *
+ * Accepts the position in the list, the option's name, or its id — the three
+ * things a reply can unambiguously be. Everything else is null, including
+ * anything that merely resembles agreement.
+ */
+export function matchPermissionAnswer(
+  reply: string,
+  options: PermissionOption[]
+): string | null {
+  const text = reply.trim().toLowerCase();
+  if (text === "") return null;
+
+  // A bare number, 1-based, as printed.
+  if (/^\d+$/.test(text)) {
+    const index = Number(text) - 1;
+    return options[index]?.optionId ?? null;
+  }
+
+  const byName = options.find((o) => o.name.trim().toLowerCase() === text);
+  if (byName) return byName.optionId;
+
+  const byId = options.find((o) => o.optionId.trim().toLowerCase() === text);
+  return byId?.optionId ?? null;
+}
+
+/** What to say when a reply matched nothing — the options again, not a scolding. */
+export function unmatchedAnswerText(options: PermissionOption[]): string {
+  const names = options.map((o, i) => `${i + 1}. ${o.name}`).join("\n");
+  return [
+    "That is not one of the options, so nothing has been approved.",
+    "",
+    names,
+    "",
+    "Reply with the number, or the option's name.",
+  ].join("\n");
+}

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -5,6 +5,11 @@ import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant, deleteGrant } from "../../src/services/grants";
 import { handleRoomMessage } from "../../src/services/matrix-as/inbound";
+import {
+  clearPendingPermission,
+  notePendingPermission,
+  pendingPermissionFor,
+} from "../../src/services/matrix-as/permissions";
 
 /**
  * Where a Matrix message becomes work.
@@ -70,6 +75,34 @@ function deps() {
   };
 }
 
+/** `deps()` plus the ability to answer a parked permission request. */
+function depsWithPermissions() {
+  const base = deps();
+  return {
+    ...base,
+    acp: {
+      ...base.acp,
+      answerPermission: async (
+        userId: string,
+        sessionId: string,
+        requestSeq: number,
+        optionId: string
+      ) => {
+        if (answerFails) throw answerFails;
+        answered.push({ userId, sessionId, requestSeq, optionId });
+      },
+    },
+  };
+}
+
+let answered: Array<{
+  userId: string;
+  sessionId: string;
+  requestSeq: number;
+  optionId: string;
+}> = [];
+let answerFails: Error | null = null;
+
 function message(sender: string, body: string, roomId = ROOM) {
   return {
     type: "m.room.message",
@@ -109,6 +142,9 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+  answered = [];
+  answerFails = null;
+  clearPendingPermission(ROOM);
   sent = [];
   created = [];
   prompts = [];
@@ -316,5 +352,88 @@ describe("an inbound room message", () => {
     await handleRoomMessage(message(OTHER_MXID, "hello"), deps());
 
     expect(created[0]!.userId).toBe(OTHER);
+  });
+});
+
+describe("answering a permission request from the room", () => {
+  const OPTIONS = [
+    { optionId: "allow_once", name: "Allow once" },
+    { optionId: "reject", name: "Reject" },
+  ];
+
+  const parkOn = (sessionId = "acps_parked") =>
+    notePendingPermission(ROOM, { sessionId, requestSeq: 7, options: OPTIONS });
+
+  test("a number answers it, and nothing is prompted", async () => {
+    // While a permission is pending the session is PARKED — it cannot take a
+    // prompt. Treating the answer as a message would lose the answer and fail
+    // the prompt in the same breath.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    parkOn();
+
+    await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
+
+    expect(answered).toEqual([
+      { userId: OWNER, sessionId: "acps_parked", requestSeq: 7, optionId: "allow_once" },
+    ]);
+    expect(created).toHaveLength(0);
+    expect(prompts).toHaveLength(0);
+  });
+
+  test("the option's name answers it too", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    parkOn();
+
+    await handleRoomMessage(message(OWNER_MXID, "Reject"), depsWithPermissions());
+
+    expect(answered[0]!.optionId).toBe("reject");
+  });
+
+  test("a reply that is not an option approves nothing and says so", async () => {
+    // "yes" against options named "Allow once" and "Allow always" does not say
+    // which. Resolving it to the nearest-looking one is the failure this must
+    // never have.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    parkOn();
+
+    await handleRoomMessage(message(OWNER_MXID, "yes go ahead"), depsWithPermissions());
+
+    expect(answered).toEqual([]);
+    expect(sent.at(-1)!.body).toMatch(/nothing has been approved/i);
+    // …and the question still stands, so the next reply can answer it.
+    expect(pendingPermissionFor(ROOM)).toBeDefined();
+  });
+
+  test("someone who may not dispatch the agent may not approve for it either", async () => {
+    // Approving an action IS dispatching the agent, by another name.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:other/*"], mayGrantReach: false });
+    parkOn();
+
+    await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
+
+    expect(answered).toEqual([]);
+    expect(sent.at(-1)!.body).toMatch(/not permitted/i);
+  });
+
+  test("a refused answer leaves the question standing", async () => {
+    // A cleared question plus a failed answer would park the agent forever
+    // with nothing able to release it.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    parkOn();
+    answerFails = new Error("No pending permission request.");
+
+    await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
+
+    expect(pendingPermissionFor(ROOM)).toBeDefined();
+    expect(sent.at(-1)!.body).toMatch(/could not record that answer/i);
+  });
+
+  test("an ordinary message is still an ordinary message when nothing is pending", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+
+    await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
+
+    expect(answered).toEqual([]);
+    expect(prompts.at(-1)!.text).toBe("1");
   });
 });

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -851,7 +851,33 @@ so everything it can do is something the control pair already governs.
 Matrix account first and the agent second; now the station must exist before it
 can have an identity.
 
-### 7f. Purpose: what an agent is FOR
+### 7f. Approving an agent's action from the room
+
+An agent in `ask` mode parks when it wants to run a tool, and the bridge posts
+the question where you are:
+
+```
+Permission needed: Write src/main.ts
+
+1. Allow once
+2. Allow always
+3. Reject
+
+Reply with the number, or the option's name.
+```
+
+Reply with `1`, or `Allow once`. Nothing else counts: a reply that is not
+plainly one of the options approves nothing and shows the list again. That is
+deliberate — against options named *Allow once* and *Allow always*, a bare
+"yes" does not say which, and approving a tool call you did not mean to
+approve is the one failure worth being pedantic about.
+
+Approving is dispatching by another name, so it needs the same `mayDispatch`
+grant as sending the agent a message. A question stops standing the moment the
+turn moves on — answered in the console, cancelled, or failed — so a room can
+never approve something already decided.
+
+### 7g. Purpose: what an agent is FOR
 
 A flat roster is fine at 32 agents and unreadable at 200. The axis to group by
 is **purpose** — personal, work, ad hoc, whatever you type — and deliberately
@@ -894,7 +920,7 @@ it is created; **accept the invite or you will not see it**.
 Filing happens during provisioning, so it is idempotent and self-healing: set a
 purpose and the room moves; restart the hub and nothing moves twice.
 
-### 7g. What happened to the Synapse history
+### 7h. What happened to the Synapse history
 
 The old homeserver's 19,603 events are **not in tuwunel** — there is no supported
 import path from Synapse into the Conduit lineage, and Matrix here carries a


### PR DESCRIPTION
The bridge posted *"Permission needed: … Answer in the console; this room cannot yet."* That's the product with its last step missing — an agent that asks for permission and can only be answered somewhere else hasn't moved the decision to where the operator is, it has added a notification.

The question now arrives answerable:

```
Permission needed: Write src/main.ts

1. Allow once
2. Allow always
3. Reject

Reply with the number, or the option's name.
```

A number, the option's name, or its id counts. **Nothing else does.** A reply that isn't plainly one of the options approves nothing and shows the list again — against options named *Allow once* and *Allow always*, a bare "yes" doesn't say which, and approving a tool call the operator didn't mean to approve is the one failure this must never have.

Three rules the tests pin:

- **The same grant.** Approving is dispatching by another name, so the control-pair check runs before the answer is accepted — somebody who may not dispatch the agent may not approve its next tool call either.
- **Checked before prompting.** While a permission is pending the session is *parked* and cannot take a prompt, so treating the answer as an ordinary message would lose the answer and fail the prompt in one breath.
- **A refused answer leaves the question standing.** Clearing it on failure would park the agent with nothing able to release it. It's also cleared whenever the turn moves on — answered in the console, cancelled, failed — so a room can never approve something already decided.

`event.seq` is the request's own sequence number, the same address the console's WebSocket answers on; no new addressing was invented.

10 unit tests on the matching (including that every phrasing of "yes" is refused) + 6 integration tests on the round trip. Hub: 1385 pass. Operator docs: `OPERATING.md` §7f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW