### PR TITLE
feat: group agents by the machine they run on, not by purpose

### DIFF
--- a/apps/hub/src/db/drizzle-migrations/0052_node_spaces.sql
+++ b/apps/hub/src/db/drizzle-migrations/0052_node_spaces.sql
@@ -1,0 +1,19 @@
+-- Spaces group by NODE, not by purpose.
+--
+-- Purpose was the axis for a day: an operator's fleet is laid out by use case,
+-- and node lined up with it only by accident. The operator has since chosen the
+-- machine as the grouping — it is the thing they can point at, it needs no
+-- labelling step before a new agent lands somewhere sensible, and purpose is
+-- better served later as tags, which can overlap and do not fight a hierarchy.
+--
+-- `purpose` on stations and nodes is deliberately KEPT. It is still the record
+-- of what an agent is for, and it is what tags will be built from; nothing reads
+-- it for grouping any more.
+ALTER TABLE matrix_purpose_spaces RENAME TO matrix_spaces;
+ALTER TABLE matrix_spaces RENAME COLUMN purpose TO space_key;
+
+-- The existing rows named purposes ("personal", "work"). Under the new keying
+-- they would be read as node names, so they are dropped and the node spaces are
+-- made fresh. The rooms they point at are cleaned up on the homeserver
+-- separately — a space nobody is in is invisible, not harmful.
+DELETE FROM matrix_spaces;

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1786687170202,
       "tag": "0051_purpose_space_creator",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1786687171202,
+      "tag": "0052_node_spaces",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -72,20 +72,24 @@ export const matrixRooms = pgTable(
  * the other shape, and is an ordinary room precisely because it is not one-to-one.
  */
 /**
- * One space per purpose — personal, work, whatever the operator types.
+ * One space per node, plus one for missions.
  *
- * Keyed by (tenant, purpose) rather than by an alias: an alias is a global
- * address on the homeserver, and "personal" is exactly the kind of everyday
- * word two tenants would both use. Nobody types this room's address anyway;
- * it is a container, not a destination.
+ * Keyed by (tenant, key) rather than by an alias: an alias is a global address
+ * on the homeserver, and a node called `laptop` is exactly what two tenants
+ * would both have. Nobody types this room's address anyway — it is a
+ * container, not a destination.
+ *
+ * The key is a node's name, or [`GENERAL_MISSIONS_KEY`] for the one space that
+ * holds missions. It used to be a purpose; see migration 0052 for why the
+ * grouping moved to the machine.
  */
-export const matrixPurposeSpaces = pgTable(
-  "matrix_purpose_spaces",
+export const matrixSpaces = pgTable(
+  "matrix_spaces",
   {
     tenantId: text("tenant_id")
       .notNull()
       .references(() => tenants.id, { onDelete: "restrict" }),
-    purpose: text("purpose").notNull(),
+    spaceKey: text("space_key").notNull(),
     roomId: text("room_id").notNull(),
     /**
      * The agent that created the space, and therefore the only one that can
@@ -97,7 +101,7 @@ export const matrixPurposeSpaces = pgTable(
     creator: text("creator"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
-  (t) => [primaryKey({ columns: [t.tenantId, t.purpose] })]
+  (t) => [primaryKey({ columns: [t.tenantId, t.spaceKey] })]
 );
 
 export const matrixMissions = pgTable(

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -43,7 +43,7 @@ import {
   matrixRooms,
   matrixMissions,
   matrixMissionMembers,
-  matrixPurposeSpaces,
+  matrixSpaces,
 } from "./schema/matrix";
 import { principalIdentities } from "./schema/identities";
 import { principalGrants } from "./schema/grants";
@@ -112,7 +112,7 @@ export const TENANT_SCOPED_TABLES = {
   matrixRooms,
   matrixMissions,
   matrixMissionMembers,
-  matrixPurposeSpaces,
+  matrixSpaces,
 } as const satisfies Record<string, TenantScopedTable>;
 
 /**

--- a/apps/hub/src/routes/missions.ts
+++ b/apps/hub/src/routes/missions.ts
@@ -23,11 +23,10 @@ import { isControlPairEnforced } from "../services/control-pair";
 import { bridgeUserId } from "../services/matrix-as/names";
 import { missionAlias } from "../services/matrix-as/missions";
 import {
-  ensurePurposeSpace,
   ensureSpaceRecord,
   GENERAL_MISSIONS_KEY,
   type Space,
-} from "../services/matrix-as/purpose-spaces";
+} from "../services/matrix-as/spaces";
 import { createLogger } from "../utils/logger";
 import type { AuthUser } from "../auth/middleware";
 
@@ -93,7 +92,6 @@ export function createMissionRoutes(deps: MissionDeps) {
         id: stations.id,
         tenantId: stations.tenantId,
         stationKey: stations.stationKey,
-        purpose: stations.purpose,
         nodeName: nodes.name,
       })
       .from(stations)
@@ -169,25 +167,16 @@ export function createMissionRoutes(deps: MissionDeps) {
         )
       );
 
-    // A mission of work agents is a work mission, and belongs where the
-    // operator is already looking. That only holds when the members AGREE: one
-    // labelled member does not make a purpose, and a cross-purpose mission
-    // belongs to both and to neither — which is exactly the case the one shared
-    // Missions space is right for. Inferring from a majority would file it
-    // somewhere nobody chose.
-    const purposes = new Set(members.map((m) => m.purpose));
-    const shared =
-      purposes.size === 1 && members[0]!.purpose !== null ? members[0]!.purpose : null;
-
-    const space = shared
-      ? await ensurePurposeSpace(
-          tenantId,
-          shared,
-          speaker,
-          identity?.externalId ?? null,
-          deps
-        )
-      : await missionsSpace(tenantId, speaker, identity?.externalId ?? null, deps);
+    // Every mission goes in the one Missions space. Grouping is by NODE now,
+    // and a mission that spans machines — which is most of them, since that is
+    // the point of a mission — belongs to all of them and to none. Filing it
+    // under one member's node would be picking a member.
+    const space = await missionsSpace(
+      tenantId,
+      speaker,
+      identity?.externalId ?? null,
+      deps
+    );
 
     // As the SPACE's creator, never as this mission's speaker: `m.space.child`
     // state lives on the space, and a user who merely made one of its rooms is

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -18,7 +18,7 @@ import { nodes } from "../../db/schema/nodes";
 import { matrixRooms } from "../../db/schema/matrix";
 import { principalIdentities } from "../../db/schema/identities";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
-import { ensurePurposeSpace, fileRoomUnderSpace } from "./purpose-spaces";
+import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
 import { createLogger } from "../../utils/logger";
 
@@ -210,19 +210,19 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
       .where(eq(stations.id, s.stationId));
   }
 
-  await fileByPurpose(s, speaker, deps);
+  await fileByNode(s, speaker, deps);
 }
 
 /**
- * Hang the station's room under the space its purpose calls for.
+ * Hang the station's room under its node's space.
  *
- * Runs on every provision, which is what makes a purpose change take effect:
- * setting one announces the station, and the announcement is this same
- * reconciler. Skipped entirely when the deployment's client cannot do spaces —
+ * Runs on every provision, which is what makes a move take effect: an agent
+ * that turns up on a different machine is re-filed the next time its station is
+ * announced. Skipped entirely when the deployment's client cannot do spaces —
  * a test client asserting on rooms, mainly — because an agent you can talk to
  * matters more than where it is filed.
  */
-async function fileByPurpose(
+async function fileByNode(
   s: NonNullable<Awaited<ReturnType<typeof context>>>,
   speaker: string,
   deps: ProvisionDeps
@@ -241,18 +241,17 @@ async function fileByPurpose(
     client: { createSpace, addSpaceChild, removeSpaceChild, invite: deps.client.invite },
   };
 
-  // An unlabelled station belongs under nothing — not under an invented
-  // `Unsorted` space. It still shows up in All rooms, which is where a fresh
-  // ad-hoc runtime belongs until somebody says otherwise.
-  const desired = s.purpose
-    ? await ensurePurposeSpace(
-        s.tenantId,
-        s.purpose,
-        speaker,
-        await ownerMxid(s.userId),
-        spaceDeps
-      )
-    : null;
+  // Every station has a node, so every station has a space — no labelling step
+  // stands between a new agent and a sensible place in the roster. A space that
+  // could not be made leaves the room in All rooms rather than under an
+  // invented `Unsorted`.
+  const desired = await ensureNodeSpace(
+    s.tenantId,
+    s.nodeName,
+    speaker,
+    await ownerMxid(s.userId),
+    spaceDeps
+  );
 
   await fileRoomUnderSpace(room.roomId, desired, room.spaceRoomId, spaceDeps);
 }

--- a/apps/hub/src/services/matrix-as/spaces.ts
+++ b/apps/hub/src/services/matrix-as/spaces.ts
@@ -1,25 +1,31 @@
 /**
- * Filing an agent's room under what it is FOR.
+ * Filing an agent's room under the machine it runs on.
  *
- * A flat roster is fine at 32 agents and unusable at 200, and the axis an
- * operator actually thinks in is purpose — personal, work, ad hoc — not the
- * host a process happens to run on. Node correlates with purpose in this fleet
- * today by accident of how it was built, and that accident is already
- * scheduled to break: coming use cases span harnesses and runtimes.
+ * A flat roster is fine at 32 agents and unusable at 200. The grouping is the
+ * NODE: it is the thing an operator can point at, it needs no labelling step
+ * before a new agent lands somewhere sensible, and it is true by construction
+ * rather than by anybody remembering to keep it true.
  *
- * The mechanism is a Matrix space per purpose, and the reason it is worth
- * doing here rather than in the client is that it costs the client nothing:
+ * This replaced a purpose-based grouping that lasted a day (migration 0052).
+ * `stations.purpose` is still recorded — it is what an agent is FOR, which a
+ * machine name cannot say — and is meant to become tags, which can overlap and
+ * do not fight a hierarchy the way a second axis of spaces would.
+ *
+ * The mechanism is a Matrix space per node, and the reason it is worth doing
+ * here rather than in the client is that it costs the client nothing:
  * supermessage's rail already scopes its roster by `m.space.child` edges, and
  * Element reads the same hierarchy. One `m.space.child` state event per room is
  * the whole feature.
  *
  * Three rules this module exists to keep:
  *
- *   1. **A station with no purpose hangs nowhere.** Not under `Unsorted` — an
- *      invented space is a claim nobody made. It still appears in All rooms.
- *   2. **A room has at most one purpose parent.** Purposes change, so filing
- *      must remove the old edge as well as add the new one; a room that only
- *      ever gained parents would show up under every purpose it ever had.
+ *   1. **A station whose space could not be made hangs nowhere.** Not under an
+ *      invented `Unsorted` — that is a claim nobody made. It still appears in
+ *      All rooms.
+ *   2. **A room has at most one parent.** An agent can move between machines,
+ *      so filing must remove the old edge as well as add the new one; a room
+ *      that only ever gained parents would show up under every node it ever
+ *      ran on.
  *   3. **Re-running changes nothing.** Provisioning runs at every boot and on
  *      every adoption, and `space_room_id` is what makes the second run a
  *      no-op instead of a re-write.
@@ -27,10 +33,10 @@
 
 import { and, eq } from "drizzle-orm";
 import { db } from "../../db/drizzle";
-import { matrixPurposeSpaces, matrixRooms } from "../../db/schema/matrix";
+import { matrixSpaces, matrixRooms } from "../../db/schema/matrix";
 import { createLogger } from "../../utils/logger";
 
-const log = createLogger("matrix-purpose-spaces");
+const log = createLogger("matrix-spaces");
 
 /** What making a space needs. Split from filing: a caller that only ever
  *  creates one (missions) has no business knowing how to unfile a room. */
@@ -50,24 +56,23 @@ export interface SpaceFileDeps {
 }
 
 /**
- * How a purpose reads as a space name. `personal` → `Personal`.
+ * How a node reads as a space name.
  *
- * Only the first letter, and only when the operator typed it lowercase: a
- * purpose is their word, and title-casing every word would turn "ad hoc R&D"
- * into "Ad Hoc R&d".
+ * Its own name, unchanged. A machine called `molt-bot` is called that
+ * everywhere else an operator looks — the console, `apn`, their ssh config —
+ * and prettifying it here would make the space the one place it is spelled
+ * differently.
  */
-export function spaceNameFor(purpose: string): string {
-  const trimmed = purpose.trim();
-  if (trimmed === "") return trimmed;
-  return trimmed[0]!.toUpperCase() + trimmed.slice(1);
+export function spaceNameFor(nodeName: string): string {
+  return nodeName.trim();
 }
 
 /**
- * The space for `purpose` in this tenant, creating it the first time.
+ * The space for `nodeName` in this tenant, creating it the first time.
  *
  * `creator` is the agent whose room is being filed — an appservice must act as
- * some user in its namespace, and the first agent to need a space is as good a
- * creator as any. `owner` is invited so the space appears in their client at
+ * some user in its namespace, and the first agent on a node to need its space
+ * is as good a creator as any. `owner` is invited so the space appears in their client at
  * all: a space nobody has joined is one the roster rail cannot show, and then
  * the whole feature is invisible.
  *
@@ -75,14 +80,14 @@ export function spaceNameFor(purpose: string): string {
  * rather than failing the provisioning that called it. An agent you can talk to
  * in the wrong part of the roster beats an agent that was never provisioned.
  */
-export async function ensurePurposeSpace(
+export async function ensureNodeSpace(
   tenantId: string,
-  purpose: string,
+  nodeName: string,
   creator: string,
   owner: string | null,
   deps: SpaceCreateDeps
 ): Promise<Space | null> {
-  return ensureSpaceRecord(tenantId, purpose, spaceNameFor(purpose), creator, owner, deps);
+  return ensureSpaceRecord(tenantId, nodeName, spaceNameFor(nodeName), creator, owner, deps);
 }
 
 /**
@@ -103,25 +108,25 @@ export interface Space {
 /**
  * The key under which the one general missions space is remembered.
  *
- * The empty string, and reachable only from here: the purpose routes trim what
- * an operator types and map an empty result to `null`, so no purpose can ever
- * be `""`. That is what makes this a sentinel rather than a name somebody
- * could collide with by typing "missions".
+ * The empty string, and unreachable as a node name: enrolment refuses an empty
+ * one (`uniqueNodeName` falls back to "node"). That is what makes this a
+ * sentinel rather than a name somebody could collide with by calling a machine
+ * "missions".
  *
- * It lives in the same table as the purpose spaces because it is the same kind
- * of thing — a per-tenant space this deployment made and has to find again.
+ * It lives in the same table as the node spaces because it is the same kind of
+ * thing — a per-tenant space this deployment made and has to find again.
  * The alternative it replaced was reading the space id off any existing
- * mission row, which stopped being correct the moment some missions started
- * hanging under purpose spaces instead: the next cross-purpose mission would
- * have been filed under whichever purpose that arbitrary row happened to hold.
+ * mission row, which stopped being correct the moment some missions hung
+ * elsewhere: the next one would have been filed under whichever space that
+ * arbitrary row happened to hold.
  */
 export const GENERAL_MISSIONS_KEY = "";
 
 /**
  * A per-tenant space, created once and remembered by `key`.
  *
- * See [`ensurePurposeSpace`] for the purpose case and [`GENERAL_MISSIONS_KEY`]
- * for the other one.
+ * See [`ensureNodeSpace`] for the node case and [`GENERAL_MISSIONS_KEY`] for
+ * the other one.
  */
 export async function ensureSpaceRecord(
   tenantId: string,
@@ -131,19 +136,10 @@ export async function ensureSpaceRecord(
   owner: string | null,
   deps: SpaceCreateDeps
 ): Promise<Space | null> {
-  const purpose = key;
   const [existing] = await db
-    .select({
-      roomId: matrixPurposeSpaces.roomId,
-      creator: matrixPurposeSpaces.creator,
-    })
-    .from(matrixPurposeSpaces)
-    .where(
-      and(
-        eq(matrixPurposeSpaces.tenantId, tenantId),
-        eq(matrixPurposeSpaces.purpose, purpose)
-      )
-    );
+    .select({ roomId: matrixSpaces.roomId, creator: matrixSpaces.creator })
+    .from(matrixSpaces)
+    .where(and(eq(matrixSpaces.tenantId, tenantId), eq(matrixSpaces.spaceKey, key)));
   if (existing) return existing;
 
   const roomId = await deps.client.createSpace({ creator, name }).catch(() => null);
@@ -153,8 +149,8 @@ export async function ensureSpaceRecord(
   }
 
   await db
-    .insert(matrixPurposeSpaces)
-    .values({ tenantId, purpose, roomId, creator })
+    .insert(matrixSpaces)
+    .values({ tenantId, spaceKey: key, roomId, creator })
     .onConflictDoNothing();
 
   // Without this the space exists and nobody can see it.
@@ -165,12 +161,11 @@ export async function ensureSpaceRecord(
 }
 
 /**
- * Put `roomId` under the space its station's purpose calls for — and take it
- * out of the one it is under now, if that is a different one.
+ * Put `roomId` under the space its station's node calls for — and take it out
+ * of the one it is under now, if that is a different one.
  *
- * `desired` of null means "belongs under nothing", which is what an unlabelled
- * station wants and also what a station whose purpose was just cleared wants.
- * Both cases still have work to do: the old edge has to go.
+ * `desired` of null means "belongs under nothing" — a station whose node space
+ * could not be made, mainly. It still has work to do: the old edge has to go.
  *
  * Every edge is written **as the space's own creator**, never as the room's
  * agent — see [`Space`] for the production failure that rule comes from.
@@ -189,9 +184,9 @@ export async function fileRoomUnderSpace(
 
   if (currentSpaceRoomId) {
     const [current] = await db
-      .select({ creator: matrixPurposeSpaces.creator })
-      .from(matrixPurposeSpaces)
-      .where(eq(matrixPurposeSpaces.roomId, currentSpaceRoomId));
+      .select({ creator: matrixSpaces.creator })
+      .from(matrixSpaces)
+      .where(eq(matrixSpaces.roomId, currentSpaceRoomId));
 
     if (!current?.creator) {
       log.warn("cannot unfile a room from a space with no known creator", {

--- a/apps/hub/tests/integration/matrix-missions.test.ts
+++ b/apps/hub/tests/integration/matrix-missions.test.ts
@@ -93,7 +93,7 @@ beforeEach(async () => {
   invited = [];
   await rawSql`DELETE FROM matrix_mission_members`;
   await rawSql`DELETE FROM matrix_missions`;
-  await rawSql`DELETE FROM matrix_purpose_spaces`;
+  await rawSql`DELETE FROM matrix_spaces`;
   await rawSql`UPDATE stations SET purpose = NULL WHERE node_id = ${NODE}`;
   await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*", "agentpod:*/openclaw:*"], mayGrantReach: false });
 });
@@ -103,7 +103,7 @@ afterAll(async () => {
   try {
     await rawSql`DELETE FROM matrix_mission_members`;
     await rawSql`DELETE FROM matrix_missions`;
-    await rawSql`DELETE FROM matrix_purpose_spaces`;
+    await rawSql`DELETE FROM matrix_spaces`;
     await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
     await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
     await rawSql`DELETE FROM stations WHERE id IN (${A}, ${B})`;
@@ -196,38 +196,27 @@ describe("POST /api/missions", () => {
   });
 });
 
-describe("a mission and the purpose of its members", () => {
-  test("hangs under the purpose its members agree on", async () => {
-    // A mission of work agents is a work mission. Filing it under the general
-    // missions space instead would put it somewhere the operator does not look
-    // for the thing they were just doing.
+describe("where a mission hangs", () => {
+  test("always in the one Missions space, whatever nodes its members are on", async () => {
+    // Grouping is by node now, and a mission that spans machines — which is
+    // most of them, since that is the point of a mission — belongs to all of
+    // them and to none. Filing it under one member's node would be picking a
+    // member.
     await rawSql`UPDATE stations SET purpose = 'work' WHERE id IN (${A}, ${B})`;
 
     await post("/missions", { name: "Q4 rollout", stationIds: [A, B] });
 
-    expect(spaces).toEqual([{ name: "Work" }]);
+    expect(spaces).toEqual([{ name: "Missions" }]);
     expect(children).toHaveLength(1);
-    expect(children[0]!.space).toBe("!space1:id.agentpod.dev");
   });
 
-  test("falls back to the general missions space when they disagree", async () => {
-    // A cross-purpose mission is exactly the case one shared space is right
-    // for: it belongs to both and to neither, and picking one member's purpose
-    // would be picking a member.
+  test("a purpose on its members changes nothing", async () => {
+    // `purpose` is still recorded — it is what an agent is FOR — but nothing
+    // groups by it any more.
     await rawSql`UPDATE stations SET purpose = 'work' WHERE id = ${A}`;
     await rawSql`UPDATE stations SET purpose = 'personal' WHERE id = ${B}`;
 
     await post("/missions", { name: "Cross thing", stationIds: [A, B] });
-
-    expect(spaces).toEqual([{ name: "Missions" }]);
-  });
-
-  test("falls back when a member is unlabelled, rather than guessing from the rest", async () => {
-    // One labelled member does not make a mission's purpose. Inferring from a
-    // majority would file it somewhere nobody chose.
-    await rawSql`UPDATE stations SET purpose = 'work' WHERE id = ${A}`;
-
-    await post("/missions", { name: "Half known", stationIds: [A, B] });
 
     expect(spaces).toEqual([{ name: "Missions" }]);
   });

--- a/apps/hub/tests/integration/matrix-node-spaces.test.ts
+++ b/apps/hub/tests/integration/matrix-node-spaces.test.ts
@@ -6,16 +6,15 @@ import { resolveTenantForUser } from "../../src/auth/tenant";
 import { provisionStation } from "../../src/services/matrix-as/provision";
 
 /**
- * Filing an agent's room under what it is for.
+ * Filing an agent's room under the machine it runs on.
  *
- * The operator's fleet is laid out by use case, and a flat roster of every
- * agent stops being readable somewhere between 32 and 200. The axis is purpose
- * — not the node, which carries purpose only by accident in this fleet and is
- * already scheduled to stop.
+ * A flat roster of every agent stops being readable somewhere between 32 and
+ * 200. The axis is the NODE: true by construction, and needing no labelling
+ * step before a new agent lands somewhere sensible.
  *
  * These assert against the real `provisionStation`, because filing has to be
- * part of provisioning rather than a second path: setting a purpose announces
- * the station, and the announcement is what re-files it.
+ * part of provisioning rather than a second path: a station announced after it
+ * moves is re-filed by the same reconciler that created it.
  */
 
 const OWNER = "test-user-purpose-spaces";
@@ -78,7 +77,7 @@ beforeAll(async () => {
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${A}, ${B})`;
   await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
-  await rawSql`DELETE FROM matrix_purpose_spaces WHERE tenant_id = ${tenant}`;
+  await rawSql`DELETE FROM matrix_spaces WHERE tenant_id = ${tenant}`;
   await rawSql`
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${OWNER}, 'ps-box', 'ps-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
@@ -105,7 +104,7 @@ beforeEach(async () => {
   addFails = false;
   const tenant = await resolveTenantForUser(OWNER);
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${A}, ${B})`;
-  await rawSql`DELETE FROM matrix_purpose_spaces WHERE tenant_id = ${tenant}`;
+  await rawSql`DELETE FROM matrix_spaces WHERE tenant_id = ${tenant}`;
   await setPurpose(A, null);
   await setPurpose(B, null);
 });
@@ -114,7 +113,7 @@ afterAll(async () => {
   try {
     const tenant = await resolveTenantForUser(OWNER);
     await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${A}, ${B})`;
-    await rawSql`DELETE FROM matrix_purpose_spaces WHERE tenant_id = ${tenant}`;
+    await rawSql`DELETE FROM matrix_spaces WHERE tenant_id = ${tenant}`;
     await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
     await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
@@ -124,13 +123,11 @@ afterAll(async () => {
   }
 });
 
-describe("filing a station's room by purpose", () => {
-  test("hangs the room under a space named for its purpose", async () => {
-    await setPurpose(A, "personal");
-
+describe("filing a station's room by node", () => {
+  test("hangs the room under a space named for its node", async () => {
     await provisionStation(A, deps());
 
-    expect(created).toEqual([{ name: "Personal", creator: expect.any(String) }]);
+    expect(created).toEqual([{ name: "ps-box", creator: expect.any(String) }]);
     expect(added).toHaveLength(1);
     expect(await spaceOf(A)).toBe(added[0]!.space);
   });
@@ -138,17 +135,12 @@ describe("filing a station's room by purpose", () => {
   test("invites the owner, or the space is one nobody can see", async () => {
     // The rail lists JOINED spaces. A space the operator was never invited to
     // is a container that exists and does nothing.
-    await setPurpose(A, "personal");
-
     await provisionStation(A, deps());
 
     expect(invited.some((i) => i.invitee === `@owner-ps:${DOMAIN}`)).toBe(true);
   });
 
-  test("two stations with one purpose share one space", async () => {
-    await setPurpose(A, "work");
-    await setPurpose(B, "work");
-
+  test("two stations on one node share one space", async () => {
     await provisionStation(A, deps());
     await provisionStation(B, deps());
 
@@ -156,46 +148,21 @@ describe("filing a station's room by purpose", () => {
     expect(await spaceOf(A)).toBe(await spaceOf(B));
   });
 
-  test("an unlabelled station hangs nowhere at all", async () => {
-    // Not under an invented `Unsorted`: that is a claim nobody made. It still
-    // appears in All rooms, which is where a fresh ad-hoc runtime belongs.
-    await provisionStation(A, deps());
-
-    expect(created).toEqual([]);
-    expect(added).toEqual([]);
-    expect(await spaceOf(A)).toBeNull();
-  });
-
-  test("a changed purpose moves the room instead of adding a second parent", async () => {
+  test("a purpose on the station changes nothing", async () => {
+    // `purpose` is still recorded — it is what an agent is FOR, which a machine
+    // name cannot say — but nothing groups by it. It is what tags will be built
+    // from later.
     await setPurpose(A, "personal");
-    await provisionStation(A, deps());
-    const personal = added[0]!.space;
 
-    await setPurpose(A, "work");
     await provisionStation(A, deps());
 
-    expect(removed).toEqual([{ space: personal, child: expect.any(String) }]);
-    expect(await spaceOf(A)).not.toBe(personal);
-    expect(added).toHaveLength(2);
-  });
-
-  test("clearing a purpose takes the room out of its space", async () => {
-    await setPurpose(A, "personal");
-    await provisionStation(A, deps());
-    const personal = added[0]!.space;
-
-    await setPurpose(A, null);
-    await provisionStation(A, deps());
-
-    expect(removed).toEqual([{ space: personal, child: expect.any(String) }]);
-    expect(await spaceOf(A)).toBeNull();
+    expect(created).toEqual([{ name: "ps-box", creator: expect.any(String) }]);
   });
 
   test("provisioning again changes nothing", async () => {
     // Provisioning runs at every boot. A second run that re-sent the child
     // event would be harmless on the homeserver and a lie in the logs; worse,
     // it is the shape of code that eventually re-creates the space too.
-    await setPurpose(A, "personal");
     await provisionStation(A, deps());
 
     created = [];
@@ -215,16 +182,13 @@ describe("who writes the child edge", () => {
     // agent that merely owns one of the rooms is not a member of the space, so
     // the homeserver refused every edge after the first. Ten rooms were
     // recorded as filed and one of them was.
-    await setPurpose(A, "personal");
     await provisionStation(A, deps());
     const creatorOfSpace = created[0]!.creator;
 
-    await setPurpose(B, "personal");
     await provisionStation(B, deps());
 
     expect(added).toHaveLength(2);
     expect(added[1]!.creator).toBe(creatorOfSpace);
-    // …which is emphatically not B's own agent, the actor that used to be used.
     expect(added[1]!.creator).not.toBe(added[1]!.child);
   });
 
@@ -232,7 +196,6 @@ describe("who writes the child edge", () => {
     // The other half of the same bug: the failure was caught and the room was
     // marked as filed anyway, so the next run saw nothing to do and the room
     // stayed outside the space forever.
-    await setPurpose(A, "personal");
     addFails = true;
 
     await provisionStation(A, deps());
@@ -241,7 +204,6 @@ describe("who writes the child edge", () => {
   });
 
   test("and the next run tries again", async () => {
-    await setPurpose(A, "personal");
     addFails = true;
     await provisionStation(A, deps());
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -877,48 +877,35 @@ grant as sending the agent a message. A question stops standing the moment the
 turn moves on — answered in the console, cancelled, or failed — so a room can
 never approve something already decided.
 
-### 7g. Purpose: what an agent is FOR
+### 7g. Spaces: one per node
 
-A flat roster is fine at 32 agents and unreadable at 200. The axis to group by
-is **purpose** — personal, work, ad hoc, whatever you type — and deliberately
-**not** the node: this fleet's nodes line up with use cases today by accident of
-how it was built, and coming use cases span harnesses and runtimes.
+A flat roster is fine at 32 agents and unusable at 200, so every agent's room
+hangs under a Matrix space named for the machine it runs on — `molt-bot`,
+`superchotu`, and so on. Clients that read the hierarchy group the roster by it
+for free: supermessage's space rail scopes its list this way, and Element reads
+the same edges. **You are invited to each space as it is created; accept the
+invite or you will not see it.**
 
-Purpose lives on the **station**. A node has one too, but only as the default a
-station inherits when it is adopted — the station's is what anything reads.
+Nothing to configure. Every station has a node, so every station has a space —
+there is no labelling step between adopting an agent and it landing somewhere
+sensible.
 
-```sh
-# what one agent is for
-curl -X PUT -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d '{"purpose":"work"}' https://hub.agentpod.dev/api/stations/<id>/purpose
+- An agent that **moves machines** moves space: the old `m.space.child` edge is
+  removed and the new one added, so a room never hangs under two nodes at once.
+- A **mission** hangs in the one shared `Missions` space, whatever its members'
+  nodes. A mission that spans machines — which is the point of a mission —
+  belongs to all of them and to none, and filing it under one member's node
+  would be picking a member.
 
-# the default for a node — ALSO labels the agents on it that have none,
-# and the response says how many that was
-curl -X PUT -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d '{"purpose":"personal"}' https://hub.agentpod.dev/api/nodes/<id>/purpose
-```
+Filing happens during provisioning, so it is idempotent and self-healing: a
+node that reconnects re-files its stations, and restarting the hub moves
+nothing twice.
 
-Both are in the console: a **Purpose of agents here** field on the node page,
-and a **Purpose** field on each agent's page that overrides it.
-
-**What it does on Matrix.** Each purpose gets one space, and every labelled
-agent's room is hung under it (`m.space.child`). Clients that read the hierarchy
-group the roster by it for free — supermessage's space rail already scopes its
-list this way, and Element reads the same edges. You are invited to each space as
-it is created; **accept the invite or you will not see it**.
-
-- Changing a purpose **moves** the room: the old edge is removed and the new one
-  added, so a room never hangs under two purposes at once.
-- Clearing a purpose takes the room out of its space. It is then filed nowhere
-  and appears only in All rooms, which is where a fresh ad-hoc runtime belongs
-  until somebody says otherwise. There is no `Unsorted` space — an invented
-  group is a claim nobody made.
-- A **mission** hangs under the purpose its members agree on. When they do not
-  agree, or any member is unlabelled, it stays in the general **Missions**
-  space — a cross-purpose mission belongs to both and to neither.
-
-Filing happens during provisioning, so it is idempotent and self-healing: set a
-purpose and the room moves; restart the hub and nothing moves twice.
+**`purpose` is still recorded** on stations and nodes (`PUT
+/api/stations/:id/purpose`, `PUT /api/nodes/:id/purpose`, and the fields in the
+console). It says what an agent is FOR, which a machine name cannot — but
+nothing groups by it. It is the raw material for tags, which can overlap and do
+not fight a hierarchy the way a second axis of spaces would.
 
 ### 7h. What happened to the Synapse history
 


### PR DESCRIPTION
Purpose was the axis for a day. You've chosen the node instead, and the reasons are better than the ones I argued for:

- **True by construction.** Every station has a node, so every station has a space — no labelling step between adopting an agent and it landing somewhere sensible, and nothing drifts when somebody forgets.
- **It's the thing you can point at.** A machine appears in the console, in `apn`, in your ssh config. A purpose lives in your head.
- **Purpose is better as tags**, which can overlap. An agent that is both personal and experimental cannot be in two spaces, and forcing that choice is what a hierarchy does to a facet.

`stations.purpose` and `nodes.purpose` are **kept**, with their routes and console fields. Purpose is still what an agent is FOR, which a machine name cannot say — now recorded rather than acted on, and the raw material for tags.

**Missions** lose the purpose-agreement rule and always hang in the one `Missions` space. A mission that spans machines — the point of a mission — belongs to all of them and to none; filing it under one member's node would be picking a member.

`matrix_purpose_spaces` becomes `matrix_spaces`, keyed by a space key that is now a node name, or the empty-string sentinel for Missions (no node name can collide: enrolment refuses an empty one). Its rows are dropped, since the old ones named purposes and would be misread as node names.

Hub: 1382 pass. Operator docs: `OPERATING.md` §7g.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW