### PR TITLE
Stream a turn to the reader's devices, not into the room

### DIFF
--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -60,6 +60,18 @@ export interface MatrixClient {
   ): Promise<string | null>;
   sendText(userId: string, roomId: string, body: string): Promise<string | null>;
   sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
+  /**
+   * Send a to-device event as `userId` to every device `targetUserId` has.
+   *
+   * Never stored in a room. Carries a turn's live text (`live.ts`) so the
+   * stream and the durable record stay separate channels.
+   */
+  sendToDevice(
+    userId: string,
+    targetUserId: string,
+    eventType: string,
+    content: Record<string, unknown>
+  ): Promise<void>;
   setDisplayName(userId: string, displayName: string): Promise<void>;
   invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
   /** Mark another event — 👀 while working, ✅ done, ❌ failed. */
@@ -302,6 +314,25 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
       );
       assertOkOrAlready("send", res);
       return String(res.body.event_id ?? "") || null;
+    },
+
+    async sendToDevice(userId, targetUserId, eventType, content) {
+      // Delivered to the target's devices and never stored in a room — see
+      // `live.ts` for why a turn's live text goes here rather than into the
+      // timeline as edits.
+      //
+      // `*` is every device the reader has. A device that is asleep simply
+      // misses the stream and gets the real message when it wakes, which is
+      // correct rather than a gap: nothing here is the source of truth.
+      const res = await call(
+        `/_matrix/client/v3/sendToDevice/${encodeURIComponent(eventType)}/${crypto.randomUUID()}`,
+        {
+          method: "PUT",
+          userId,
+          body: { messages: { [targetUserId]: { "*": content } } },
+        }
+      );
+      assertOkOrAlready("sendToDevice", res);
     },
 
     async sendTyping(userId, roomId, typing) {

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -12,9 +12,11 @@
  * nothing.
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "../../db/drizzle";
 import { stations } from "../../db/schema/stations";
+import { matrixRooms } from "../../db/schema/matrix";
+import { principalIdentities } from "../../db/schema/identities";
 import * as broker from "../broker";
 import { createMatrixClient, type MatrixClient } from "./client";
 import { provisionStation, provisionAll } from "./provision";
@@ -44,6 +46,34 @@ export interface MatrixBridgeConfig {
 }
 
 /** What the deployment says. Read once, at boot, like every other switch here. */
+/**
+ * Who a room's live stream is for: the Matrix id of the person the station
+ * belongs to.
+ *
+ * A turn's text is pushed to that person's own devices while it is being
+ * written (see `live.ts`), so this answers "whose devices". `null` — a room
+ * whose owner has no Matrix identity mapped — simply means no live view; the
+ * room still gets its message.
+ *
+ * Looked up once per attachment rather than per chunk: this is three joins and
+ * an agent can emit hundreds of chunks in a turn.
+ */
+async function readerForRoom(roomId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(matrixRooms)
+    .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
+    .innerJoin(
+      principalIdentities,
+      and(
+        eq(principalIdentities.principalId, stations.userId),
+        eq(principalIdentities.system, "matrix")
+      )
+    )
+    .where(eq(matrixRooms.roomId, roomId));
+  return row?.externalId ?? null;
+}
+
 export function matrixBridgeConfig(env = process.env): MatrixBridgeConfig {
   return {
     // The literal lowercase "true" — see the note above.
@@ -162,7 +192,10 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
     // prompted, and answers into a stream nobody is listening to — which is
     // exactly what happened the first time this ran against the real fleet.
     attach: (sessionId: string, roomId: string, agentUser: string) =>
-      attachRoomToSession(sessionId, roomId, agentUser, { client }),
+      attachRoomToSession(sessionId, roomId, agentUser, {
+        client,
+        readerFor: readerForRoom,
+      }),
     noteTrigger: noteTurnTrigger,
   };
 

--- a/apps/hub/src/services/matrix-as/live.test.ts
+++ b/apps/hub/src/services/matrix-as/live.test.ts
@@ -1,0 +1,104 @@
+/**
+ * When a turn's live text is worth pushing to the reader's devices.
+ *
+ * The rule is boundary-first, not timer-first, and these tests are mostly about
+ * that: a timer chops sentences in half, and half a sentence on screen reads
+ * worse than a pause. See `live.ts` for why this channel exists at all rather
+ * than streaming into the room by edits.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  deltaContent,
+  endsAtBoundary,
+  MAX_DELTA_WAIT_MS,
+  MIN_DELTA_CHARS,
+  shouldSendDelta,
+} from "./live";
+
+describe("deciding when to send", () => {
+  test("nothing new is never worth a round trip", () => {
+    expect(shouldSendDelta("", 0)).toBe(false);
+    expect(shouldSendDelta("", MAX_DELTA_WAIT_MS * 10)).toBe(false);
+  });
+
+  test("a finished sentence with enough behind it goes at once", () => {
+    expect(shouldSendDelta("I looked at the node and it is online.", 200)).toBe(true);
+  });
+
+  test("a sentence still in progress waits, however long it is", () => {
+    // The failure this prevents: "I looked at the node and it is" on screen,
+    // then a jump. Waiting reads better than tearing.
+    const midSentence = "I looked at the node and it is currently".padEnd(400, " x");
+    expect(shouldSendDelta(midSentence, 200)).toBe(false);
+  });
+
+  test("a boundary with almost nothing behind it waits too", () => {
+    // "Hi." on its own is a round trip to move three characters.
+    expect("Hi.".length).toBeLessThan(MIN_DELTA_CHARS);
+    expect(shouldSendDelta("Hi.", 200)).toBe(false);
+  });
+
+  test("the backstop fires for text that never reaches a boundary", () => {
+    // An agent emitting one long unpunctuated block still has to show
+    // movement. This is the only case where a delta may cut mid-sentence.
+    const noBoundary = "and then it kept going without ever stopping to punctuate";
+    expect(shouldSendDelta(noBoundary, MAX_DELTA_WAIT_MS)).toBe(true);
+  });
+});
+
+describe("what counts as a boundary", () => {
+  test("sentence enders do, with or without a closing quote", () => {
+    for (const text of ["Done.", "Really?", "Stop!", "wait…", 'He said "no."', "See these:"]) {
+      expect(endsAtBoundary(text)).toBe(true);
+    }
+  });
+
+  test("a newline does, because a paragraph break is a pause a reader takes", () => {
+    expect(endsAtBoundary("First point\n")).toBe(true);
+    expect(endsAtBoundary("First point\n\n")).toBe(true);
+  });
+
+  test("a comma does not — stopping there reads as a stall, not a beat", () => {
+    expect(endsAtBoundary("I checked the node,")).toBe(false);
+  });
+
+  test("mid-word does not", () => {
+    expect(endsAtBoundary("I checked the nod")).toBe(false);
+  });
+});
+
+describe("the wire body", () => {
+  test("carries everything so far, not the increment", () => {
+    // To-device delivery is at-least-once and unordered. An increment would let
+    // one dropped or reordered delta corrupt the text with nothing able to
+    // notice; cumulative text plus a seq is self-correcting.
+    const content = deltaContent({
+      roomId: "!r:x.org",
+      sessionId: "s1",
+      seq: 3,
+      text: "One. Two. Three.",
+      done: false,
+    });
+
+    expect(content).toEqual({
+      room_id: "!r:x.org",
+      session_id: "s1",
+      seq: 3,
+      text: "One. Two. Three.",
+      done: false,
+    });
+  });
+
+  test("marks the last delta of a turn, so a reader can drop the live view", () => {
+    const content = deltaContent({
+      roomId: "!r:x.org",
+      sessionId: "s1",
+      seq: 9,
+      text: "All of it.",
+      done: true,
+    });
+
+    expect(content.done).toBe(true);
+  });
+});

--- a/apps/hub/src/services/matrix-as/live.ts
+++ b/apps/hub/src/services/matrix-as/live.ts
@@ -1,0 +1,109 @@
+/**
+ * The live view of a turn, sent to the reader's own devices and never to the
+ * room.
+ *
+ * **Why not edits.** The obvious way to stream in Matrix is to send a message
+ * and then replace it repeatedly (`m.replace`, and MSC4357 formalises exactly
+ * that). It works, every client understands it, and it is what Slack, Discord
+ * and Telegram bots do — because a bot has no other channel to the client. It
+ * is a workaround for not owning the transport, not a design anyone chose.
+ *
+ * The cost is that every intermediate state becomes a permanent event. That is
+ * not storage — this homeserver is 91 MB — but four things that are real:
+ * `/search` returns half-written fragments of one answer; back-pagination
+ * fetches twenty events to reveal one message; read markers drift as edits land
+ * after them; and every phone on the account receives the churn. Worst of all,
+ * more events per turn means more limited syncs, and a limited sync unloads the
+ * timeline (see supermessage's `core::timeline`) — so streaming by edits would
+ * pay for itself by making the timeline blink more often.
+ *
+ * **So the stream and the record are different channels**, which is what every
+ * product that owns both ends does — ChatGPT, Claude and Gemini stream over a
+ * connection that persists nothing and write one record at the end. Matrix has
+ * the same shape available: to-device messages are delivered per device and are
+ * never part of room history.
+ *
+ * The room therefore ends a turn exactly as it does today: one message,
+ * flushed when the turn ends. A reader watching in supermessage sees it arrive
+ * a sentence at a time; a reader in Element sees it appear complete, which is
+ * what Element does today anyway. Nothing regresses for anyone, and room
+ * history is byte-for-byte unchanged.
+ *
+ * Deliberately **not** encrypted and deliberately best-effort: a dropped delta
+ * costs a moment of staleness and is corrected by the next one, and by the real
+ * message regardless. Nothing here is the source of truth.
+ */
+
+/** The to-device event type carrying a turn's live text. */
+export const LIVE_DELTA_TYPE = "dev.agentpod.stream.delta";
+
+/**
+ * The smallest amount of new text worth sending on its own.
+ *
+ * Below this, a delta costs a round trip to move a few characters. Chosen
+ * against a short sentence rather than a word: the point is to read as prose
+ * arriving, not as a typewriter.
+ */
+export const MIN_DELTA_CHARS = 24;
+
+/**
+ * How long new text may sit unsent when it has not reached a boundary.
+ *
+ * The backstop for an agent that emits one enormous unpunctuated block — the
+ * reader still sees movement, just not at a natural break.
+ */
+export const MAX_DELTA_WAIT_MS = 1_500;
+
+/**
+ * Whether the text accumulated since the last delta is worth sending now.
+ *
+ * Boundary-first rather than timer-first, and that is the whole point: a
+ * timer chops sentences in half, which reads worse than waiting. A boundary
+ * with enough behind it goes immediately; anything else waits, until the
+ * backstop.
+ */
+export function shouldSendDelta(pending: string, msSincePrevious: number): boolean {
+  if (pending.length === 0) return false;
+  if (msSincePrevious >= MAX_DELTA_WAIT_MS) return true;
+  return pending.length >= MIN_DELTA_CHARS && endsAtBoundary(pending);
+}
+
+/**
+ * Whether text ends somewhere a reader would accept a pause.
+ *
+ * Sentence enders and newlines only. A comma is not a boundary: stopping there
+ * reads as a stall rather than a beat.
+ */
+export function endsAtBoundary(text: string): boolean {
+  return /[.!?…:;]["')\]]?\s*$/.test(text) || /\n\s*$/.test(text);
+}
+
+/** One delta, as it goes on the wire. */
+export interface LiveDelta {
+  roomId: string;
+  sessionId: string;
+  /** Monotonic per turn. A receiver drops anything older than what it has. */
+  seq: number;
+  /**
+   * **Everything so far**, not the increment.
+   *
+   * To-device delivery is at-least-once and unordered, so an increment would
+   * make a dropped or reordered delta corrupt the text with no way to notice.
+   * Cumulative text plus a sequence number is self-correcting: apply the
+   * highest seq seen and the result is right no matter what arrived when.
+   */
+  text: string;
+  /** True on the last delta of a turn — the room now holds the real message. */
+  done: boolean;
+}
+
+/** The wire body for a delta. Snake case, like every other Matrix event. */
+export function deltaContent(delta: LiveDelta): Record<string, unknown> {
+  return {
+    room_id: delta.roomId,
+    session_id: delta.sessionId,
+    seq: delta.seq,
+    text: delta.text,
+    done: delta.done,
+  };
+}

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -431,3 +431,117 @@ describe("live feedback, so a room is not a black box", () => {
     expect(reactions).toHaveLength(0);
   });
 });
+
+describe("streaming a turn to the reader's own devices", () => {
+  /**
+   * The deps above plus a to-device sink and a reader. Kept separate from
+   * `deps()` so every existing test goes on proving the no-streaming case:
+   * without `sendToDevice` the room is identical, which is the property that
+   * makes this safe to turn on against a live fleet.
+   */
+  function streamingDeps() {
+    const base = deps();
+    const deltas: Array<{ to: string; type: string; content: any }> = [];
+    return {
+      deltas,
+      deps: {
+        ...base,
+        client: {
+          ...base.client,
+          sendToDevice: async (
+            _userId: string,
+            targetUserId: string,
+            eventType: string,
+            content: Record<string, unknown>
+          ) => {
+            deltas.push({ to: targetUserId, type: eventType, content });
+          },
+        },
+        readerFor: async () => "@rakesh:x.org",
+      },
+    };
+  }
+
+  test("pushes the answer as it arrives, and the room still gets one message", async () => {
+    const { deltas, deps } = streamingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, deps as any);
+
+    // Two finished sentences, each long enough to be worth sending.
+    // Emitted back-to-back, like the coalescing test above: `flushDelayMs` is
+    // 0 here, so settling between chunks would end the turn between them and
+    // the second sentence would belong to a different answer.
+    emit(chunk("I looked at the node and it is online. "));
+    emit(chunk("Nothing else needs doing right now."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    // The live view moved more than once...
+    expect(deltas.length).toBeGreaterThan(1);
+    expect(deltas.every((d) => d.to === "@rakesh:x.org")).toBe(true);
+    expect(deltas.every((d) => d.type === "dev.agentpod.stream.delta")).toBe(true);
+
+    // ...while the room received exactly one message, unchanged by any of it.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toBe(
+      "I looked at the node and it is online. Nothing else needs doing right now."
+    );
+  });
+
+  test("carries the whole answer each time, so a dropped delta cannot corrupt it", async () => {
+    const { deltas, deps } = streamingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, deps as any);
+
+    emit(chunk("First sentence, long enough to send. "));
+    emit(chunk("Second sentence, also long enough."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    const texts = deltas.map((d) => d.content.text as string);
+    // Each delta is a prefix of the next: cumulative, never an increment.
+    for (let i = 1; i < texts.length; i++) {
+      expect(texts[i]!.startsWith(texts[i - 1]!)).toBe(true);
+    }
+    expect(texts.at(-1)).toBe("First sentence, long enough to send. Second sentence, also long enough.");
+  });
+
+  test("marks the last delta done, and numbers each turn from one", async () => {
+    const { deltas, deps } = streamingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, deps as any);
+
+    emit(chunk("A complete first answer, long enough to stream."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(deltas.at(-1)!.content.done).toBe(true);
+    expect(deltas.map((d) => d.content.seq)).toEqual(
+      deltas.map((_, i) => i + 1)
+    );
+
+    // A second turn starts its own sequence, so a reader can tell a new answer
+    // from more of the last one.
+    const before = deltas.length;
+    emit(chunk("A second answer, also long enough to stream."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(deltas[before]!.content.seq).toBe(1);
+  });
+
+  test("says nothing to a room with nobody to show it to", async () => {
+    const { deltas, deps } = streamingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, { ...deps, readerFor: async () => null } as any);
+
+    emit(chunk("An answer nobody is watching for, long enough to stream."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(deltas).toHaveLength(0);
+    // ...and the room is unaffected.
+    expect(sent).toHaveLength(1);
+  });
+});

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -13,6 +13,7 @@
 
 import type { AcpEvent } from "@agentpod/contract";
 import { subscribe as subscribeToSession } from "../acp-sessions";
+import { deltaContent, LIVE_DELTA_TYPE, shouldSendDelta } from "./live";
 import {
   clearPendingPermission,
   notePendingPermission,
@@ -34,7 +35,23 @@ export interface OutboundDeps {
       key: string
     ): Promise<string | null>;
     redact?(userId: string, roomId: string, eventId: string): Promise<void>;
+    /**
+     * Push a turn's live text to the reader's own devices. Optional: a
+     * deployment without it simply does not stream, and the room is identical
+     * either way — see `live.ts`.
+     */
+    sendToDevice?(
+      userId: string,
+      targetUserId: string,
+      eventType: string,
+      content: Record<string, unknown>
+    ): Promise<void>;
   };
+  /**
+   * Who to stream this room's turns to — the reader's Matrix id, or null for a
+   * room with nobody to show it to. Resolved once per attachment.
+   */
+  readerFor?: (roomId: string) => Promise<string | null>;
   subscribe?: (sessionId: string, fn: (e: AcpEvent) => void) => () => void;
   /**
    * A safety net, not a chunking strategy — see `FLUSH_SAFETY_MS`. 0 in tests
@@ -55,6 +72,19 @@ interface Attachment {
   ended: boolean;
   /** The message that started the current turn, if a person started it. */
   triggerEventId: string | null;
+  /** Monotonic delta counter for the current turn — see `live.ts`. */
+  liveSeq: number;
+  /** How much of the buffered text has already been streamed. */
+  liveSentChars: number;
+  /** When the last delta went out, for the boundary backstop. */
+  liveSentAt: number;
+  /**
+   * The reader's Matrix id, resolved lazily on the first chunk and cached for
+   * the room's life. `undefined` means "not looked up yet"; `null` means
+   * "looked up, nobody to stream to" — a distinction that stops a room with no
+   * reader repeating the lookup on every chunk.
+   */
+  reader: string | null | undefined;
   /** The 👀 we put on it, so it can be taken off again. */
   workingReactionId: string | null;
 }
@@ -181,6 +211,10 @@ export function attachRoomToSession(
     ended: false,
     triggerEventId: null,
     workingReactionId: null,
+    liveSeq: 0,
+    liveSentChars: 0,
+    liveSentAt: 0,
+    reader: undefined,
   };
 
   const say = async (body: string) => {
@@ -204,9 +238,60 @@ export function attachRoomToSession(
       state.timer = null;
     }
     const text = state.buffer.join("");
+    // Before the buffer is cleared: the last delta carries the whole answer and
+    // marks the live view finished, so a reader's provisional text is replaced
+    // by the room's own message rather than lingering beside it.
+    await streamLive(true);
     state.buffer = [];
+    // A new turn starts its own sequence — the reader keys on it to know that
+    // what follows is a fresh answer rather than more of the last one.
+    state.liveSeq = 0;
+    state.liveSentChars = 0;
+    state.liveSentAt = 0;
     if (text.trim() === "") return;
     await say(text);
+  };
+
+  /**
+   * Push what the agent has said so far to the reader's devices.
+   *
+   * Best-effort in every direction: no reader, no `sendToDevice`, or a failed
+   * send all mean the same thing — no live view this turn — and none of them
+   * touch the room. The durable message is unaffected either way, which is
+   * what makes this safe to run against a live fleet.
+   */
+  const streamLive = async (done: boolean) => {
+    const send = deps.client.sendToDevice;
+    if (!send) return;
+
+    if (state.reader === undefined) {
+      state.reader = deps.readerFor ? await deps.readerFor(roomId).catch(() => null) : null;
+    }
+    if (!state.reader) return;
+
+    const text = state.buffer.join("");
+    const pending = text.slice(state.liveSentChars);
+    if (!done && !shouldSendDelta(pending, Date.now() - state.liveSentAt)) return;
+    // The final delta is worth sending even with nothing new: it is what tells
+    // a reader the live view is over and the room now holds the real message.
+    if (done && pending.length === 0 && state.liveSeq === 0) return;
+
+    state.liveSeq += 1;
+    state.liveSentChars = text.length;
+    state.liveSentAt = Date.now();
+
+    await send(
+      agentUser,
+      state.reader,
+      LIVE_DELTA_TYPE,
+      deltaContent({ roomId, sessionId, seq: state.liveSeq, text, done })
+    ).catch((err) => {
+      log.debug("could not stream a turn to the reader's devices", {
+        sessionId,
+        roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   };
 
   const scheduleFlush = () => {
@@ -272,6 +357,7 @@ export function attachRoomToSession(
           const text = messageChunkText(event.payload);
           if (text !== undefined) {
             state.buffer.push(text);
+            void streamLive(false);
             scheduleFlush();
           }
           return;


### PR DESCRIPTION
An agent's answer arrives at the room complete, after the turn ends. For a three-minute answer that is three minutes of a typing indicator.

The reason is written into `outbound.ts`: *"a Matrix event per token would buzz a phone forty times for one answer, hit the homeserver's rate limits, and make a shared room unreadable."* That argument is right — and it is an argument against streaming **by editing the record**, which is what Slack, Discord and Telegram bots do and what [MSC4357](https://github.com/matrix-org/matrix-spec-proposals/pull/4357) formalises for Matrix. They all do it because a bot has no other channel to the client; it's a workaround for not owning the transport, not a design anyone chose. Every product that owns both ends — ChatGPT, Claude, Gemini — streams over a connection that persists nothing and writes one record at the end.

Matrix has that channel: **to-device messages**, delivered per device, never part of room history.

## What this costs the room: nothing

One message per turn, flushed when the turn ends, exactly as before. Element sees what it sees today. And the four costs of the edit approach never arrive:

- `/search` isn't polluted with half-written fragments of one answer
- back-pagination doesn't fetch twenty events to reveal one message
- read markers don't drift as edits land after them
- event volume per turn doesn't rise — **the one that would have bitten hardest**, since a limited sync unloads the timeline ([matrix-rust-sdk#4694](https://github.com/matrix-org/matrix-rust-sdk/pull/4694)) and streaming by edits would have paid for itself by making the timeline blink more often

## The policy

**Boundary-first, not timer-first.** A delta goes when the text reaches a sentence or paragraph break with enough behind it, or after 1.5s for an agent that never punctuates. A timer alone chops sentences in half, which reads worse than waiting.

**Cumulative, not incremental.** To-device delivery is at-least-once and unordered; an increment would let one dropped or reordered delta corrupt the text with nothing able to notice. Whole text plus a sequence number is self-correcting.

**Best-effort throughout.** No reader, no `sendToDevice`, or a failed send all mean "no live view this turn", and none of them touch the room.

## Verification

The transport was proved against the live homeserver before any code was written: an appservice can send a to-device event as one of its agents, and tuwunel accepts it (`200`).

`bun test` 1397 pass. The one failure (`a node offline only briefly is inside the grace window`) fails identically on a clean tree — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW