### PR TITLE
feat(gates): project the work a gate is asking about

### DIFF
--- a/apps/hub/src/services/matrix-as/gates.test.ts
+++ b/apps/hub/src/services/matrix-as/gates.test.ts
@@ -47,6 +47,21 @@ describe("the gate event's wire shape", () => {
     }
   });
 
+  test("carries the work the reviewer is being asked to approve", () => {
+    // supermessage#37. A gate that shows a title and no work asks someone to
+    // approve something they cannot see.
+    const c = gateEventContent({ ...DELIVERY, handoffSummary: "Wrote the haiku." });
+    expect(c.handoff_summary).toBe("Wrote the haiku.");
+    expect(c.schema_version).toBe(2);
+  });
+
+  test("omits the summary entirely when the board sent none", () => {
+    // A board that predates this sends nothing, and an empty row reads like a
+    // card that failed to load.
+    expect(gateEventContent(DELIVERY).handoff_summary).toBeUndefined();
+    expect(gateEventContent({ ...DELIVERY, handoffSummary: null }).handoff_summary).toBeUndefined();
+  });
+
   test("carries none of the four fields kaambaan#34 proposed that do not exist", () => {
     // run_id and task_id name no column; gates do not expire; tenant_id is
     // kaambaan's internal boundary and a room can be wider than a board.

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -64,6 +64,14 @@ export interface GatePendingDelivery {
   returnStageKey: string;
   cardTitle: string;
   producedBy: string;
+  /**
+   * What the reviewer is being asked to approve — the previous stage's
+   * handoff, bounded by the board at 600 characters.
+   *
+   * Optional because a board that has not shipped kaambaan#… yet sends none,
+   * and a gate without it must still render.
+   */
+  handoffSummary?: string | null;
   options: Array<{ id: string; label: string }>;
   ts: string;
 }
@@ -178,7 +186,7 @@ export function gateEventContent(
   const options = d.options.filter((o) => isGateOptionId(o.id));
   return {
     body: gateProseBody(d, deepLink),
-    schema_version: 1,
+    schema_version: 2,
     board_id: d.boardId,
     card_id: d.cardId,
     gate_id: d.gateId,
@@ -187,6 +195,11 @@ export function gateEventContent(
     card_title: d.cardTitle,
     produced_by: d.producedBy,
     prompt: `Approve "${d.cardTitle}"?`,
+    // supermessage#37: without this the card asks a reviewer to approve work
+    // it does not show them. Additive, so `schema_version` moves rather than
+    // the type — a renderer written against v1 ignores it and still draws the
+    // buttons.
+    ...(d.handoffSummary ? { handoff_summary: d.handoffSummary } : {}),
     options,
     ...(deepLink ? { deep_link: deepLink } : {}),
   };

--- a/fixtures/ecosystem-identity/matrix_gate_events.json
+++ b/fixtures/ecosystem-identity/matrix_gate_events.json
@@ -1,6 +1,6 @@
 {
   "corpus": "ecosystem-identity/matrix-gate-events",
-  "version": 1,
+  "version": 2,
   "authoredAt": "2026-08-30",
   "authoredFrom": "the gates table in kaambaan apps/api/src/board/board-do.ts, the GateDecision union it resolves against, and charter decisions/2026-08-30-a-gate-closes-over-chat.md",
   "purpose": "A kaambaan approval gate crosses into a Matrix room and a human's answer crosses back. Three codebases must agree on the field names: the board that opens the gate, the Application Service that projects and resolves it, and the client that draws the buttons. A rename in any one of them is a gate that silently never resolves — which reads to the human as a button that does nothing.",
@@ -51,7 +51,7 @@
           "why": "the ordinary case",
           "content": {
             "body": "Approval needed — \"Add OAuth login\" at stage `review`. Approve, request changes, or reject: https://kaambaan.dev/b/brd_7c1f/c/crd_9a22",
-            "schema_version": 1,
+            "schema_version": 2,
             "board_id": "brd_7c1f",
             "card_id": "crd_9a22",
             "gate_id": "gate_4e8b",
@@ -74,7 +74,8 @@
                 "label": "Reject"
               }
             ],
-            "deep_link": "https://kaambaan.dev/b/brd_7c1f/c/crd_9a22"
+            "deep_link": "https://kaambaan.dev/b/brd_7c1f/c/crd_9a22",
+            "handoff_summary": "Added the OAuth routes and a test for the refresh-token path."
           }
         },
         {
@@ -257,11 +258,39 @@
               }
             ]
           }
+        },
+        {
+          "why": "a handoff_summary that is not a string. It is displayed text; an object here would be rendered by whatever a host does with a non-string, which is exactly the coercion the renderers refuse.",
+          "content": {
+            "body": "Approval needed.",
+            "schema_version": 2,
+            "board_id": "brd_7c1f",
+            "card_id": "crd_9a22",
+            "gate_id": "gate_4e8b",
+            "stage_key": "review",
+            "return_stage_key": "code",
+            "card_title": "Add OAuth login",
+            "produced_by": "agt_31d0",
+            "prompt": "Ship it?",
+            "handoff_summary": {
+              "summary": "nested"
+            },
+            "options": [
+              {
+                "id": "approve",
+                "label": "Approve"
+              }
+            ]
+          }
         }
       ],
       "matrixEventType": "dev.kaambaan.gate.v1",
       "companion": "Sent beside a plain m.room.message carrying the same question, so stock clients can follow the room. The companion is prose only and carries no structured fields; nothing resolves against it.",
-      "bodyIsForThisClient": "`body` is supermessage's own FallbackBody path, used when the renderer cannot draw the card — not a stock-client fallback. That is what the companion message is for."
+      "bodyIsForThisClient": "`body` is supermessage's own FallbackBody path, used when the renderer cannot draw the card — not a stock-client fallback. That is what the companion message is for.",
+      "schemaVersions": {
+        "1": "card title, stage, produced_by, prompt, options.",
+        "2": "adds `handoff_summary` — what the reviewer is being asked to approve. Additive, so a v1 renderer ignores it and still draws the buttons. Added after a gate reached a phone showing a card title and no work: the reviewer was asked to approve a haiku with no haiku on the card (supermessage#37). Bounded by the board at 600 characters, because a room is not a document store and the client caps content at 8 KiB anyway."
+      }
     },
     {
       "suiteEventType": "dev.kaambaan.gate.decision.v1",


### PR DESCRIPTION
`SuperJackfruitLabs/supermessage#37`, the bridge half.

kaambaan now sends `handoffSummary` on `gate.pending` (`SuperJackfruitLabs/kaambaan#49`); this carries it into the room as `handoff_summary`.

## Additive, so the type does not move

`schema_version` goes to **2** rather than the event type going to `.v2`. A renderer written against v1 ignores the field and still draws the buttons — which is the entire reason this suite versions on two axes, and the first time that design has been exercised.

Omitted **entirely** when the board sends none, rather than sent empty. A board that predates this is a normal case for a while, and an empty row reads like a card that failed to load.

## Fixture

Gains the field, a v2 accept case, and a reject case for a **non-string** summary — it is displayed prose, and an object there would be rendered by whatever a host does with a non-string, which is the coercion every renderer in this suite refuses.

## The other halves

- `SuperJackfruitLabs/kaambaan#49` — the board sends it, bounded at 600 characters
- `SuperJackfruitLabs/supermessage` → `feat/gate-shows-the-work` — renders it as the card's reasoning, collapsed by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr
