### PR TITLE
station-matrix: rotate credentials via appservice login, not an admin account

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -173,11 +173,12 @@ if (matrixBridge) {
       provisionStation: (stationId) => matrixBridge.provision(stationId),
       credentials: {
         // An appservice registration returns an access_token directly — no
-        // admin command, no password, no login round-trip. `rotate` is
-        // deliberately absent: replacing an existing identity's credentials
-        // needs the homeserver's admin account, and the route says so plainly
-        // rather than pretending.
+        // admin command, no password, no login round-trip.
         register: (localpart) => matrixBridge.client.registerWithCredentials(localpart),
+        // And an appservice may LOG IN as any user in its own namespace, which
+        // is how an identity that already exists gets new credentials without
+        // the homeserver admin account this service exists to do away with.
+        rotate: (localpart) => matrixBridge.client.rotateCredentials(localpart),
       },
     }),
   );

--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -214,3 +214,71 @@ describe("an alias that is already taken", () => {
     expect(roomId).toBeNull();
   });
 });
+
+describe("rotateCredentials", () => {
+  test("invalidates every existing token before issuing a new one", async () => {
+    replies = [
+      { status: 200, body: {} },
+      {
+        status: 200,
+        body: {
+          user_id: "@agent_box_pi-x:id.agentpod.dev",
+          access_token: "syt_new",
+          device_id: "DEV2",
+        },
+      },
+    ];
+
+    const out = await client().rotateCredentials("agent_box_pi-x");
+
+    expect(calls).toHaveLength(2);
+    // logout/all first, or rotation accumulates devices forever.
+    expect(calls[0]!.url).toContain("/_matrix/client/v3/logout/all");
+    expect(calls[1]!.url).toContain("/_matrix/client/v3/login");
+    expect(out).toEqual({
+      userId: "@agent_box_pi-x:id.agentpod.dev",
+      accessToken: "syt_new",
+      deviceId: "DEV2",
+    });
+  });
+
+  test("impersonates for logout/all and does not for login", async () => {
+    replies = [
+      { status: 200, body: {} },
+      { status: 200, body: { access_token: "syt_new", device_id: "DEV2" } },
+    ];
+
+    await client().rotateCredentials("agent_box_pi-x");
+
+    // The appservice acts AS the user to clear its sessions...
+    expect(calls[0]!.url).toContain("user_id=%40agent_box_pi-x%3Aid.agentpod.dev");
+    // ...but the login body names the user, and impersonating there is rejected.
+    expect(calls[1]!.url).not.toContain("user_id=");
+    expect(calls[1]!.body).toEqual({
+      type: "m.login.application_service",
+      identifier: { type: "m.id.user", user: "agent_box_pi-x" },
+    });
+  });
+
+  test("does not issue credentials when the old ones could not be cleared", async () => {
+    replies = [{ status: 403, body: { errcode: "M_FORBIDDEN" } }];
+
+    await expect(client().rotateCredentials("agent_box_pi-x")).rejects.toThrow(
+      /logout\/all/
+    );
+    // Crucially it stopped: a login here would have added a device to an
+    // identity whose existing tokens are still live.
+    expect(calls).toHaveLength(1);
+  });
+
+  test("refuses a login that comes back without a token", async () => {
+    replies = [
+      { status: 200, body: {} },
+      { status: 200, body: { user_id: "@agent_box_pi-x:id.agentpod.dev" } },
+    ];
+
+    await expect(client().rotateCredentials("agent_box_pi-x")).rejects.toThrow(
+      /no access_token/
+    );
+  });
+});

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -39,6 +39,23 @@ export interface MatrixClient {
   registerWithCredentials(
     localpart: string
   ): Promise<{ userId: string; accessToken: string; deviceId: string }>;
+  /**
+   * Replace the credentials of an identity that already exists.
+   *
+   * An Application Service may log in as any user inside its own namespace, so
+   * this needs no homeserver admin account — which matters, because the admin
+   * credential this service exists to eliminate may not exist at all.
+   *
+   * Every existing token is invalidated first. Login alone would MINT a device
+   * rather than replace one, so repeated rotations would accumulate devices and
+   * live tokens on an identity forever, and nothing can delete them afterwards:
+   * `DELETE /devices/{id}` requires User-Interactive Auth, which an appservice
+   * session has no password to satisfy. `rotate` therefore means replace, and
+   * an identity ends every rotation holding exactly one device.
+   */
+  rotateCredentials(
+    localpart: string
+  ): Promise<{ userId: string; accessToken: string; deviceId: string }>;
   ensureRoom(
     alias: string,
     opts: {
@@ -243,6 +260,52 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
 
       return {
         userId: String(res.body.user_id ?? `@${localpart}:${deps.domain ?? ""}`),
+        accessToken,
+        deviceId: String(res.body.device_id ?? ""),
+      };
+    },
+
+    async rotateCredentials(localpart) {
+      const userId = `@${localpart}:${deps.domain ?? ""}`;
+
+      // Impersonated, so no admin account is involved: an appservice may act as
+      // any user in its namespace. Verified against tuwunel 1.8.3.
+      const out = await call("/_matrix/client/v3/logout/all", {
+        method: "POST",
+        body: {},
+        userId,
+      });
+      if (out.status < 200 || out.status >= 300) {
+        throw new Error(
+          `matrix logout/all ${localpart} failed: ${out.status} ${String(out.body.errcode ?? "")}`.trim()
+        );
+      }
+
+      // Not impersonated — the login body names the user, and passing
+      // `?user_id=` as well is rejected.
+      const res = await call("/_matrix/client/v3/login", {
+        method: "POST",
+        body: {
+          type: "m.login.application_service",
+          identifier: { type: "m.id.user", user: localpart },
+        },
+      });
+      if (res.status < 200 || res.status >= 300) {
+        throw new Error(
+          `matrix login ${localpart} failed: ${res.status} ${String(res.body.errcode ?? "")}`.trim()
+        );
+      }
+
+      const accessToken = String(res.body.access_token ?? "");
+      if (!accessToken) {
+        throw new Error(
+          `matrix login ${localpart} returned no access_token — this homeserver ` +
+            "does not issue appservice credentials this way"
+        );
+      }
+
+      return {
+        userId: String(res.body.user_id ?? userId),
         accessToken,
         deviceId: String(res.body.device_id ?? ""),
       };


### PR DESCRIPTION
Closes #383.

## What changes

`MatrixClient` gains `rotateCredentials(localpart)`, and `index.ts` wires it as the `rotate` dependency `station-matrix` already expects. Nothing else moves — the route's logic and its existing tests are unchanged.

## Why it works without an admin account

An Application Service may log in as any user inside its own namespace. Verified against tuwunel 1.8.3 using only the registration's `as_token`:

```
POST /_matrix/client/v3/register  {"username":"agent_guild_hermes-coder-kai"}
  → 400 M_USER_IN_USE

POST /_matrix/client/v3/login     {"type":"m.login.application_service",
                                   "identifier":{"type":"m.id.user","user":"…"}}
  → 200  user_id + device_id + access_token
```

The comment `rotate` was omitted under — *"needs the homeserver's admin account"* — is true of the mechanism it was imagined with, and not of this one.

## Why it clears before it issues

Login **mints** a device rather than replacing one. A rotate built on login alone would accumulate devices and live access tokens on an identity indefinitely, and **nothing can remove them afterwards**: `DELETE /devices/{id}` requires User-Interactive Auth, which an appservice session has no password to satisfy.

That isn't hypothetical. Three strays accumulated on one identity while investigating #383 — two of them created by attempts to remove the first. With `logout/all` first, an identity ends every rotation holding exactly one device, verified live:

```
logout/all (impersonated) → 200
login                     → devices: ['FbM0TiGGvW']   count: 1
```

## The part that's easy to get backwards

The two calls differ in whether they impersonate, and both directions are asserted in tests:

- **`logout/all` is impersonated** — the appservice acts *as* the user to clear that user's sessions
- **`login` is not** — the body names the user, and passing `?user_id=` as well is rejected

## Tests

Four cases in `client.test.ts`:

- clears before issuing, in that order
- impersonates for `logout/all`, does not for `login`
- **when `logout/all` fails, no login is attempted** — issuing a fresh credential while the old ones are still live is the outcome worth preventing, and it fails silently if nothing asserts it
- refuses a login that returns no `access_token`

`bun test src/services/matrix-as/` → 157 pass, 0 fail. Typecheck: 15 pre-existing errors on `main`, 15 with this change, none in the touched files.

## Not included, deliberately

Issuing guild's stations their credentials is a separate act, gated on `mayGrantReach` and the control pair, because [granting an agent reach changes what the agent is](https://github.com/SuperJackfruitLabs/charter). This PR makes that possible; it doesn't do it.

## Context

Fourteen Hermes gateways on one node share a single Matrix account. That account was lost when the homeserver database was rebuilt on 2026-08-16, and all fourteen lost Matrix simultaneously — while `hermes gateway list` showed fourteen green ticks. Their per-station identities survived the rebuild (appservice users live in the registration namespace, not the user database); they simply could not be handed tokens. This is what unblocks that.