### PR TITLE
chore(fly): pin the node images to v0.1.31, before the tag

### DIFF
--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -15,7 +15,7 @@
 # bun base (Debian) for opencode, matching Dockerfile.opencode.
 FROM oven/bun:1-slim
 
-ARG AGENTPOD_VERSION=v0.1.30
+ARG AGENTPOD_VERSION=v0.1.31
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git procps \

--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.30
+ARG AGENTPOD_VERSION=v0.1.31
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.30
+ARG AGENTPOD_VERSION=v0.1.31
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
Ahead of cutting **v0.1.31**, deliberately, and in this order.

`check-version-pin.sh` passes a pin that is **ahead** of the resolved release — its own comment says that case is *"only reachable while a release is mid-flight"* — and fails one that is **behind**.

So bumping first keeps `main` green through the gap. Tagging first turns it red the moment the release resolves, which is exactly what happened with v0.1.30 and **sat red for a day** (#388, fixed this morning). Doing it the other way round twice in one day would be careless.

```
ok: fly/node-image/Dockerfile pins v0.1.31 (ahead of the resolved release v0.1.30)
ok: fly/node-image/Dockerfile.pi pins v0.1.31 (ahead of the resolved release v0.1.30)
ok: cloudflare/worker-v2/Dockerfile pins v0.1.31 (ahead of the resolved release v0.1.30)
```

## What v0.1.31 carries

The node-agent fix from #391: a station's Matrix id is no longer read from any `user_id:` at any depth, so a Hermes profile with a home channel stops reporting the **operator's** mxid as the **agent's** identity.

Until the fleet is on it, `guild:writer-quill`'s `config.yaml` has that line commented out as a stopgap — the config was never wrong, the parser was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr
