### PR TITLE
Stop the node agent burning a core on leaked health sweeps

### DIFF
--- a/apps/node-agent/cmd/agentpod-node/gatherhealth_test.go
+++ b/apps/node-agent/cmd/agentpod-node/gatherhealth_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/descriptor"
+)
+
+// countingDescriptor is a fake harness that reports stationCount stations and
+// counts how many times Detect is called.
+type countingDescriptor struct {
+	stationCount int
+	detects      atomic.Int64
+
+	// healthFor, when true, makes the fake implement HealthForStation.
+	healthFor bool
+}
+
+func (c *countingDescriptor) Harness() string { return "counting" }
+
+func (c *countingDescriptor) Detect() ([]descriptor.Station, error) {
+	c.detects.Add(1)
+	stations := make([]descriptor.Station, 0, c.stationCount)
+	for i := 0; i < c.stationCount; i++ {
+		ws := fmt.Sprintf("/tmp/ws-%d", i)
+		stations = append(stations, descriptor.Station{
+			Key:           fmt.Sprintf("counting:%d", i),
+			Harness:       "counting",
+			Kind:          "leaf",
+			WorkspacePath: &ws,
+		})
+	}
+	return stations, nil
+}
+
+// Health resolves the key the expensive way — by re-running Detect — which is
+// exactly what the real workspace descriptors do.
+func (c *countingDescriptor) Health(key string) (descriptor.Health, error) {
+	stations, err := c.Detect()
+	if err != nil {
+		return descriptor.Health{}, err
+	}
+	for _, s := range stations {
+		if s.Key == key {
+			return descriptor.Health{Running: true}, nil
+		}
+	}
+	return descriptor.Health{}, fmt.Errorf("no such station %q", key)
+}
+
+func (c *countingDescriptor) ListDir(string, string) ([]descriptor.FsEntry, error) {
+	return nil, nil
+}
+func (c *countingDescriptor) ReadFile(string, string, int64) ([]byte, string, bool, error) {
+	return nil, "", false, nil
+}
+func (c *countingDescriptor) TailLogs(context.Context, string, bool, func([]byte) error) error {
+	return nil
+}
+
+// countingWithHealthFor is countingDescriptor plus the HealthForStation
+// fast path.
+type countingWithHealthFor struct{ countingDescriptor }
+
+func (c *countingWithHealthFor) HealthFor(s descriptor.Station) (descriptor.Health, error) {
+	if s.WorkspacePath == nil || *s.WorkspacePath == "" {
+		return c.Health(s.Key)
+	}
+	return descriptor.Health{Running: true}, nil
+}
+
+// TestGatherHealthReportsDetectsOncePerSweep is the regression guard for the
+// O(N²) health sweep.
+//
+// gatherHealthReports used to call d.Health(s.Key) for each station, and for
+// the workspace harnesses Health(key) resolves the key by re-running Detect.
+// One sweep of N stations therefore triggered 1+N host scans, each of which
+// forks git once per project: on a 26-project host that was 702 git processes
+// every 30 s.
+func TestGatherHealthReportsDetectsOncePerSweep(t *testing.T) {
+	const stations = 12
+
+	fake := &countingWithHealthFor{countingDescriptor{stationCount: stations, healthFor: true}}
+	reg := descriptor.NewRegistry()
+	reg.Register(fake)
+
+	reports := gatherHealthReports(reg)
+
+	if len(reports) != stations {
+		t.Fatalf("got %d reports, want %d", len(reports), stations)
+	}
+	for _, r := range reports {
+		if !r.OK {
+			t.Fatalf("station %s reported not-OK; the fast path must still produce health", r.Key)
+		}
+	}
+
+	// One DetectAll for the sweep. Anything more means health is being resolved
+	// per station, which is the quadratic path.
+	if got := fake.detects.Load(); got != 1 {
+		t.Fatalf("Detect called %d times for a %d-station sweep, want exactly 1; "+
+			"health is being resolved per station (O(N^2) host scans)", got, stations)
+	}
+}
+
+// TestGatherHealthReportsFallsBackToHealth asserts a descriptor that does NOT
+// implement HealthForStation still works — it just pays the old cost. The
+// fast path is an optimisation, never a requirement.
+func TestGatherHealthReportsFallsBackToHealth(t *testing.T) {
+	const stations = 3
+
+	fake := &countingDescriptor{stationCount: stations}
+	reg := descriptor.NewRegistry()
+	reg.Register(fake)
+
+	reports := gatherHealthReports(reg)
+
+	if len(reports) != stations {
+		t.Fatalf("got %d reports, want %d", len(reports), stations)
+	}
+	for _, r := range reports {
+		if !r.OK || !r.Running {
+			t.Fatalf("station %s: OK=%v Running=%v, want both true via the Health fallback",
+				r.Key, r.OK, r.Running)
+		}
+	}
+}

--- a/apps/node-agent/cmd/agentpod-node/run.go
+++ b/apps/node-agent/cmd/agentpod-node/run.go
@@ -73,39 +73,48 @@ func runCmd() {
 		}
 	})
 
-	// gatherHealth enumerates all detected stations and collects a point-in-time
-	// health snapshot for each one. Called by the gateway health ticker (~30 s).
-	gatherHealth := func() []gateway.HealthReport {
-		stations := reg.DetectAll()
-		reports := make([]gateway.HealthReport, 0, len(stations))
-		for _, s := range stations {
-			d, err := reg.For(s.Key)
-			if err != nil {
-				reports = append(reports, gateway.HealthReport{Key: s.Key, OK: false})
-				continue
-			}
-			h, err := d.Health(s.Key)
-			if err != nil {
-				reports = append(reports, gateway.HealthReport{Key: s.Key, OK: false})
-				continue
-			}
-			reports = append(reports, gateway.HealthReport{
-				Key:       s.Key,
-				OK:        true,
-				Running:   h.Running,
-				PID:       h.PID,
-				CPUPct:    h.CpuPct,
-				MemBytes:  h.MemBytes,
-				UptimeSec: h.UptimeSec,
-			})
-		}
-		return reports
-	}
-
 	h := gateway.NewTerminalHandler(descriptor.NewHandler(reg), resolver, mgr, lifecycleFn)
 	h = gateway.NewChangesetHandler(h, resolver)
 	h = gateway.NewPostureHandler(h, func() int { return len(reg.DetectAll()) })
 	h = gateway.NewACPHandler(h, acpMgr, descriptor.NewCapabilityHandler(reg).ACPCommand)
 	h = gateway.NewUpdateHandler(h, version)
-	gateway.Run(ctx, cfg, h, version, gatherHealth)
+	gateway.Run(ctx, cfg, h, version, func() []gateway.HealthReport {
+		return gatherHealthReports(reg)
+	})
+}
+
+// gatherHealthReports enumerates all detected stations and collects a
+// point-in-time health snapshot for each one. Called by the gateway health
+// ticker (~30 s).
+//
+// The station list is detected ONCE and each station is then passed whole to
+// descriptor.HealthOf. Resolving health by key instead (d.Health(s.Key)) makes
+// every station re-run its descriptor's Detect, so a sweep of N stations costs
+// N+N² host scans — 702 git processes per tick on a 26-project host, which is
+// what pinned a real node's CPU. See descriptor.HealthForStation.
+func gatherHealthReports(reg *descriptor.Registry) []gateway.HealthReport {
+	stations := reg.DetectAll()
+	reports := make([]gateway.HealthReport, 0, len(stations))
+	for _, s := range stations {
+		d, err := reg.For(s.Key)
+		if err != nil {
+			reports = append(reports, gateway.HealthReport{Key: s.Key, OK: false})
+			continue
+		}
+		h, err := descriptor.HealthOf(d, s)
+		if err != nil {
+			reports = append(reports, gateway.HealthReport{Key: s.Key, OK: false})
+			continue
+		}
+		reports = append(reports, gateway.HealthReport{
+			Key:       s.Key,
+			OK:        true,
+			Running:   h.Running,
+			PID:       h.PID,
+			CPUPct:    h.CpuPct,
+			MemBytes:  h.MemBytes,
+			UptimeSec: h.UptimeSec,
+		})
+	}
+	return reports
 }

--- a/apps/node-agent/internal/descriptor/claudecode.go
+++ b/apps/node-agent/internal/descriptor/claudecode.go
@@ -348,7 +348,22 @@ func (c *claudeCodeDescriptor) Health(key string) (Health, error) {
 	if err != nil {
 		return Health{}, err
 	}
+	return c.healthAt(projPath), nil
+}
 
+// HealthFor implements HealthForStation: it reads the workspace off the station
+// the caller already detected instead of re-running Detect to find it again,
+// which is what turns a health sweep from O(N²) host scans into O(N).
+func (c *claudeCodeDescriptor) HealthFor(s Station) (Health, error) {
+	if s.WorkspacePath == nil || *s.WorkspacePath == "" {
+		return c.Health(s.Key)
+	}
+	return c.healthAt(*s.WorkspacePath), nil
+}
+
+// healthAt is the shared body of Health and HealthFor, keyed on a workspace
+// path the caller has already resolved.
+func (c *claudeCodeDescriptor) healthAt(projPath string) Health {
 	health := Health{}
 
 	// Disk usage from the shared async cache — never walk on the request path
@@ -369,7 +384,7 @@ func (c *claudeCodeDescriptor) Health(key string) (Health, error) {
 		health.LastActivity = &s
 	}
 
-	return health, nil
+	return health
 }
 
 // claudeProcessRunning checks for a running claude process whose working

--- a/apps/node-agent/internal/descriptor/codex.go
+++ b/apps/node-agent/internal/descriptor/codex.go
@@ -457,7 +457,22 @@ func (c *codexDescriptor) Health(key string) (Health, error) {
 	if err != nil {
 		return Health{}, err
 	}
+	return c.healthAt(projPath), nil
+}
 
+// HealthFor implements HealthForStation: it reads the workspace off the station
+// the caller already detected instead of re-running Detect to find it again,
+// which is what turns a health sweep from O(N²) host scans into O(N).
+func (c *codexDescriptor) HealthFor(s Station) (Health, error) {
+	if s.WorkspacePath == nil || *s.WorkspacePath == "" {
+		return c.Health(s.Key)
+	}
+	return c.healthAt(*s.WorkspacePath), nil
+}
+
+// healthAt is the shared body of Health and HealthFor, keyed on a workspace
+// path the caller has already resolved.
+func (c *codexDescriptor) healthAt(projPath string) Health {
 	health := Health{}
 
 	// Disk usage from the shared async cache — never walk on the request path
@@ -470,7 +485,7 @@ func (c *codexDescriptor) Health(key string) (Health, error) {
 		health.Note = &note
 	}
 
-	return health, nil
+	return health
 }
 
 // codexProcessRunning reports whether a codex CLI session is running with its

--- a/apps/node-agent/internal/descriptor/descriptor.go
+++ b/apps/node-agent/internal/descriptor/descriptor.go
@@ -167,6 +167,35 @@ type Descriptor interface {
 	TailLogs(ctx context.Context, key string, follow bool, emit func([]byte) error) error
 }
 
+// HealthForStation is an OPTIONAL interface a Descriptor may implement to
+// report health for a station the caller has ALREADY detected.
+//
+// Health(key) must resolve key back to a workspace path, and for the workspace
+// harnesses (claude-code, codex, opencode) that means re-running Detect — a
+// full host re-scan that forks git once per project. A caller that sweeps
+// every station, which is exactly what the health tick does, therefore pays
+// O(N²) scans for N stations: 26 projects cost 702 git processes per tick.
+// HealthFor takes the Station the caller already holds and reads its
+// WorkspacePath directly, making the sweep O(N).
+//
+// Implementations MUST fall back to Health(s.Key) when s.WorkspacePath is nil.
+type HealthForStation interface {
+	HealthFor(s Station) (Health, error)
+}
+
+// HealthOf returns d's health snapshot for an already-detected station, taking
+// the O(N) path when d implements HealthForStation and falling back to the
+// key-resolving Health otherwise.
+//
+// Any caller sweeping many stations should use this rather than d.Health(s.Key)
+// — see HealthForStation for what the difference costs.
+func HealthOf(d Descriptor, s Station) (Health, error) {
+	if hf, ok := d.(HealthForStation); ok {
+		return hf.HealthFor(s)
+	}
+	return d.Health(s.Key)
+}
+
 // ACPCommander is an OPTIONAL interface implemented by descriptors whose
 // harness can serve an ACP (Agent Client Protocol) session over stdio. The
 // "acp" capability is advertised in Detect output ONLY when the descriptor

--- a/apps/node-agent/internal/descriptor/healthfor_test.go
+++ b/apps/node-agent/internal/descriptor/healthfor_test.go
@@ -1,0 +1,94 @@
+package descriptor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// workspaceStation builds a Station carrying an already-resolved workspace, as
+// a caller would have after DetectAll. The key deliberately does NOT correspond
+// to anything the descriptor would discover on this host.
+func workspaceStation(key, ws string) Station {
+	return Station{Key: key, Harness: "test", Kind: "leaf", WorkspacePath: &ws}
+}
+
+// TestWorkspaceDescriptorsImplementHealthForStation pins the optimisation in
+// place: these three descriptors resolve a station key by re-running Detect, so
+// they are the ones a health sweep must not call by key. If one stops
+// implementing HealthForStation, the sweep silently returns to O(N²) host
+// scans with nothing failing — hence this assertion.
+func TestWorkspaceDescriptorsImplementHealthForStation(t *testing.T) {
+	home := t.TempDir()
+	for _, tc := range []struct {
+		name string
+		d    Descriptor
+	}{
+		{"claude-code", NewClaudeCode(filepath.Join(home, ".claude"))},
+		{"codex", NewCodex(filepath.Join(home, ".codex"))},
+		{"opencode", NewOpenCode(filepath.Join(home, "opencode"))},
+	} {
+		if _, ok := tc.d.(HealthForStation); !ok {
+			t.Errorf("%s descriptor (%T) must implement HealthForStation: its Health(key) "+
+				"re-runs Detect, which makes a health sweep quadratic", tc.name, tc.d)
+		}
+	}
+}
+
+// TestHealthForUsesStationWorkspace proves the fast path really does read the
+// workspace off the Station rather than re-resolving the key.
+//
+// The station key is unknown to the descriptor — Detect on an empty HOME finds
+// nothing — so any implementation that went back through projectPathForKey
+// would fail with "station not found". Succeeding is the proof.
+func TestHealthForUsesStationWorkspace(t *testing.T) {
+	home := t.TempDir()
+	ws := t.TempDir()
+
+	for _, tc := range []struct {
+		name string
+		d    Descriptor
+	}{
+		{"claude-code", NewClaudeCode(filepath.Join(home, ".claude"))},
+		{"codex", NewCodex(filepath.Join(home, ".codex"))},
+		{"opencode", NewOpenCode(filepath.Join(home, "opencode"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hf, ok := tc.d.(HealthForStation)
+			if !ok {
+				t.Skipf("%s does not implement HealthForStation", tc.name)
+			}
+			if _, err := hf.HealthFor(workspaceStation("test:not-a-real-key", ws)); err != nil {
+				t.Fatalf("HealthFor with a resolved workspace: %v; the workspace on the "+
+					"Station must be used directly, not re-resolved from the key", err)
+			}
+		})
+	}
+}
+
+// TestHealthForFallsBackWhenWorkspaceMissing asserts the documented contract:
+// a Station with no workspace falls back to the key-resolving Health, which on
+// an empty HOME means a "not found" error rather than a bogus snapshot.
+func TestHealthForFallsBackWhenWorkspaceMissing(t *testing.T) {
+	home := t.TempDir()
+	d := NewClaudeCode(filepath.Join(home, ".claude"))
+
+	hf, ok := d.(HealthForStation)
+	if !ok {
+		t.Fatal("claude-code must implement HealthForStation")
+	}
+	if _, err := hf.HealthFor(Station{Key: "claude-code:nope"}); err == nil {
+		t.Fatal("HealthFor with a nil WorkspacePath must fall back to Health(key), " +
+			"which cannot resolve an unknown key — got no error")
+	}
+}
+
+// TestHealthOfPrefersFastPath covers the dispatch helper itself.
+func TestHealthOfPrefersFastPath(t *testing.T) {
+	ws := t.TempDir()
+	d := NewClaudeCode(filepath.Join(t.TempDir(), ".claude"))
+
+	// Unknown key + resolved workspace: only the fast path can answer this.
+	if _, err := HealthOf(d, workspaceStation("claude-code:unknown", ws)); err != nil {
+		t.Fatalf("HealthOf did not take the HealthForStation path: %v", err)
+	}
+}

--- a/apps/node-agent/internal/descriptor/opencode.go
+++ b/apps/node-agent/internal/descriptor/opencode.go
@@ -331,7 +331,22 @@ func (o *openCodeDescriptor) Health(key string) (Health, error) {
 	if err != nil {
 		return Health{}, err
 	}
+	return o.healthAt(projPath), nil
+}
 
+// HealthFor implements HealthForStation: it reads the workspace off the station
+// the caller already detected instead of re-running Detect to find it again,
+// which is what turns a health sweep from O(N²) host scans into O(N).
+func (o *openCodeDescriptor) HealthFor(s Station) (Health, error) {
+	if s.WorkspacePath == nil || *s.WorkspacePath == "" {
+		return o.Health(s.Key)
+	}
+	return o.healthAt(*s.WorkspacePath), nil
+}
+
+// healthAt is the shared body of Health and HealthFor, keyed on a workspace
+// path the caller has already resolved.
+func (o *openCodeDescriptor) healthAt(projPath string) Health {
 	health := Health{}
 
 	// Disk usage from the shared async cache — never walk on the request path.
@@ -351,7 +366,7 @@ func (o *openCodeDescriptor) Health(key string) (Health, error) {
 		health.LastActivity = &s
 	}
 
-	return health, nil
+	return health
 }
 
 // openCodeProcessRunning checks for a running opencode process via pgrep.

--- a/apps/node-agent/internal/gateway/client.go
+++ b/apps/node-agent/internal/gateway/client.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"math/rand"
 	"strings"
@@ -25,6 +26,13 @@ const (
 // frames to the hub. Exported as a package-level var so tests can override it
 // without touching production code paths.
 var healthTickInterval = 30 * time.Second
+
+// heartbeatInterval is the cadence of the keepalive frame, which doubles as
+// this connection's liveness probe: a failed heartbeat write is one of the two
+// things that returns connectOnce so the reconnect loop can dial again. A
+// package-level var for the same reason as healthTickInterval — a test must not
+// have to wait 15 s to observe a dropped connection.
+var heartbeatInterval = 15 * time.Second
 
 // HealthReport is a single station's health snapshot inside a health push frame.
 // Metrics fields are nullable (pointer) so they can be omitted as JSON null when
@@ -168,7 +176,15 @@ type HelloMsg struct {
 // gatherHealth, if non-nil, is called on each health tick (healthTickInterval)
 // and the result is pushed as a {"type":"health","stations":[...]} frame. The
 // health ticker runs in its own goroutine, independent of the heartbeat path.
-func connectOnce(ctx context.Context, cfg config.Config, h Handler, onConnected func(), version string, gatherHealth func() []HealthReport) error {
+//
+// Every goroutine started here is scoped to a per-connection context derived
+// from parent, cancelled on return. It MUST stay that way: started on parent
+// directly, the health ticker's only exit was node shutdown, so each reconnect
+// left another one sweeping stations against a dead socket forever.
+func connectOnce(parent context.Context, cfg config.Config, h Handler, onConnected func(), version string, gatherHealth func() []HealthReport) error {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
 	c, _, err := websocket.Dial(ctx, wsURL(cfg.Hub), &websocket.DialOptions{
 		HTTPHeader: map[string][]string{"Authorization": {"Bearer " + cfg.NodeID + ":" + cfg.NodeSecret}},
 	})
@@ -195,7 +211,14 @@ func connectOnce(ctx context.Context, cfg config.Config, h Handler, onConnected 
 	var writeMu sync.Mutex
 
 	// Start the inbound read-loop; shares writeMu with the heartbeat below.
-	go serve(ctx, c, h, &writeMu)
+	// Its exit closes serveDone, which ends this connection: a socket that has
+	// stopped reading is gone, and waiting for the next heartbeat to discover
+	// that leaves the connection nominally alive for up to heartbeatInterval.
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		serve(ctx, c, h, &writeMu)
+	}()
 
 	// Health ticker — runs in its own goroutine, entirely separate from the
 	// heartbeat path, so a slow gatherHealth call never delays heartbeats.
@@ -213,19 +236,29 @@ func connectOnce(ctx context.Context, cfg config.Config, h Handler, onConnected 
 						"stations": gatherHealth(),
 					})
 					writeMu.Lock()
-					_ = c.Write(ctx, websocket.MessageText, frame)
+					werr := c.Write(ctx, websocket.MessageText, frame)
 					writeMu.Unlock()
+					// A failed push means the socket is gone. Stop: the read
+					// loop is about to end the connection, and sweeping
+					// stations to write into a dead socket is exactly the
+					// runaway this ticker's scoping now prevents.
+					if werr != nil {
+						return
+					}
 				}
 			}
 		}()
 	}
 
-	ticker := time.NewTicker(15 * time.Second)
+	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-serveDone:
+			// serve logs the underlying read error before returning.
+			return errors.New("inbound read loop closed")
 		case <-ticker.C:
 			hb, _ := json.Marshal(map[string]any{"type": "heartbeat", "ts": time.Now().UnixMilli()})
 			writeMu.Lock()

--- a/apps/node-agent/internal/gateway/healthticker_test.go
+++ b/apps/node-agent/internal/gateway/healthticker_test.go
@@ -1,0 +1,125 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/config"
+)
+
+// shortIntervals shrinks both connection tickers for the duration of a test.
+func shortIntervals(t *testing.T, d time.Duration) {
+	t.Helper()
+	origHealth, origHB := healthTickInterval, heartbeatInterval
+	healthTickInterval, heartbeatInterval = d, d
+	t.Cleanup(func() { healthTickInterval, heartbeatInterval = origHealth, origHB })
+}
+
+// droppingServer accepts one websocket, drains frames for hold, then drops the
+// connection — the shape of a flapping hub link.
+func droppingServer(hold time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+		readCtx, done := context.WithTimeout(r.Context(), hold)
+		defer done()
+		for {
+			if _, _, err := c.Read(readCtx); err != nil {
+				return // hold elapsed (or client gone) — drop the connection
+			}
+		}
+	}))
+}
+
+// TestHealthTickerStopsWhenConnectionEnds asserts that the health ticker a
+// connection starts is gone once that connection ends.
+//
+// REGRESSION: the ticker goroutine was started on the caller's context, which
+// is the process-lifetime context owned by runWithOpts, so its only exit path
+// was node shutdown. Every reconnect therefore left another ticker running
+// against a dead socket, and each one kept calling gatherHealth — a full
+// station sweep — every healthTickInterval, forever. On a flapping link the
+// sweeps accumulated linearly with the reconnect count (a real node reached
+// ~11 concurrent sweeps after 228 reconnects, spawning ~290 processes/second).
+func TestHealthTickerStopsWhenConnectionEnds(t *testing.T) {
+	const tick = 10 * time.Millisecond
+	shortIntervals(t, tick)
+
+	var calls atomic.Int64
+	gather := func() []HealthReport {
+		calls.Add(1)
+		return []HealthReport{{Key: "hermes:coder-kai", OK: true}}
+	}
+
+	srv := droppingServer(20 * tick)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := config.Config{Hub: srv.URL, NodeID: "n", NodeSecret: "s"}
+
+	// Drive the same sequence runWithOpts does: connect, get dropped, repeat.
+	const reconnects = 5
+	for i := 0; i < reconnects; i++ {
+		_ = connectOnce(ctx, cfg, stubHandler, func() {}, "dev", gather)
+	}
+
+	if calls.Load() == 0 {
+		t.Fatal("gatherHealth was never called; the test never exercised a live ticker")
+	}
+
+	// Every connection above is closed and connectOnce has returned for each.
+	// Let any tick already in flight land, then assert the count is frozen:
+	// no ticker may outlive its connection.
+	time.Sleep(5 * tick)
+	settled := calls.Load()
+	time.Sleep(20 * tick)
+
+	if got := calls.Load(); got != settled {
+		t.Fatalf("health ticker outlived its connection: gatherHealth calls went %d -> %d "+
+			"over 20 tick intervals after all %d connections closed; leaked tickers keep "+
+			"sweeping stations forever", settled, got, reconnects)
+	}
+}
+
+// TestReadLoopDeathEndsConnection asserts that connectOnce returns promptly
+// when the inbound read loop dies, rather than waiting for the next heartbeat
+// write to fail. A dropped socket should not leave a connection nominally
+// alive for up to a full heartbeatInterval.
+func TestReadLoopDeathEndsConnection(t *testing.T) {
+	const tick = 10 * time.Millisecond
+	// Health ticks stay fast; the heartbeat is deliberately slow so that the
+	// only way connectOnce can return quickly is the read loop reporting the
+	// drop.
+	origHealth, origHB := healthTickInterval, heartbeatInterval
+	healthTickInterval, heartbeatInterval = tick, 10*time.Second
+	t.Cleanup(func() { healthTickInterval, heartbeatInterval = origHealth, origHB })
+
+	srv := droppingServer(5 * tick)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := config.Config{Hub: srv.URL, NodeID: "n", NodeSecret: "s"}
+
+	done := make(chan struct{})
+	go func() {
+		_ = connectOnce(ctx, cfg, stubHandler, func() {}, "dev", nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("connectOnce did not return after the read loop died; it is waiting " +
+			"for the heartbeat to notice the connection is gone")
+	}
+}


### PR DESCRIPTION
A node on this fleet sat at ~90% CPU for a day and a half, spawning **~290 child processes per second** — 94% of them `git rev-parse --is-inside-work-tree`. Two bugs, compounding multiplicatively.

## 1. Leaked health tickers

`connectOnce` started its health ticker and read loop on the **caller's** context — the process-lifetime context owned by `runWithOpts`. The ticker's only exit was node shutdown, so every reconnect left another one running against a dead socket, sweeping every station every `healthTickInterval` forever. The write that would have revealed the dead connection was discarded (`_ = c.Write`).

The affected host is behind a flapping VPN link: 228 reconnects in its log, ~11 concurrent sweeps live when measured.

**Fix:** derive a per-connection context, `defer cancel()`. Also: the read loop's exit now ends the connection (a socket that stopped reading is gone — waiting for the next heartbeat left it nominally alive for up to 15s), and a failed health push returns instead of writing into a dead socket.

## 2. O(N²) station sweep

`gatherHealth` resolved health by key, and `Health(key)` on the workspace harnesses re-runs `Detect()`. `Detect` forks `git rev-parse` per project for `AppendChangesetCap`, so a sweep of N stations cost N+N² host scans — **702 git processes per 30s tick** on a 26-project host. The capabilities that inner `Detect` computed were discarded; `Health` only wanted a workspace path.

**Fix:** an optional `HealthForStation` interface plus a `HealthOf` dispatcher. claude-code, codex and opencode split `Health(key)` into a workspace-keyed `healthAt()` and implement `HealthFor`, reading the workspace off the `Station` the caller already holds. Each falls back to `Health(s.Key)` when the station has no workspace — the fast path is an optimisation, never a requirement, and no descriptor is forced to implement it.

## Measured against the live hub

| | Before | After |
|---|---|---|
| Child processes | 287/sec | **1.5/sec** |
| `git rev-parse` per tick | 702 | 26 |
| Steady-state CPU (`top`) | ~90% sustained | **0.0–1.8%** |

## Tests

Each was verified red before green:

- `gateway/healthticker_test.go` — a ticker dies with its connection; read-loop death ends the connection. Reproduces the leak exactly: 5 reconnects → 5 leaked tickers → 100 extra sweeps over 20 intervals.
- `cmd/agentpod-node/gatherhealth_test.go` — exactly one `Detect` per sweep; the non-`HealthFor` fallback still works. Reverting the fix fails it with `Detect called 13 times for a 12-station sweep`.
- `descriptor/healthfor_test.go` — the three workspace descriptors implement `HealthForStation`, and `HealthFor` really uses the station's workspace (its key is unknown to `Detect`, so re-resolving would error).

`go test -race ./...` green across all 15 node-agent packages; new tests stable over 8 repeat runs.

## Notes for the reviewer

- **Not fixed here:** `AppendChangesetCap` still forks `git rev-parse` per station per tick (the remaining 26). A pure-Go `.git` probe would take that to zero.
- **Now the dominant cost:** `diskUsage` walks entire workspaces every 5 minutes with no exclusions — one workspace on the affected host is 132,517 files. A cold start burns ~34% CPU for ~90s on that alone.
- **Pre-existing flake spotted:** `TestBuildRegistry_ThreadsClaudeCodeACPKeys` shells out to a `node --version` stub under a 2s timeout (`binary.go:102`). It failed once here while the machine was still loaded by the very bug being fixed, then passed consistently. Present on `main`; will flake on a loaded CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)