### PR TITLE
chore(fly): pin the node-agent to v0.1.29

### DIFF
--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -15,7 +15,7 @@
 # bun base (Debian) for opencode, matching Dockerfile.opencode.
 FROM oven/bun:1-slim
 
-ARG AGENTPOD_VERSION=v0.1.28
+ARG AGENTPOD_VERSION=v0.1.29
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git procps \

--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.28
+ARG AGENTPOD_VERSION=v0.1.29
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.28
+ARG AGENTPOD_VERSION=v0.1.29
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
Moves `ARG AGENTPOD_VERSION` onto **v0.1.29** in both Fly Dockerfiles and the Cloudflare worker-v2 Dockerfile, so `fly/node-image/check-version-pin.sh` stops refusing a Fly publish.

The images still download the released binary and verify it against this release's `SHA256SUMS` — unchanged.

Merging this is all that is needed; publishing the images is still a separate, manual `publish-images` run.

## Why this was opened by hand (again)

`release-node-agent.yml` builds this branch and opens this PR itself. The branch was pushed; the PR step failed:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

**Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** is off, so the workflow's `GITHUB_TOKEN` cannot open PRs. This has now failed the same step on **v0.1.27, v0.1.28 and v0.1.29** — it will keep failing on every tag until that setting is enabled.

The release itself is complete and verified:
- The workflow's own `Refuse to pin to an incomplete release` guard passed (`release v0.1.29 carries the linux binaries and SHA256SUMS`).
- All seven assets published, not a draft.
- `agentpod-node-darwin-arm64` checksum matches `SHA256SUMS` (`317b4795…`) and the binary reports `v0.1.29`.

Branch contents are exactly the three `ARG` bumps the workflow produced — no hand edits.