### PR TITLE
station-matrix: ask the homeserver whether an identity exists, rather than inferring it

### DIFF
--- a/apps/hub/src/routes/station-matrix.ts
+++ b/apps/hub/src/routes/station-matrix.ts
@@ -24,6 +24,7 @@ import { nodes } from "../db/schema/nodes";
 import { requireIssueCredentials } from "../services/grant-reach";
 import { isGrantReachDenied } from "../services/control-pair";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "../services/matrix-as/names";
+import { isMatrixUserInUse } from "../services/matrix-as/client";
 import type { AuthUser } from "../auth/middleware";
 
 export interface IssuedCredentials {
@@ -125,26 +126,33 @@ export function createStationMatrixRoutes(deps: StationMatrixDeps) {
 
       const localpart = bridgeLocalpart(station.nodeName, station.stationKey);
 
-      // An identity provisioned earlier already exists, so "already registered"
-      // is the normal case here rather than an error — but replacing its
-      // credentials needs the homeserver's admin account.
-      const alreadyHasIdentity = station.mode === "harness";
+      // Register, and rotate if the identity turns out to already exist.
+      //
+      // An earlier version branched on `station.mode === "harness"`, which reads
+      // as "does this identity exist" and is not. The bridge provisions an
+      // identity for every station it adopts, so a station in `bridge` mode has
+      // one too — it simply does not hold its own credentials. Every station on
+      // a real deployment was therefore sent down the `register` path and every
+      // one of them failed `M_USER_IN_USE`, which reached the operator as a 500.
+      //
+      // The homeserver is the authority on whether a user exists, so this asks
+      // it rather than inferring from a column that means something else.
       let issued: IssuedCredentials;
-
-      if (alreadyHasIdentity) {
+      try {
+        issued = await deps.credentials.register(localpart);
+      } catch (e) {
+        if (!isMatrixUserInUse(e)) throw e;
         if (!deps.credentials.rotate) {
           return c.json(
             {
               error:
-                "This identity already exists, and rotating its credentials needs the " +
-                "homeserver admin account, which this hub is not configured with.",
+                "This identity already exists, and rotating its credentials needs a " +
+                "capability this hub is not configured with.",
             },
             409
           );
         }
         issued = await deps.credentials.rotate(localpart);
-      } else {
-        issued = await deps.credentials.register(localpart);
       }
 
       await db

--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { createMatrixClient } from "./client";
+import { createMatrixClient, isMatrixUserInUse } from "./client";
 
 /**
  * Speaking to a homeserver *as* a station.
@@ -280,5 +280,29 @@ describe("rotateCredentials", () => {
     await expect(client().rotateCredentials("agent_box_pi-x")).rejects.toThrow(
       /no access_token/
     );
+  });
+});
+
+describe("registerWithCredentials", () => {
+  test("throws a typed error when the identity already exists", async () => {
+    replies = [{ status: 400, body: { errcode: "M_USER_IN_USE" } }];
+
+    const err = await client()
+      .registerWithCredentials("agent_box_pi-x")
+      .catch((e: unknown) => e);
+
+    // Typed, so the caller can branch on it without matching a message.
+    expect(isMatrixUserInUse(err)).toBe(true);
+  });
+
+  test("any other failure stays an ordinary error", async () => {
+    replies = [{ status: 403, body: { errcode: "M_FORBIDDEN" } }];
+
+    const err = await client()
+      .registerWithCredentials("agent_box_pi-x")
+      .catch((e: unknown) => e);
+
+    expect(isMatrixUserInUse(err)).toBe(false);
+    expect(String(err)).toContain("M_FORBIDDEN");
   });
 });

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -144,6 +144,24 @@ export interface MatrixClient {
   uploadImage(userId: string, bytes: Uint8Array, contentType: string): Promise<string | null>;
 }
 
+/**
+ * A registration refused because the identity already exists.
+ *
+ * Typed rather than a string match, for the same reason `GrantReachDenied` is:
+ * the caller has to *decide* what to do about it, and deciding on a substring of
+ * an error message is how that breaks silently later.
+ */
+export class MatrixUserInUse extends Error {
+  readonly errcode = "M_USER_IN_USE";
+  constructor(localpart: string) {
+    super(`matrix register ${localpart} refused: the identity already exists`);
+    this.name = "MatrixUserInUse";
+  }
+}
+
+export const isMatrixUserInUse = (e: unknown): e is MatrixUserInUse =>
+  e instanceof MatrixUserInUse;
+
 export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
   const doFetch = deps.fetch ?? fetch;
 
@@ -245,6 +263,11 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
       // for credentials to an identity that already has some, and answering with
       // nothing would leave a harness holding no token while believing it does.
       if (res.status < 200 || res.status >= 300) {
+        // Distinguished from every other failure because it is the one the
+        // caller can act on: the identity exists, so rotate it instead.
+        if (String(res.body.errcode ?? "") === "M_USER_IN_USE") {
+          throw new MatrixUserInUse(localpart);
+        }
         throw new Error(
           `matrix register ${localpart} failed: ${res.status} ${String(res.body.errcode ?? "")}`.trim()
         );

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -6,6 +6,7 @@ import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant } from "../../src/services/grants";
 import { createStationMatrixRoutes } from "../../src/routes/station-matrix";
+import { MatrixUserInUse } from "../../src/services/matrix-as/client";
 
 /**
  * Registering an agent's Matrix identity, without an admin credential on a node.
@@ -30,6 +31,8 @@ let provisioned: string[] = [];
 let issued: Array<{ localpart: string }> = [];
 let rotated: Array<{ localpart: string }> = [];
 let canRotate = true;
+/** The homeserver already has this localpart — the normal case on a real deployment. */
+let identityExists = false;
 let logged: string[] = [];
 
 function app() {
@@ -40,6 +43,7 @@ function app() {
     },
     credentials: {
       register: async (localpart: string) => {
+        if (identityExists) throw new MatrixUserInUse(localpart);
         issued.push({ localpart });
         return {
           userId: `@${localpart}:${DOMAIN}`,
@@ -94,6 +98,7 @@ beforeEach(async () => {
   rotated = [];
   logged = [];
   canRotate = true;
+  identityExists = false;
   await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
 });
 
@@ -189,7 +194,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
     // The identity is provisioned long before anyone asks for credentials, so
     // "already registered" is the normal case, not an error.
     await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
-    await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
+    identityExists = true;
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);
 
@@ -205,12 +210,41 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
     // is not configured, the honest answer is that this cannot be done here —
     // not a 500, and not a silent no-op that leaves a harness without a token.
     canRotate = false;
+    identityExists = true;
     await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
-    await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);
 
     expect(res.status).toBe(409);
-    expect((await res.text()).toLowerCase()).toMatch(/admin|rotate|configur/);
+    expect((await res.text()).toLowerCase()).toMatch(/rotate|configur/);
+  });
+
+  test("a station in BRIDGE mode whose identity exists is rotated, not refused", async () => {
+    // The regression this file did not have. The bridge provisions an identity
+    // for every station it adopts, so a station in `bridge` mode has one — it
+    // simply does not hold its own credentials. Branching on the mode sent every
+    // station on a real deployment down the register path, where all 32 of them
+    // failed M_USER_IN_USE and the operator saw a 500.
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
+    identityExists = true;
+
+    const res = await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(res.status).toBe(200);
+    expect(rotated).toHaveLength(1);
+    expect(issued).toHaveLength(0);
+    expect(((await res.json()) as { mode: string }).mode).toBe("harness");
+  });
+
+  test("registers, without rotating, when the identity is genuinely new", async () => {
+    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    identityExists = false;
+
+    const res = await post(`/stations/${STATION}/matrix/credentials`);
+
+    expect(res.status).toBe(200);
+    expect(issued).toHaveLength(1);
+    expect(rotated).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Follow-up to #384. That PR wired `rotate`; this one makes a station actually reach it.

## The bug

`POST /stations/:id/matrix/credentials` returns **500 for every station** on a real deployment:

```
matrix register agent_guild_hermes-analyst-echo failed: 400 M_USER_IN_USE
    at client.ts:248
```

The route branched on:

```ts
const alreadyHasIdentity = station.mode === "harness";
```

which reads as *"does this identity exist"* and means something else. The bridge provisions an identity for every station it adopts, so a station in `bridge` mode **has** one — it just doesn't hold its own credentials.

On the deployment:

```
matrix_identity_mode | count | with bridge_matrix_id
bridge               | 32    | 32
```

All 32 stations take the `register` branch. All 32 fail `M_USER_IN_USE`. All 32 surface as an unhandled 500.

## The change

Register, and rotate if the identity turns out to already exist. The homeserver is the authority on whether a user exists, so the route asks it instead of inferring from a column that means something else. That also makes the call idempotent — which matters, because the column and the homeserver can disagree, as they did here on every row.

`M_USER_IN_USE` becomes a typed `MatrixUserInUse` rather than a substring match, for the same reason `GrantReachDenied` is typed: the caller must *decide* what to do about it, and deciding on an error message is how that breaks quietly later.

## Why the tests didn't catch it

Both existing route tests forced the rotate branch with:

```ts
await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
```

— the column that turned out not to drive the real behaviour. They passed while the deployment was broken, because they asserted the branch they had set up rather than the state a deployment is actually in.

They now drive the branch through the fake homeserver, and two cases are added:

- **a station in `bridge` mode whose identity exists is rotated, not refused** — the regression this file was missing
- a station whose identity is genuinely new is registered, without rotating

## Also

The 409 message no longer says rotation needs the homeserver admin account. Since #384, it doesn't.

## Verification

`bun test src/services/matrix-as/` → **159 pass, 0 fail**. Typecheck: 15 pre-existing errors on `main`, 15 with this change, none in touched files. The integration suite needs Postgres and runs in CI.

Found by deploying #384 and calling the route against a real station, which is the step that should have come before claiming #384 unblocked anything.