### PR TITLE
Bound the workspace disk-usage walk

### DIFF
--- a/apps/node-agent/internal/descriptor/diskusage.go
+++ b/apps/node-agent/internal/descriptor/diskusage.go
@@ -2,6 +2,8 @@ package descriptor
 
 import (
 	"io/fs"
+	"log"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -15,23 +17,113 @@ import (
 // diskUsage returns the last computed value immediately (nil before the first
 // walk completes) and refreshes stale entries in the background — at most one
 // walk per directory at a time.
+//
+// The walk is bounded on three axes, because an unbounded one does not merely
+// cost more — it never finishes. ~/.claude.json records every directory Claude
+// Code has been run from and Detect turns each into a station, so running
+// `claude` once from / or from $HOME made the entire filesystem a "workspace".
+// Walking that took longer than diskUsageTTL, so the refresh restarted the
+// moment it ended and the walker never idled: 2.2M+ files per pass and 21% of
+// a core, permanently, on a real host. The bounds are:
+//
+//   - unboundedRoot paths (/ and $HOME) are refused outright — their size
+//     describes the machine, not a workspace, so "unknown" is the honest answer.
+//   - skippedDirs (node_modules, .git, build output, vendored code) are pruned;
+//     they are most of a real workspace's file count and none of its content.
+//   - diskWalkBudget caps a single walk. Over budget reports unknown rather
+//     than the partial total, and backs off to diskUsageTruncatedTTL so an
+//     unwalkable tree is not re-walked every few minutes.
 
+// diskUsageTTL is how long a computed size stays fresh.
 var diskUsageTTL = 5 * time.Minute
+
+// diskUsageTruncatedTTL is the (much longer) retry interval after a walk blew
+// its budget. Retrying such a tree on the normal TTL is the permanent-walker
+// problem again, just slower.
+var diskUsageTruncatedTTL = 1 * time.Hour
+
+// diskWalkBudget bounds one directory's walk.
+var diskWalkBudget = 15 * time.Second
+
+// diskWalkSlots caps how many workspaces are walked concurrently. Every station
+// asks on the same health tick, so without this a host with 26 of them starts
+// 26 simultaneous walks and saturates every core at once.
+var diskWalkSlots = make(chan struct{}, 2)
+
+// skippedDirs are directory names whose contents are never counted: build
+// output, caches, and vendored dependencies. They are reproducible artefacts
+// rather than the workspace's own data, and they dominate its file count.
+var skippedDirs = map[string]bool{
+	"node_modules": true,
+	".git":         true,
+	".hg":          true,
+	".svn":         true,
+	"target":       true,
+	"dist":         true,
+	"build":        true,
+	".next":        true,
+	".nuxt":        true,
+	".turbo":       true,
+	".venv":        true,
+	"venv":         true,
+	"__pycache__":  true,
+	"vendor":       true,
+	".cache":       true,
+	".gradle":      true,
+	".terraform":   true,
+}
 
 type diskEntry struct {
 	bytes      int64
 	computedAt time.Time
 	refreshing bool
+	// truncated records that the last walk ran out of budget, so bytes is not
+	// a usable total and the retry interval is diskUsageTruncatedTTL.
+	truncated bool
 }
 
 var (
 	diskMu    sync.Mutex
 	diskCache = map[string]*diskEntry{}
+
+	// refusedOnce keeps the "not walking this" line to one per path, rather
+	// than one per health tick forever.
+	refusedOnce sync.Map
 )
 
-// diskUsage returns the cached size of dir in bytes, or nil when no walk has
-// completed yet. Missing or stale entries trigger a background refresh.
+// unboundedRoot reports whether dir is a filesystem root or the user's home
+// directory — paths whose subtree is the whole machine rather than a workspace.
+//
+// Exact match only: an ordinary project that happens to live inside $HOME is
+// still measured. It is only $HOME itself, and /, that are refused.
+func unboundedRoot(dir string) bool {
+	clean := filepath.Clean(dir)
+	if clean == string(filepath.Separator) {
+		return true
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if clean == filepath.Clean(home) {
+			return true
+		}
+	}
+	return false
+}
+
+// diskUsage returns the cached size of dir in bytes, or nil when the size is
+// not known: no walk has completed yet, the last walk ran out of budget, or dir
+// is a path we refuse to walk at all.
+//
+// Missing or stale entries trigger a background refresh; the call never blocks
+// on the filesystem.
 func diskUsage(dir string) *int64 {
+	if unboundedRoot(dir) {
+		if _, seen := refusedOnce.LoadOrStore(dir, struct{}{}); !seen {
+			log.Printf("descriptor: not measuring disk usage of %q — a filesystem root or "+
+				"home directory is not a workspace; its size would describe the host", dir)
+		}
+		return nil
+	}
+
 	diskMu.Lock()
 	defer diskMu.Unlock()
 
@@ -42,36 +134,74 @@ func diskUsage(dir string) *int64 {
 		return nil
 	}
 
+	// A truncated entry has no usable total, and is retried far less often.
+	ttl := diskUsageTTL
+	if e.truncated {
+		ttl = diskUsageTruncatedTTL
+	}
+
 	var result *int64
-	if !e.computedAt.IsZero() {
+	if !e.computedAt.IsZero() && !e.truncated {
 		b := e.bytes
 		result = &b
 	}
-	if !e.refreshing && time.Since(e.computedAt) > diskUsageTTL {
+	if !e.refreshing && time.Since(e.computedAt) > ttl {
 		e.refreshing = true
 		go refreshDiskUsage(dir)
 	}
 	return result
 }
 
-func refreshDiskUsage(dir string) {
-	var total int64
-	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+// walkDiskUsage totals the regular-file bytes under dir, pruning skippedDirs
+// and giving up once budget is spent. truncated reports whether it gave up.
+func walkDiskUsage(dir string, budget time.Duration) (total int64, truncated bool) {
+	deadline := time.Now().Add(budget)
+	// Checking the clock on every entry is itself measurable on a large tree,
+	// so it is sampled. Every entry counts, directories included: a tree that
+	// is deep and sparse rather than wide must still be able to run out of
+	// budget. The offset makes the first entry a checkpoint, so an already
+	// spent budget stops the walk immediately instead of after checkEvery.
+	const checkEvery = 512
+	n := 0
+
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip unreadable entries
 		}
-		if !d.IsDir() {
-			if info, err := d.Info(); err == nil {
-				total += info.Size()
+		if n++; n%checkEvery == 1 && time.Now().After(deadline) {
+			truncated = true
+			return filepath.SkipAll
+		}
+		if d.IsDir() {
+			// Never prune the root itself, even if it is named e.g. "build".
+			if path != dir && skippedDirs[d.Name()] {
+				return fs.SkipDir
 			}
+			return nil
+		}
+		if info, err := d.Info(); err == nil {
+			total += info.Size()
 		}
 		return nil
 	})
+	return total, truncated
+}
+
+func refreshDiskUsage(dir string) {
+	diskWalkSlots <- struct{}{}
+	defer func() { <-diskWalkSlots }()
+
+	total, truncated := walkDiskUsage(dir, diskWalkBudget)
+	if truncated {
+		log.Printf("descriptor: disk usage of %q gave up after %s — reporting unknown; "+
+			"next attempt in %s", dir, diskWalkBudget, diskUsageTruncatedTTL)
+	}
 
 	diskMu.Lock()
 	e := diskCache[dir]
 	e.bytes = total
 	e.computedAt = time.Now()
 	e.refreshing = false
+	e.truncated = truncated
 	diskMu.Unlock()
 }

--- a/apps/node-agent/internal/descriptor/diskusage_bounds_test.go
+++ b/apps/node-agent/internal/descriptor/diskusage_bounds_test.go
@@ -1,0 +1,188 @@
+package descriptor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// resetDiskCache clears the package-level cache so one test's entries cannot
+// satisfy another's lookups.
+func resetDiskCache(t *testing.T) {
+	t.Helper()
+	diskMu.Lock()
+	diskCache = map[string]*diskEntry{}
+	diskMu.Unlock()
+}
+
+// TestDiskUsageRefusesUnboundedRoots is the regression guard for the walk that
+// never ended.
+//
+// ~/.claude.json records every directory Claude Code has been run from, and
+// Detect turns each into a station — so running `claude` once from / or from
+// $HOME made the whole filesystem a "workspace". diskUsage then walked it
+// recursively every diskUsageTTL. On a real host that was 2.2M+ files per
+// refresh, a walk that could not finish inside the TTL, and therefore a
+// background walker that never idled: 21% of a core, permanently.
+//
+// A size for these paths is meaningless anyway — it describes the machine, not
+// a workspace — so the answer is "unknown", not a number.
+func TestDiskUsageRefusesUnboundedRoots(t *testing.T) {
+	resetDiskCache(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "f.bin"), make([]byte, 512), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, dir string }{
+		{"filesystem root", string(filepath.Separator)},
+		{"home directory", home},
+		{"home with trailing separator", home + string(filepath.Separator)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if v := diskUsage(tc.dir); v != nil {
+				t.Fatalf("diskUsage(%q) = %d, want nil — this path must never be walked", tc.dir, *v)
+			}
+			// It must STAY nil: a refused path may not quietly kick off a
+			// background walk that populates the cache a moment later.
+			time.Sleep(150 * time.Millisecond)
+			if v := diskUsage(tc.dir); v != nil {
+				t.Fatalf("diskUsage(%q) populated to %d after waiting; a refused path "+
+					"must not be walked in the background either", tc.dir, *v)
+			}
+		})
+	}
+}
+
+// TestDiskUsageWalksOrdinaryWorkspaceUnderHome asserts the refusal is exact:
+// a normal project that happens to live inside $HOME is still measured. Only
+// $HOME itself is refused.
+func TestDiskUsageWalksOrdinaryWorkspaceUnderHome(t *testing.T) {
+	resetDiskCache(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	proj := filepath.Join(home, "Projects", "app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "main.go"), make([]byte, 777), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := waitForDisk(t, proj, 2*time.Second); got != 777 {
+		t.Fatalf("workspace under $HOME = %d, want 777; only $HOME itself is refused", got)
+	}
+}
+
+// TestDiskUsageSkipsHeavyDirs asserts the walk ignores directories whose
+// contents are build output or vendored code. They dominate the file count of
+// a real workspace (one repo on the affected host held 132,517 files, nearly
+// all of them node_modules) and none of it is the user's data.
+func TestDiskUsageSkipsHeavyDirs(t *testing.T) {
+	resetDiskCache(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "src.go"), make([]byte, 100), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, heavy := range []string{"node_modules", ".git", "target", "dist", ".venv"} {
+		sub := filepath.Join(dir, heavy, "nested")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sub, "junk.bin"), make([]byte, 10_000), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := waitForDisk(t, dir, 2*time.Second); got != 100 {
+		t.Fatalf("disk usage = %d, want 100 — build/vendor dirs must not be counted", got)
+	}
+}
+
+// TestDiskUsageBudgetReportsUnknownNotPartial asserts that a walk which runs
+// out of budget reports "unknown" rather than the partial total it had
+// accumulated. A confidently wrong, far-too-small size is worse than none.
+func TestDiskUsageBudgetReportsUnknownNotPartial(t *testing.T) {
+	resetDiskCache(t)
+
+	orig := diskWalkBudget
+	diskWalkBudget = time.Nanosecond // every walk exceeds this immediately
+	t.Cleanup(func() { diskWalkBudget = orig })
+
+	dir := t.TempDir()
+	for i := 0; i < 50; i++ {
+		if err := os.WriteFile(filepath.Join(dir, string(rune('a'+i%26))+".bin"), make([]byte, 64), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	diskUsage(dir) // kick the walk
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		diskMu.Lock()
+		e, ok := diskCache[dir]
+		done := ok && !e.refreshing
+		diskMu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if v := diskUsage(dir); v != nil {
+		t.Fatalf("truncated walk reported %d bytes; an over-budget walk must report "+
+			"unknown (nil), never the partial total", *v)
+	}
+}
+
+// TestDiskUsageTruncatedWalkBacksOff asserts a walk that blew its budget is not
+// retried on the normal TTL. Retrying an unwalkable tree every few minutes is
+// the same permanent-walker problem in a slower form.
+func TestDiskUsageTruncatedWalkBacksOff(t *testing.T) {
+	resetDiskCache(t)
+
+	origBudget, origTTL := diskWalkBudget, diskUsageTTL
+	diskWalkBudget = time.Nanosecond
+	diskUsageTTL = time.Millisecond // normal entries would be stale instantly
+	t.Cleanup(func() { diskWalkBudget, diskUsageTTL = origBudget, origTTL })
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.bin"), make([]byte, 64), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	diskUsage(dir)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		diskMu.Lock()
+		e, ok := diskCache[dir]
+		done := ok && !e.refreshing
+		diskMu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	diskMu.Lock()
+	firstAttempt := diskCache[dir].computedAt
+	diskMu.Unlock()
+
+	time.Sleep(20 * time.Millisecond) // well past the 1ms normal TTL
+	diskUsage(dir)                    // must NOT kick a fresh walk
+
+	diskMu.Lock()
+	e := diskCache[dir]
+	refreshing, at := e.refreshing, e.computedAt
+	diskMu.Unlock()
+
+	if refreshing || !at.Equal(firstAttempt) {
+		t.Fatal("a truncated entry was retried on the normal TTL; it must back off to " +
+			"diskUsageTruncatedTTL so an unwalkable tree is not re-walked every few minutes")
+	}
+}


### PR DESCRIPTION
Follow-up to #379. With the fork storm fixed, the node still burned **21% of a core, permanently** — and it turned out not to be a slow walk, but a walk that never ended.

## What was happening

`~/.claude.json` records every directory Claude Code has been run from, and `Detect` turns each into a station. Running `claude` once from `/` or from `$HOME` made the entire filesystem a "workspace":

```
26 workspaces that diskUsage walked every 5 minutes:
  /                        <-- ENTIRE FILESYSTEM
  /Users/<user>            <-- ENTIRE HOME DIRECTORY
  /Users/<user>/.claude
  ... 23 ordinary repos
```

`diskUsage` had no bounds of any kind. I counted **2,227,723 files and the walk had not finished** at 284 seconds. Since a pass takes longer than `diskUsageTTL`, the refresh restarted the moment it ended — the background walker never idled. It also drove `mds_stores` to 13% CPU / 657 MB.

Pruning the two entries by hand took the node from 21% to **3.4%** of a core. But Claude Code recreates them the next time it is run from either path, so the node has to defend itself.

## Three bounds

**`unboundedRoot`** — `/` and `$HOME` are refused outright. Their size describes the host, not a workspace, so `nil` ("unknown") is the honest answer; `Health.DiskBytes` is already nullable. Exact match only: a project that merely *lives* inside `$HOME` is still measured.

**`skippedDirs`** — prunes `node_modules`, `.git`, `target`, `dist`, `build`, `.venv`, `vendor`, caches. On the affected host one repo held 132,517 files, nearly all `node_modules`. These are reproducible artefacts, not the workspace's content.

**`diskWalkBudget`** — caps a single walk at 15s. Over budget reports **unknown rather than the partial total** (a confidently wrong, far-too-small size is worse than none) and backs off to `diskUsageTruncatedTTL` (1h), so an unwalkable tree is not re-walked every few minutes — that is the same permanent-walker bug in a slower form.

Plus **`diskWalkSlots`**, capping concurrent walks at 2. Every station asks on the same health tick, so 26 stations previously started 26 simultaneous walks and saturated every core at once.

The deadline is sampled every 512 entries rather than checked per entry (the clock call is itself measurable on a large tree), counting directories too so a deep-but-sparse tree can also run out of budget, with the offset arranged so an already-spent budget stops the walk on the first entry.

## Tests

Each verified to fail with its guard disabled:

- `TestDiskUsageRefusesUnboundedRoots` — `/` and `$HOME` return nil and *stay* nil (a refused path must not be walked in the background either).
- `TestDiskUsageWalksOrdinaryWorkspaceUnderHome` — the refusal is exact; a project under `$HOME` is still measured.
- `TestDiskUsageSkipsHeavyDirs` — fails with `disk usage = 50100, want 100` when pruning is off.
- `TestDiskUsageBudgetReportsUnknownNotPartial` — an over-budget walk reports nil, never its partial total.
- `TestDiskUsageTruncatedWalkBacksOff` — a truncated entry is not retried on the normal TTL.

`go test -race ./...` green across all 15 packages (two consecutive full runs).

## Not fixed here — worth a decision

`/` should arguably never become a station at all. Beyond disk usage it means `cleanPlanCommon` offers **`/tmp`** as a cleanup candidate for that station, and the changeset capability runs git against `/`. Fixing that means declining to promote such paths in `Detect`, which changes what the console shows — a product call rather than a bug fix, so I have left it out.

Also unchanged: the pre-existing flake in `TestBuildRegistry_ThreadsClaudeCodeACPKeys` noted in #379 (a `node --version` stub under a 2s timeout, `binary.go:102`). It fired once during this work under heavy local load and passed on two subsequent full runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)