### PR TITLE
Stop asserting that a rejected socket never opened

### DIFF
--- a/apps/hub/tests/integration/gateway.test.ts
+++ b/apps/hub/tests/integration/gateway.test.ts
@@ -159,24 +159,48 @@ test("a node with invalid credentials is rejected", async () => {
       } as RequestInit & { headers: Record<string, string> }
     );
 
+    // The socket opening is NOT a failure, and asserting otherwise is what
+    // made this test flaky: the gateway accepts the connection and only then
+    // authenticates, inside `onOpen`, where `verifyNodeCredential` is an
+    // argon2id verify costing ~105ms. The handshake has long since completed
+    // by the time the close is sent, so a client is perfectly entitled to see
+    // `open` first — and on a loaded two-core runner it does, which is why
+    // this failed on CI while passing on every developer's machine.
+    //
+    // Accept-then-close is the design, not an accident (it is the same reason
+    // `onMessage` has to await `authReady`). What must be true is that the
+    // connection is terminated and the node never becomes usable.
     let closeCode: number | null = null;
-    await new Promise<void>((res, rej) => {
-      ws.onclose = (e) => {
-        closeCode = e.code;
-        res();
-      };
-      ws.onopen = () => {
-        ws.close();
-        rej(new Error("connection should have been rejected but was accepted"));
-      };
-    });
+    await Promise.race([
+      new Promise<void>((res) => {
+        ws.onclose = (e) => {
+          closeCode = e.code;
+          res();
+        };
+      }),
+      new Promise<void>((_, rej) =>
+        setTimeout(
+          () => rej(new Error("bad credentials left the socket open")),
+          5000
+        )
+      ),
+    ]);
 
     // Server calls ws.close(1008, "unauthorized"); Bun's WS client normalises
     // the server-sent 1008 to 1000 on the receiving end (a Bun quirk), so we
-    // accept either.  The unconditional assertion still proves the connection
-    // was terminated — the hardened onopen handler above is what proves no
-    // successful open ever happened.
+    // accept either.
     expect([1000, 1008]).toContain(closeCode);
+
+    // The security property, and the one the old `onopen` guard was reaching
+    // for: a rejected node is never registered, so nothing can be sent to it
+    // and it never counts as online. Deterministic — it is read after the
+    // close, not raced against it.
+    expect(connectionManager.isOnline(nodeId)).toBe(false);
+    expect(
+      (await listNodes(TEST_USER_ID)).find(
+        (n) => n.id === nodeId && n.status === "online"
+      )
+    ).toBeUndefined();
   } finally {
     server.stop(true);
   }


### PR DESCRIPTION
**`main` is currently red**, and with `strict` branch protection that blocks every PR in the repo. This is the fix.

## What's failing

`a node with invalid credentials is rejected` fails on CI, passes locally. I confirmed it is not any particular branch by running CI via `workflow_dispatch` against **unmodified `main`** — [run 32440506202](https://github.com/SuperJackfruitLabs/agentpod/actions/runs/32440506202) — same job, same test, `118.99ms`.

## Why

The test treated the client seeing `open` as the failure:

```ts
ws.onopen = () => { ws.close(); rej(new Error("connection should have been rejected but was accepted")); };
```

But the gateway accepts the connection and *then* authenticates, inside `onOpen`, where `verifyNodeCredential` is an argon2id verify costing ~105ms. The handshake completed long before the close is sent, so the client is entitled to see `open` first — and on a loaded two-core runner it does.

Accept-then-close is deliberate here; it's the same reason `onMessage` has to await `authReady`. So the test was asserting a property the code never promised, and passing on timing luck.

## The fix

Wait for the close, bounded at 5s so a socket that *stays* open fails rather than hangs. Keep the close-code assertion. Add the two that carry the security property the old handler was reaching for:

```ts
expect(connectionManager.isOnline(nodeId)).toBe(false);
expect((await listNodes(TEST_USER_ID)).find((n) => n.id === nodeId && n.status === "online")).toBeUndefined();
```

Read *after* the close rather than raced against it, so they're deterministic.

## Verification

Mutant-tested rather than assumed. With `onOpen` changed to register the node and mark it online instead of closing, the test fails at the 5s bound; restored, it passes. It catches a gateway that accepts bad credentials, which is the regression worth having.

Full hub suite: 1443 pass. The one failure, `typecheck-baseline`, is pre-existing on `main` — an error in `packages/types/src/opencode.ts` that `typecheck-known-red.txt` doesn't list. Untouched here per the "don't fix in passing" note in `apps/hub/CLAUDE.md`, but it's worth its own issue since that guard is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EohapceVTgobwUGTQ5LuyW