### PR TITLE
fix: file a room into its new space even when the old one is forgotten

### DIFF
--- a/apps/hub/src/services/matrix-as/spaces.ts
+++ b/apps/hub/src/services/matrix-as/spaces.ts
@@ -189,21 +189,30 @@ export async function fileRoomUnderSpace(
       .where(eq(matrixSpaces.roomId, currentSpaceRoomId));
 
     if (!current?.creator) {
-      log.warn("cannot unfile a room from a space with no known creator", {
+      // The space this room hangs under is no longer one we have a record of —
+      // which is what a change of grouping looks like from here (migration 0052
+      // dropped the purpose spaces). The edge cannot be removed without knowing
+      // who may write it, but refusing to continue strands the room in a space
+      // nothing will ever move it out of: in production this left 24 of 32
+      // rooms filed nowhere the reader could see.
+      //
+      // So the new edge is added anyway. A room briefly listed under an
+      // abandoned space is a cosmetic wrong; a room in no space at all is the
+      // feature not working.
+      log.warn("filing into the new space without unfiling from a forgotten one", {
         roomId,
-        spaceRoomId: currentSpaceRoomId,
+        forgottenSpace: currentSpaceRoomId,
       });
-      return;
-    }
-
-    try {
-      await deps.client.removeSpaceChild(current.creator, currentSpaceRoomId, roomId);
-    } catch (err) {
-      log.warn("could not take a room out of its space; leaving it where it is", {
-        roomId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return;
+    } else {
+      try {
+        await deps.client.removeSpaceChild(current.creator, currentSpaceRoomId, roomId);
+      } catch (err) {
+        log.warn("could not take a room out of its space; leaving it where it is", {
+          roomId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
     }
   }
 

--- a/apps/hub/tests/integration/matrix-node-spaces.test.ts
+++ b/apps/hub/tests/integration/matrix-node-spaces.test.ts
@@ -214,3 +214,28 @@ describe("who writes the child edge", () => {
     expect(await spaceOf(A)).toBe(added[0]!.space);
   });
 });
+
+describe("a room whose old space we have forgotten", () => {
+  test("is still filed into its new one", async () => {
+    // What a change of grouping looks like from here: migration 0052 dropped
+    // the purpose spaces, so every room pointed at a space with no record. The
+    // unfile step could not know who was allowed to remove the edge and gave
+    // up — which stranded 24 of 32 rooms in production, filed nowhere.
+    await provisionStation(A, deps());
+    const forgotten = added[0]!.space;
+
+    // The space record disappears, exactly as a re-keying migration leaves it.
+    await rawSql`DELETE FROM matrix_spaces`;
+    await rawSql`UPDATE matrix_rooms SET space_room_id = ${forgotten} WHERE station_id = ${A}`;
+    added = [];
+    removed = [];
+
+    await provisionStation(A, deps());
+
+    expect(added).toHaveLength(1);
+    expect(await spaceOf(A)).toBe(added[0]!.space);
+    // Nothing was removed, because nothing knew how — that is the compromise,
+    // and it is the cosmetic half rather than the functional one.
+    expect(removed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Deploying #368 stranded **24 of 32 rooms** — filed nowhere the reader could see, with 48 `cannot unfile` warnings behind them.

`fileRoomUnderSpace` looks up the current space's creator so it can remove the old `m.space.child` edge (only a member of a space may write its state). When that lookup found nothing it gave up entirely — which is exactly what a change of grouping produces: migration 0052 dropped the purpose-space rows, so every room pointed at a space with no record.

The guard was right about what it *couldn't* do and wrong about what to do next. It now adds the new edge anyway and says so. A room briefly listed under an abandoned space is a cosmetic wrong; a room in no space at all is the feature not working.

Found by counting rooms per space against the live database rather than trusting `provisioned 32, failed 0` — which was true, and said nothing about where those rooms ended up.

Hub: 1383 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW