### PR TITLE
Make an agent's activity visible in the room

### DIFF
--- a/apps/hub/src/routes/runtimes.test.ts
+++ b/apps/hub/src/routes/runtimes.test.ts
@@ -2029,14 +2029,24 @@ async function seedUnobserved(id: string, agoMs = 45 * 60_000) {
   // starts from a clean slate rather than counting probes it did not cause.
   await rawSql`DELETE FROM provisioned_runtimes WHERE id LIKE 'rt_unobs_%'`;
   await rawSql`DELETE FROM nodes WHERE id LIKE 'node_unobs_%'`;
+  // The tenant is named, not scavenged. This read `(SELECT tenant_id FROM
+  // provisioned_runtimes LIMIT 1)` — from a table the two DELETEs above have
+  // just emptied of this helper's own rows, so it resolved to whatever some
+  // *other* test happened to have left lying around. When nothing had, the
+  // subquery returned NULL and the insert died on `nodes.tenant_id`'s NOT NULL
+  // constraint. That made the test order-dependent: green in a full run where a
+  // neighbour's row survived, red on its own, for a reason nothing in the test
+  // body could explain. `bun test` shares one process and one database across
+  // every file, which is exactly the condition that makes a scavenged fixture a
+  // coin toss. Every sibling in this file already names the same literal.
   await rawSql`
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, last_seen_at, created_at)
-    VALUES (${nodeId}, (SELECT tenant_id FROM provisioned_runtimes LIMIT 1), ${TEST_USER},
+    VALUES (${nodeId}, ${BOOTSTRAP_TENANT_ID}, ${TEST_USER},
             ${id}, ${id}, 'linux', 'amd64', 2, 'offline', 'x',
             now() - (${agoMs} || ' milliseconds')::interval, now())`;
   await rawSql`
     INSERT INTO provisioned_runtimes (id, tenant_id, user_id, provider, external_id, status, node_id, name, harness, created_at, updated_at)
-    VALUES (${id}, (SELECT tenant_id FROM nodes WHERE id = ${nodeId}), ${TEST_USER}, 'docker',
+    VALUES (${id}, ${BOOTSTRAP_TENANT_ID}, ${TEST_USER}, 'docker',
             ${`fake-container-${id}`}, 'online', ${nodeId}, ${id}, 'none',
             now() - (${agoMs} || ' milliseconds')::interval,
             now() - (${agoMs} || ' milliseconds')::interval)`;

--- a/apps/hub/src/services/matrix-as/activity.test.ts
+++ b/apps/hub/src/services/matrix-as/activity.test.ts
@@ -9,7 +9,13 @@
 // the path that lacked it.
 
 import { beforeEach, describe, expect, it } from "bun:test";
-import { _resetUnmappedForTest, noteUnmappedKind, unmappedKinds } from "./activity";
+import {
+  _resetUnmappedForTest,
+  foldToolUpdate,
+  noteUnmappedKind,
+  unmappedKinds,
+  type ToolRecord,
+} from "./activity";
 
 describe("unmapped session update kinds", () => {
   beforeEach(() => {
@@ -48,5 +54,140 @@ describe("unmapped session update kinds", () => {
     expect(noteUnmappedKind(42 as unknown as string)).toBe(false);
     expect(noteUnmappedKind("")).toBe(false);
     expect(unmappedKinds()).toEqual([]);
+  });
+});
+
+// Folding `tool_call` / `tool_call_update` into a turn's record.
+//
+// The rule that matters is **upsert, never append**, and the console records
+// why at `transcript.ts:299-305`: a buggy or hostile agent repeating a
+// `toolCallId` must merge rather than produce two records with one identity.
+describe("folding tool calls", () => {
+  it("records a tool call", () => {
+    const tools = new Map<string, ToolRecord>();
+    const record = foldToolUpdate(tools, {
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      title: "Read src/main.ts",
+      kind: "read",
+      status: "in_progress",
+      locations: [{ path: "src/main.ts" }],
+    });
+
+    expect(record).toEqual({
+      id: "c1",
+      title: "Read src/main.ts",
+      kind: "read",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+    });
+    expect(tools.size).toBe(1);
+  });
+
+  it("merges an update onto the call it belongs to", () => {
+    const tools = new Map<string, ToolRecord>();
+    foldToolUpdate(tools, {
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      title: "Run tests",
+      status: "pending",
+    });
+    const record = foldToolUpdate(tools, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "c1",
+      status: "failed",
+    });
+
+    // The title survives an update that did not carry one: a ticker that
+    // forgets what it is doing halfway through is worse than one a moment stale.
+    expect(record).toMatchObject({ id: "c1", title: "Run tests", status: "failed" });
+    expect(tools.size).toBe(1);
+  });
+
+  it("merges a repeated tool_call id rather than recording it twice", () => {
+    const tools = new Map<string, ToolRecord>();
+    foldToolUpdate(tools, { sessionUpdate: "tool_call", toolCallId: "c1", title: "First" });
+    foldToolUpdate(tools, { sessionUpdate: "tool_call", toolCallId: "c1", title: "Second" });
+
+    expect(tools.size).toBe(1);
+    expect(tools.get("c1")?.title).toBe("Second");
+  });
+
+  it("keeps the order tools were first used in", () => {
+    const tools = new Map<string, ToolRecord>();
+    foldToolUpdate(tools, { sessionUpdate: "tool_call", toolCallId: "z", title: "Z" });
+    foldToolUpdate(tools, { sessionUpdate: "tool_call", toolCallId: "a", title: "A" });
+    // An update to the earlier call must not move it to the end.
+    foldToolUpdate(tools, { sessionUpdate: "tool_call_update", toolCallId: "z", status: "completed" });
+
+    expect([...tools.keys()]).toEqual(["z", "a"]);
+  });
+
+  it("ignores a call with no id, since nothing could merge onto it", () => {
+    const tools = new Map<string, ToolRecord>();
+    expect(foldToolUpdate(tools, { sessionUpdate: "tool_call", title: "Nameless" })).toBeNull();
+    expect(tools.size).toBe(0);
+  });
+
+  it("ignores anything that is not a tool update", () => {
+    const tools = new Map<string, ToolRecord>();
+    expect(foldToolUpdate(tools, { sessionUpdate: "agent_message_chunk" })).toBeNull();
+    expect(foldToolUpdate(tools, null)).toBeNull();
+    expect(foldToolUpdate(tools, "nonsense")).toBeNull();
+    expect(tools.size).toBe(0);
+  });
+
+  it("defaults a status nobody sent, rather than inventing one", () => {
+    const tools = new Map<string, ToolRecord>();
+    const record = foldToolUpdate(tools, { sessionUpdate: "tool_call", toolCallId: "c1" });
+    expect(record?.status).toBe("pending");
+    // And falls back to the id when there is no title at all, so a card can
+    // never render a nameless row.
+    expect(record?.title).toBe("c1");
+  });
+
+  it("ignores a status outside ACP's vocabulary", () => {
+    const tools = new Map<string, ToolRecord>();
+    foldToolUpdate(tools, { sessionUpdate: "tool_call", toolCallId: "c1", status: "completed" });
+    const record = foldToolUpdate(tools, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "c1",
+      status: "cancelled",
+    });
+    expect(record?.status).toBe("completed");
+  });
+
+  it("reads location paths and skips entries that have none", () => {
+    const tools = new Map<string, ToolRecord>();
+    const record = foldToolUpdate(tools, {
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      locations: [{ path: "a.ts" }, { line: 3 }, "b.ts", null],
+    });
+    expect(record?.locations).toEqual(["a.ts"]);
+  });
+});
+
+describe("kinds this path does handle", () => {
+  beforeEach(() => {
+    _resetUnmappedForTest();
+  });
+
+  it("never records a handled kind, however malformed one payload was", () => {
+    // A `tool_call` with no `toolCallId` is malformed, not unsupported. Since a
+    // kind is recorded at most once, letting one bad payload through would
+    // leave `tool_call` listed as dropped for the life of the process — a lie
+    // that never corrects itself. Caught by reading a test's log output rather
+    // than its pass count.
+    expect(noteUnmappedKind("tool_call")).toBe(false);
+    expect(noteUnmappedKind("tool_call_update")).toBe(false);
+    expect(noteUnmappedKind("agent_message_chunk")).toBe(false);
+    expect(noteUnmappedKind("agent_thought_chunk")).toBe(false);
+    expect(unmappedKinds()).toEqual([]);
+  });
+
+  it("still records one nobody handles", () => {
+    expect(noteUnmappedKind("usage_update")).toBe(true);
+    expect(unmappedKinds()).toEqual(["usage_update"]);
   });
 });

--- a/apps/hub/src/services/matrix-as/activity.test.ts
+++ b/apps/hub/src/services/matrix-as/activity.test.ts
@@ -9,10 +9,14 @@
 // the path that lacked it.
 
 import { beforeEach, describe, expect, it } from "bun:test";
+import { PermissionRequestEvent, TurnActivity, type ToolStatus } from "@agentpod/contract";
 import {
   _resetUnmappedForTest,
   foldToolUpdate,
   noteUnmappedKind,
+  permissionRequestContent,
+  TURN_TOOLS_MAX,
+  turnActivityContent,
   unmappedKinds,
   type ToolRecord,
 } from "./activity";
@@ -189,5 +193,91 @@ describe("kinds this path does handle", () => {
   it("still records one nobody handles", () => {
     expect(noteUnmappedKind("usage_update")).toBe(true);
     expect(unmappedKinds()).toEqual(["usage_update"]);
+  });
+});
+
+// The durable record: one event per turn, never one per action.
+describe("the per-turn record", () => {
+  function rec(id: string, status: ToolStatus = "completed"): ToolRecord {
+    return { id, title: `Do ${id}`, kind: "execute", status, locations: [] };
+  }
+
+  it("counts everything and lists what fits", () => {
+    const tools = new Map([
+      ["a", rec("a")],
+      ["b", rec("b", "failed")],
+    ]);
+    const content = turnActivityContent("sess_1", tools);
+    expect(content.schema_version).toBe(1);
+    expect(content.session_id).toBe("sess_1");
+    expect(content.tools).toHaveLength(2);
+    expect(content.counts).toEqual({ total: 2, failed: 1, omitted: 0 });
+  });
+
+  it("caps the list and says how many it left out", () => {
+    // A pathological turn must not produce an unbounded event. The counts still
+    // describe the whole turn, so a capped list is never mistaken for a
+    // complete one.
+    const tools = new Map(
+      Array.from({ length: TURN_TOOLS_MAX + 5 }, (_, i) => [`t${i}`, rec(`t${i}`)] as const)
+    );
+    const content = turnActivityContent("sess_1", tools);
+    expect(content.tools).toHaveLength(TURN_TOOLS_MAX);
+    expect(content.counts.total).toBe(TURN_TOOLS_MAX + 5);
+    expect(content.counts.omitted).toBe(5);
+  });
+
+  it("keeps the order the tools were first used in", () => {
+    const tools = new Map([
+      ["z", rec("z")],
+      ["a", rec("a")],
+    ]);
+    expect(turnActivityContent("sess_1", tools).tools.map((t) => t.id)).toEqual(["z", "a"]);
+  });
+
+  it("omits a kind the harness never gave", () => {
+    const tools = new Map([["a", { ...rec("a"), kind: undefined }]]);
+    expect("kind" in turnActivityContent("sess_1", tools).tools[0]!).toBe(false);
+  });
+
+  it("produces a body the contract accepts", () => {
+    // The schema is the shared vocabulary; a builder that drifts from it would
+    // be caught here rather than on a homeserver.
+    const tools = new Map([["a", rec("a")]]);
+    expect(TurnActivity.safeParse(turnActivityContent("sess_1", tools)).success).toBe(true);
+  });
+});
+
+describe("a permission request a client can render", () => {
+  const opts = [
+    { optionId: "allow_once", name: "Allow once" },
+    { optionId: "reject", name: "Reject" },
+  ];
+
+  it("carries the options a card can offer", () => {
+    const content = permissionRequestContent("sess_1", 41, "Write src/main.ts", opts)!;
+    expect(content.options).toEqual([
+      { option_id: "allow_once", name: "Allow once" },
+      { option_id: "reject", name: "Reject" },
+    ]);
+    expect(content.request_seq).toBe(41);
+  });
+
+  it("says nothing when there is nothing to choose between", () => {
+    // The prose already handles this case in words. An event carrying an empty
+    // option list would render as a card with no way to answer it.
+    expect(permissionRequestContent("sess_1", 41, "x", [])).toBeNull();
+  });
+
+  it("caps at four, the most a card can render", () => {
+    const five = Array.from({ length: 5 }, (_, i) => ({ optionId: `o${i}`, name: `O${i}` }));
+    const content = permissionRequestContent("sess_1", 41, "x", five)!;
+    expect(content.options).toHaveLength(4);
+  });
+
+  it("produces a body the contract accepts", () => {
+    expect(
+      PermissionRequestEvent.safeParse(permissionRequestContent("sess_1", 41, "x", opts)).success
+    ).toBe(true);
   });
 });

--- a/apps/hub/src/services/matrix-as/activity.test.ts
+++ b/apps/hub/src/services/matrix-as/activity.test.ts
@@ -1,0 +1,52 @@
+// What the Matrix path does with an ACP update kind it does not handle.
+//
+// It used to do nothing at all — no default case, no log, no record — which is
+// how `tool_call` came to be discarded for the entire life of the bridge
+// without a single line anywhere saying so. The kaambaan coalescer keeps
+// `unmapped()`/`losses()` for exactly this reason, and lists its dropped kinds
+// explicitly "so a NEW kind shows up in `unmapped()` instead of joining this
+// set by accident" (`bridge/coalesce.ts:53-62`). This is that discipline, on
+// the path that lacked it.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { _resetUnmappedForTest, noteUnmappedKind, unmappedKinds } from "./activity";
+
+describe("unmapped session update kinds", () => {
+  beforeEach(() => {
+    _resetUnmappedForTest();
+  });
+
+  it("has nothing to report before anything unknown arrives", () => {
+    expect(unmappedKinds()).toEqual([]);
+  });
+
+  it("reports a kind it has never seen, so the caller can log it once", () => {
+    expect(noteUnmappedKind("plan")).toBe(true);
+    expect(unmappedKinds()).toEqual(["plan"]);
+  });
+
+  it("does not report the same kind twice, so a busy session logs once", () => {
+    // A single turn emits hundreds of the same update. A line per event would
+    // bury the signal this exists to raise.
+    expect(noteUnmappedKind("plan")).toBe(true);
+    expect(noteUnmappedKind("plan")).toBe(false);
+    expect(noteUnmappedKind("plan")).toBe(false);
+    expect(unmappedKinds()).toEqual(["plan"]);
+  });
+
+  it("keeps kinds sorted, so two runs of the same fleet read the same", () => {
+    noteUnmappedKind("usage_update");
+    noteUnmappedKind("current_mode_update");
+    noteUnmappedKind("plan");
+    expect(unmappedKinds()).toEqual(["current_mode_update", "plan", "usage_update"]);
+  });
+
+  it("ignores a kind that is not a string, rather than recording garbage", () => {
+    // `payload.sessionUpdate` comes off a `z.unknown()` payload — nothing
+    // upstream promises it is a string, or present at all.
+    expect(noteUnmappedKind(undefined as unknown as string)).toBe(false);
+    expect(noteUnmappedKind(42 as unknown as string)).toBe(false);
+    expect(noteUnmappedKind("")).toBe(false);
+    expect(unmappedKinds()).toEqual([]);
+  });
+});

--- a/apps/hub/src/services/matrix-as/activity.ts
+++ b/apps/hub/src/services/matrix-as/activity.ts
@@ -1,0 +1,57 @@
+/**
+ * What the Matrix path does with the parts of an ACP turn it does not forward.
+ *
+ * `outbound.ts` answered exactly one question — "is this an
+ * `agent_message_chunk`?" — and returned `undefined` for everything else. No
+ * default case, no logging, no record. That is how `tool_call`,
+ * `agent_thought_chunk`, `plan` and `usage_update` came to be discarded for the
+ * whole life of the bridge with nothing anywhere saying so, while the console
+ * rendered all of them.
+ *
+ * The kaambaan coalescer already keeps `unmapped()`/`losses()` and lists its
+ * dropped kinds explicitly "so a NEW kind shows up in `unmapped()` instead of
+ * joining this set by accident" (`bridge/coalesce.ts:53-62`). This is that
+ * discipline, on the path that lacked it — and it ships before anything else in
+ * this feature, because it is what makes the rest observable.
+ */
+
+/**
+ * Kinds seen and not handled, for the life of the process.
+ *
+ * Module-level rather than per-attachment: the question is "does this fleet's
+ * harness emit something we ignore", which is not a property of any one room.
+ * A `Set` is also what makes the log once-per-kind rather than once-per-event —
+ * a single turn emits hundreds of the same update, and a line per event would
+ * bury the signal this exists to raise.
+ */
+const unmapped = new Set<string>();
+
+/**
+ * Records `kind` as unhandled. Returns whether it was **new**, so the caller
+ * logs only the first time — a kind that arrives four hundred times says so
+ * once.
+ *
+ * Guards the type rather than trusting it: `payload.sessionUpdate` comes off a
+ * `z.unknown()` payload (`packages/contract`'s `AcpEvent`), so nothing upstream
+ * promises it is a string or present at all. A non-string is not recorded,
+ * because "we dropped something called 42" would be worse than silence.
+ */
+export function noteUnmappedKind(kind: string): boolean {
+  if (typeof kind !== "string" || kind === "") return false;
+  if (unmapped.has(kind)) return false;
+  unmapped.add(kind);
+  return true;
+}
+
+/** Every unhandled kind seen so far, sorted so two runs of a fleet read the same. */
+export function unmappedKinds(): string[] {
+  return [...unmapped].sort();
+}
+
+/**
+ * Test seam. The set deliberately outlives any one attachment, so a test that
+ * wants to observe it from empty has to say so.
+ */
+export function _resetUnmappedForTest(): void {
+  unmapped.clear();
+}

--- a/apps/hub/src/services/matrix-as/activity.ts
+++ b/apps/hub/src/services/matrix-as/activity.ts
@@ -15,6 +15,8 @@
  * this feature, because it is what makes the rest observable.
  */
 
+import { ToolStatus } from "@agentpod/contract";
+
 /**
  * Kinds seen and not handled, for the life of the process.
  *
@@ -25,6 +27,18 @@
  * bury the signal this exists to raise.
  */
 const unmapped = new Set<string>();
+
+/**
+ * The kinds this path forwards.
+ *
+ * Checked before recording an unmapped kind, because "we handle this" and "this
+ * particular payload was usable" are different questions. A `tool_call` with no
+ * `toolCallId` is malformed, not unsupported — and since a kind is recorded at
+ * most once, letting one bad payload in would leave `tool_call` listed as
+ * dropped for the life of the process, which is a lie that never corrects
+ * itself.
+ */
+const HANDLED_KINDS = new Set(["agent_message_chunk", "agent_thought_chunk", "tool_call", "tool_call_update"]);
 
 /**
  * Records `kind` as unhandled. Returns whether it was **new**, so the caller
@@ -38,6 +52,7 @@ const unmapped = new Set<string>();
  */
 export function noteUnmappedKind(kind: string): boolean {
   if (typeof kind !== "string" || kind === "") return false;
+  if (HANDLED_KINDS.has(kind)) return false;
   if (unmapped.has(kind)) return false;
   unmapped.add(kind);
   return true;
@@ -54,4 +69,80 @@ export function unmappedKinds(): string[] {
  */
 export function _resetUnmappedForTest(): void {
   unmapped.clear();
+}
+
+// ─── A turn's tool calls ─────────────────────────────────────────────────────
+
+/** One tool call, accumulated across its `tool_call` and every update to it. */
+export interface ToolRecord {
+  id: string;
+  title: string;
+  kind: string | undefined;
+  status: ToolStatus;
+  locations: string[];
+}
+
+function toolStatus(value: unknown): ToolStatus | undefined {
+  const parsed = ToolStatus.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/**
+ * The `path` of every location that has one.
+ *
+ * `undefined` rather than `[]` when the field is absent, so a `tool_call_update`
+ * that says nothing about locations keeps the ones its `tool_call` gave, while
+ * one that says "no locations" can still clear them.
+ */
+function locationPaths(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const entry of value) {
+    if (entry !== null && typeof entry === "object") {
+      const path = (entry as Record<string, unknown>).path;
+      if (typeof path === "string") out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * Folds a `tool_call` or `tool_call_update` into `tools`, returning the record
+ * as it now stands — or `null` when the payload is neither.
+ *
+ * **Upsert, never append.** A repeated `toolCallId` merges, for the reason the
+ * console records at `transcript.ts:299-305`: a buggy or hostile agent
+ * repeating an id must not produce two records with one identity. `Map`
+ * preserves insertion order, so an update to an early call leaves it where it
+ * was and the durable record reads in the order the work actually happened.
+ *
+ * Every field falls back to what the call already had, so an update carrying
+ * only a status keeps its title. A ticker that forgets what it is doing halfway
+ * through is worse than one a moment out of date.
+ */
+export function foldToolUpdate(
+  tools: Map<string, ToolRecord>,
+  payload: unknown
+): ToolRecord | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (p.sessionUpdate !== "tool_call" && p.sessionUpdate !== "tool_call_update") return null;
+
+  // Nothing can merge onto a call with no id, and inventing one would make two
+  // updates of the same call look like two calls.
+  const id = typeof p.toolCallId === "string" ? p.toolCallId : undefined;
+  if (id === undefined) return null;
+
+  const existing = tools.get(id);
+  const record: ToolRecord = {
+    id,
+    // The id is the last resort rather than a blank: a card must never render a
+    // nameless row.
+    title: typeof p.title === "string" ? p.title : (existing?.title ?? id),
+    kind: typeof p.kind === "string" ? p.kind : existing?.kind,
+    status: toolStatus(p.status) ?? existing?.status ?? "pending",
+    locations: locationPaths(p.locations) ?? existing?.locations ?? [],
+  };
+  tools.set(id, record);
+  return record;
 }

--- a/apps/hub/src/services/matrix-as/activity.ts
+++ b/apps/hub/src/services/matrix-as/activity.ts
@@ -15,7 +15,7 @@
  * this feature, because it is what makes the rest observable.
  */
 
-import { ToolStatus } from "@agentpod/contract";
+import { ToolStatus, type PermissionRequestEvent, type TurnActivity } from "@agentpod/contract";
 
 /**
  * Kinds seen and not handled, for the life of the process.
@@ -145,4 +145,87 @@ export function foldToolUpdate(
   };
   tools.set(id, record);
   return record;
+}
+
+// ─── The durable record ──────────────────────────────────────────────────────
+
+/** The room event type carrying what an agent did during one turn. */
+export const TURN_ACTIVITY_TYPE = "dev.agentpod.turn.v1";
+
+/**
+ * How many tool calls the durable record lists.
+ *
+ * A cap, not a sample: `counts` describes the whole turn regardless, so a
+ * capped list can never be mistaken for a complete one. Twenty is enough to
+ * read as a record of what happened, and small enough that no single turn can
+ * produce an event worth paginating around — which matters here more than it
+ * looks, because more and larger events per turn is exactly what makes limited
+ * syncs more frequent, and a limited sync unloads the reader's timeline.
+ */
+export const TURN_TOOLS_MAX = 20;
+
+/**
+ * The wire body for one turn's record.
+ *
+ * Sent once, before the answer, so a room reads in the order things happened:
+ * did these things, then said this.
+ */
+export function turnActivityContent(
+  sessionId: string,
+  tools: Map<string, ToolRecord>
+): TurnActivity {
+  const all = [...tools.values()];
+  return {
+    schema_version: 1,
+    session_id: sessionId,
+    tools: all.slice(0, TURN_TOOLS_MAX).map((t) => ({
+      id: t.id,
+      title: t.title,
+      // Omitted rather than null: absent means the harness never said.
+      ...(t.kind === undefined ? {} : { kind: t.kind }),
+      status: t.status,
+      locations: t.locations,
+    })),
+    counts: {
+      total: all.length,
+      failed: all.filter((t) => t.status === "failed").length,
+      omitted: Math.max(0, all.length - TURN_TOOLS_MAX),
+    },
+  };
+}
+
+// ─── Approvals ───────────────────────────────────────────────────────────────
+
+/** The room event type carrying a permission request a client can render. */
+export const PERMISSION_REQUEST_TYPE = "dev.agentpod.permission.v1";
+
+/**
+ * The wire body for a permission request, or `null` when there is nothing a
+ * client could render.
+ *
+ * Sent **beside** the prose message, never instead of it. The prose is what
+ * keeps Element and reply-by-number working, and the answer to either arrives
+ * as an ordinary room message through the same matcher — which is why
+ * structured approvals need no new send path on either side.
+ *
+ * Capped at four options because supermessage's `DECISION_MAX_OPTIONS` renders
+ * four and silently drops the rest; enforcing it here means the hub never sends
+ * something it knows will be discarded. The prose is not capped and still lists
+ * every option, so a fifth stays answerable by number or name — it just does
+ * not get a button.
+ */
+export function permissionRequestContent(
+  sessionId: string,
+  requestSeq: number,
+  title: string,
+  options: readonly { optionId: string; name: string }[]
+): PermissionRequestEvent | null {
+  if (options.length === 0) return null;
+  return {
+    schema_version: 1,
+    session_id: sessionId,
+    request_seq: requestSeq,
+    title,
+    options: options.slice(0, 4).map((o) => ({ option_id: o.optionId, name: o.name })),
+  };
 }

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -59,6 +59,20 @@ export interface MatrixClient {
     }
   ): Promise<string | null>;
   sendText(userId: string, roomId: string, body: string): Promise<string | null>;
+  /**
+   * Send a message-like event of any type into a room.
+   *
+   * The escape hatch `sendText` is a special case of. Used for the suite's own
+   * event types (`dev.agentpod.turn.v1`, `dev.agentpod.permission.v1`), which
+   * no other Matrix client will render — the answer text still arrives as an
+   * ordinary `m.room.message`, so nothing essential is invisible in Element.
+   */
+  sendCustomEvent(
+    userId: string,
+    roomId: string,
+    eventType: string,
+    content: Record<string, unknown>
+  ): Promise<string | null>;
   sendTyping(userId: string, roomId: string, typing: boolean): Promise<void>;
   /**
    * Send a to-device event as `userId` to every device `targetUserId` has.
@@ -313,6 +327,19 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
         { method: "PUT", userId, body: { msgtype: "m.text", body } }
       );
       assertOkOrAlready("send", res);
+      return String(res.body.event_id ?? "") || null;
+    },
+
+    async sendCustomEvent(userId, roomId, eventType, content) {
+      // A fresh transaction id per send, exactly as `sendText`: the homeserver
+      // deduplicates on it, so reusing one would silently drop a genuinely new
+      // event.
+      const txn = `apb-${crypto.randomUUID()}`;
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/${encodeURIComponent(eventType)}/${txn}`,
+        { method: "PUT", userId, body: content }
+      );
+      assertOkOrAlready("sendCustomEvent", res);
       return String(res.body.event_id ?? "") || null;
     },
 

--- a/apps/hub/src/services/matrix-as/live.test.ts
+++ b/apps/hub/src/services/matrix-as/live.test.ts
@@ -11,9 +11,12 @@ import { describe, expect, test } from "bun:test";
 import {
   deltaContent,
   endsAtBoundary,
+  LIVE_DELTA_TYPE,
   MAX_DELTA_WAIT_MS,
   MIN_DELTA_CHARS,
   shouldSendDelta,
+  THOUGHT_DELTA_TYPE,
+  toolUpdateContent,
 } from "./live";
 
 describe("deciding when to send", () => {
@@ -100,5 +103,53 @@ describe("the wire body", () => {
     });
 
     expect(content.done).toBe(true);
+  });
+});
+
+describe("activity to-device types", () => {
+  test("names the thought channel distinctly from the answer channel", () => {
+    // Same body, different type: the shape is reused so the client needs no
+    // second implementation, but a reader must still be able to tell an agent's
+    // reasoning from its answer.
+    expect(THOUGHT_DELTA_TYPE).toBe("dev.agentpod.thought.delta");
+    expect(THOUGHT_DELTA_TYPE).not.toBe(LIVE_DELTA_TYPE);
+  });
+
+  test("builds a tool update body in snake_case, like every other Matrix event", () => {
+    expect(
+      toolUpdateContent({
+        roomId: "!r:example.org",
+        sessionId: "sess_1",
+        seq: 2,
+        toolCallId: "call_1",
+        title: "Read src/main.ts",
+        kind: "read",
+        status: "in_progress",
+        locations: ["src/main.ts"],
+      })
+    ).toEqual({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 2,
+      tool_call_id: "call_1",
+      title: "Read src/main.ts",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+      kind: "read",
+    });
+  });
+
+  test("omits a kind ACP did not give, rather than sending an empty string", () => {
+    const body = toolUpdateContent({
+      roomId: "!r:example.org",
+      sessionId: "sess_1",
+      seq: 2,
+      toolCallId: "call_1",
+      title: "Something",
+      kind: undefined,
+      status: "pending",
+      locations: [],
+    });
+    expect("kind" in body).toBe(false);
   });
 });

--- a/apps/hub/src/services/matrix-as/live.ts
+++ b/apps/hub/src/services/matrix-as/live.ts
@@ -107,3 +107,57 @@ export function deltaContent(delta: LiveDelta): Record<string, unknown> {
     done: delta.done,
   };
 }
+
+// ─── Activity: reasoning and tool use ────────────────────────────────────────
+
+/**
+ * The to-device event type carrying a turn's reasoning.
+ *
+ * A separate type from [`LIVE_DELTA_TYPE`] carrying an identical body. The
+ * *shape* is reused so the client's seq-ordering and reveal pacing work
+ * unchanged; the *type* must differ, or a reader cannot tell an agent's
+ * thinking from its answer.
+ *
+ * Reasoning is never written to the room, and that decision predates this
+ * channel — `outbound.ts` has said so since the day it was written: it "belongs
+ * in the console's transcript, not in a room people share, where it would turn
+ * one answer into a monologue". 202 thought chunks in one observed Hermes turn
+ * is the number behind that sentence. This makes it watchable without making it
+ * permanent.
+ */
+export const THOUGHT_DELTA_TYPE = "dev.agentpod.thought.delta";
+
+/** The to-device event type carrying one tool call's state. */
+export const TOOL_UPDATE_TYPE = "dev.agentpod.tool.update";
+
+/** One tool call's state, as it goes on the wire. */
+export interface ToolUpdate {
+  roomId: string;
+  sessionId: string;
+  /** Monotonic per turn. A receiver drops anything older than what it has. */
+  seq: number;
+  /** The identity later updates merge onto. */
+  toolCallId: string;
+  title: string;
+  /** ACP's tool kind. Absent when the harness did not say. */
+  kind: string | undefined;
+  status: "pending" | "in_progress" | "completed" | "failed";
+  locations: string[];
+}
+
+/** The wire body for a tool update. Snake case, like every other Matrix event. */
+export function toolUpdateContent(update: ToolUpdate): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    room_id: update.roomId,
+    session_id: update.sessionId,
+    seq: update.seq,
+    tool_call_id: update.toolCallId,
+    title: update.title,
+    status: update.status,
+    locations: update.locations,
+  };
+  // Omitted rather than sent empty: absent means "the harness did not say",
+  // where `""` would render as a kind called nothing.
+  if (update.kind !== undefined) body.kind = update.kind;
+  return body;
+}

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -694,3 +694,180 @@ describe("an agent's thinking and tool use", () => {
     expect(sent[0]!.body).toBe("Here is the answer.");
   });
 });
+
+describe("the durable record of a turn", () => {
+  /** Deps with a custom-event sink, and a shared clock so order is assertable. */
+  function recordingDeps() {
+    const base = deps();
+    let tick = 0;
+    const custom: Array<{ type: string; content: any; at: number }> = [];
+    const said: Array<{ body: string; at: number }> = [];
+    return {
+      custom,
+      said,
+      deps: {
+        ...base,
+        client: {
+          ...base.client,
+          sendText: async (_userId: string, _roomId: string, body: string) => {
+            said.push({ body, at: tick++ });
+            return `$msg-${said.length}`;
+          },
+          sendCustomEvent: async (
+            _userId: string,
+            _roomId: string,
+            eventType: string,
+            content: Record<string, unknown>
+          ) => {
+            custom.push({ type: eventType, content, at: tick++ });
+            return `$custom-${custom.length}`;
+          },
+        },
+      },
+    };
+  }
+
+  const tool = (payload: Record<string, unknown>, seq = 2) => ({
+    sessionId: SESSION,
+    seq,
+    type: "agent-update",
+    payload,
+    createdAt: new Date().toISOString(),
+  });
+
+  test("records one card per turn, before the answer", async () => {
+    // Reading order is the point: did these things, then said this.
+    const { custom, said, deps: d } = recordingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(tool({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read a", status: "completed" }));
+    emit(chunk("Done."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(custom).toHaveLength(1);
+    expect(custom[0]!.type).toBe("dev.agentpod.turn.v1");
+    expect(custom[0]!.content.tools[0]).toMatchObject({ id: "c1", title: "Read a" });
+    expect(said).toHaveLength(1);
+    expect(custom[0]!.at).toBeLessThan(said[0]!.at);
+  });
+
+  test("says nothing extra for a turn that used no tools", async () => {
+    const { custom, said, deps: d } = recordingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(chunk("Just talking."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(custom).toHaveLength(0);
+    expect(said).toHaveLength(1);
+  });
+
+  test("records a turn that worked and said nothing", async () => {
+    // The empty-text guard sits after the card on purpose: an agent that did
+    // things and reported none of them is exactly when the record matters.
+    const { custom, said, deps: d } = recordingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(tool({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Tidy up", status: "completed" }));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(custom).toHaveLength(1);
+    expect(said).toHaveLength(0);
+  });
+
+  test("does not report the previous turn's work on the next turn", async () => {
+    const { custom, deps: d } = recordingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(tool({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read a", status: "completed" }));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    emit(chunk("Second turn, no tools."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(custom).toHaveLength(1);
+  });
+
+  test("a deployment without sendCustomEvent still says the answer", async () => {
+    // The property that makes this safe to roll out: the card is additive, and
+    // its absence changes nothing else.
+    const base = deps();
+    attachRoomToSession(SESSION, ROOM, AGENT, base as any);
+
+    emit(tool({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read a" }));
+    emit(chunk("Answer regardless."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toBe("Answer regardless.");
+  });
+});
+
+describe("a permission request a client can render", () => {
+  function recordingDeps() {
+    const base = deps();
+    const custom: Array<{ type: string; content: any }> = [];
+    return {
+      custom,
+      deps: {
+        ...base,
+        client: {
+          ...base.client,
+          sendCustomEvent: async (
+            _userId: string,
+            _roomId: string,
+            eventType: string,
+            content: Record<string, unknown>
+          ) => {
+            custom.push({ type: eventType, content });
+            return "$custom-1";
+          },
+        },
+      },
+    };
+  }
+
+  test("sends the structured event beside the prose, never instead of it", async () => {
+    // The regression that matters: a client that cannot read the custom event
+    // must be exactly as able to approve as it was before.
+    const { custom, deps: d } = recordingDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(permission());
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toContain("Permission needed: write /etc/hosts");
+    expect(sent[0]!.body).toContain("1. Allow");
+    expect(sent[0]!.body).toContain("Reply with the number, or the option's name.");
+
+    expect(custom).toHaveLength(1);
+    expect(custom[0]!.type).toBe("dev.agentpod.permission.v1");
+    expect(custom[0]!.content.options).toEqual([
+      { option_id: "allow", name: "Allow" },
+      { option_id: "reject", name: "Reject" },
+    ]);
+  });
+
+  test("a deployment without sendCustomEvent still asks in words", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps() as any);
+
+    emit(permission());
+    await settle();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toContain("Permission needed");
+  });
+});

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -871,3 +871,97 @@ describe("a permission request a client can render", () => {
     expect(sent[0]!.body).toContain("Permission needed");
   });
 });
+
+describe("a turn that ends without saying anything", () => {
+  test("does not mark it done, and says what happened", async () => {
+    // Measured in production on 2026-08-17: a provider quota was exhausted,
+    // every model in the failover chain failed, and openclaw ended the turn
+    // `idle` without emitting an ACP error. The room put a ✅ on the reader's
+    // message and showed nothing else. They asked twice — "Hi", then "No
+    // reply?" — and got a green tick both times.
+    //
+    // The hub cannot know *why* nothing came back. It can know that nothing
+    // did, and refuse to call that success.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps() as any);
+    noteTurnTrigger(SESSION, "$user-msg-silent");
+
+    emit(state("working"));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(reactions.at(-1)).toEqual({ targetId: "$user-msg-silent", key: "❌" });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toMatch(/without a reply/i);
+  });
+
+  test("still marks a turn done when the agent actually said something", async () => {
+    attachRoomToSession(SESSION, ROOM, AGENT, deps() as any);
+    noteTurnTrigger(SESSION, "$user-msg-answered");
+
+    emit(state("working"));
+    emit(chunk("Here you go."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(reactions.at(-1)).toEqual({ targetId: "$user-msg-answered", key: "✅" });
+    expect(sent.some((m) => /without a reply/i.test(m.body))).toBe(false);
+  });
+
+  test("counts tool work as having happened, even with nothing said", async () => {
+    // An agent that tidied up and reported nothing did something. The turn
+    // card records it, and a ❌ would be wrong.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps() as any);
+    noteTurnTrigger(SESSION, "$user-msg-tools");
+
+    emit(state("working"));
+    emit({
+      sessionId: SESSION,
+      seq: 2,
+      type: "agent-update",
+      payload: { sessionUpdate: "tool_call", toolCallId: "c1", title: "Tidy up", status: "completed" },
+      createdAt: new Date().toISOString(),
+    });
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(reactions.at(-1)).toEqual({ targetId: "$user-msg-tools", key: "✅" });
+    expect(sent.some((m) => /without a reply/i.test(m.body))).toBe(false);
+  });
+
+  test("leaves a reported error to the error path, which already explains itself", async () => {
+    // The `error` event says what went wrong. Adding "ended without a reply"
+    // underneath it would be the same news twice, and less specific.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps() as any);
+    noteTurnTrigger(SESSION, "$user-msg-error");
+
+    emit(state("working"));
+    emit({
+      sessionId: SESSION,
+      seq: 2,
+      type: "error",
+      payload: { message: "harness exited" },
+      createdAt: new Date().toISOString(),
+    });
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(sent.some((m) => /without a reply/i.test(m.body))).toBe(false);
+    expect(sent.some((m) => /harness exited/.test(m.body))).toBe(true);
+  });
+
+  test("says nothing about a turn nobody in the room started", async () => {
+    // A cron job speaking has no reader waiting on it, and no message to mark.
+    attachRoomToSession(SESSION, ROOM, AGENT, deps() as any);
+
+    emit(state("working"));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/apps/hub/src/services/matrix-as/outbound.test.ts
+++ b/apps/hub/src/services/matrix-as/outbound.test.ts
@@ -545,3 +545,152 @@ describe("streaming a turn to the reader's own devices", () => {
     expect(sent).toHaveLength(1);
   });
 });
+
+describe("an agent's thinking and tool use", () => {
+  /** The same shape as `streamingDeps` above, with its own sink. */
+  function activityDeps() {
+    const base = deps();
+    const events: Array<{ type: string; content: any }> = [];
+    return {
+      events,
+      deps: {
+        ...base,
+        client: {
+          ...base.client,
+          sendToDevice: async (
+            _userId: string,
+            _targetUserId: string,
+            eventType: string,
+            content: Record<string, unknown>
+          ) => {
+            events.push({ type: eventType, content });
+          },
+        },
+        readerFor: async () => "@rakesh:x.org",
+      },
+    };
+  }
+
+  const toolCall = (payload: Record<string, unknown>, seq = 2) => ({
+    sessionId: SESSION,
+    seq,
+    type: "agent-update",
+    payload,
+    createdAt: new Date().toISOString(),
+  });
+
+  test("reasoning reaches the reader's devices and never the room", async () => {
+    // The decision this defends is older than this test: reasoning "belongs in
+    // the console's transcript, not in a room people share, where it would turn
+    // one answer into a monologue". 202 thought chunks in one observed Hermes
+    // turn is the number behind that sentence. Watchable, never permanent.
+    const { events, deps: d } = activityDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(thought("Weighing whether the node is really down. "));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(events.filter((e) => e.type === "dev.agentpod.thought.delta").length).toBeGreaterThan(0);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("reasoning keeps its own sequence, so it cannot be read as the answer", async () => {
+    const { events, deps: d } = activityDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(chunk("The answer, long enough to be worth sending. "));
+    emit(thought("The reasoning, also long enough to send. "));
+    await settle();
+
+    const answer = events.find((e) => e.type === "dev.agentpod.stream.delta");
+    const reasoning = events.find((e) => e.type === "dev.agentpod.thought.delta");
+    expect(answer!.content.seq).toBe(1);
+    expect(reasoning!.content.seq).toBe(1);
+    expect(answer!.content.text).toBe("The answer, long enough to be worth sending. ");
+    expect(reasoning!.content.text).toBe("The reasoning, also long enough to send. ");
+  });
+
+  test("a tool call reaches the devices and not the room", async () => {
+    const { events, deps: d } = activityDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(
+      toolCall({
+        sessionUpdate: "tool_call",
+        toolCallId: "c1",
+        title: "Read src/main.ts",
+        kind: "read",
+        status: "in_progress",
+        locations: [{ path: "src/main.ts" }],
+      })
+    );
+    await settle();
+
+    const update = events.find((e) => e.type === "dev.agentpod.tool.update");
+    expect(update!.content).toMatchObject({
+      tool_call_id: "c1",
+      title: "Read src/main.ts",
+      kind: "read",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+    });
+    expect(sent).toHaveLength(0);
+  });
+
+  test("an update to a tool call carries the title the call was given", async () => {
+    const { events, deps: d } = activityDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(toolCall({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Run tests" }, 2));
+    emit(toolCall({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "failed" }, 3));
+    await settle();
+
+    const updates = events.filter((e) => e.type === "dev.agentpod.tool.update");
+    expect(updates).toHaveLength(2);
+    expect(updates[1]!.content).toMatchObject({
+      tool_call_id: "c1",
+      title: "Run tests",
+      status: "failed",
+    });
+  });
+
+  test("a tool call with no id is ignored, since nothing could merge onto it", async () => {
+    const { events, deps: d } = activityDeps();
+    attachRoomToSession(SESSION, ROOM, AGENT, d as any);
+
+    emit(toolCall({ sessionUpdate: "tool_call", title: "Nameless" }));
+    await settle();
+
+    expect(events.filter((e) => e.type === "dev.agentpod.tool.update")).toHaveLength(0);
+  });
+
+  test("a room with no reader sends nothing anywhere, and still says the answer", async () => {
+    // The property that makes this safe against a live fleet: every activity
+    // channel is best-effort and none of them touches the room.
+    const base = deps();
+    const events: Array<{ type: string }> = [];
+    attachRoomToSession(SESSION, ROOM, AGENT, {
+      ...base,
+      client: {
+        ...base.client,
+        sendToDevice: async (_u: string, _t: string, type: string) => {
+          events.push({ type });
+        },
+      },
+      readerFor: async () => null,
+    } as any);
+
+    emit(thought("Thinking about it. "));
+    emit(toolCall({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read a file" }));
+    emit(chunk("Here is the answer."));
+    await settle();
+    emit(state("idle"));
+    await settle();
+
+    expect(events).toHaveLength(0);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.body).toBe("Here is the answer.");
+  });
+});

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -133,6 +133,19 @@ interface Attachment {
   tools: Map<string, ToolRecord>;
   /** Monotonic per turn, shared by every tool update. */
   toolSeq: number;
+  /**
+   * Whether this turn produced anything at all — a word, or a tool call.
+   *
+   * A turn that produced nothing is not a turn that succeeded, and the ✅ this
+   * used to put on the reader's message said otherwise. Measured on
+   * 2026-08-17: a provider quota was exhausted, every model in the failover
+   * chain failed, and openclaw ended the turn `idle` without emitting an ACP
+   * error — so the room marked it done and showed nothing. The reader asked
+   * twice and got a green tick both times.
+   */
+  produced: boolean;
+  /** Whether the harness already explained a failure this turn. */
+  reportedError: boolean;
 }
 
 /**
@@ -177,6 +190,18 @@ export const TYPING_REFRESH_MS = 20_000;
  * "did it even hear me" without costing a message.
  */
 const REACTION = { working: "👀", done: "✅", failed: "❌" } as const;
+
+/**
+ * What the room is told when a turn ends having produced nothing.
+ *
+ * Deliberately says only what is known. The hub sees a turn go `working` and
+ * then `idle` with no text, no tool call and no error — it does not know
+ * whether the model refused, ran out of quota, or crashed, because the harness
+ * that failed did not say. Guessing would be worse than the tick this replaces.
+ */
+const SILENT_TURN_NOTICE =
+  "This turn ended without a reply — the agent reported no answer and no error. " +
+  "Its own logs will say why.";
 
 /**
  * The message that started the turn about to run, per session.
@@ -278,6 +303,8 @@ export function attachRoomToSession(
     thoughtSentAt: 0,
     tools: new Map(),
     toolSeq: 0,
+    produced: false,
+    reportedError: false,
   };
 
   const say = async (body: string) => {
@@ -542,6 +569,7 @@ export function attachRoomToSession(
         case "agent-update": {
           const text = messageChunkText(event.payload);
           if (text !== undefined) {
+            state.produced = true;
             state.buffer.push(text);
             void streamLive(false);
             scheduleFlush();
@@ -557,6 +585,7 @@ export function attachRoomToSession(
 
           const tool = foldToolUpdate(state.tools, event.payload);
           if (tool !== null) {
+            state.produced = true;
             void streamTool(tool);
             return;
           }
@@ -599,7 +628,24 @@ export function attachRoomToSession(
           await flush();
           await stopTyping();
 
-          if (status === "idle" || status === "ended") await mark(REACTION.done);
+          if (status === "idle" || status === "ended") {
+            // A turn that said nothing, ran nothing, and reported nothing is
+            // not a turn that worked. The hub cannot know *why* — the harness
+            // that failed did not say — but it can refuse to call silence
+            // success, and it can tell the reader that their question went
+            // unanswered rather than leaving them to infer it from a tick.
+            //
+            // Nothing is said when nobody asked: an unprompted turn (a cron
+            // job speaking) has no reader waiting and no message to mark.
+            if (!state.produced && !state.reportedError) {
+              await mark(REACTION.failed);
+              if (state.triggerEventId) await say(SILENT_TURN_NOTICE);
+            } else if (!state.reportedError) {
+              await mark(REACTION.done);
+            }
+            state.produced = false;
+            state.reportedError = false;
+          }
 
           if (status === "ended") {
             // A session that ended takes its attachment with it — an
@@ -658,6 +704,9 @@ export function attachRoomToSession(
 
         case "error": {
           const message = isRecord(event.payload) ? event.payload.message : undefined;
+          // The error path explains itself; the silence check below must not
+          // repeat the same news less specifically.
+          state.reportedError = true;
           await stopTyping();
           await mark(REACTION.failed);
           await say(`This agent reported an error: ${String(message ?? "unknown")}`);

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -13,8 +13,15 @@
 
 import type { AcpEvent } from "@agentpod/contract";
 import { subscribe as subscribeToSession } from "../acp-sessions";
-import { deltaContent, LIVE_DELTA_TYPE, shouldSendDelta } from "./live";
-import { noteUnmappedKind } from "./activity";
+import {
+  deltaContent,
+  LIVE_DELTA_TYPE,
+  shouldSendDelta,
+  THOUGHT_DELTA_TYPE,
+  TOOL_UPDATE_TYPE,
+  toolUpdateContent,
+} from "./live";
+import { foldToolUpdate, noteUnmappedKind, type ToolRecord } from "./activity";
 import {
   clearPendingPermission,
   notePendingPermission,
@@ -88,6 +95,25 @@ interface Attachment {
   reader: string | null | undefined;
   /** The 👀 we put on it, so it can be taken off again. */
   workingReactionId: string | null;
+  /**
+   * The reasoning stream's own buffer and cursor.
+   *
+   * Separate from the answer's rather than shared: the two arrive interleaved
+   * and are read on different channels, so one cursor would make an agent's
+   * thinking and its answer overwrite each other. See `THOUGHT_DELTA_TYPE`.
+   */
+  thoughtBuffer: string[];
+  thoughtSeq: number;
+  thoughtSentChars: number;
+  thoughtSentAt: number;
+  /**
+   * This turn's tool calls, in the order they were first used, keyed by
+   * `toolCallId` so an update merges rather than appending. Cleared with the
+   * rest of the per-turn state in `flush`.
+   */
+  tools: Map<string, ToolRecord>;
+  /** Monotonic per turn, shared by every tool update. */
+  toolSeq: number;
 }
 
 /**
@@ -158,10 +184,21 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 /** The text of an `agent_message_chunk`, or undefined for anything else. */
 function messageChunkText(payload: unknown): string | undefined {
   if (!isRecord(payload)) return undefined;
-  // Thought chunks are deliberately excluded: reasoning belongs in the
-  // console's transcript, not in a room people share, where it would turn one
-  // answer into a monologue.
+  // Thought chunks are deliberately excluded *from the room*: reasoning
+  // belongs in the console's transcript, not in a room people share, where it
+  // would turn one answer into a monologue. They are streamed to the reader's
+  // own devices instead — see `streamThought`, which makes them watchable
+  // without making them permanent.
   if (payload.sessionUpdate !== "agent_message_chunk") return undefined;
+  const content = payload.content;
+  if (!isRecord(content) || content.type !== "text") return undefined;
+  return typeof content.text === "string" ? content.text : undefined;
+}
+
+/** The text of a chunk of the given kind, or undefined for anything else. */
+function chunkTextOfKind(payload: unknown, kind: string): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  if (payload.sessionUpdate !== kind) return undefined;
   const content = payload.content;
   if (!isRecord(content) || content.type !== "text") return undefined;
   return typeof content.text === "string" ? content.text : undefined;
@@ -216,6 +253,12 @@ export function attachRoomToSession(
     liveSentChars: 0,
     liveSentAt: 0,
     reader: undefined,
+    thoughtBuffer: [],
+    thoughtSeq: 0,
+    thoughtSentChars: 0,
+    thoughtSentAt: 0,
+    tools: new Map(),
+    toolSeq: 0,
   };
 
   const say = async (body: string) => {
@@ -249,6 +292,14 @@ export function attachRoomToSession(
     state.liveSeq = 0;
     state.liveSentChars = 0;
     state.liveSentAt = 0;
+    // The reasoning and tool state belong to the turn that just ended. Without
+    // this the next turn reports the previous one's work as its own.
+    state.thoughtBuffer = [];
+    state.thoughtSeq = 0;
+    state.thoughtSentChars = 0;
+    state.thoughtSentAt = 0;
+    state.tools = new Map();
+    state.toolSeq = 0;
     if (text.trim() === "") return;
     await say(text);
   };
@@ -265,10 +316,8 @@ export function attachRoomToSession(
     const send = deps.client.sendToDevice;
     if (!send) return;
 
-    if (state.reader === undefined) {
-      state.reader = deps.readerFor ? await deps.readerFor(roomId).catch(() => null) : null;
-    }
-    if (!state.reader) return;
+    const reader = await resolveReader();
+    if (!reader) return;
 
     const text = state.buffer.join("");
     const pending = text.slice(state.liveSentChars);
@@ -283,11 +332,99 @@ export function attachRoomToSession(
 
     await send(
       agentUser,
-      state.reader,
+      reader,
       LIVE_DELTA_TYPE,
       deltaContent({ roomId, sessionId, seq: state.liveSeq, text, done })
     ).catch((err) => {
       log.debug("could not stream a turn to the reader's devices", {
+        sessionId,
+        roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
+
+  /**
+   * The reader's Matrix id, looked up once per room and cached.
+   *
+   * Shared by all three live channels so a room with no reader does the lookup
+   * once rather than once per stream.
+   */
+  const resolveReader = async (): Promise<string | null> => {
+    if (state.reader === undefined) {
+      state.reader = deps.readerFor ? await deps.readerFor(roomId).catch(() => null) : null;
+    }
+    return state.reader;
+  };
+
+  /**
+   * Push the agent's reasoning so far to the reader's devices.
+   *
+   * The same policy and the same best-effort posture as `streamLive`, against
+   * its own buffer and cursor. Unlike the answer there is no durable copy
+   * behind this: a dropped delta is simply reasoning nobody saw, which costs
+   * nothing, because reasoning is never written to the room at all.
+   */
+  const streamThought = async (done: boolean) => {
+    const send = deps.client.sendToDevice;
+    if (!send) return;
+    const reader = await resolveReader();
+    if (!reader) return;
+
+    const text = state.thoughtBuffer.join("");
+    const pending = text.slice(state.thoughtSentChars);
+    if (!done && !shouldSendDelta(pending, Date.now() - state.thoughtSentAt)) return;
+    if (done && pending.length === 0 && state.thoughtSeq === 0) return;
+
+    state.thoughtSeq += 1;
+    state.thoughtSentChars = text.length;
+    state.thoughtSentAt = Date.now();
+
+    await send(
+      agentUser,
+      reader,
+      THOUGHT_DELTA_TYPE,
+      deltaContent({ roomId, sessionId, seq: state.thoughtSeq, text, done })
+    ).catch((err) => {
+      log.debug("could not stream a turn's reasoning to the reader's devices", {
+        sessionId,
+        roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
+
+  /**
+   * Push one tool call's current state to the reader's devices.
+   *
+   * Sent on every change rather than batched: this is the answer to "what is it
+   * doing right now", and a batched ticker is a contradiction. The durable
+   * record at the end of the turn is what makes it worth not batching — nothing
+   * here has to survive, so nothing here has to be complete.
+   */
+  const streamTool = async (record: ToolRecord) => {
+    const send = deps.client.sendToDevice;
+    if (!send) return;
+    const reader = await resolveReader();
+    if (!reader) return;
+
+    state.toolSeq += 1;
+    await send(
+      agentUser,
+      reader,
+      TOOL_UPDATE_TYPE,
+      toolUpdateContent({
+        roomId,
+        sessionId,
+        seq: state.toolSeq,
+        toolCallId: record.id,
+        title: record.title,
+        kind: record.kind,
+        status: record.status,
+        locations: record.locations,
+      })
+    ).catch((err) => {
+      log.debug("could not stream a tool call to the reader's devices", {
         sessionId,
         roomId,
         error: err instanceof Error ? err.message : String(err),
@@ -360,6 +497,19 @@ export function attachRoomToSession(
             state.buffer.push(text);
             void streamLive(false);
             scheduleFlush();
+            return;
+          }
+
+          const thought = chunkTextOfKind(event.payload, "agent_thought_chunk");
+          if (thought !== undefined) {
+            state.thoughtBuffer.push(thought);
+            void streamThought(false);
+            return;
+          }
+
+          const tool = foldToolUpdate(state.tools, event.payload);
+          if (tool !== null) {
+            void streamTool(tool);
             return;
           }
 

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -14,6 +14,7 @@
 import type { AcpEvent } from "@agentpod/contract";
 import { subscribe as subscribeToSession } from "../acp-sessions";
 import { deltaContent, LIVE_DELTA_TYPE, shouldSendDelta } from "./live";
+import { noteUnmappedKind } from "./activity";
 import {
   clearPendingPermission,
   notePendingPermission,
@@ -359,6 +360,18 @@ export function attachRoomToSession(
             state.buffer.push(text);
             void streamLive(false);
             scheduleFlush();
+            return;
+          }
+
+          // Everything this path does not forward is recorded once, so the next
+          // capability a harness gains does not vanish here the way `tool_call`
+          // did for the whole life of the bridge. See `activity.ts`.
+          const kind = isRecord(event.payload) ? event.payload.sessionUpdate : undefined;
+          if (typeof kind === "string" && noteUnmappedKind(kind)) {
+            log.info("a session update kind reaches Matrix and is not forwarded", {
+              sessionId,
+              kind,
+            });
           }
           return;
         }

--- a/apps/hub/src/services/matrix-as/outbound.ts
+++ b/apps/hub/src/services/matrix-as/outbound.ts
@@ -21,7 +21,15 @@ import {
   TOOL_UPDATE_TYPE,
   toolUpdateContent,
 } from "./live";
-import { foldToolUpdate, noteUnmappedKind, type ToolRecord } from "./activity";
+import {
+  foldToolUpdate,
+  noteUnmappedKind,
+  PERMISSION_REQUEST_TYPE,
+  permissionRequestContent,
+  TURN_ACTIVITY_TYPE,
+  turnActivityContent,
+  type ToolRecord,
+} from "./activity";
 import {
   clearPendingPermission,
   notePendingPermission,
@@ -54,6 +62,17 @@ export interface OutboundDeps {
       eventType: string,
       content: Record<string, unknown>
     ): Promise<void>;
+    /**
+     * Send one of the suite's own event types into the room. Optional for the
+     * same reason `sendToDevice` is: a deployment without it records no
+     * activity card, and the conversation is identical either way.
+     */
+    sendCustomEvent?(
+      userId: string,
+      roomId: string,
+      eventType: string,
+      content: Record<string, unknown>
+    ): Promise<string | null>;
   };
   /**
    * Who to stream this room's turns to — the reader's Matrix id, or null for a
@@ -293,13 +312,21 @@ export function attachRoomToSession(
     state.liveSentChars = 0;
     state.liveSentAt = 0;
     // The reasoning and tool state belong to the turn that just ended. Without
-    // this the next turn reports the previous one's work as its own.
+    // clearing it, the next turn reports the previous one's work as its own.
     state.thoughtBuffer = [];
     state.thoughtSeq = 0;
     state.thoughtSentChars = 0;
     state.thoughtSentAt = 0;
+
+    // Handed over and replaced in the same step, before the `await` below.
+    // `flush` runs twice for an ordinary turn — once on the debounce, once when
+    // the state event ends it — and the second call must find nothing left to
+    // record. Clearing after the await instead would let the second flush start
+    // while the first was still sending, and the turn would be recorded twice.
+    const tools = state.tools;
     state.tools = new Map();
     state.toolSeq = 0;
+    if (tools.size > 0) await recordTurn(tools);
     if (text.trim() === "") return;
     await say(text);
   };
@@ -342,6 +369,27 @@ export function attachRoomToSession(
         error: err instanceof Error ? err.message : String(err),
       });
     });
+  };
+
+  /**
+   * Write what the agent did during the turn into the room, once.
+   *
+   * Before the answer, so the room reads in the order things happened: did
+   * these things, then said this. Best-effort like every other outbound call
+   * here — a card that fails to send must not cost the answer behind it.
+   */
+  const recordTurn = async (tools: Map<string, ToolRecord>) => {
+    const send = deps.client.sendCustomEvent;
+    if (!send) return;
+    await send(agentUser, roomId, TURN_ACTIVITY_TYPE, turnActivityContent(sessionId, tools)).catch(
+      (err) => {
+        log.error("could not record a turn's activity in its room", {
+          sessionId,
+          roomId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    );
   };
 
   /**
@@ -582,6 +630,29 @@ export function attachRoomToSession(
           }
 
           await say(permissionPrompt(request.title, request.options));
+
+          // Beside the prose, never instead of it. The prose is what keeps
+          // Element and reply-by-number working; this only lets a client that
+          // understands it render buttons. Both answers come back as an
+          // ordinary message through the same matcher, so nothing downstream
+          // has to know which one a reader used.
+          const structured = permissionRequestContent(
+            sessionId,
+            event.seq,
+            request.title,
+            request.options
+          );
+          if (structured && deps.client.sendCustomEvent) {
+            await deps.client
+              .sendCustomEvent(agentUser, roomId, PERMISSION_REQUEST_TYPE, structured)
+              .catch((err) => {
+                log.error("could not send a structured permission request", {
+                  sessionId,
+                  roomId,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              });
+          }
           return;
         }
 

--- a/docs/superpowers/plans/2026-08-17-agent-activity-in-the-room.md
+++ b/docs/superpowers/plans/2026-08-17-agent-activity-in-the-room.md
@@ -1,0 +1,1422 @@
+# Agent activity in the room — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an agent's thinking, tool use and permission requests visible in a Matrix room without making the room noisier.
+
+**Architecture:** Extends the split `matrix-as/live.ts` already argues for — live activity goes to-device and is never stored, the durable record is one event per turn. Four independently shippable pieces, in dependency order: a diagnostic for what the hub drops, live thought/tool streaming, a per-turn durable record, and structured approvals.
+
+**Tech Stack:** Bun + TypeScript (hub), zod (contract), Rust + ruma/matrix-sdk (supermessage core), Svelte 5 runes (supermessage UI).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-agent-activity-in-the-room-design.md`
+
+## Global Constraints
+
+- **Contract first.** `packages/contract` is the shared vocabulary; a frame or API shape changes there before anywhere else.
+- **TDD, always.** Failing test first, including a regression test for every bug fix.
+- **Hub tests need an explicit DATABASE_URL and a pgvector Postgres on :5434.** The tasks here are unit tests that do not touch the DB, but `bun test` runs the whole file set in one process: `cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test`.
+- **`bun run typecheck` is KNOWN RED** in the hub (`typecheck-known-red.txt`). Do not "fix" unrelated errors in passing. Do not add new ones — `tests/unit/typecheck-baseline.test.ts` holds the line.
+- **Rust: `cargo fmt` runs LAST**, after any clippy-driven edit. Running it earlier and then editing is how PR #15 went red on main.
+- **Never `{@html}` a payload.** `customPayload` is arbitrary JSON from anyone who can send to the room. Renderers read named fields one level at a time with `safeStringField` and return text only.
+- **Event type strings are frozen once shipped.** Major version is baked into the type (`dev.agentpod.turn.v1`); additive fields bump `content.schema_version`, which is **snake_case** because that is what `readSchemaVersion` reads.
+- **Branch:** `feat/agent-activity-in-the-room` off `main`. Trunk-based, PR per piece is acceptable and preferred over one large PR.
+
+---
+
+## File Structure
+
+**Created**
+- `packages/contract/src/matrix-events.ts` — zod schemas + inferred types for all four payloads and the shared `ToolStatus` vocabulary.
+- `packages/contract/src/matrix-events.test.ts` — round-trip and rejection tests.
+- `apps/hub/src/services/matrix-as/activity.ts` — the pure part: tool-record accumulation, the turn-event builder, the unmapped-kind set. No I/O, so it is testable without a homeserver.
+- `apps/hub/src/services/matrix-as/activity.test.ts`
+
+**Modified**
+- `packages/contract/src/index.ts` — re-export the new module.
+- `apps/hub/src/services/matrix-as/live.ts` — two new to-device type constants and their content builders.
+- `apps/hub/src/services/matrix-as/live.test.ts` — cover them.
+- `apps/hub/src/services/matrix-as/client.ts` — one new method, `sendCustomEvent`.
+- `apps/hub/src/services/matrix-as/outbound.ts` — the switch, the per-turn state, the emit points.
+- `apps/hub/src/services/matrix-as/outbound.test.ts` — the behaviour tests.
+- `supermessage/src-tauri/src/core/live.rs` — two more to-device handlers.
+- `supermessage/src/lib/ipc.ts` — two more channel subscriptions.
+- `supermessage/src/lib/stores/live.svelte.ts` — thought text alongside answer text.
+- `supermessage/src/lib/components/customEvents.ts` — two renderers + one entry in `DECISION_BEARING_EVENT_TYPES`.
+- `supermessage/src/lib/components/Timeline.svelte` — `onDecide` sends instead of warning.
+
+**Deliberately untouched**
+- `apps/hub/src/services/matrix-as/permissions.ts` — `matchPermissionAnswer` already accepts the option's name. Using it is the whole reason approvals cost no new plumbing.
+- `supermessage/src-tauri/src/core/timeline.rs` — `timeline_event_filter` already whitelists `AnyMessageLikeEventContent::_Custom(_)` generically, so a new event type needs no Rust change to reach the timeline.
+
+---
+
+## Task 1: The diagnostic — record what the hub drops
+
+Ship first. It makes every later task observable, and it is the reason the next capability a harness gains will not vanish the way tool calls did.
+
+**Files:**
+- Create: `apps/hub/src/services/matrix-as/activity.ts`
+- Create: `apps/hub/src/services/matrix-as/activity.test.ts`
+- Modify: `apps/hub/src/services/matrix-as/outbound.ts`
+
+**Interfaces:**
+- Produces: `noteUnmappedKind(kind: string): boolean`, `unmappedKinds(): string[]`, `_resetUnmappedForTest(): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/hub/src/services/matrix-as/activity.test.ts`:
+
+```ts
+// What the Matrix path does with an ACP update kind it does not handle.
+//
+// It used to do nothing at all — no default case, no log — which is how
+// `tool_call` was discarded for the entire life of the bridge without a single
+// line anywhere saying so. The kaambaan coalescer keeps `unmapped()`/`losses()`
+// for exactly this reason (`bridge/coalesce.ts:104-111`); this is the same idea
+// on the path that lacked it.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { _resetUnmappedForTest, noteUnmappedKind, unmappedKinds } from "./activity";
+
+describe("unmapped session update kinds", () => {
+  beforeEach(() => {
+    _resetUnmappedForTest();
+  });
+
+  it("has nothing to report before anything unknown arrives", () => {
+    expect(unmappedKinds()).toEqual([]);
+  });
+
+  it("reports a kind it has never seen, so the caller can log it once", () => {
+    expect(noteUnmappedKind("plan")).toBe(true);
+    expect(unmappedKinds()).toEqual(["plan"]);
+  });
+
+  it("does not report the same kind twice, so a busy session logs once", () => {
+    expect(noteUnmappedKind("plan")).toBe(true);
+    expect(noteUnmappedKind("plan")).toBe(false);
+    expect(noteUnmappedKind("plan")).toBe(false);
+    expect(unmappedKinds()).toEqual(["plan"]);
+  });
+
+  it("keeps kinds sorted, so two runs of the same fleet read the same", () => {
+    noteUnmappedKind("usage_update");
+    noteUnmappedKind("current_mode_update");
+    noteUnmappedKind("plan");
+    expect(unmappedKinds()).toEqual(["current_mode_update", "plan", "usage_update"]);
+  });
+
+  it("ignores a kind that is not a string, rather than recording garbage", () => {
+    // `payload.sessionUpdate` is `unknown` — it comes off a `z.unknown()`
+    // payload and nothing validates it upstream.
+    expect(noteUnmappedKind(undefined as unknown as string)).toBe(false);
+    expect(noteUnmappedKind(42 as unknown as string)).toBe(false);
+    expect(unmappedKinds()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/matrix-as/activity.test.ts
+```
+
+Expected: FAIL — `Cannot find module './activity'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/hub/src/services/matrix-as/activity.ts`:
+
+```ts
+/**
+ * What the Matrix path does with the parts of an ACP turn it does not forward.
+ *
+ * `outbound.ts` used to answer "is this an `agent_message_chunk`?" and return
+ * `undefined` for everything else — no default case, no logging, no record.
+ * That is how `tool_call` came to be discarded for the whole life of the bridge
+ * with nothing anywhere saying so. The kaambaan coalescer already keeps
+ * `unmapped()`/`losses()` and lists its dropped kinds explicitly "so a NEW kind
+ * shows up in `unmapped()` instead of joining this set by accident"
+ * (`bridge/coalesce.ts:53-62`). This is that discipline, on the path that
+ * lacked it.
+ */
+
+/**
+ * Kinds seen and not handled, for the life of the process.
+ *
+ * Module-level rather than per-attachment: the question is "does this fleet's
+ * harness emit something we ignore", which is not a property of one room. A
+ * `Set` also makes the log once-per-kind rather than once-per-event — a busy
+ * session emits hundreds of the same update, and a line per event would bury
+ * the signal it exists to raise.
+ */
+const unmapped = new Set<string>();
+
+/**
+ * Records `kind` as unhandled. Returns whether it was **new** — the caller logs
+ * only when it was, so a kind that arrives four hundred times says so once.
+ */
+export function noteUnmappedKind(kind: string): boolean {
+  if (typeof kind !== "string" || kind === "") return false;
+  if (unmapped.has(kind)) return false;
+  unmapped.add(kind);
+  return true;
+}
+
+/** Every unhandled kind seen so far, sorted so two runs read the same. */
+export function unmappedKinds(): string[] {
+  return [...unmapped].sort();
+}
+
+/** Test seam: the set outlives any one test by design. */
+export function _resetUnmappedForTest(): void {
+  unmapped.clear();
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/matrix-as/activity.test.ts
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Wire it into the `agent-update` case**
+
+In `apps/hub/src/services/matrix-as/outbound.ts`, add to the imports:
+
+```ts
+import { noteUnmappedKind } from "./activity";
+```
+
+Replace the `agent-update` case body (currently lines 356-364) with:
+
+```ts
+        case "agent-update": {
+          const text = messageChunkText(event.payload);
+          if (text !== undefined) {
+            state.buffer.push(text);
+            void streamLive(false);
+            scheduleFlush();
+            return;
+          }
+          // Anything this path does not forward is recorded once, so the next
+          // capability a harness gains does not vanish here the way tool calls
+          // did. See `activity.ts`.
+          const kind = isRecord(event.payload) ? event.payload.sessionUpdate : undefined;
+          if (typeof kind === "string" && noteUnmappedKind(kind)) {
+            log.info("a session update kind reaches Matrix and is not forwarded", {
+              sessionId,
+              kind,
+            });
+          }
+          return;
+        }
+```
+
+- [ ] **Step 6: Run the hub suite**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+```
+
+Expected: PASS, no new failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/hub/src/services/matrix-as/activity.ts apps/hub/src/services/matrix-as/activity.test.ts apps/hub/src/services/matrix-as/outbound.ts
+git commit -m "fix: say so when the Matrix path drops a session update kind"
+```
+
+---
+
+## Task 2: Contract — the shared vocabulary
+
+**Files:**
+- Create: `packages/contract/src/matrix-events.ts`
+- Create: `packages/contract/src/matrix-events.test.ts`
+- Modify: `packages/contract/src/index.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ToolStatus`, `LiveThoughtDelta`, `LiveToolUpdate`, `TurnActivity`, `TurnActivityTool`, `PermissionRequestEvent` — each a zod schema with an inferred type of the same name.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/contract/src/matrix-events.test.ts`:
+
+```ts
+// The wire shapes the hub sends and supermessage reads.
+//
+// Snake_case throughout, like every other Matrix event — see `live.ts`'s
+// `deltaContent`. `schema_version` in particular is snake_case because that is
+// the field supermessage's `readSchemaVersion` looks for; camelCasing it means
+// every payload silently reads as "assume the baseline version".
+
+import { describe, expect, it } from "bun:test";
+import {
+  LiveThoughtDelta,
+  LiveToolUpdate,
+  PermissionRequestEvent,
+  ToolStatus,
+  TurnActivity,
+} from "./matrix-events";
+
+describe("ToolStatus", () => {
+  it("is exactly ACP's vocabulary, so the console and the room cannot drift", () => {
+    expect(ToolStatus.options).toEqual(["pending", "in_progress", "completed", "failed"]);
+  });
+
+  it("rejects a status nobody defined", () => {
+    expect(ToolStatus.safeParse("cancelled").success).toBe(false);
+  });
+});
+
+describe("LiveThoughtDelta", () => {
+  it("accepts a delta", () => {
+    const parsed = LiveThoughtDelta.parse({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 3,
+      text: "Considering the node's uptime.",
+      done: false,
+    });
+    expect(parsed.seq).toBe(3);
+  });
+
+  it("requires done, because a receiver keys the end of a turn off it", () => {
+    expect(
+      LiveThoughtDelta.safeParse({
+        room_id: "!r:example.org",
+        session_id: "sess_1",
+        seq: 3,
+        text: "x",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("LiveToolUpdate", () => {
+  it("accepts an update", () => {
+    const parsed = LiveToolUpdate.parse({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 4,
+      tool_call_id: "call_1",
+      title: "Read src/main.ts",
+      kind: "read",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+    });
+    expect(parsed.tool_call_id).toBe("call_1");
+  });
+
+  it("tolerates a missing kind, which ACP does not always send", () => {
+    const parsed = LiveToolUpdate.parse({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 4,
+      tool_call_id: "call_1",
+      title: "Something",
+      status: "pending",
+      locations: [],
+    });
+    expect(parsed.kind).toBeUndefined();
+  });
+
+  it("requires the tool call id, since it is the identity updates merge onto", () => {
+    expect(
+      LiveToolUpdate.safeParse({
+        room_id: "!r:example.org",
+        session_id: "sess_1",
+        seq: 4,
+        title: "Something",
+        status: "pending",
+        locations: [],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("TurnActivity", () => {
+  it("accepts a turn's record", () => {
+    const parsed = TurnActivity.parse({
+      schema_version: 1,
+      session_id: "sess_1",
+      tools: [
+        {
+          id: "call_1",
+          title: "Read src/main.ts",
+          kind: "read",
+          status: "completed",
+          locations: ["src/main.ts"],
+        },
+      ],
+      counts: { total: 1, failed: 0, omitted: 0 },
+    });
+    expect(parsed.counts.total).toBe(1);
+  });
+
+  it("carries schema_version in snake_case, which is what the client reads", () => {
+    expect(
+      TurnActivity.safeParse({
+        schemaVersion: 1,
+        session_id: "sess_1",
+        tools: [],
+        counts: { total: 0, failed: 0, omitted: 0 },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("PermissionRequestEvent", () => {
+  it("accepts a request", () => {
+    const parsed = PermissionRequestEvent.parse({
+      schema_version: 1,
+      session_id: "sess_1",
+      request_seq: 41,
+      title: "Write src/main.ts",
+      options: [
+        { option_id: "allow_once", name: "Allow once" },
+        { option_id: "reject", name: "Reject" },
+      ],
+    });
+    expect(parsed.options).toHaveLength(2);
+  });
+
+  it("refuses more than four options, the cap the card can actually render", () => {
+    // `DECISION_MAX_OPTIONS` in supermessage's `customEvents.ts` silently drops
+    // the fifth. Refusing here means the hub never sends one it knows will be
+    // discarded — the cap is enforced where it can still be reported.
+    expect(
+      PermissionRequestEvent.safeParse({
+        schema_version: 1,
+        session_id: "sess_1",
+        request_seq: 41,
+        title: "x",
+        options: [
+          { option_id: "a", name: "A" },
+          { option_id: "b", name: "B" },
+          { option_id: "c", name: "C" },
+          { option_id: "d", name: "D" },
+          { option_id: "e", name: "E" },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+```bash
+cd packages/contract && bun test src/matrix-events.test.ts
+```
+
+Expected: FAIL — `Cannot find module './matrix-events'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/contract/src/matrix-events.ts`:
+
+```ts
+import { z } from "zod";
+
+// ─── Matrix event payloads the hub sends ─────────────────────────────────────
+//
+// Snake_case throughout, like every other Matrix event body and like
+// `matrix-as/live.ts`'s existing `deltaContent`. `schema_version` in particular
+// is snake_case because that is the field supermessage's `readSchemaVersion`
+// looks for; camelCasing it makes every payload read as "assume the baseline
+// version" with no error anywhere.
+
+/** ACP's tool lifecycle, verbatim. Matches the console's `TOOL_STATUSES`. */
+export const ToolStatus = z.enum(["pending", "in_progress", "completed", "failed"]);
+export type ToolStatus = z.infer<typeof ToolStatus>;
+
+/**
+ * A turn's reasoning, streamed to the reader's own devices.
+ *
+ * Deliberately the same shape as the existing `dev.agentpod.stream.delta`: the
+ * client's seq-ordering and its reveal pacer already handle "cumulative text
+ * with a monotonic seq, at-least-once and unordered", so reusing the shape
+ * costs one registration rather than a second implementation. `text` is
+ * EVERYTHING so far, never the increment — see `live.ts`.
+ */
+export const LiveThoughtDelta = z.object({
+  room_id: z.string(),
+  session_id: z.string(),
+  seq: z.number().int().nonnegative(),
+  text: z.string(),
+  done: z.boolean(),
+});
+export type LiveThoughtDelta = z.infer<typeof LiveThoughtDelta>;
+
+/**
+ * One tool call's state, streamed as it changes.
+ *
+ * `tool_call` and `tool_call_update` both produce this; the receiver upserts by
+ * `tool_call_id`. Tool *output* is deliberately absent — it is unbounded, and
+ * this is a live ticker rather than a viewer.
+ */
+export const LiveToolUpdate = z.object({
+  room_id: z.string(),
+  session_id: z.string(),
+  seq: z.number().int().nonnegative(),
+  tool_call_id: z.string(),
+  title: z.string(),
+  /** ACP's tool kind, passed through unvalidated. Treat as opaque display text. */
+  kind: z.string().optional(),
+  status: ToolStatus,
+  locations: z.array(z.string()),
+});
+export type LiveToolUpdate = z.infer<typeof LiveToolUpdate>;
+
+/** One tool call as it appears in the durable per-turn record. */
+export const TurnActivityTool = z.object({
+  id: z.string(),
+  title: z.string(),
+  kind: z.string().optional(),
+  status: ToolStatus,
+  locations: z.array(z.string()),
+});
+export type TurnActivityTool = z.infer<typeof TurnActivityTool>;
+
+/**
+ * What an agent did during one turn — the durable record, sent into the room
+ * once, before the answer.
+ *
+ * `tools` is capped by the sender; `counts` still reports the truth about the
+ * whole turn, so a capped list never reads as a complete one.
+ */
+export const TurnActivity = z.object({
+  schema_version: z.literal(1),
+  session_id: z.string(),
+  tools: z.array(TurnActivityTool),
+  counts: z.object({
+    total: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    omitted: z.number().int().nonnegative(),
+  }),
+});
+export type TurnActivity = z.infer<typeof TurnActivity>;
+
+/**
+ * A permission request, structured so a client can render buttons.
+ *
+ * Sent **beside** the existing prose message, which is unchanged and remains
+ * the interop path for any other Matrix client. The answer travels back as an
+ * ordinary message carrying the option's `name`, which
+ * `matrix-as/permissions.ts`'s `matchPermissionAnswer` already accepts.
+ *
+ * Four options maximum, because supermessage's `DECISION_MAX_OPTIONS` renders
+ * four and silently drops the rest. Enforcing it here means the hub never sends
+ * something it knows will be discarded.
+ */
+export const PermissionRequestEvent = z.object({
+  schema_version: z.literal(1),
+  session_id: z.string(),
+  /** The request's own ACP sequence number — how `answerPermission` addresses it. */
+  request_seq: z.number().int().nonnegative(),
+  title: z.string(),
+  options: z
+    .array(z.object({ option_id: z.string(), name: z.string() }))
+    .min(1)
+    .max(4),
+});
+export type PermissionRequestEvent = z.infer<typeof PermissionRequestEvent>;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd packages/contract && bun test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Re-export from the package index**
+
+Append to `packages/contract/src/index.ts`, following the existing export style in that file:
+
+```ts
+export * from "./matrix-events";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contract/src/matrix-events.ts packages/contract/src/matrix-events.test.ts packages/contract/src/index.ts
+git commit -m "feat(contract): the wire shapes for an agent's activity in a room"
+```
+
+---
+
+## Task 3: Live thought and tool streaming (hub side)
+
+**Files:**
+- Modify: `apps/hub/src/services/matrix-as/live.ts`
+- Modify: `apps/hub/src/services/matrix-as/live.test.ts`
+- Modify: `apps/hub/src/services/matrix-as/outbound.ts`
+- Modify: `apps/hub/src/services/matrix-as/outbound.test.ts`
+
+**Interfaces:**
+- Consumes: `ToolStatus` (Task 2); `shouldSendDelta`, `LIVE_DELTA_TYPE`, `deltaContent` (existing in `live.ts`).
+- Produces: `THOUGHT_DELTA_TYPE`, `TOOL_UPDATE_TYPE`, `toolUpdateContent(...)`.
+
+- [ ] **Step 1: Write the failing test for the content builders**
+
+Append to `apps/hub/src/services/matrix-as/live.test.ts`:
+
+```ts
+describe("activity to-device types", () => {
+  it("names the thought channel distinctly from the answer channel", () => {
+    // Same shape, different type: a reader must be able to tell an agent's
+    // reasoning from its answer, and the shape is reused precisely so the
+    // client needs no second implementation to do it.
+    expect(THOUGHT_DELTA_TYPE).toBe("dev.agentpod.thought.delta");
+    expect(THOUGHT_DELTA_TYPE).not.toBe(LIVE_DELTA_TYPE);
+  });
+
+  it("builds a tool update body in snake_case, like every other Matrix event", () => {
+    expect(
+      toolUpdateContent({
+        roomId: "!r:example.org",
+        sessionId: "sess_1",
+        seq: 2,
+        toolCallId: "call_1",
+        title: "Read src/main.ts",
+        kind: "read",
+        status: "in_progress",
+        locations: ["src/main.ts"],
+      }),
+    ).toEqual({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 2,
+      tool_call_id: "call_1",
+      title: "Read src/main.ts",
+      kind: "read",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+    });
+  });
+
+  it("omits a kind ACP did not give, rather than sending an empty string", () => {
+    const body = toolUpdateContent({
+      roomId: "!r:example.org",
+      sessionId: "sess_1",
+      seq: 2,
+      toolCallId: "call_1",
+      title: "Something",
+      kind: undefined,
+      status: "pending",
+      locations: [],
+    });
+    expect("kind" in body).toBe(false);
+  });
+});
+```
+
+Add `THOUGHT_DELTA_TYPE`, `TOOL_UPDATE_TYPE` and `toolUpdateContent` to that file's existing import from `./live`.
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/matrix-as/live.test.ts
+```
+
+Expected: FAIL — the imports do not exist.
+
+- [ ] **Step 3: Add them to `live.ts`**
+
+Append to `apps/hub/src/services/matrix-as/live.ts`:
+
+```ts
+/**
+ * The to-device event type carrying a turn's reasoning.
+ *
+ * A separate type from `LIVE_DELTA_TYPE` carrying an identical body: the
+ * *shape* is reused so the client's seq-ordering and reveal pacing work
+ * unchanged, but the *type* must differ or a reader cannot tell an agent's
+ * thinking from its answer. Reasoning is never written to the room — see
+ * `outbound.ts`, where that decision has been recorded since before this
+ * channel existed.
+ */
+export const THOUGHT_DELTA_TYPE = "dev.agentpod.thought.delta";
+
+/** The to-device event type carrying one tool call's state. */
+export const TOOL_UPDATE_TYPE = "dev.agentpod.tool.update";
+
+/** One tool call's state, as it goes on the wire. */
+export interface ToolUpdate {
+  roomId: string;
+  sessionId: string;
+  /** Monotonic per turn, sharing the turn's activity sequence. */
+  seq: number;
+  /** The identity later updates merge onto. */
+  toolCallId: string;
+  title: string;
+  /** ACP's tool kind. Absent when the harness did not say. */
+  kind: string | undefined;
+  status: "pending" | "in_progress" | "completed" | "failed";
+  locations: string[];
+}
+
+/** The wire body for a tool update. Snake case, like every other Matrix event. */
+export function toolUpdateContent(update: ToolUpdate): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    room_id: update.roomId,
+    session_id: update.sessionId,
+    seq: update.seq,
+    tool_call_id: update.toolCallId,
+    title: update.title,
+    status: update.status,
+    locations: update.locations,
+  };
+  // Omitted rather than sent empty: absent means "the harness did not say",
+  // and `""` would render as a kind called nothing.
+  if (update.kind !== undefined) body.kind = update.kind;
+  return body;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/matrix-as/live.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing behaviour test**
+
+Append to `apps/hub/src/services/matrix-as/outbound.test.ts`, following that file's existing fake-client and `attachRoomToSession` setup:
+
+```ts
+describe("an agent's thinking", () => {
+  it("reaches the reader's devices and never the room", async () => {
+    // The decision this test defends is older than this test: reasoning
+    // "belongs in the console's transcript, not in a room people share, where
+    // it would turn one answer into a monologue". 202 thought chunks in one
+    // observed Hermes turn is the number behind that sentence.
+    const { client, emit, toDevice, sent } = attachFixture();
+
+    emit({
+      type: "agent-update",
+      seq: 1,
+      payload: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "Weighing the options carefully. " },
+      },
+    });
+    await flushMicrotasks();
+
+    expect(toDevice.filter((d) => d.eventType === THOUGHT_DELTA_TYPE)).toHaveLength(1);
+    expect(sent).toHaveLength(0);
+    void client;
+  });
+
+  it("keeps its own sequence, so it cannot be mistaken for the answer", async () => {
+    const { emit, toDevice } = attachFixture();
+
+    emit({
+      type: "agent-update",
+      seq: 1,
+      payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Answer. " } },
+    });
+    emit({
+      type: "agent-update",
+      seq: 2,
+      payload: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "Thought. " } },
+    });
+    await flushMicrotasks();
+
+    const answer = toDevice.find((d) => d.eventType === LIVE_DELTA_TYPE);
+    const thought = toDevice.find((d) => d.eventType === THOUGHT_DELTA_TYPE);
+    expect(answer?.content.seq).toBe(1);
+    expect(thought?.content.seq).toBe(1);
+    expect(answer?.content.text).toBe("Answer. ");
+    expect(thought?.content.text).toBe("Thought. ");
+  });
+});
+
+describe("tool calls", () => {
+  it("streams a tool call to the reader's devices", async () => {
+    const { emit, toDevice, sent } = attachFixture();
+
+    emit({
+      type: "agent-update",
+      seq: 1,
+      payload: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call_1",
+        title: "Read src/main.ts",
+        kind: "read",
+        status: "in_progress",
+        locations: [{ path: "src/main.ts" }],
+      },
+    });
+    await flushMicrotasks();
+
+    const update = toDevice.find((d) => d.eventType === TOOL_UPDATE_TYPE);
+    expect(update?.content).toMatchObject({
+      tool_call_id: "call_1",
+      title: "Read src/main.ts",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+    });
+    expect(sent).toHaveLength(0);
+  });
+
+  it("merges an update onto its call rather than starting a second one", async () => {
+    const { emit, toDevice } = attachFixture();
+
+    emit({
+      type: "agent-update",
+      seq: 1,
+      payload: { sessionUpdate: "tool_call", toolCallId: "call_1", title: "Run tests", status: "pending" },
+    });
+    emit({
+      type: "agent-update",
+      seq: 2,
+      payload: { sessionUpdate: "tool_call_update", toolCallId: "call_1", status: "failed" },
+    });
+    await flushMicrotasks();
+
+    const updates = toDevice.filter((d) => d.eventType === TOOL_UPDATE_TYPE);
+    expect(updates).toHaveLength(2);
+    // The title survives an update that did not carry one.
+    expect(updates[1]?.content).toMatchObject({
+      tool_call_id: "call_1",
+      title: "Run tests",
+      status: "failed",
+    });
+  });
+
+  it("ignores a tool call with no id, which nothing could merge onto", async () => {
+    const { emit, toDevice } = attachFixture();
+
+    emit({
+      type: "agent-update",
+      seq: 1,
+      payload: { sessionUpdate: "tool_call", title: "Nameless", status: "pending" },
+    });
+    await flushMicrotasks();
+
+    expect(toDevice.filter((d) => d.eventType === TOOL_UPDATE_TYPE)).toHaveLength(0);
+  });
+});
+```
+
+If `attachFixture` and `flushMicrotasks` do not already exist in that file, add them next to the existing setup, capturing `sendToDevice` calls into a `toDevice` array of `{ eventType, content }` and `sendText` calls into `sent`.
+
+- [ ] **Step 6: Run it to make sure it fails**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test src/services/matrix-as/outbound.test.ts
+```
+
+Expected: FAIL — no thought or tool events are sent.
+
+- [ ] **Step 7: Implement in `outbound.ts`**
+
+Add to the imports:
+
+```ts
+import {
+  deltaContent,
+  LIVE_DELTA_TYPE,
+  shouldSendDelta,
+  THOUGHT_DELTA_TYPE,
+  TOOL_UPDATE_TYPE,
+  toolUpdateContent,
+} from "./live";
+import { noteUnmappedKind, type ToolRecord } from "./activity";
+```
+
+Add to `interface Attachment`:
+
+```ts
+  /** The reasoning stream's own buffer and cursor — see `THOUGHT_DELTA_TYPE`. */
+  thoughtBuffer: string[];
+  thoughtSeq: number;
+  thoughtSentChars: number;
+  thoughtSentAt: number;
+  /**
+   * This turn's tool calls, in the order they first appeared, keyed by
+   * `toolCallId` so an update merges rather than appending. Cleared with the
+   * rest of the per-turn state in `flush`.
+   */
+  tools: Map<string, ToolRecord>;
+  /** Monotonic per turn, shared by every tool update. */
+  toolSeq: number;
+```
+
+Initialise them in the `state` literal:
+
+```ts
+    thoughtBuffer: [],
+    thoughtSeq: 0,
+    thoughtSentChars: 0,
+    thoughtSentAt: 0,
+    tools: new Map(),
+    toolSeq: 0,
+```
+
+Add a chunk reader beside `messageChunkText`:
+
+```ts
+/** The text of a chunk of the given kind, or undefined for anything else. */
+function chunkTextOfKind(payload: unknown, kind: string): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  if (payload.sessionUpdate !== kind) return undefined;
+  const content = payload.content;
+  if (!isRecord(content) || content.type !== "text") return undefined;
+  return typeof content.text === "string" ? content.text : undefined;
+}
+```
+
+Add the streaming function beside `streamLive`:
+
+```ts
+  /**
+   * Push the agent's reasoning so far to the reader's devices.
+   *
+   * The same policy and the same best-effort posture as `streamLive`, against
+   * its own buffer and cursor. Reasoning never touches the room, so unlike the
+   * answer there is no durable copy behind this — a dropped delta is simply
+   * reasoning the reader did not see, which costs nothing.
+   */
+  const streamThought = async (done: boolean) => {
+    const send = deps.client.sendToDevice;
+    if (!send) return;
+    if (state.reader === undefined) {
+      state.reader = deps.readerFor ? await deps.readerFor(roomId).catch(() => null) : null;
+    }
+    if (!state.reader) return;
+
+    const text = state.thoughtBuffer.join("");
+    const pending = text.slice(state.thoughtSentChars);
+    if (!done && !shouldSendDelta(pending, Date.now() - state.thoughtSentAt)) return;
+    if (done && pending.length === 0 && state.thoughtSeq === 0) return;
+
+    state.thoughtSeq += 1;
+    state.thoughtSentChars = text.length;
+    state.thoughtSentAt = Date.now();
+
+    await send(
+      agentUser,
+      state.reader,
+      THOUGHT_DELTA_TYPE,
+      deltaContent({ roomId, sessionId, seq: state.thoughtSeq, text, done })
+    ).catch(() => {});
+  };
+
+  /** Push one tool call's current state to the reader's devices. */
+  const streamTool = async (record: ToolRecord) => {
+    const send = deps.client.sendToDevice;
+    if (!send) return;
+    if (state.reader === undefined) {
+      state.reader = deps.readerFor ? await deps.readerFor(roomId).catch(() => null) : null;
+    }
+    if (!state.reader) return;
+
+    state.toolSeq += 1;
+    await send(
+      agentUser,
+      state.reader,
+      TOOL_UPDATE_TYPE,
+      toolUpdateContent({
+        roomId,
+        sessionId,
+        seq: state.toolSeq,
+        toolCallId: record.id,
+        title: record.title,
+        kind: record.kind,
+        status: record.status,
+        locations: record.locations,
+      })
+    ).catch(() => {});
+  };
+```
+
+Extend the `agent-update` case (built on Task 1's version):
+
+```ts
+        case "agent-update": {
+          const text = messageChunkText(event.payload);
+          if (text !== undefined) {
+            state.buffer.push(text);
+            void streamLive(false);
+            scheduleFlush();
+            return;
+          }
+
+          const thought = chunkTextOfKind(event.payload, "agent_thought_chunk");
+          if (thought !== undefined) {
+            state.thoughtBuffer.push(thought);
+            void streamThought(false);
+            return;
+          }
+
+          const record = foldToolUpdate(state.tools, event.payload);
+          if (record !== null) {
+            void streamTool(record);
+            return;
+          }
+
+          const kind = isRecord(event.payload) ? event.payload.sessionUpdate : undefined;
+          if (typeof kind === "string" && noteUnmappedKind(kind)) {
+            log.info("a session update kind reaches Matrix and is not forwarded", {
+              sessionId,
+              kind,
+            });
+          }
+          return;
+        }
+```
+
+Clear the new per-turn state inside `flush`, next to the existing reset:
+
+```ts
+    state.thoughtBuffer = [];
+    state.thoughtSeq = 0;
+    state.thoughtSentChars = 0;
+    state.thoughtSentAt = 0;
+    state.tools = new Map();
+    state.toolSeq = 0;
+```
+
+- [ ] **Step 8: Add `foldToolUpdate` and `ToolRecord` to `activity.ts`**
+
+```ts
+import type { ToolStatus } from "@agentpod/contract";
+
+/** One tool call, accumulated across its `tool_call` and every update to it. */
+export interface ToolRecord {
+  id: string;
+  title: string;
+  kind: string | undefined;
+  status: ToolStatus;
+  locations: string[];
+}
+
+const TOOL_STATUSES: readonly string[] = ["pending", "in_progress", "completed", "failed"];
+
+function toolStatus(value: unknown): ToolStatus | undefined {
+  return typeof value === "string" && TOOL_STATUSES.includes(value)
+    ? (value as ToolStatus)
+    : undefined;
+}
+
+function locationPaths(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const entry of value) {
+    if (entry !== null && typeof entry === "object") {
+      const path = (entry as Record<string, unknown>).path;
+      if (typeof path === "string") out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * Folds a `tool_call` or `tool_call_update` into `tools`, returning the record
+ * as it now stands — or `null` when the payload is neither.
+ *
+ * **Upsert, never append.** A repeated `toolCallId` merges, for the reason the
+ * console records at `transcript.ts:299-305`: a buggy or hostile agent
+ * repeating an id must not produce two records with one identity. An update
+ * carrying only a status keeps the title it was given first, because a ticker
+ * that forgets what it is doing halfway through is worse than one that is a
+ * moment stale.
+ */
+export function foldToolUpdate(
+  tools: Map<string, ToolRecord>,
+  payload: unknown
+): ToolRecord | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  const kindOfUpdate = p.sessionUpdate;
+  if (kindOfUpdate !== "tool_call" && kindOfUpdate !== "tool_call_update") return null;
+
+  const id = typeof p.toolCallId === "string" ? p.toolCallId : undefined;
+  // Nothing can merge onto a call with no id, and inventing one would make two
+  // updates of the same call look like two calls.
+  if (id === undefined) return null;
+
+  const existing = tools.get(id);
+  const record: ToolRecord = {
+    id,
+    title: typeof p.title === "string" ? p.title : (existing?.title ?? id),
+    kind: typeof p.kind === "string" ? p.kind : existing?.kind,
+    status: toolStatus(p.status) ?? existing?.status ?? "pending",
+    locations: locationPaths(p.locations) ?? existing?.locations ?? [],
+  };
+  tools.set(id, record);
+  return record;
+}
+```
+
+Write its tests in `activity.test.ts` first, covering: a `tool_call` creates a record; a `tool_call_update` merges and keeps the title; a repeated `tool_call` id merges rather than duplicating; a missing id returns null; a non-tool payload returns null; insertion order is preserved across updates.
+
+- [ ] **Step 9: Run the tests**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/hub/src/services/matrix-as/ packages/contract/
+git commit -m "feat: stream an agent's thinking and tool use to the reader's devices"
+```
+
+---
+
+## Task 4: The durable per-turn record
+
+**Files:**
+- Modify: `apps/hub/src/services/matrix-as/activity.ts` (+ its test)
+- Modify: `apps/hub/src/services/matrix-as/client.ts`
+- Modify: `apps/hub/src/services/matrix-as/outbound.ts` (+ its test)
+
+**Interfaces:**
+- Consumes: `ToolRecord`, `TurnActivity` (Tasks 2–3).
+- Produces: `TURN_ACTIVITY_TYPE`, `turnActivityContent(sessionId, tools)`, `client.sendCustomEvent(userId, roomId, eventType, content)`.
+
+- [ ] **Step 1: Write the failing test for the builder**
+
+Append to `activity.test.ts`:
+
+```ts
+describe("the per-turn record", () => {
+  function record(id: string, status: ToolStatus = "completed"): ToolRecord {
+    return { id, title: `Do ${id}`, kind: "execute", status, locations: [] };
+  }
+
+  it("counts everything and lists what fits", () => {
+    const tools = new Map([["a", record("a")], ["b", record("b", "failed")]]);
+    const content = turnActivityContent("sess_1", tools);
+    expect(content.counts).toEqual({ total: 2, failed: 1, omitted: 0 });
+    expect(content.tools).toHaveLength(2);
+    expect(content.schema_version).toBe(1);
+  });
+
+  it("caps the list and says how many it left out", () => {
+    // A pathological turn must not produce an unbounded event; the counts still
+    // tell the truth about the whole turn, so a capped list never reads as a
+    // complete one.
+    const tools = new Map(
+      Array.from({ length: TURN_TOOLS_MAX + 5 }, (_, i) => [`t${i}`, record(`t${i}`)] as const),
+    );
+    const content = turnActivityContent("sess_1", tools);
+    expect(content.tools).toHaveLength(TURN_TOOLS_MAX);
+    expect(content.counts.total).toBe(TURN_TOOLS_MAX + 5);
+    expect(content.counts.omitted).toBe(5);
+  });
+
+  it("keeps the order the tools were first used in", () => {
+    const tools = new Map([["z", record("z")], ["a", record("a")]]);
+    expect(turnActivityContent("sess_1", tools).tools.map((t) => t.id)).toEqual(["z", "a"]);
+  });
+
+  it("produces a body the contract accepts", () => {
+    expect(TurnActivity.safeParse(turnActivityContent("sess_1", new Map([["a", record("a")]]))).success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails, then implement**
+
+Add to `activity.ts`:
+
+```ts
+/** The room event type carrying what an agent did during one turn. */
+export const TURN_ACTIVITY_TYPE = "dev.agentpod.turn.v1";
+
+/**
+ * How many tool calls the durable record lists.
+ *
+ * A cap, not a sample: `counts` reports the whole turn regardless, so a capped
+ * list is never mistaken for a complete one. Twenty is enough to read as a
+ * record of what happened and small enough that one turn cannot produce an
+ * event worth paginating around.
+ */
+export const TURN_TOOLS_MAX = 20;
+
+/** The wire body for a turn's record. */
+export function turnActivityContent(
+  sessionId: string,
+  tools: Map<string, ToolRecord>
+): TurnActivity {
+  const all = [...tools.values()];
+  return {
+    schema_version: 1,
+    session_id: sessionId,
+    tools: all.slice(0, TURN_TOOLS_MAX).map((t) => ({
+      id: t.id,
+      title: t.title,
+      ...(t.kind === undefined ? {} : { kind: t.kind }),
+      status: t.status,
+      locations: t.locations,
+    })),
+    counts: {
+      total: all.length,
+      failed: all.filter((t) => t.status === "failed").length,
+      omitted: Math.max(0, all.length - TURN_TOOLS_MAX),
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Add `sendCustomEvent` to `client.ts`**
+
+Beside `sendText`, mirroring its transaction-id discipline:
+
+```ts
+    async sendCustomEvent(userId, roomId, eventType, content) {
+      // A fresh transaction id per send, exactly as `sendText`: the homeserver
+      // deduplicates on it, so reusing one silently drops a genuinely new event.
+      const txn = `apb-${crypto.randomUUID()}`;
+      const res = await call(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/${encodeURIComponent(eventType)}/${txn}`,
+        { method: "PUT", userId, body: content }
+      );
+      assertOkOrAlready("sendCustomEvent", res);
+      return String(res.body.event_id ?? "") || null;
+    },
+```
+
+Declare it on the client's interface and add it to `OutboundDeps["client"]` as **optional**, for the same reason `sendToDevice` is optional: a deployment without it simply does not send activity cards, and the room is otherwise identical.
+
+- [ ] **Step 4: Write the failing behaviour test**
+
+Append to `outbound.test.ts`:
+
+```ts
+describe("the durable record of a turn", () => {
+  it("sends one activity event before the answer", async () => {
+    // Reading order is the point: did these things, then said this.
+    const { emit, sent, custom } = attachFixture();
+
+    emit({ type: "agent-update", seq: 1, payload: { sessionUpdate: "tool_call", toolCallId: "c1", title: "Read a", status: "completed" } });
+    emit({ type: "agent-update", seq: 2, payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Done." } } });
+    emit({ type: "state", seq: 3, payload: { status: "idle" } });
+    await flushMicrotasks();
+
+    expect(custom).toHaveLength(1);
+    expect(custom[0]?.eventType).toBe(TURN_ACTIVITY_TYPE);
+    expect(custom[0]?.order).toBeLessThan(sent[0]?.order ?? Infinity);
+  });
+
+  it("sends nothing extra for a turn that used no tools", async () => {
+    const { emit, sent, custom } = attachFixture();
+    emit({ type: "agent-update", seq: 1, payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Just talking." } } });
+    emit({ type: "state", seq: 2, payload: { status: "idle" } });
+    await flushMicrotasks();
+
+    expect(custom).toHaveLength(0);
+    expect(sent).toHaveLength(1);
+  });
+
+  it("does not report the previous turn's work on the next turn", async () => {
+    const { emit, custom } = attachFixture();
+    emit({ type: "agent-update", seq: 1, payload: { sessionUpdate: "tool_call", toolCallId: "c1", title: "Read a", status: "completed" } });
+    emit({ type: "state", seq: 2, payload: { status: "idle" } });
+    await flushMicrotasks();
+    emit({ type: "agent-update", seq: 3, payload: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Second turn." } } });
+    emit({ type: "state", seq: 4, payload: { status: "idle" } });
+    await flushMicrotasks();
+
+    expect(custom).toHaveLength(1);
+  });
+});
+```
+
+`attachFixture` needs a `custom` array capturing `sendCustomEvent` calls, and both it and `sent` need a monotonic `order` stamped on capture so the ordering assertion is real rather than incidental.
+
+- [ ] **Step 5: Implement the emit point**
+
+In `outbound.ts`'s `flush`, before `await say(text)` and before the per-turn state is cleared:
+
+```ts
+    // Before the answer, so the room reads in the order things happened: did
+    // these things, then said this. Best-effort like every other outbound call
+    // here — a failed card must not cost the answer behind it.
+    if (state.tools.size > 0 && deps.client.sendCustomEvent) {
+      await deps.client
+        .sendCustomEvent(agentUser, roomId, TURN_ACTIVITY_TYPE, turnActivityContent(sessionId, state.tools))
+        .catch((err) => {
+          log.error("could not record a turn's activity in its room", {
+            sessionId,
+            roomId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+    }
+```
+
+Note the existing `if (text.trim() === "") return;` guard sits *after* this, so a turn that used tools and said nothing still records what it did.
+
+- [ ] **Step 6: Run the tests, then commit**
+
+```bash
+cd apps/hub && DATABASE_URL="postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod" bun test
+git add apps/hub/src/services/matrix-as/
+git commit -m "feat: record what an agent did during a turn, once, in the room"
+```
+
+---
+
+## Task 5: Structured approvals (hub side)
+
+**Files:**
+- Modify: `apps/hub/src/services/matrix-as/activity.ts` (+ test), `outbound.ts` (+ test)
+
+- [ ] **Step 1: Failing test, then implement the builder**
+
+```ts
+/** The room event type carrying a permission request a client can render. */
+export const PERMISSION_REQUEST_TYPE = "dev.agentpod.permission.v1";
+
+/**
+ * The wire body for a permission request, or `null` when there is nothing a
+ * client could render.
+ *
+ * Capped at four options because supermessage's `DECISION_MAX_OPTIONS` renders
+ * four and silently drops the rest — enforced here so the hub never sends
+ * something it knows will be discarded. The prose message is **not** capped and
+ * still lists every option: a fifth remains answerable by number or name, it
+ * just does not get a button.
+ */
+export function permissionRequestContent(
+  sessionId: string,
+  requestSeq: number,
+  title: string,
+  options: readonly { optionId: string; name: string }[]
+): PermissionRequestEvent | null {
+  if (options.length === 0) return null;
+  return {
+    schema_version: 1,
+    session_id: sessionId,
+    request_seq: requestSeq,
+    title,
+    options: options.slice(0, 4).map((o) => ({ option_id: o.optionId, name: o.name })),
+  };
+}
+```
+
+- [ ] **Step 2: Emit it beside the prose**
+
+In `outbound.ts`'s `permission-request` case, after the existing `await say(...)`:
+
+```ts
+          // Beside the prose, never instead of it. The prose is what keeps
+          // Element and reply-by-number working, and the answer to either
+          // arrives as an ordinary message through the same matcher.
+          const structured = permissionRequestContent(
+            sessionId,
+            event.seq,
+            request.title,
+            request.options
+          );
+          if (structured && deps.client.sendCustomEvent) {
+            await deps.client
+              .sendCustomEvent(agentUser, roomId, PERMISSION_REQUEST_TYPE, structured)
+              .catch(() => {});
+          }
+```
+
+- [ ] **Step 3: Test that the prose is unchanged**
+
+The regression that matters: a client that cannot read the custom event must be exactly as able to approve as it was before. Assert the prose message is still sent, still numbered, and still matched by `matchPermissionAnswer`.
+
+- [ ] **Step 4: Run the suite and commit**
+
+---
+
+## Task 6: supermessage — receive the live channels
+
+**Files:**
+- Modify: `supermessage/src-tauri/src/core/live.rs`, `src/lib/ipc.ts`, `src/lib/stores/live.svelte.ts`
+
+- [ ] **Step 1: Two more ruma event contents, mirroring `StreamDeltaToDeviceEventContent`**
+
+```rust
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "dev.agentpod.thought.delta", kind = ToDevice)]
+pub struct ThoughtDeltaToDeviceEventContent { /* same fields as the stream delta */ }
+
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "dev.agentpod.tool.update", kind = ToDevice)]
+pub struct ToolUpdateToDeviceEventContent { /* room_id, session_id, seq, tool_call_id, title, kind, status, locations */ }
+```
+
+Register both handlers in `listen`, forwarding on two new channels (`sm://thought`, `sm://tool`). Reuse `LiveState`'s `supersedes`/`starts_new_turn` for the thought channel unchanged — that is why the shape was reused.
+
+- [ ] **Step 2: Tests**
+
+`live.rs`'s existing pure tests are the template: a later seq supersedes an earlier one; a seq of 1 starts a new turn; a duplicate is dropped. Add one asserting the two channels do not share state, so an agent thinking and answering at once cannot have one overwrite the other.
+
+- [ ] **Step 3: Store and IPC**
+
+Extend `live.svelte.ts` with a second keyed record for thought text and a third for tool records keyed by `tool_call_id` (upsert by id, exactly as the hub does). `pacer.ts` is reused for the thought text with no change.
+
+- [ ] **Step 4: `cargo fmt` LAST, then commit**
+
+---
+
+## Task 7: supermessage — render the room events
+
+**Files:**
+- Modify: `src/lib/components/customEvents.ts` (+ test), `Timeline.svelte`
+
+- [ ] **Step 1: The turn-activity renderer**
+
+Registered on `customEventRegistry`, following `demoNoteRenderer` exactly. Reads `counts` and `tools` one level at a time; returns `fields` only — no decision. `maxKnownSchemaVersion: 1`.
+
+Tests, following `customEvents.test.ts`: a well-formed payload; a higher `schema_version` (must still render, flagged `newerVersion`); a hostile payload with nested objects where strings are expected (must degrade, never coerce); an empty `tools` array.
+
+- [ ] **Step 2: The permission renderer, which sets a decision**
+
+Returns `fields` plus `decision`, where each `CustomEventDecisionOption.id` is the option's **name**, not its `option_id` — `id` is what `onDecide` receives verbatim and what will be sent, and the room transcript should read `Allow once`, not `allow_once`. `permissionPrompt`'s own doc comment is the argument: names are printed *"because '1' alone would make the transcript unreadable afterwards"*.
+
+This trips the existing guard test `keeps the shipped demo renderer decision-free` only if the demo renderer is touched — it must not be.
+
+- [ ] **Step 3: Make `onDecide` send**
+
+Replace the `console.warn` stub at `Timeline.svelte:865`:
+
+```ts
+  function onDecide(itemId: string, optionId: string): void {
+    void timelineStore.send(roomId, optionId).catch((err: unknown) => {
+      console.error("failed to send a decision", { itemId, optionId, err });
+    });
+  }
+```
+
+`optionId` here carries the option's name, per Step 2.
+
+- [ ] **Step 4: Add the type to `DECISION_BEARING_EVENT_TYPES`**
+
+`dev.agentpod.permission.v1`. Read that constant's doc comment first: **reason 2 still holds** — the SDK's latest-event builder swallows `_Custom`, so `RoomSummary.lastEventType` is `null` and the roster's amber row remains unreachable. Adding the entry is correct and changes nothing visible; the doc comment must be updated to say so rather than left claiming the set is empty.
+
+- [ ] **Step 5: `pnpm check && pnpm test && pnpm build`, then commit**
+
+---
+
+## Task 8: Verify against the live fleet
+
+Per the repo's standing rule: features touching the live fleet are verified against the real deployment before their issue closes.
+
+- [ ] Deploy the hub, talk to an agent on `ashram` that uses tools, and confirm: tool updates arrive to-device while it works; one activity card lands before the answer; a second turn does not repeat the first's tools; an approval renders buttons and tapping one resolves it.
+- [ ] Check the hub log for `a session update kind reaches Matrix and is not forwarded` — whatever it names is the next thing worth forwarding, and it is now visible for the first time.

--- a/docs/superpowers/specs/2026-08-17-agent-activity-in-the-room-design.md
+++ b/docs/superpowers/specs/2026-08-17-agent-activity-in-the-room-design.md
@@ -1,0 +1,419 @@
+# Agent activity in the room
+
+**Status:** design, approved in outline 2026-08-17
+**Spans:** `packages/contract`, `apps/hub` (matrix-as), `supermessage` (Rust core + Svelte)
+
+## The problem
+
+The hub is a wide funnel with a very narrow spout.
+
+Every ACP `session/update` a harness emits is persisted verbatim
+(`apps/hub/src/services/acp-sessions.ts:489-493`). The console renders most of
+it. The Matrix path forwards **one** kind of update, and does so by returning
+`undefined` for everything else:
+
+```ts
+/** The text of an `agent_message_chunk`, or undefined for anything else. */
+function messageChunkText(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  if (payload.sessionUpdate !== "agent_message_chunk") return undefined;
+  ...
+```
+— `apps/hub/src/services/matrix-as/outbound.ts:157-167`
+
+So `tool_call`, `tool_call_update`, `plan`, `usage_update`,
+`available_commands_update`, `session_info_update` and `current_mode_update` all
+fall through, silently, with no `default` case and no logging.
+
+The visible consequence: **a room watching an agent do twenty minutes of file
+edits sees a typing indicator, then one message.** Everything the agent
+actually *did* — every file read, every command run, every test — is discarded
+at one function in one file.
+
+This spec covers making that work visible without making the room worse.
+
+## What reaches a Matrix client today
+
+| Signal | Harness emits | Hub → Matrix | Client renders |
+| --- | --- | --- | --- |
+| `agent_message_chunk` | yes | yes — buffered, one `m.room.message` per turn; also to-device as `dev.agentpod.stream.delta` | yes |
+| `agent_thought_chunk` | yes (202 in one observed Hermes turn) | **no** — dropped at `outbound.ts:163` | — |
+| `tool_call` / `tool_call_update` | yes, full shape | **no** — not handled at all | — |
+| permission request | yes | yes, **as prose only** | as a text bubble |
+| `available_commands_update` | yes | no | — |
+| `plan` | never observed from any harness | no | — |
+| token usage / cost | **never emitted by any harness** | — | — |
+
+The last two rows are why this spec does not mention plans, task lists, token
+counters or cost meters. `plan` handling exists in the kaambaan coalescer and
+has never fired. For tokens and cost, the bridge spike searched 1,108 captured
+events for `inputTokens`, `outputTokens`, `costUsd` and `total_cost_usd` and
+found **zero occurrences**; `usage_update` carries `{used, size}`, which is
+context-window occupancy, not spend. **A component with nothing behind it is
+not worth building**, and the client already has 45 lines arguing exactly that
+(`customEvents.ts:517-561`).
+
+## The governing principle
+
+**The stream and the record are different channels.** This is not new here — it
+is the argument `matrix-as/live.ts` already makes, and this spec extends it
+rather than reopening it:
+
+> The cost is that every intermediate state becomes a permanent event. That is
+> not storage — this homeserver is 91 MB — but four things that are real:
+> `/search` returns half-written fragments of one answer; back-pagination
+> fetches twenty events to reveal one message; read markers drift as edits land
+> after them; and every phone on the account receives the churn. Worst of all,
+> more events per turn means more limited syncs, and a limited sync unloads the
+> timeline.
+
+That last clause is not hypothetical. On 2026-08-17 a limited sync collapsed a
+live room from 19834px of history to 1001px in front of a reader
+(supermessage#20). Anything that multiplies events per turn makes that more
+frequent.
+
+So:
+
+- **Live activity is ephemeral**, delivered to-device, never in room history.
+- **The durable record is one event per turn**, not one per action.
+- **Reasoning is never durable at all.**
+
+That third point is a decision, and `outbound.ts:160-162` already states it:
+reasoning *"belongs in the console's transcript, not in a room people share,
+where it would turn one answer into a monologue."* 202 thought chunks in a
+single turn is the number behind that sentence. Thinking becomes watchable
+live and is then gone. If someone needs it afterwards, the console's transcript
+is the place that already has it, in full, addressed by session and seq.
+
+## Architecture
+
+Three channels, two of them new.
+
+```
+harness ──ACP──▶ hub ──┬─▶ to-device  dev.agentpod.thought.delta   (live, ephemeral)
+                       ├─▶ to-device  dev.agentpod.tool.update     (live, ephemeral)
+                       ├─▶ room       dev.agentpod.turn.v1         (durable, 1 per turn)
+                       ├─▶ room       dev.agentpod.permission.v1   (durable, rare)
+                       └─▶ room       m.room.message               (unchanged)
+```
+
+### 1. `dev.agentpod.thought.delta` — to-device
+
+**Byte-for-byte the same content shape as `dev.agentpod.stream.delta`.** That
+is the point: the client's `core::live::LiveState`, its seq-ordering, and
+supermessage's `pacer.ts` all already handle "cumulative text with a monotonic
+seq, at-least-once and unordered". Reusing the shape means the only new client
+code is a second registration and a different pane; reusing the *type* would
+mean the reader could not tell an answer from its reasoning.
+
+```jsonc
+{
+  "room_id":    "!abc:id.agentpod.dev",
+  "session_id": "sess_...",
+  "seq":        7,        // monotonic per turn, independent of stream.delta's
+  "text":       "...",    // EVERYTHING so far, not the increment
+  "done":       false
+}
+```
+
+Emitted under the same policy as text (`shouldSendDelta`: a boundary with ≥24
+characters behind it, or a 1.5s backstop). Reasoning is lower-value than the
+answer, so it reuses the policy rather than getting a tighter one.
+
+### 2. `dev.agentpod.tool.update` — to-device
+
+One event per `tool_call` / `tool_call_update`, forwarded as it happens.
+
+```jsonc
+{
+  "room_id":      "!abc:id.agentpod.dev",
+  "session_id":   "sess_...",
+  "seq":          12,           // monotonic per turn
+  "tool_call_id": "call_01...",  // the identity; updates merge onto it
+  "title":        "Read src/main.ts",
+  "kind":         "read",        // ACP's tool kind, passed through, may be absent
+  "status":       "in_progress", // pending | in_progress | completed | failed
+  "locations":    ["src/main.ts"]
+}
+```
+
+`tool_call` and `tool_call_update` produce the same event; the client **upserts
+by `tool_call_id`**, exactly as the console does — and for the same reason
+recorded at `transcript.ts:299-305`: a buggy or hostile agent repeating a
+`toolCallId` must merge, not produce two items with the same key.
+
+Not forwarded: `content` (`rawInput` / `rawOutput` / diffs). Tool output is
+unbounded — a `cat` of a large file, a full test log — and this is a live
+ticker, not a viewer. `locations` and `title` are what answer "what is it doing
+right now".
+
+### 3. `dev.agentpod.turn.v1` — a room event, once per turn
+
+The durable record. Sent **before** the answer flushes, so a room reads in the
+order things happened: *did these things, then said this.*
+
+```jsonc
+{
+  "schema_version": 1,
+  "session_id": "sess_...",
+  "tools": [
+    { "id": "call_01...", "title": "Read src/main.ts", "kind": "read",    "status": "completed", "locations": ["src/main.ts"] },
+    { "id": "call_02...", "title": "Run tests",        "kind": "execute", "status": "failed",    "locations": [] }
+  ],
+  "counts": { "total": 7, "failed": 1, "omitted": 0 }
+}
+```
+
+- **Only sent when the turn used at least one tool.** A conversational turn
+  produces exactly the events it does today.
+- **`tools` is capped at `TURN_TOOLS_MAX = 20`**, with the overflow recorded in
+  `counts.omitted`. A pathological turn cannot produce an unbounded event, and
+  the count still tells the truth about what happened.
+- `schema_version` is snake_case because that is what the client reads
+  (`customEvents.ts:408-412`, `readSchemaVersion`).
+
+**Why a custom event type and not `m.room.message` with an extension key.** The
+client's dispatch card — described in its own source as *"this design's
+signature element"* — is reached only via `MsgLikeKind::Other`, i.e. a
+message-like custom event, which `timeline_event_filter` already whitelists.
+That mechanism is **fully built and deliberately empty**: the production
+registry holds one demo renderer and nothing else, and
+`DECISION_BEARING_EVENT_TYPES` is an empty set shipped with 45 lines explaining
+that shipping the mechanism unreachable was the point. This is the event type
+it was waiting for.
+
+The cost, stated plainly: **other Matrix clients render nothing for it.** The
+answer still arrives as an ordinary `m.room.message`, so nothing essential is
+hidden from Element — only the activity card. The alternative (an
+`m.room.message` carrying a `dev.agentpod.turn` key) would render everywhere,
+but needs new Rust plumbing to surface unknown content keys and bypasses the
+mechanism above. This choice is reversible; adding a body later is additive.
+
+### 4. `dev.agentpod.permission.v1` — a room event, alongside the existing prose
+
+Approvals already reach rooms and already work. What they lack is structure: the
+client gets prose and can only offer a text box.
+
+**The existing prose message is sent unchanged.** This event is added beside it:
+
+```jsonc
+{
+  "schema_version": 1,
+  "session_id": "sess_...",
+  "request_seq": 41,
+  "title": "Write src/main.ts",
+  "options": [
+    { "option_id": "allow_once",   "name": "Allow once" },
+    { "option_id": "allow_always", "name": "Allow always" },
+    { "option_id": "reject",       "name": "Reject" }
+  ]
+}
+```
+
+**The answer path needs no new plumbing at all**, which is the part of this
+design worth checking twice. `matchPermissionAnswer`
+(`matrix-as/permissions.ts:87-105`) already accepts a bare number, the option's
+name, **or its `optionId`**. So a button in the client sends one of those as an
+ordinary `m.room.message` and the existing inbound path resolves it. No new hub
+route, no change to `inbound.ts`, and — confirmed against the client — **no new
+Tauri command**: supermessage has no outbound path for custom events at all
+(`send_custom`, `send_event`, `send_raw` match nothing anywhere in the tree),
+and this design needs none, because `timelineStore.send` already exists.
+
+**The button sends the option's `name`, not its `option_id`.** The room
+transcript is a shared human record, and `permissionPrompt`'s own doc comment
+is the argument: names are printed alongside the numbers *"because '1' alone
+would make the transcript unreadable afterwards"*. A button that leaves
+`allow_once` in the room is the same mistake in a different alphabet, where
+`Allow once` reads as what a person decided. `option_id` is carried in the
+event anyway, so a future client can switch without a schema change.
+
+The cost is that two options sharing a name resolve to whichever comes first.
+That is a harness authoring its own menu badly, it is already true for anyone
+typing the name today, and the numbers remain unambiguous.
+
+Two events per approval request is acceptable: approvals are rare, and the
+prose message is what keeps Element and reply-by-number working.
+
+`DECISION_BEARING_EVENT_TYPES` gains its first member, `dev.agentpod.permission.v1`.
+
+**Known limitation, not fixed here.** The hub's pending-permission map
+(`permissions.ts:36`) is process memory. A hub restart drops in-flight requests
+and the room has no way to learn that the question it is showing is dead.
+Fixing that means persisting pending permissions, which is its own change.
+
+### 5. The diagnostic
+
+`outbound.ts` drops unknown `sessionUpdate` kinds with no record. The kaambaan
+coalescer does not — it keeps `unmapped()` and `losses()`
+(`bridge/coalesce.ts:104-111`) and lists dropped kinds explicitly *"so a NEW
+kind shows up in `unmapped()` instead of joining this set by accident"*.
+
+Add the same to the Matrix path: a module-level `Set` of kinds seen and not
+handled, logged **once per kind per process** at `info`. Without this, the next
+capability a harness gains will vanish here exactly as tool calls did, and
+nothing will say so.
+
+## Contract
+
+New file `packages/contract/src/matrix-events.ts`, exporting zod schemas and
+inferred types for all four payloads above, plus the shared vocabulary:
+
+```ts
+export const ToolStatus = z.enum(["pending", "in_progress", "completed", "failed"]);
+```
+
+taken from ACP and matching the console's `TOOL_STATUSES`
+(`transcript.ts:161-164`) exactly, so the two consumers cannot drift.
+
+The contract is the shared vocabulary, so it changes first — per the repo's own
+rule: *"Change here first when a frame/API shape changes."*
+
+## Hub changes
+
+All in `apps/hub/src/services/matrix-as/`.
+
+**`live.ts`** — add `THOUGHT_DELTA_TYPE` and `TOOL_UPDATE_TYPE`, and the
+content builders. `shouldSendDelta` and `endsAtBoundary` are reused unchanged.
+
+**`outbound.ts`** —
+- `Attachment` gains per-turn state: a thought buffer with its own
+  `thoughtSeq`/`thoughtSentChars`/`thoughtSentAt` (mirroring the text ones), and
+  an ordered `Map<toolCallId, ToolRecord>` for the turn.
+- The `agent-update` case stops being a single `if` and becomes a switch over
+  `payload.sessionUpdate`, handling `agent_message_chunk` (unchanged),
+  `agent_thought_chunk`, `tool_call`, `tool_call_update`, and recording anything
+  else in the unmapped set.
+- The `state` case emits `dev.agentpod.turn.v1` before `flush()` when the turn's
+  tool map is non-empty, then clears the per-turn state.
+- The `permission-request` case sends the structured event after the prose.
+
+**`permissions.ts`** — unchanged. Deliberately: the whole point of using
+`option_id` is that this file already handles it.
+
+## Client changes (supermessage)
+
+**Rust core** — two new to-device handlers in `core/live.rs`, registered exactly
+like `StreamDeltaToDeviceEventContent`, each with its own ruma `EventContent`
+derive and `kind = ToDevice`. They forward to two new IPC channels.
+
+The room events need **no** Rust change: `timeline_event_filter` already admits
+`AnyMessageLikeEventContent::_Custom`, and `classify_content` already projects
+it to `kind: "customMessage"` with `detail` = the raw event type and
+`customPayload` = the parsed content.
+
+**Renderers** — two `CustomEventRenderer`s registered on the shared
+`customEventRegistry`:
+
+```ts
+export interface CustomEventRenderer {
+  eventType: string;
+  maxKnownSchemaVersion: number;
+  render(content: unknown, body: string | null): CustomEventRenderResult;
+}
+```
+
+Both read fields one level at a time with `safeStringField` and never recurse,
+per that module's rules. The caps they must live within are already defined
+there: `FIELD_MAX_COUNT = 12`, `FIELD_VALUE_MAX_CHARS = 300`,
+`FIELD_LABEL_MAX_CHARS = 60`, and — the one that constrains the wire format —
+**`DECISION_MAX_OPTIONS = 4`**.
+
+That last cap is load-bearing and it fits: ACP permission requests in practice
+offer allow-once / allow-always / reject-once / reject-always, which is exactly
+four. A harness offering five would have the fifth dropped by `boundDecision`,
+so the hub caps `options` at four and the renderer must not assume more.
+
+**The decision path** — `Timeline.svelte:865`'s stub
+
+```ts
+console.warn("dispatch decision has no outbound event type yet", …)
+```
+
+becomes: send the chosen option through the existing `timelineStore.send`.
+
+The renderer therefore puts the option's **name** in
+`CustomEventDecisionOption.id` — not the `option_id` — because `id` is what
+`onDecide` receives verbatim and what will be sent. That reads backwards until
+you see that `id` here is a *client-side* identifier for an answer, explicitly
+documented as "what a renderer's own event type calls this answer", not a
+promise to echo a wire field.
+
+**Live panes** — the thought stream reuses `pacer.ts` unchanged. Presentation
+(a collapsed "thinking" disclosure, a tool ticker) is deliberately left to
+implementation; the data contract is what this spec fixes.
+
+## What this spec deliberately does not do
+
+- **No token, cost or budget UI.** No harness emits the data.
+- **No plan or task list.** `plan` has never been observed.
+- **No slash-command palette.** `available_commands_update` is dropped on
+  purpose in both bridges; that is its own decision, already made.
+- **No tool output viewer.** `content`/`rawOutput` is unbounded; showing it
+  needs a design for truncation and expansion that this does not attempt.
+- **No roster preview for activity events.** `RoomSummary.lastEventType` is
+  `null` for every custom event, because the matrix-sdk latest-event builder
+  swallows `_Custom` into a catch-all with no hook. Already documented at
+  `customEvents.ts:544` as an accepted blocker.
+
+## Testing
+
+**Contract** — zod round-trips per payload; a rejected payload for each
+required field.
+
+**Hub** (`bun test`, no DB needed for these):
+- a `tool_call` produces a to-device event and **no** room event;
+- a turn with tools emits exactly one `dev.agentpod.turn.v1`, **before** the
+  answer message;
+- a turn with no tools emits none;
+- more than `TURN_TOOLS_MAX` tools caps the list and sets `counts.omitted`;
+- `tool_call_update` merges onto its `tool_call` rather than appending;
+- a repeated `toolCallId` merges (the console's hostile-agent case);
+- `agent_thought_chunk` produces a to-device event and never a room event —
+  the regression test for the decision above;
+- an unknown `sessionUpdate` kind is recorded once in the unmapped set;
+- per-turn tool state is cleared, so turn two does not report turn one's work.
+
+**Client** — renderer unit tests against fixtures, following
+`customEvents.test.ts`: a well-formed payload, a payload with a higher
+`schema_version` (must still render, flagged `newerVersion`), a hostile payload
+(nested objects where strings are expected — must degrade, never coerce), an
+empty `tools` array, and a decision with more than four options.
+
+**End to end** — the fleet is the test environment. Verified against a real
+agent on `ashram` before the issue closes, per the repo's standing rule for
+anything touching the live fleet.
+
+## Sequencing
+
+Four independently shippable pieces. Each is useful alone and none blocks the
+next, so they need not land together:
+
+1. **The diagnostic.** Smallest, and it makes everything after it observable —
+   once it is in, anything the hub drops says so. Ship first regardless.
+2. **Live activity** (`thought.delta`, `tool.update`). Room history untouched,
+   so the least risky of the four, and the biggest visible change: a reader
+   watching sees the agent work.
+3. **The durable record** (`turn.v1`). The first piece that adds a room event
+   per turn, so it is the one to measure limited-sync frequency against, before
+   and after.
+4. **Structured approvals** (`permission.v1`). Last, because it is the only one
+   that touches an interaction that already works. The prose path keeps working
+   throughout, so it stays purely additive until the buttons are trusted.
+
+## Risks
+
+**Volume.** One extra room event per tool-using turn, and one per approval. That
+is the smallest increment that still produces a durable record, and it is
+bounded — but it is not zero, and the limited-sync behaviour it feeds is the
+thing that collapsed a room this morning. If measurement shows turn events
+making limited syncs materially more frequent, the fallback is to fold the
+activity into the answer message rather than send a second event.
+
+**Silent invisibility elsewhere.** Element shows nothing for the activity card.
+Acceptable while supermessage is the reading client; revisit if that stops
+being true.
+
+**Schema churn.** Tool `kind` is passed through from ACP without validation, so
+a harness inventing a new kind lands as an unknown string. Renderers must treat
+it as opaque display text, never switch on it exhaustively.

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -12,3 +12,4 @@ export * from "./run";
 export * from "./card-prompt";
 export * from "./changeset";
 export * from "./posture";
+export * from "./matrix-events";

--- a/packages/contract/src/matrix-events.test.ts
+++ b/packages/contract/src/matrix-events.test.ts
@@ -1,0 +1,187 @@
+// The wire shapes the hub sends and supermessage reads.
+//
+// Snake_case throughout, like every other Matrix event body and like
+// `matrix-as/live.ts`'s existing `deltaContent`. `schema_version` in particular
+// is snake_case because that is the field supermessage's `readSchemaVersion`
+// looks for; camelCasing it makes every payload read as "assume the baseline
+// version" with no error raised anywhere.
+
+import { describe, expect, it } from "bun:test";
+import {
+  LiveThoughtDelta,
+  LiveToolUpdate,
+  PermissionRequestEvent,
+  ToolStatus,
+  TurnActivity,
+} from "./matrix-events";
+
+describe("ToolStatus", () => {
+  it("is exactly ACP's vocabulary, so the console and the room cannot drift", () => {
+    expect(ToolStatus.options).toEqual(["pending", "in_progress", "completed", "failed"]);
+  });
+
+  it("rejects a status nobody defined", () => {
+    expect(ToolStatus.safeParse("cancelled").success).toBe(false);
+  });
+});
+
+describe("LiveThoughtDelta", () => {
+  it("accepts a delta", () => {
+    const parsed = LiveThoughtDelta.parse({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 3,
+      text: "Considering the node's uptime.",
+      done: false,
+    });
+    expect(parsed.seq).toBe(3);
+  });
+
+  it("requires done, because a receiver keys the end of a turn off it", () => {
+    expect(
+      LiveThoughtDelta.safeParse({
+        room_id: "!r:example.org",
+        session_id: "sess_1",
+        seq: 3,
+        text: "x",
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("LiveToolUpdate", () => {
+  it("accepts an update", () => {
+    const parsed = LiveToolUpdate.parse({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 4,
+      tool_call_id: "call_1",
+      title: "Read src/main.ts",
+      kind: "read",
+      status: "in_progress",
+      locations: ["src/main.ts"],
+    });
+    expect(parsed.tool_call_id).toBe("call_1");
+  });
+
+  it("tolerates a missing kind, which ACP does not always send", () => {
+    const parsed = LiveToolUpdate.parse({
+      room_id: "!r:example.org",
+      session_id: "sess_1",
+      seq: 4,
+      tool_call_id: "call_1",
+      title: "Something",
+      status: "pending",
+      locations: [],
+    });
+    expect(parsed.kind).toBeUndefined();
+  });
+
+  it("requires the tool call id, since it is the identity updates merge onto", () => {
+    expect(
+      LiveToolUpdate.safeParse({
+        room_id: "!r:example.org",
+        session_id: "sess_1",
+        seq: 4,
+        title: "Something",
+        status: "pending",
+        locations: [],
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("TurnActivity", () => {
+  it("accepts a turn's record", () => {
+    const parsed = TurnActivity.parse({
+      schema_version: 1,
+      session_id: "sess_1",
+      tools: [
+        {
+          id: "call_1",
+          title: "Read src/main.ts",
+          kind: "read",
+          status: "completed",
+          locations: ["src/main.ts"],
+        },
+      ],
+      counts: { total: 1, failed: 0, omitted: 0 },
+    });
+    expect(parsed.counts.total).toBe(1);
+  });
+
+  it("carries schema_version in snake_case, which is what the client reads", () => {
+    expect(
+      TurnActivity.safeParse({
+        schemaVersion: 1,
+        session_id: "sess_1",
+        tools: [],
+        counts: { total: 0, failed: 0, omitted: 0 },
+      }).success
+    ).toBe(false);
+  });
+
+  it("allows an empty tool list, so the shape does not depend on the sender's guard", () => {
+    // The hub only sends this when a turn used tools, but that is the hub's
+    // rule and not the schema's — a schema that made it impossible to express
+    // "no tools" would be describing the caller rather than the wire.
+    expect(
+      TurnActivity.safeParse({
+        schema_version: 1,
+        session_id: "sess_1",
+        tools: [],
+        counts: { total: 0, failed: 0, omitted: 0 },
+      }).success
+    ).toBe(true);
+  });
+});
+
+describe("PermissionRequestEvent", () => {
+  it("accepts a request", () => {
+    const parsed = PermissionRequestEvent.parse({
+      schema_version: 1,
+      session_id: "sess_1",
+      request_seq: 41,
+      title: "Write src/main.ts",
+      options: [
+        { option_id: "allow_once", name: "Allow once" },
+        { option_id: "reject", name: "Reject" },
+      ],
+    });
+    expect(parsed.options).toHaveLength(2);
+  });
+
+  it("refuses an empty option list, which nothing could answer", () => {
+    expect(
+      PermissionRequestEvent.safeParse({
+        schema_version: 1,
+        session_id: "sess_1",
+        request_seq: 41,
+        title: "x",
+        options: [],
+      }).success
+    ).toBe(false);
+  });
+
+  it("refuses more than four options, the cap the card can actually render", () => {
+    // supermessage's `DECISION_MAX_OPTIONS` renders four and silently drops the
+    // rest. Refusing here means the hub never sends one it knows will be
+    // discarded — the cap is enforced where it can still be reported, rather
+    // than where it can only be lost.
+    expect(
+      PermissionRequestEvent.safeParse({
+        schema_version: 1,
+        session_id: "sess_1",
+        request_seq: 41,
+        title: "x",
+        options: [
+          { option_id: "a", name: "A" },
+          { option_id: "b", name: "B" },
+          { option_id: "c", name: "C" },
+          { option_id: "d", name: "D" },
+          { option_id: "e", name: "E" },
+        ],
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/contract/src/matrix-events.ts
+++ b/packages/contract/src/matrix-events.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+// ─── Matrix event payloads the hub sends ─────────────────────────────────────
+//
+// What an agent is doing, as it reaches a Matrix client. Two channels, and the
+// split between them is the design rather than an implementation detail — see
+// `apps/hub/src/services/matrix-as/live.ts`, which argues it at length for the
+// answer text and which this extends rather than reopens:
+//
+//   - **Live** activity goes to-device. It is delivered per device, never
+//     stored in a room, and costs room history nothing. A device that was
+//     asleep simply misses it.
+//   - **The durable record** is one room event per turn. Not one per action:
+//     more events per turn means more limited syncs, and a limited sync
+//     unloads the timeline.
+//
+// Snake_case throughout, like every other Matrix event body and like `live.ts`'s
+// existing `deltaContent`. `schema_version` in particular is snake_case because
+// that is the field supermessage's `readSchemaVersion` looks for; camelCasing it
+// makes every payload read as "assume the baseline version" with no error
+// raised anywhere.
+
+/**
+ * ACP's tool lifecycle, verbatim.
+ *
+ * Kept identical to the console's own `TOOL_STATUSES` so the two consumers of
+ * the same harness cannot drift into disagreeing about what a tool call is
+ * doing.
+ */
+export const ToolStatus = z.enum(["pending", "in_progress", "completed", "failed"]);
+export type ToolStatus = z.infer<typeof ToolStatus>;
+
+/**
+ * A turn's reasoning, streamed to the reader's own devices.
+ *
+ * **Deliberately the same shape as `dev.agentpod.stream.delta`.** The client's
+ * seq-ordering and its reveal pacer already handle "cumulative text with a
+ * monotonic seq, delivered at-least-once and unordered", so reusing the shape
+ * costs one registration rather than a second implementation. The *type* still
+ * differs, because a reader must be able to tell an agent's thinking from its
+ * answer.
+ *
+ * `text` is EVERYTHING so far, never the increment — to-device delivery is
+ * at-least-once and unordered, so an increment would let a dropped or reordered
+ * delta corrupt the text with no way to notice.
+ */
+export const LiveThoughtDelta = z.object({
+  room_id: z.string(),
+  session_id: z.string(),
+  seq: z.number().int().nonnegative(),
+  text: z.string(),
+  done: z.boolean(),
+});
+export type LiveThoughtDelta = z.infer<typeof LiveThoughtDelta>;
+
+/**
+ * One tool call's state, streamed as it changes.
+ *
+ * `tool_call` and `tool_call_update` both produce this; the receiver upserts by
+ * `tool_call_id` rather than appending, for the reason the console records: an
+ * agent repeating an id must merge, not produce two records with one identity.
+ *
+ * Tool *output* is deliberately absent. `rawOutput` is unbounded — a `cat` of a
+ * large file, a full test log — and this is a live ticker, not a viewer.
+ * `title` and `locations` are what answer "what is it doing right now".
+ */
+export const LiveToolUpdate = z.object({
+  room_id: z.string(),
+  session_id: z.string(),
+  seq: z.number().int().nonnegative(),
+  tool_call_id: z.string(),
+  title: z.string(),
+  /**
+   * ACP's tool kind, passed through unvalidated. Treat as opaque display text
+   * and never switch on it exhaustively: a harness inventing a new kind must
+   * land as an unknown string rather than as a crash.
+   */
+  kind: z.string().optional(),
+  status: ToolStatus,
+  locations: z.array(z.string()),
+});
+export type LiveToolUpdate = z.infer<typeof LiveToolUpdate>;
+
+/** One tool call as it appears in the durable per-turn record. */
+export const TurnActivityTool = z.object({
+  id: z.string(),
+  title: z.string(),
+  kind: z.string().optional(),
+  status: ToolStatus,
+  locations: z.array(z.string()),
+});
+export type TurnActivityTool = z.infer<typeof TurnActivityTool>;
+
+/**
+ * What an agent did during one turn — the durable record, sent into the room
+ * once, before the answer.
+ *
+ * `tools` is capped by the sender; `counts` reports the whole turn regardless,
+ * so a capped list can never be mistaken for a complete one.
+ *
+ * An empty `tools` array is valid here even though the hub only sends this when
+ * a turn used at least one tool. That guard is the caller's rule, not the
+ * wire's — a schema that made "no tools" inexpressible would be describing the
+ * sender rather than the format.
+ */
+export const TurnActivity = z.object({
+  schema_version: z.literal(1),
+  session_id: z.string(),
+  tools: z.array(TurnActivityTool),
+  counts: z.object({
+    total: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    omitted: z.number().int().nonnegative(),
+  }),
+});
+export type TurnActivity = z.infer<typeof TurnActivity>;
+
+/**
+ * A permission request, structured so a client can render buttons.
+ *
+ * Sent **beside** the existing prose message, which is unchanged and remains
+ * the interop path for every other Matrix client. The answer travels back as an
+ * ordinary room message carrying the option's `name`, which
+ * `matrix-as/permissions.ts`'s `matchPermissionAnswer` already accepts — which
+ * is why structured approvals need no new send path on either side.
+ *
+ * Four options maximum, because supermessage's `DECISION_MAX_OPTIONS` renders
+ * four and silently drops the rest. Enforcing it here means the hub never sends
+ * something it knows will be discarded — the cap is applied where it can still
+ * be reported rather than where it can only be lost. The prose message is not
+ * capped and still lists every option, so a fifth stays answerable by number or
+ * name; it just does not get a button.
+ */
+export const PermissionRequestEvent = z.object({
+  schema_version: z.literal(1),
+  session_id: z.string(),
+  /** The request's own ACP sequence number — how `answerPermission` addresses it. */
+  request_seq: z.number().int().nonnegative(),
+  title: z.string(),
+  options: z.array(z.object({ option_id: z.string(), name: z.string() })).min(1).max(4),
+});
+export type PermissionRequestEvent = z.infer<typeof PermissionRequestEvent>;


### PR DESCRIPTION
## What

The hub side of showing what an agent is doing while it does it.

- **contract**: wire shapes for an agent's activity — thought deltas,
  tool updates, a turn's folded activity record, and permission
  requests (`packages/contract/src/matrix-events.ts`).
- **hub**: an agent's reasoning and tool calls stream to the reader's
  devices over to-device events rather than being written into the
  room, so a turn in progress leaves no history behind. When the turn
  ends, its work lands once as a durable `dev.agentpod.turn.v1` card.
- **approvals**: a permission request reaches the client as an event it
  can render as a card, so an agent can be answered from the room it
  asked in.

## Two fixes found along the way

A turn that produced no answer and no error was reported as done, which
left the reader staring at nothing with no explanation. It now says so
explicitly, carrying whether the agent produced anything and whether it
reported an error.

The Matrix path silently dropped session-update kinds it did not
recognise. It now says which kind it dropped — found because a
malformed `tool_call` was being logged as unforwarded when it was in
fact handled.

## Verified live

The full path was driven end to end against `ashram`: a message sent
from supermessage reaches openclaw over ACP, and the turn's tool calls
come back as both a live ticker and a folded turn card in the room.

## Tests

1443 hub tests. Contract, hub, node-agent, console and worker checks
all apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW