### PR TITLE
fix(node-agent): a station's matrix id is not any user_id in the file

### DIFF
--- a/apps/node-agent/internal/descriptor/matrix.go
+++ b/apps/node-agent/internal/descriptor/matrix.go
@@ -80,26 +80,51 @@ func mxidFromConfigYAML(profileDir string) *string {
 		return nil
 	}
 
-	// Look for bare scalar keys: "user_id:", "mxid:", or nested "matrix:" section
-	// with "  user_id:" beneath it. We use simple line scanning (no YAML parser
-	// dependency) — sufficient for this use-case and avoids parsing side-channels.
+	// A station's own Matrix id lives at the top level of the file, or as an
+	// IMMEDIATE child of `matrix:`. Depth is the whole point of this function.
+	//
+	// The first version matched `user_id:` at any indentation and tracked a
+	// `matrix:` section it then never consulted. That is not a style problem. A
+	// Hermes profile with a home channel looks like this:
+	//
+	//	platforms:
+	//	  matrix:
+	//	    home_channel:
+	//	      user_id: '@rakesh:id.agentpod.dev'
+	//
+	// and that `user_id` is correct config — it names the human counterpart of
+	// the DM. Read as the station's own identity it made the operator's mxid
+	// ambiguous, so `resolveMatrixId` could attribute nothing they sent; it made
+	// the agent's messages attributable to them; and it made fleet liveness
+	// check the operator's phone to decide whether an agent was alive. The fleet
+	// reported 14/14 throughout.
+	//
+	// Line scanning still, rather than a YAML dependency — but indentation is
+	// now read instead of ignored.
 	lines := strings.Split(string(data), "\n")
-	inMatrixSection := false
+	matrixIndent := -1 // indent of the `matrix:` key, or -1 when outside it
+	childIndent := -1  // indent of its immediate children, learned from the first
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-
-		// Detect "matrix:" section header (no value on the same line).
-		if trimmed == "matrix:" {
-			inMatrixSection = true
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		// Exit the matrix section when we see a non-indented key.
-		if inMatrixSection && len(line) > 0 && line[0] != ' ' && line[0] != '\t' && line[0] != '#' && line[0] != '\n' {
-			inMatrixSection = false
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+
+		// Leaving the matrix section: a key at or above its own indentation.
+		if matrixIndent >= 0 && indent <= matrixIndent {
+			matrixIndent, childIndent = -1, -1
 		}
 
-		// Match "user_id: <value>" and "mxid: <value>" at any indentation level,
-		// or within the matrix section.
+		if trimmed == "matrix:" {
+			matrixIndent, childIndent = indent, -1
+			continue
+		}
+
+		if matrixIndent >= 0 && childIndent == -1 {
+			childIndent = indent
+		}
+
 		var value string
 		switch {
 		case strings.HasPrefix(trimmed, "user_id:"):
@@ -110,8 +135,15 @@ func mxidFromConfigYAML(profileDir string) *string {
 			continue
 		}
 
-		// Strip surrounding quotes if present.
-		value = strings.Trim(value, `"'`)
+		// Top level, or an immediate child of `matrix:`. Anything deeper belongs
+		// to some other object and is not this station's identity.
+		atTopLevel := matrixIndent < 0 && indent == 0
+		isMatrixChild := matrixIndent >= 0 && indent == childIndent
+		if !atTopLevel && !isMatrixChild {
+			continue
+		}
+
+		value = strings.Trim(value, `"\'`)
 
 		if m := validateMXID(value); m != nil {
 			return m

--- a/apps/node-agent/internal/descriptor/matrix_test.go
+++ b/apps/node-agent/internal/descriptor/matrix_test.go
@@ -57,3 +57,81 @@ func TestMatrixIDFromConfigYAML(t *testing.T) {
 		t.Fatalf("want mxid from config.yaml, got %v", got)
 	}
 }
+
+// TestMatrixIDIgnoresNestedUserID is the regression for a real incident.
+//
+// A Hermes profile with a home channel carries a `user_id` naming the human
+// counterpart of that DM. The parser matched `user_id:` at any indentation and
+// reported it as the STATION's own identity, so:
+//
+//   - the operator's mxid was claimed by both a principal and a station, which
+//     made `resolveMatrixId` ambiguous and meant nothing they sent could be
+//     attributed — approving a gate from their phone was silently refused
+//   - the agent's messages were attributable to the operator
+//   - fleet liveness checked the operator's phone to decide whether the agent
+//     was alive, and reported the fleet fully healthy throughout
+//
+// Correcting the database did not hold: the node re-reports on every adoption,
+// so the row was rewritten within minutes. The config is the source.
+func TestMatrixIDIgnoresNestedUserID(t *testing.T) {
+	dir := t.TempDir()
+	const cfg = `_config_version: 37
+platforms:
+  matrix:
+    enabled: true
+    home_channel:
+      platform: matrix
+      chat_id: '!6HOezBXFk71L5hqwm9:id.agentpod.dev'
+      name: writer-quill
+      user_id: '@rakesh:id.agentpod.dev'
+      scope_id: id.agentpod.dev
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if got := MatrixIDFromProfile(dir, "id.agentpod.dev"); got != nil {
+		t.Fatalf("a home channel's user_id is the human it talks to, not this station: got %q", *got)
+	}
+}
+
+// TestMatrixIDFromMatrixSection keeps the case the fix must not break.
+func TestMatrixIDFromMatrixSection(t *testing.T) {
+	dir := t.TempDir()
+	const cfg = `platforms:
+  matrix:
+    enabled: true
+    user_id: '@agent_guild_hermes-writer-quill:id.agentpod.dev'
+    home_channel:
+      user_id: '@rakesh:id.agentpod.dev'
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	got := MatrixIDFromProfile(dir, "id.agentpod.dev")
+	if got == nil || *got != "@agent_guild_hermes-writer-quill:id.agentpod.dev" {
+		t.Fatalf("an immediate child of matrix: is the station's own identity, got %v", got)
+	}
+}
+
+// TestMatrixIDPrefersEnvOverNestedNoise is the shape the live fleet was in:
+// no usable id in config.yaml, the right one in .env.
+func TestMatrixIDPrefersEnvOverNestedNoise(t *testing.T) {
+	dir := t.TempDir()
+	const cfg = `platforms:
+  matrix:
+    enabled: true
+    home_channel:
+      user_id: '@rakesh:id.agentpod.dev'
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	env := "MATRIX_USER_ID=@agent_guild_hermes-writer-quill:id.agentpod.dev\nMATRIX_ACCESS_TOKEN=secret\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(env), 0600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	got := MatrixIDFromProfile(dir, "id.agentpod.dev")
+	if got == nil || *got != "@agent_guild_hermes-writer-quill:id.agentpod.dev" {
+		t.Fatalf("want the .env identity once config.yaml offers nothing usable, got %v", got)
+	}
+}


### PR DESCRIPTION
Found because approving a gate from a phone was refused with **"decision from an unlinked sender"** — for a sender who was demonstrably linked.

## The bug

`mxidFromConfigYAML` matched `user_id:` at any indentation, and tracked a `matrix:` section it then **never consulted**. A Hermes profile with a home channel looks like this:

```yaml
platforms:
  matrix:
    home_channel:
      chat_id: '!6HOezBXFk71L5hqwm9:id.agentpod.dev'
      user_id: '@rakesh:id.agentpod.dev'
```

That `user_id` is **correct config** — it names the human counterpart of the DM. Read as the *station's own* identity it did three things, all silent:

- the operator's mxid was claimed by both a principal and a station, so `resolveMatrixId` went **ambiguous** and nothing they sent could be attributed — the gate refusal above
- the agent's messages became attributable to the operator
- **fleet liveness checked the operator's phone** to decide whether the agent was alive, and reported 14/14 throughout

One station of fourteen had a home channel, so one station of fourteen was wrong — and it was wrong in a way that broke the *operator*, not the agent.

## Why the obvious fix didn't work

Correcting `stations.matrix_id` directly held for a few minutes and reverted. The node re-reports on every adoption and the hub upserts what it is told. The config is the source; the parser is the defect. I fixed the mirror first and had to be shown otherwise by it reverting.

## The fix

A station's own id is read only from the **top level** or as an **immediate child of `matrix:`**. Anything deeper belongs to some other object.

Still line scanning rather than a YAML dependency — but indentation is now read instead of computed and discarded.

## Tests

Three regressions: the home-channel shape must yield nothing; a real `matrix:` child must still win over a nested one; and `.env` must still be reached when `config.yaml` offers nothing usable — which is the shape the live fleet is actually in.

`cmd/agentpod-node` has one unrelated failure, **#293**, the known PATH-empty flake. `internal/descriptor` passes.

## Follow-on

`guild:/root/.hermes/profiles/writer-quill/config.yaml` currently has that `user_id` line commented out with an explanation. Once this ships and the fleet updates, the line goes back and the comment comes out — the config was never wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr
