### PR TITLE
The floor beneath push: ask which gates never arrived

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -13,7 +13,8 @@ import { rateLimitMiddleware } from './middleware/rate-limit.ts';
 import { csrfMiddleware } from './middleware/csrf.ts';
 import { createKaambaanPushRoutes } from './routes/kaambaan-push.ts';
 import { servicePublicJwks } from './auth/service-signing.ts';
-import { tenantForBoard } from './services/matrix-as/gates.ts';
+import { projectGate, tenantForBoard } from './services/matrix-as/gates.ts';
+import { startGateSweeper } from './services/matrix-as/gate-sweep.ts';
 import { createLogger } from './utils/logger.ts';
 import { healthRoutes } from './routes/health.ts';
 // Node gateway WebSocket routes
@@ -185,6 +186,22 @@ const app = new Hono()
 // unconfigured hub answers a homeserver with 404 rather than with a bridge that
 // cannot act.
 if (matrixBridge) {
+  // How a gate reaches a room, however it got here. Shared by the push
+  // receiver and the sweep beneath it, so a swept gate and a pushed one cannot
+  // be posted by two slightly different projections.
+  const gateProjection = {
+    domain: matrixBridge.config.domain,
+    boardBaseUrl: process.env.KAAMBAAN_BOARD_URL,
+    sendText: (userId: string, roomId: string, body: string) =>
+      matrixBridge.client.sendText(userId, roomId, body),
+    sendCustomEvent: (
+      userId: string,
+      roomId: string,
+      eventType: string,
+      content: Record<string, unknown>,
+    ) => matrixBridge.client.sendCustomEvent(userId, roomId, eventType, content),
+  };
+
   // POST /public/bridge/kaambaan/push — a board telling us a gate is open.
   //
   // Under /public, not /api, because the caller is a Worker holding a signing
@@ -195,14 +212,20 @@ if (matrixBridge) {
     '/public',
     createKaambaanPushRoutes({
       secret: process.env.KAAMBAAN_PUSH_SECRET,
-      domain: matrixBridge.config.domain,
-      boardBaseUrl: process.env.KAAMBAAN_BOARD_URL,
       tenantIdFor: tenantForBoard,
-      sendText: (userId, roomId, body) => matrixBridge.client.sendText(userId, roomId, body),
-      sendCustomEvent: (userId, roomId, eventType, content) =>
-        matrixBridge.client.sendCustomEvent(userId, roomId, eventType, content),
+      ...gateProjection,
     }),
   );
+
+  // …and the floor beneath it. kaambaan retries a push five times and then
+  // dead-letters it, at which point the gate is silent on both sides: a card
+  // blocked on an approval nobody was told about. This asks each board what it
+  // is still waiting on. `projectGate` is idempotent on `gate_id`, so the two
+  // paths are meant to overlap rather than to be arbitrated between.
+  startGateSweeper({
+    tenantIdFor: tenantForBoard,
+    project: (tenantId, delivery) => projectGate(tenantId, delivery, gateProjection),
+  });
 
   app.route(
     '/_matrix/app/v1',

--- a/apps/hub/src/routes/kaambaan-push.ts
+++ b/apps/hub/src/routes/kaambaan-push.ts
@@ -23,6 +23,7 @@ import { Hono } from "hono";
 
 import { createLogger } from "../utils/logger";
 import {
+  isGatePending,
   projectGate,
   type GatePendingDelivery,
   type GateProjectionDeps,
@@ -59,21 +60,6 @@ async function signatureMatches(secret: string, raw: string, header: string): Pr
     diff |= expected.charCodeAt(i) ^ header.charCodeAt(i);
   }
   return diff === 0;
-}
-
-function isGatePending(v: unknown): v is GatePendingDelivery {
-  if (typeof v !== "object" || v === null) return false;
-  const d = v as Record<string, unknown>;
-  return (
-    d.event === "gate.pending" &&
-    typeof d.boardId === "string" &&
-    typeof d.cardId === "string" &&
-    typeof d.gateId === "string" &&
-    d.gateId.length > 0 &&
-    typeof d.stageKey === "string" &&
-    typeof d.cardTitle === "string" &&
-    Array.isArray(d.options)
-  );
 }
 
 export function createKaambaanPushRoutes(deps: KaambaanPushDeps) {

--- a/apps/hub/src/services/bridge/kaambaan.test.ts
+++ b/apps/hub/src/services/bridge/kaambaan.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { KaambaanApiError, KaambaanClient, isForeignRun, isLeaseSuperseded } from "./kaambaan";
+import type { GatePendingDelivery } from "../matrix-as/gates";
 
 const TOKEN = `kbn_${"a1b2c3d4".repeat(6)}`;
 const BOARD = "brd_9c1d4e5f6a7b8c9d";
@@ -220,5 +221,44 @@ describe("KaambaanClient — 403 and 409 are different facts", () => {
     const err = (await client.activity(work, { type: "thought" }).catch((e) => e)) as KaambaanApiError;
     expect(err.message).toContain("activities");
     expect(err.message).toContain("no active lease for this run");
+  });
+});
+
+describe("KaambaanClient — pending gates", () => {
+  const gate: GatePendingDelivery = {
+    event: "gate.pending",
+    boardId: BOARD,
+    cardId: "crd_1a2b3c4d5e6f7a8b",
+    gateId: "gate_4e8b",
+    stageKey: "review",
+    returnStageKey: "code",
+    cardTitle: "Add OAuth login",
+    producedBy: "agt_31d0",
+    handoffSummary: "Wrote the haiku.",
+    options: [{ id: "approve", label: "Approve" }],
+    ts: "2026-08-30T00:00:00.000Z",
+  };
+
+  test("reads the gates a board is still waiting on", async () => {
+    const { client, calls } = fakeBoard(() => ({ status: 200, body: { gates: [gate] } }));
+
+    expect(await client.pendingGates()).toEqual([gate]);
+    expect(calls[0]!.url).toBe(`https://board.test/v1/boards/${BOARD}/gates/pending`);
+    expect(calls[0]!.method).toBe("GET");
+    // The agent's own token. The board snapshot carrying the same gates is a
+    // human route, and reaching it would mean asserting a person on a timer.
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test("reads an empty board as no gates, not as a failure", async () => {
+    const { client } = fakeBoard(() => ({ status: 200, body: { gates: [] } }));
+    expect(await client.pendingGates()).toEqual([]);
+  });
+
+  test("throws on a refusal rather than reporting a quiet board", async () => {
+    // A rejected token that read as "no gates pending" would let the sweep
+    // report healthy forever while every gate it exists to catch stayed silent.
+    const { client } = fakeBoard(() => ({ status: 401, body: boardError("UNAUTHORIZED") }));
+    await expect(client.pendingGates()).rejects.toBeInstanceOf(KaambaanApiError);
   });
 });

--- a/apps/hub/src/services/bridge/kaambaan.ts
+++ b/apps/hub/src/services/bridge/kaambaan.ts
@@ -43,12 +43,25 @@
  */
 
 import type { BoardActivity } from "./coalesce";
+import type { GatePendingDelivery } from "../matrix-as/gates";
 
 /** Injected so the client runs in a test with no network and no wrangler. */
 export type Fetcher = (
   url: string,
   init: { method: string; headers: Record<string, string>; body?: string },
 ) => Promise<{ status: number; ok: boolean; json(): Promise<unknown> }>;
+
+/**
+ * Global `fetch`, narrowed to the shape the client injects.
+ *
+ * Lives beside `Fetcher` rather than in each caller so that the bridge loop and
+ * the gate sweep reach a board through the same adapter — two of these would be
+ * two places for a header or a status to be handled differently.
+ */
+export const fetchAdapter: Fetcher = async (url, init) => {
+  const res = await fetch(url, init);
+  return { status: res.status, ok: res.ok, json: () => res.json() as Promise<unknown> };
+};
 
 export interface KaambaanClientOptions {
   baseUrl: string;
@@ -278,6 +291,30 @@ export class KaambaanClient {
    */
   async context(runId: string): Promise<RunContext> {
     return (await this.send("GET", `/v1/boards/${this.boardId}/runs/${runId}`)) as RunContext;
+  }
+
+  /**
+   * Every gate on this board still waiting on a human.
+   *
+   * The read half of the reconciliation sweep. kaambaan pushes a gate when it
+   * opens and dead-letters the delivery after five attempts, at which point
+   * the gate is silent on both sides — the card blocked on an approval nobody
+   * was told about. This is how the hub asks instead of waiting to be told.
+   *
+   * Authenticated with the agent's own `kbn_` token. The board snapshot
+   * carries the same gates and is a human route; reaching it would mean
+   * minting an assertion for a person on a timer, and the property that makes
+   * assertions safe is that their subject is never chosen by the caller.
+   *
+   * A refusal throws. "No gates pending" and "this token is rejected" have the
+   * same shape and opposite meanings, and reporting the second as the first is
+   * how a floor beneath push becomes a floor that was never there.
+   */
+  async pendingGates(): Promise<GatePendingDelivery[]> {
+    const res = (await this.send("GET", `/v1/boards/${this.boardId}/gates/pending`)) as {
+      gates?: GatePendingDelivery[];
+    };
+    return res.gates ?? [];
   }
 
   private verb(lease: RunLease, action: string, extra: Record<string, unknown> = {}): Promise<unknown> {

--- a/apps/hub/src/services/bridge/loop.ts
+++ b/apps/hub/src/services/bridge/loop.ts
@@ -16,7 +16,7 @@ import { resolveTenantForUser } from "../../auth/tenant";
 import * as acpSessions from "../acp-sessions";
 import { isBridgeEnabled, loadBridgeConfig, type BridgeAgentConfig } from "./config";
 import { runOnce, type AcpPort, type DispatchResult } from "./dispatch";
-import { KaambaanClient } from "./kaambaan";
+import { KaambaanClient, fetchAdapter } from "./kaambaan";
 
 /** How long to wait after a claim that found nothing. */
 const DEFAULT_POLL_MS = 5_000;
@@ -179,12 +179,3 @@ const describe = (agent: BridgeAgentConfig, baseUrl: string) => ({
   mode: agent.mode,
   baseUrl,
 });
-
-/** Global `fetch`, narrowed to the shape the client injects. */
-const fetchAdapter = async (
-  url: string,
-  init: { method: string; headers: Record<string, string>; body?: string },
-) => {
-  const res = await fetch(url, init);
-  return { status: res.status, ok: res.ok, json: () => res.json() as Promise<unknown> };
-};

--- a/apps/hub/src/services/matrix-as/gate-sweep.test.ts
+++ b/apps/hub/src/services/matrix-as/gate-sweep.test.ts
@@ -1,0 +1,251 @@
+/**
+ * The floor beneath push.
+ *
+ * `charter → decisions/2026-08-30-a-gate-closes-over-chat.md` §5: "Delivery is
+ * push, made durable, with a reconciliation sweep beneath it." kaambaan retries
+ * a delivery five times and then dead-letters it. At that point the gate is
+ * silent on both sides — the card is blocked on an approval nobody was ever
+ * told about, and neither product is looking. This asks the board directly.
+ *
+ * The sweep deliberately holds no idempotency of its own. `projectGate` claims
+ * a gate in `matrix_gate_events` before it sends, so re-offering a gate that is
+ * already in a room costs one refused insert and posts nothing. Putting a
+ * second "have I sent this?" check here would be a second answer to a question
+ * that already has one, and the two would eventually disagree.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { bridgeGateSweepDeps, startGateSweeper, sweepGates, type GateSweepDeps } from "./gate-sweep";
+import type { GatePendingDelivery, ProjectionOutcome } from "./gates";
+
+function gate(gateId: string, boardId: string): GatePendingDelivery {
+  return {
+    event: "gate.pending",
+    boardId,
+    cardId: `crd_${gateId}`,
+    gateId,
+    stageKey: "review",
+    returnStageKey: "code",
+    cardTitle: "Add OAuth login",
+    producedBy: "agt_31d0",
+    options: [{ id: "approve", label: "Approve" }],
+    ts: "2026-08-30T00:00:00.000Z",
+  };
+}
+
+interface Fake {
+  deps: GateSweepDeps;
+  offered: string[];
+  asked: string[];
+}
+
+function fake(overrides: Partial<GateSweepDeps> = {}, outcomes: Record<string, ProjectionOutcome> = {}): Fake {
+  const offered: string[] = [];
+  const asked: string[] = [];
+  const deps: GateSweepDeps = {
+    boards: async () => ["brd_one"],
+    tenantIdFor: async () => "flt_a",
+    pendingGates: async (boardId) => {
+      asked.push(boardId);
+      return [gate("gate_1", boardId)];
+    },
+    project: async (_tenantId, d) => {
+      offered.push(d.gateId);
+      return outcomes[d.gateId] ?? { status: "sent", eventId: "$ev", roomId: "!r:h" };
+    },
+    ...overrides,
+  };
+  return { deps, offered, asked };
+}
+
+describe("the gate sweep", () => {
+  test("offers every pending gate on every board this hub works", async () => {
+    const f = fake({
+      boards: async () => ["brd_one", "brd_two"],
+      pendingGates: async (boardId) =>
+        boardId === "brd_one" ? [gate("gate_1", boardId)] : [gate("gate_2", boardId), gate("gate_3", boardId)],
+    });
+
+    const result = await sweepGates(f.deps);
+
+    expect(f.offered).toEqual(["gate_1", "gate_2", "gate_3"]);
+    expect(result.projected).toBe(3);
+  });
+
+  test("counts what it posted, not what it looked at", async () => {
+    // The number that matters operationally. A sweep reporting three when the
+    // room got one is a sweep whose logs say it is working while gates are
+    // being dropped somewhere below it.
+    const f = fake({ pendingGates: async (b) => [gate("gate_1", b), gate("gate_2", b)] }, {
+      gate_2: { status: "already" },
+    });
+
+    const result = await sweepGates(f.deps);
+
+    expect(result.checked).toBe(2);
+    expect(result.projected).toBe(1);
+  });
+
+  test("does not count a gate that found no room to appear in", async () => {
+    // A gate on a card no AgentPod station ran. Named as a cost in the charter
+    // decision: there is no room, so there is no projection. It must not read
+    // as delivered.
+    const f = fake({}, { gate_1: { status: "no-room" } });
+
+    expect((await sweepGates(f.deps)).projected).toBe(0);
+  });
+
+  test("never asks a board whose gates it could not place anyway", async () => {
+    // `tenantIdFor` is null for a board this hub has never dispatched work to,
+    // which means no card→station binding and therefore no room for any gate on
+    // it. Asking would spend a request to learn something already known.
+    const f = fake({ tenantIdFor: async () => null });
+
+    const result = await sweepGates(f.deps);
+
+    expect(f.asked).toEqual([]);
+    expect(result.checked).toBe(0);
+  });
+
+  test("keeps sweeping when one board cannot be reached", async () => {
+    // The regression that would matter most: a sweep that dies on the first
+    // unreachable board stops being a floor, and does it silently — the boards
+    // after it are simply never asked.
+    const f = fake({
+      boards: async () => ["brd_down", "brd_up"],
+      pendingGates: async (boardId) => {
+        if (boardId === "brd_down") throw new Error("connect ECONNREFUSED");
+        return [gate("gate_2", boardId)];
+      },
+    });
+
+    const result = await sweepGates(f.deps);
+
+    expect(f.offered).toEqual(["gate_2"]);
+    expect(result.projected).toBe(1);
+    expect(result.failedBoards).toEqual(["brd_down"]);
+  });
+
+  test("refuses to project a gate in a shape it does not understand", async () => {
+    // The push receiver validates because bytes arrive over a webhook; these
+    // arrive over an authenticated read, which is not the same as a checked
+    // one. A board a version ahead — or behind — would otherwise have this hub
+    // posting a card with an empty title and no options into someone's room.
+    // Both paths refuse through the same predicate, so neither can drift alone.
+    const f = fake({
+      pendingGates: async (b) =>
+        [{ event: "gate.pending", boardId: b, cardId: "crd_1" }, gate("gate_2", b)] as GatePendingDelivery[],
+    });
+
+    const result = await sweepGates(f.deps);
+
+    expect(f.offered).toEqual(["gate_2"]);
+    expect(result.checked).toBe(1);
+  });
+
+  test("keeps sweeping when one gate cannot be projected", async () => {
+    // One room the appservice cannot post to must not cost every gate behind it
+    // in the same pass.
+    const f = fake({
+      pendingGates: async (b) => [gate("gate_1", b), gate("gate_2", b)],
+      project: async (_t, d) => {
+        if (d.gateId === "gate_1") throw new Error("M_FORBIDDEN");
+        return { status: "sent", eventId: "$ev", roomId: "!r:h" };
+      },
+    });
+
+    expect((await sweepGates(f.deps)).projected).toBe(1);
+  });
+});
+
+describe("what the sweep reads, and as whom", () => {
+  const config = {
+    baseUrl: "https://board.test",
+    source: "kaambaan",
+    agents: [
+      { key: "forge", boardId: "brd_one", token: `kbn_${"a".repeat(48)}`, stationId: "stn_1", hubUserId: "usr_1" },
+      { key: "quill", boardId: "brd_two", token: `kbn_${"b".repeat(48)}`, stationId: "stn_2", hubUserId: "usr_1" },
+      // Two agents on one board is ordinary: an agent is not a board.
+      { key: "scout", boardId: "brd_one", token: `kbn_${"c".repeat(48)}`, stationId: "stn_3", hubUserId: "usr_1" },
+    ],
+  } as unknown as Parameters<typeof bridgeGateSweepDeps>[0];
+
+  function recordingFetch() {
+    const sent: Array<{ url: string; token: string }> = [];
+    const fetchImpl = async (url: string, init: { method: string; headers: Record<string, string> }) => {
+      sent.push({ url, token: init.headers.Authorization ?? "" });
+      return { status: 200, ok: true, json: async () => ({ gates: [] }) };
+    };
+    return { sent, fetchImpl };
+  }
+
+  test("asks each board once, however many agents work it", async () => {
+    const deps = bridgeGateSweepDeps(config, { tenantIdFor: async () => "flt_a", project: async () => ({ status: "already" }) });
+
+    // Two agents claim on brd_one. Sweeping it twice would ask the same
+    // question twice and log every recovered gate twice with it.
+    expect(await deps.boards()).toEqual(["brd_one", "brd_two"]);
+  });
+
+  test("reads a board with the credential belonging to that board", async () => {
+    // The failure this prevents is quiet: an agent's token is scoped to its own
+    // board, so sweeping brd_two with brd_one's token is a 401 that reads, in
+    // the sweep's own result, as a board that could not be reached.
+    const { sent, fetchImpl } = recordingFetch();
+    const deps = bridgeGateSweepDeps(
+      config,
+      { tenantIdFor: async () => "flt_a", project: async () => ({ status: "already" }) },
+      fetchImpl,
+    );
+
+    await deps.pendingGates("brd_two");
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.url).toBe("https://board.test/v1/boards/brd_two/gates/pending");
+    expect(sent[0]!.token).toBe(`Bearer ${config.agents[1]!.token}`);
+  });
+});
+
+describe("starting the sweeper", () => {
+  const config = {
+    baseUrl: "https://board.test",
+    source: "kaambaan",
+    agents: [{ key: "forge", boardId: "brd_one", token: `kbn_${"a".repeat(48)}`, stationId: "s", hubUserId: "u" }],
+  } as unknown as Parameters<typeof bridgeGateSweepDeps>[0];
+
+  test("does not start on a hub that works no board", async () => {
+    // Most hubs. A timer here would wake every five minutes to iterate an empty
+    // list, and any error inside it would be reported by a subsystem the
+    // operator never turned on.
+    expect(startGateSweeper({ tenantIdFor: async () => null, project: async () => ({ status: "already" }) }, { config: null })).toBeNull();
+  });
+
+  test("actually runs a pass — an unstarted sweeper is the whole bug", async () => {
+    // `dispatchPushDeliveries` existed for weeks with nothing calling it, so a
+    // queued gate sat until something external poked the board. The same shape
+    // of mistake here would be a sweep that is written, tested, deployed, and
+    // never runs.
+    let passes = 0;
+    let resolveFirst: () => void;
+    const first = new Promise<void>((r) => (resolveFirst = r));
+
+    const stop = startGateSweeper(
+      {
+        tenantIdFor: async () => {
+          passes++;
+          resolveFirst!();
+          return null;
+        },
+        project: async () => ({ status: "already" }),
+      },
+      { config, intervalMs: 5 },
+    );
+
+    expect(stop).not.toBeNull();
+    await first;
+    stop!();
+
+    expect(passes).toBeGreaterThan(0);
+  });
+});

--- a/apps/hub/src/services/matrix-as/gate-sweep.ts
+++ b/apps/hub/src/services/matrix-as/gate-sweep.ts
@@ -1,0 +1,200 @@
+/**
+ * The reconciliation sweep — asking the board which gates never arrived.
+ *
+ * `charter → decisions/2026-08-30-a-gate-closes-over-chat.md` §5 settles the
+ * delivery semantics: "push, made durable, with a reconciliation sweep beneath
+ * it". Push is the fast path and it is at-least-once *within a cap* — kaambaan
+ * retries five times with backoff and then dead-letters the delivery. A gate
+ * that exhausts its attempts is silent on both sides: the card is blocked on an
+ * approval, and neither product is looking for one that never rang.
+ *
+ * That is the same failure the estate keeps finding at other levels — a service
+ * failing 116,666 times over eight days with nothing configured to notice. The
+ * sweep is what makes "a gate cannot be lost" a property rather than a hope.
+ *
+ * ## It holds no idempotency of its own
+ *
+ * `projectGate` claims the gate in `matrix_gate_events` before it sends, so
+ * re-offering one already in a room costs a refused insert and posts nothing.
+ * Push, redelivery and this are meant to overlap; a second "have I sent this?"
+ * check here would be a second answer to a question that already has one, and
+ * two answers eventually disagree.
+ *
+ * ## Every failure is per-board and per-gate
+ *
+ * A sweep that throws on the first unreachable board stops being a floor, and
+ * does it invisibly — the boards behind it are simply never asked. So a board
+ * that cannot be reached is recorded and stepped over, and so is a gate whose
+ * room refuses the post.
+ */
+
+import { KaambaanClient, fetchAdapter, type Fetcher } from "../bridge/kaambaan";
+import { isBridgeEnabled, loadBridgeConfig, type BridgeConfig } from "../bridge/config";
+import { createLogger } from "../../utils/logger";
+import { isGatePending } from "./gates";
+import type { GatePendingDelivery, ProjectionOutcome } from "./gates";
+
+const log = createLogger("gate-sweep");
+
+export interface GateSweepDeps {
+  /** The kaambaan boards this hub works, from the bridge's own configuration. */
+  boards(): Promise<string[]>;
+  /**
+   * Which fleet a board's gates belong to, or null when this hub never worked
+   * it — in which case no card on it was ever dispatched to a station, so no
+   * gate on it can have a room.
+   */
+  tenantIdFor(boardId: string): Promise<string | null>;
+  /** Gates the board is still waiting on, read with the bridge's own token. */
+  pendingGates(boardId: string): Promise<GatePendingDelivery[]>;
+  /** Post the gate, exactly once. Idempotent on `gate_id`. */
+  project(tenantId: string, d: GatePendingDelivery): Promise<ProjectionOutcome>;
+}
+
+export interface GateSweepResult {
+  /** Pending gates seen across every board that answered. */
+  checked: number;
+  /** Gates this pass actually put in a room. Anything else was already there,
+   *  had nowhere to go, or failed — and none of those is a delivery. */
+  projected: number;
+  /** Boards that could not be asked. Named, because an empty sweep and an
+   *  unreachable board look identical from the outside. */
+  failedBoards: string[];
+}
+
+/** One sweep pass. Deps are injected so this runs with no network and no db. */
+export async function sweepGates(deps: GateSweepDeps): Promise<GateSweepResult> {
+  let checked = 0;
+  let projected = 0;
+  const failedBoards: string[] = [];
+
+  for (const boardId of await deps.boards()) {
+    const tenantId = await deps.tenantIdFor(boardId);
+    if (!tenantId) continue;
+
+    let gates: GatePendingDelivery[];
+    try {
+      gates = await deps.pendingGates(boardId);
+    } catch (err) {
+      failedBoards.push(boardId);
+      log.warn("could not ask a board for its pending gates", {
+        boardId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    for (const gate of gates) {
+      if (!isGatePending(gate)) {
+        // Loud, because this is the two repositories' contract having drifted
+        // — the thing `fixtures/ecosystem-identity/matrix_gate_events.json`
+        // exists to catch before it reaches a room.
+        log.error("board described a gate in an unknown shape", { boardId });
+        continue;
+      }
+      checked++;
+      try {
+        const outcome = await deps.project(tenantId, gate);
+        if (outcome.status === "sent") {
+          projected++;
+          // Deliberately loud. Every line here is a gate that push failed to
+          // deliver and a person was never asked about — the sweep working is
+          // also the signal that something under it is not.
+          log.warn("a gate reached its room only by sweep", {
+            gateId: gate.gateId,
+            boardId,
+            roomId: outcome.roomId,
+          });
+        }
+      } catch (err) {
+        log.warn("could not project a gate", {
+          gateId: gate.gateId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return { checked, projected, failedBoards };
+}
+
+/**
+ * The board-facing half of the sweep, built from the bridge's own configuration.
+ *
+ * The boards this hub works and the credential for each are already in
+ * `KAAMBAAN_BRIDGE_AGENTS` — the sweep needs no configuration of its own, and
+ * giving it any would create a second place for the board list to be wrong.
+ *
+ * **A board is read with its own board's token.** An agent's `kbn_` credential
+ * is scoped to the board it claims on, so using the wrong one is a 401 that
+ * arrives as `failedBoards` — a board that "could not be reached" rather than a
+ * credential that was refused. Deduplicated because two agents on one board is
+ * ordinary and asking the same board twice would recover, and log, every gate
+ * twice.
+ */
+export function bridgeGateSweepDeps(
+  config: BridgeConfig,
+  rest: Pick<GateSweepDeps, "tenantIdFor" | "project">,
+  fetchImpl: Fetcher = fetchAdapter,
+): GateSweepDeps {
+  const tokenForBoard = new Map<string, string>();
+  for (const agent of config.agents) {
+    if (!tokenForBoard.has(agent.boardId)) tokenForBoard.set(agent.boardId, agent.token);
+  }
+
+  return {
+    ...rest,
+    boards: async () => [...tokenForBoard.keys()],
+    pendingGates: async (boardId) => {
+      const token = tokenForBoard.get(boardId);
+      if (!token) return [];
+      return new KaambaanClient({
+        baseUrl: config.baseUrl,
+        boardId,
+        token,
+        fetch: fetchImpl,
+      }).pendingGates();
+    },
+  };
+}
+
+/**
+ * How often to ask.
+ *
+ * Push carries a gate in under a second and retries five times with backoff
+ * before dead-lettering, so this is not the delivery path and does not need to
+ * be quick — it is the answer to "and if all of that failed". Five minutes is
+ * one small GET per board, and it bounds how long a gate can be silent to
+ * something a person waiting on an approval would not notice as unusual.
+ */
+export const GATE_SWEEP_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * Start the periodic sweep, or return null when this hub works no board.
+ *
+ * Null rather than a timer over an empty list: most hubs run no bridge at all,
+ * and a subsystem that is off should not be constructed — the same rule
+ * `startKaambaanBridge` follows. It also means any error logged from in here
+ * belongs to something the operator actually turned on.
+ */
+export function startGateSweeper(
+  rest: Pick<GateSweepDeps, "tenantIdFor" | "project">,
+  opts: { config?: BridgeConfig | null; intervalMs?: number } = {},
+): (() => void) | null {
+  const config =
+    opts.config !== undefined ? opts.config : isBridgeEnabled() ? loadBridgeConfig() : null;
+  if (!config) return null;
+
+  const deps = bridgeGateSweepDeps(config, rest);
+  const timer = setInterval(() => {
+    void sweepGates(deps).catch((err) =>
+      log.error("gate sweep failed", { error: err instanceof Error ? err.message : String(err) }),
+    );
+  }, opts.intervalMs ?? GATE_SWEEP_INTERVAL_MS);
+
+  log.info("gate sweep started", {
+    boards: new Set(config.agents.map((a) => a.boardId)).size,
+    intervalMs: opts.intervalMs ?? GATE_SWEEP_INTERVAL_MS,
+  });
+  return () => clearInterval(timer);
+}

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -76,6 +76,30 @@ export interface GatePendingDelivery {
   ts: string;
 }
 
+/**
+ * Is this a gate this hub knows how to post?
+ *
+ * Used on both inbound paths — the signed push and the sweep's read — because
+ * "authenticated" is not "checked". A board a version ahead, or behind, would
+ * otherwise have this hub posting a card with an empty title and no buttons
+ * into somebody's room. One predicate rather than two so the two paths cannot
+ * come to disagree about what a gate is.
+ */
+export function isGatePending(v: unknown): v is GatePendingDelivery {
+  if (typeof v !== "object" || v === null) return false;
+  const d = v as Record<string, unknown>;
+  return (
+    d.event === "gate.pending" &&
+    typeof d.boardId === "string" &&
+    typeof d.cardId === "string" &&
+    typeof d.gateId === "string" &&
+    d.gateId.length > 0 &&
+    typeof d.stageKey === "string" &&
+    typeof d.cardTitle === "string" &&
+    Array.isArray(d.options)
+  );
+}
+
 export interface GateProjectionDeps {
   /** Sends as a station's own virtual user. Returns the event id, or null. */
   sendCustomEvent(


### PR DESCRIPTION
The reconciliation sweep — the last piece of `charter → decisions/2026-08-30-a-gate-closes-over-chat.md` §5 that was named, deferred, and never built.

Needs kaambaan#50, which adds the read this asks.

## Why

kaambaan retries a `gate.pending` push five times with backoff and then dead-letters it. At that point the gate is silent on both sides: the card is blocked on an approval, and neither product is looking for one that never rang. §5 settles the delivery semantics as "push, made durable, with a reconciliation sweep beneath it".

Same shape as the failure this estate keeps finding at other levels — a service failing 116,666 times over eight days with nothing configured to notice. The sweep is what makes "a gate cannot be lost" a property rather than a hope.

## What it does

Every five minutes, each board this hub works is asked what it is still waiting on. Anything with no Matrix event is projected into the station's room.

**It holds no idempotency of its own.** `projectGate` claims the gate in `matrix_gate_events` before it sends, so re-offering one already in a room costs a refused insert and posts nothing. Push, redelivery and this are meant to overlap; a second "have I sent this?" check here would be a second answer to a question that already has one, and two answers eventually disagree.

**Every failure is per-board and per-gate.** A sweep that throws on the first unreachable board stops being a floor, and does it invisibly — the boards behind it are simply never asked.

**A gate that arrives only by sweep logs at `warn`.** The sweep working is also the signal that push under it is not.

## Reading as the bridge, not as a person

The read uses the bridge's own `kbn_` token. kaambaan's board snapshot carries the same gates and is human-routed; reaching it would have meant minting a principal assertion on a timer — and the property that makes `service-signing.ts` safe to have at all is that an assertion's subject comes from a sender's mxid and is never the caller's to choose. A sweep has no sender.

Each board is read with the credential belonging to *that* board, deduplicated: two agents on one board is ordinary, and asking twice would recover and log every gate twice.

## Also here, because both follow from a second delivery path

- `isGatePending` moves from the push route into `gates.ts` and now guards the sweep too. Authenticated is not checked — a board a version ahead would otherwise have this hub posting a card with an empty title and no buttons into somebody's room.
- One `gateProjection` shared by the receiver and the sweep, so a swept gate and a pushed one cannot be posted by two slightly different projections.
- `fetchAdapter` moves beside the `Fetcher` type it satisfies, so the bridge loop and the sweep reach a board through the same adapter.

## Tests

14 new, written first and watched fail. **287 pass, 0 fail** across the modules touched. Typecheck errors are byte-identical to `main` — none new.

Worth naming: the DB-backed suites need Postgres and could not run on the machine this was written on (no daemon, nothing on 5434). Same ~64 failures before and after, checked against a stashed tree. CI is the first place they run.

- a board this hub never dispatched to is never asked — no dispatch means no room for any gate on it
- one unreachable board does not stop the rest, and is named in `failedBoards`
- one gate that cannot be projected does not cost the gates behind it
- a gate in a shape this hub does not understand is refused rather than posted
- it counts what it posted, not what it looked at
- it actually runs a pass — an unstarted sweeper is the whole bug, and `dispatchPushDeliveries` sat uncalled for weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr