### PR TITLE
fix(node-agent): the root hermes station takes its name from profile.yaml

### DIFF
--- a/apps/node-agent/internal/descriptor/hermes.go
+++ b/apps/node-agent/internal/descriptor/hermes.go
@@ -74,7 +74,7 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 			Key:           "hermes",
 			Harness:       "hermes",
 			Kind:          "composite",
-			DisplayName:   "Hermes",
+			DisplayName:   h.rootDisplayName(),
 			ParentKey:     nil,
 			WorkspacePath: &homeCopy,
 			Capabilities:  AppendChangesetCap(caps, &homeCopy),
@@ -124,6 +124,46 @@ func (h *hermesDescriptor) Detect() ([]Station, error) {
 	}
 
 	return stations, nil
+}
+
+// rootDisplayName is the name shown for the root station — the agent the bare
+// `hermes gateway run` serves.
+//
+// It was the literal "Hermes" until 2026-08-29. On a host where the root gateway
+// IS the operator's primary agent that is simply the wrong name, and there was no
+// way to correct it: profile stations take their name from their directory, but
+// the root has no directory to rename, and the hub overwrites `display_name`
+// from this value on every re-adoption — so renaming it in the console does not
+// survive either.
+//
+// Hermes already has the answer. `hermes profile rename default "<name>"` is a
+// supported command whose own help reads "for 'default': a display name — the
+// canonical id stays 'default'", and it writes that name to <home>/profile.yaml.
+// Reading it here means the operator names the agent with Hermes' own tool and
+// the name reaches the console unchanged.
+//
+// Falls back to "Hermes" whenever the file is absent or unreadable, so hosts
+// that have never been renamed behave exactly as before.
+func (h *hermesDescriptor) rootDisplayName() string {
+	const fallback = "Hermes"
+	data, err := os.ReadFile(filepath.Join(h.home, "profile.yaml"))
+	if err != nil {
+		return fallback
+	}
+	// Line-by-line, for the same reason mxidFromConfigYAML is: no YAML
+	// dependency, and only the intended field is ever read.
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "display_name:") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(trimmed, "display_name:"))
+		name = strings.Trim(name, `"'`)
+		if name != "" {
+			return name
+		}
+	}
+	return fallback
 }
 
 // hermesMatrixDomain is the default Matrix homeserver domain hint passed to the

--- a/apps/node-agent/internal/descriptor/hermes_default_profile_test.go
+++ b/apps/node-agent/internal/descriptor/hermes_default_profile_test.go
@@ -303,3 +303,89 @@ func assertNoStubRan(t *testing.T, markers ...string) {
 		}
 	}
 }
+
+// Regression tests for the root station's display name.
+//
+// The root station was named by the literal "Hermes". On a host where the root
+// gateway is the operator's primary agent that is the wrong name, and it could
+// not be corrected: the root has no directory to rename, and the hub overwrites
+// display_name from the detector on every re-adoption. Hermes already records
+// the intended name in <home>/profile.yaml via `hermes profile rename default`.
+func TestRootStationTakesDisplayNameFromProfileYAML(t *testing.T) {
+	home := defaultProfileHome(t)
+	if err := os.WriteFile(filepath.Join(home, "profile.yaml"),
+		[]byte("display_name: Super Chotu\n"), 0o644); err != nil {
+		t.Fatalf("write profile.yaml: %v", err)
+	}
+
+	stations, err := NewHermes(home).Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	root := findStation(t, stations, "hermes")
+	if root.DisplayName != "Super Chotu" {
+		t.Errorf("root display name = %q, want %q", root.DisplayName, "Super Chotu")
+	}
+
+	// Profiles keep taking their name from their directory — this changes the
+	// root only.
+	profile := findStation(t, stations, "hermes:analyst-echo")
+	if profile.DisplayName != "analyst-echo" {
+		t.Errorf("profile display name = %q, want %q", profile.DisplayName, "analyst-echo")
+	}
+}
+
+// A host that has never been renamed must behave exactly as it did before.
+func TestRootStationFallsBackToHermes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body *string
+	}{
+		{"no profile.yaml", nil},
+		{"empty file", strPtr("")},
+		{"key present but empty", strPtr("display_name:\n")},
+		{"unrelated keys only", strPtr("model:\n  default: k3-256k\n")},
+		{"quoted empty value", strPtr("display_name: \"\"\n")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := defaultProfileHome(t)
+			if tc.body != nil {
+				if err := os.WriteFile(filepath.Join(home, "profile.yaml"), []byte(*tc.body), 0o644); err != nil {
+					t.Fatalf("write profile.yaml: %v", err)
+				}
+			}
+			stations, err := NewHermes(home).Detect()
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if root := findStation(t, stations, "hermes"); root.DisplayName != "Hermes" {
+				t.Errorf("root display name = %q, want %q", root.DisplayName, "Hermes")
+			}
+		})
+	}
+}
+
+// Quoted values and trailing whitespace are written by hand often enough to test.
+func TestRootStationDisplayNameIsTrimmedAndUnquoted(t *testing.T) {
+	for _, tc := range []struct{ body, want string }{
+		{"display_name: \"Super Chotu\"\n", "Super Chotu"},
+		{"display_name: 'Super Chotu'\n", "Super Chotu"},
+		{"display_name:    Super Chotu   \n", "Super Chotu"},
+		{"# a comment\ndisplay_name: Super Chotu\n", "Super Chotu"},
+	} {
+		home := defaultProfileHome(t)
+		if err := os.WriteFile(filepath.Join(home, "profile.yaml"), []byte(tc.body), 0o644); err != nil {
+			t.Fatalf("write profile.yaml: %v", err)
+		}
+		stations, err := NewHermes(home).Detect()
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+		if root := findStation(t, stations, "hermes"); root.DisplayName != tc.want {
+			t.Errorf("body %q → display name %q, want %q", tc.body, root.DisplayName, tc.want)
+		}
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## The problem

The root Hermes station is named by a literal:

```go
Key:         "hermes",
DisplayName: "Hermes",
```

On a host where the root gateway **is** the operator's primary agent, that is the wrong name — and there is no way to correct it:

- profile stations take their name from their directory; the root has no directory to rename
- `station-registry.ts` sets `displayName` from the detector on every re-adoption, and re-adoption is routine (it is how capabilities refresh) — so renaming in the console is undone on the next sync

Worth noting `purpose` is deliberately excluded from that same upsert, with a comment explaining that a value overwritten on a schedule "would silently undo every deliberate labelling". `displayName` did not get that protection.

## The fix

Hermes already records the answer. `hermes profile rename default "<name>"` is a supported command — its own help reads *"for 'default': a display name — the canonical id stays 'default'"* — and it writes to `<home>/profile.yaml`:

```yaml
display_name: Super Chotu
```

`Detect` now reads it. The operator names the agent with Hermes' own tool and the name reaches the console unchanged, rather than being overwritten by the next sync. This sidesteps the registry overwrite entirely instead of fighting it.

Parsed line-by-line for the same reason `mxidFromConfigYAML` is: no YAML dependency, and only the intended field is ever read.

## Behaviour preserved

Falls back to `"Hermes"` when the file is absent, unreadable, empty, or carries no usable value — hosts that have never been renamed behave exactly as before. Profile stations are untouched.

## Tests

Added to `hermes_default_profile_test.go`:

- root takes the name from `profile.yaml`, while `hermes:analyst-echo` still comes from its directory
- fallback across five shapes: no file, empty file, key with no value, unrelated keys only, quoted empty value
- quoted, single-quoted, whitespace-padded and comment-preceded values

`go build ./...`, `go vet`, and the full `internal/descriptor` suite pass.

## Where this came from

Found on `guild`, whose default gateway carries **19,524 sessions against 144 across all thirteen profiled agents combined** and is the endpoint for Telegram, Discord and WhatsApp. It appeared in the console as "Hermes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr