### PR TITLE
fix(fly): pin the node images to v0.1.30

### DIFF
--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -15,7 +15,7 @@
 # bun base (Debian) for opencode, matching Dockerfile.opencode.
 FROM oven/bun:1-slim
 
-ARG AGENTPOD_VERSION=v0.1.29
+ARG AGENTPOD_VERSION=v0.1.30
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git procps \

--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.29
+ARG AGENTPOD_VERSION=v0.1.30
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.29
+ARG AGENTPOD_VERSION=v0.1.30
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
`main` has been red since **2026-08-29T14:10** — the v0.1.30 release commit.

Cutting that release did not bump the three Dockerfiles that pin the version they install, so they still fetch **v0.1.29**, and `check-version-pin.sh` — which exists to notice exactly this — has failed on every PR since.

```
fly/node-image/Dockerfile:29
fly/node-image/Dockerfile.pi:32
cloudflare/worker-v2/Dockerfile:18
```

## It is not only a red check

An image built from these defaults ships an agent **without v0.1.30** — the release where the root Hermes station learned to take its name from `profile.yaml` (#386). A runtime provisioned from a stale image would show the wrong name in the console, which is the bug that release fixed.

## Verification

```
$ sh fly/node-image/check-version-pin.sh
ok: fly/node-image/Dockerfile pins v0.1.30 (current release)
ok: fly/node-image/Dockerfile.pi pins v0.1.30 (current release)
ok: cloudflare/worker-v2/Dockerfile pins v0.1.30 (current release)
```

Kept separate from `feat/approvals-over-chat` (#387) deliberately: it is unrelated to that work, and this should be mergeable on its own to get `main` green again. #387's `node-agent` job fails for this reason and nothing else — its other four jobs pass.

**Worth a follow-up:** the release process cut a tag without bumping the pins, and nothing stopped it. The check catches the result on the next PR rather than at the moment it is created, which is why this sat red for a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr
