### PR TITLE
The organization plane: an agent is a principal, and creating one is an act

### DIFF
--- a/apps/console/src/lib/api/agents.ts
+++ b/apps/console/src/lib/api/agents.ts
@@ -43,16 +43,47 @@ export function createAgent(input: { handle: string; displayName?: string }): Pr
 }
 
 /**
- * Put a principal in a station — what makes the station dispatchable.
+ * Whether the assigned agent actually ended up with a Matrix room.
+ *
+ * The hub provisions one as part of the assignment, and provisioning talks
+ * to a homeserver, which can be down. A failure there deliberately does NOT
+ * undo the assignment — occupancy is a fact in the organization plane and a
+ * room is its shadow on a system the hub does not own — so the outcome
+ * rides back in the body instead, and the operator is told rather than left
+ * to discover it weeks later from a gate that never arrived.
+ *
+ * `no-bridge` is a configuration answer rather than a fault: a hub with no
+ * homeserver configured has no rooms for anything, and the assignment is
+ * complete without one.
+ */
+export type RoomOutcome =
+  | { status: "provisioned" }
+  | { status: "no-bridge" }
+  | { status: "failed"; error: string };
+
+/** The sentence to show for an outcome, or null when there is nothing to say. */
+export function roomProblem(room: RoomOutcome | undefined): string | null {
+  if (!room || room.status !== "failed") return null;
+  return `It has no Matrix room yet — provisioning failed: ${room.error}. It will get one when the hub next provisions; the assignment itself stands.`;
+}
+
+/**
+ * Put a principal in a station — what makes the station dispatchable, and
+ * provisions its Matrix room.
  *
  * Throws on 403 when the principal is suspended (a suspension that could be
  * routed around by handing the same agent a station would not be a
  * suspension) and on 404 when either side of the pair no longer exists.
+ *
+ * Resolves — rather than throwing — when the assignment landed but the room
+ * did not. See {@link RoomOutcome}: that is a partial success, and reporting
+ * it as a failure would tell the operator to retry something that already
+ * happened.
  */
 export function assignStationAgent(
   stationId: string,
   principalId: string
-): Promise<{ stationId: string; principalId: string }> {
+): Promise<{ stationId: string; principalId: string; room?: RoomOutcome }> {
   return http(`/api/admin/stations/${encodeURIComponent(stationId)}/agent`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },

--- a/apps/console/src/lib/api/agents.ts
+++ b/apps/console/src/lib/api/agents.ts
@@ -1,0 +1,85 @@
+/**
+ * Creating an agent, and putting it in a station — the console side of
+ * `apps/hub/src/routes/agents-admin.ts`.
+ *
+ * Until this file, the only way an agent principal came into existence was a
+ * seed script run by hand, and the only way it occupied a station was a
+ * direct database write. `charter → decisions/2026-08-30-an-agent-is-a-
+ * principal.md`: creating an agent is a deliberate act, and a station with no
+ * occupying principal is dispatchable by nobody — correct, deliberate
+ * behaviour that today has no operator-visible signal at all. This is that
+ * signal's write half.
+ */
+
+import { http } from "./client";
+
+/** The principal minted by POST /api/admin/agents. */
+export interface CreatedAgent {
+  id: string;
+  kind: "human" | "agent" | "service";
+  /** Immutable — what the agent's Matrix address is built from. Never editable after this call. */
+  handle: string;
+  displayName: string | null;
+  suspendedAt: string | null;
+}
+
+/**
+ * Mint a new agent principal. Does not put it anywhere — a station is
+ * occupied by a separate call to {@link assignStationAgent}, because minting
+ * an identity and handing it a station are two different acts with two
+ * different refusals (a bad handle vs. a suspended assignee).
+ *
+ * Throws on 400 (a handle `clean()` would rewrite into a different Matrix
+ * address) and 409 (the handle is already taken) — both readable via
+ * `(err as Error).message`, which carries the hub's own sentence rather than
+ * a generic failure.
+ */
+export function createAgent(input: { handle: string; displayName?: string }): Promise<CreatedAgent> {
+  return http<CreatedAgent>("/api/admin/agents", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+/**
+ * Put a principal in a station — what makes the station dispatchable.
+ *
+ * Throws on 403 when the principal is suspended (a suspension that could be
+ * routed around by handing the same agent a station would not be a
+ * suspension) and on 404 when either side of the pair no longer exists.
+ */
+export function assignStationAgent(
+  stationId: string,
+  principalId: string
+): Promise<{ stationId: string; principalId: string }> {
+  return http(`/api/admin/stations/${encodeURIComponent(stationId)}/agent`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ principalId }),
+  });
+}
+
+/** Take a station's agent out — it goes back to dispatchable-by-nobody. */
+export function unassignStationAgent(
+  stationId: string
+): Promise<{ stationId: string; principalId: null }> {
+  return http(`/api/admin/stations/${encodeURIComponent(stationId)}/agent`, { method: "DELETE" });
+}
+
+/**
+ * The handle an operator would actually choose, pre-filled from a station
+ * key such as `hermes:writer-quill` → `writer-quill`.
+ *
+ * The part before the colon names the harness, which is not part of an
+ * identity anyone types out loud — `charter →
+ * decisions/2026-08-30-an-agent-is-a-principal.md` §3 is exactly why an
+ * agent's handle no longer carries a plane or harness prefix. A key with no
+ * colon at all (unexpected, but not this function's place to refuse) is
+ * returned unchanged rather than throwing, since the field stays editable
+ * either way.
+ */
+export function defaultHandleFromStationKey(stationKey: string): string {
+  const i = stationKey.indexOf(":");
+  return i === -1 ? stationKey : stationKey.slice(i + 1);
+}

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -174,6 +174,15 @@ export type StationRow = {
    * in All rooms.
    */
   purpose: string | null;
+  /**
+   * The agent occupying this station, or null.
+   *
+   * The hub's row already carries this (`stations.principal_id`); it was just
+   * never typed here. Null is not an unhealthy station — it is a station
+   * dispatchable by nobody, which is a real and legitimate state the console
+   * must be able to tell apart from "assigned and running".
+   */
+  principalId: string | null;
   adoptedAt: string | Date;
   createdAt: string | Date;
 };

--- a/apps/console/src/lib/api/grants.ts
+++ b/apps/console/src/lib/api/grants.ts
@@ -44,12 +44,46 @@ export interface PrincipalSummary {
   displayName: string | null;
   /** The Better Auth login, when this principal is a person. Null otherwise. */
   userId: string | null;
+  /**
+   * When this principal was suspended, or null if it is not. Carried on the
+   * directory itself so the page can show the state without a second call
+   * per row — the hub already refuses to mint a token for a suspended
+   * principal on every path; this is what tells an operator that lever
+   * exists at all.
+   */
+  suspendedAt: string | null;
 }
 
 /** Every principal this hub knows — people, agents and services alike. */
 export async function listPrincipals(): Promise<PrincipalSummary[]> {
   const body = await http<{ principals: PrincipalSummary[] }>("/api/admin/principals");
   return body.principals;
+}
+
+/**
+ * Stop a principal from being allowed to act, from now. Idempotent — this
+ * still succeeds for a principal that is already suspended, because an
+ * operator double-clicking is ordinary, not an error to surface.
+ */
+export async function suspendPrincipal(
+  principalId: string
+): Promise<{ id: string; suspendedAt: string | null }> {
+  return http(`/api/admin/principals/${encodeURIComponent(principalId)}/suspend`, {
+    method: "POST",
+  });
+}
+
+/**
+ * Lift a suspension — the other half of the same control. Idempotent for the
+ * same reason as {@link suspendPrincipal}: restoring one that is not
+ * suspended succeeds rather than erroring.
+ */
+export async function restorePrincipal(
+  principalId: string
+): Promise<{ id: string; suspendedAt: string | null }> {
+  return http(`/api/admin/principals/${encodeURIComponent(principalId)}/restore`, {
+    method: "POST",
+  });
 }
 
 export interface PrincipalGrant extends Grant {

--- a/apps/console/src/lib/api/grants.ts
+++ b/apps/console/src/lib/api/grants.ts
@@ -14,12 +14,42 @@ import { http } from "./client";
 
 export interface Grant {
   /**
-   * Namespaced patterns. AgentPod's name a node AND a station —
-   * `agentpod:<nodeName>/<stationKey>` — because station keys repeat across
-   * nodes. `kaambaan:<agentId>` is matched by the board.
+   * The principal ids of the agents this principal may dispatch, matched by
+   * equality.
+   *
+   * One agent, named outright, with no patterns of any kind. The two namespaced
+   * pattern forms that used to live here — `agentpod:<node>/<stationKey>` and
+   * `kaambaan:<agentId>` — are deleted rather than narrowed (charter
+   * decisions/2026-08-30-an-agent-is-a-principal.md §3): they matched things
+   * nobody intended, `hermes:*` silently spanned nodes, and an agent is an
+   * identity rather than a place a station happens to be.
    */
   mayDispatch: string[];
   mayGrantReach: boolean;
+}
+
+/**
+ * A principal, as the admin API lists them.
+ *
+ * The vocabulary a grant is written in. Both sides of a grant are `prn_` ids
+ * now, and a twenty-hex id is not something anyone types from memory or
+ * recognises on sight — so the page that writes grants has to be able to read
+ * this list, or it is a text box and a hope.
+ */
+export interface PrincipalSummary {
+  id: string;
+  kind: "human" | "agent" | "service";
+  /** Immutable, and what an agent's Matrix address is built from. */
+  handle: string;
+  displayName: string | null;
+  /** The Better Auth login, when this principal is a person. Null otherwise. */
+  userId: string | null;
+}
+
+/** Every principal this hub knows — people, agents and services alike. */
+export async function listPrincipals(): Promise<PrincipalSummary[]> {
+  const body = await http<{ principals: PrincipalSummary[] }>("/api/admin/principals");
+  return body.principals;
 }
 
 export interface PrincipalGrant extends Grant {
@@ -69,8 +99,17 @@ export async function deleteGrant(principalId: string): Promise<void> {
   await http(`/api/admin/grants/${encodeURIComponent(principalId)}`, { method: "DELETE" });
 }
 
-/** The planes a value may name. Mirrors the writer's allowlist on the hub. */
-export const KNOWN_PLANES = ["agentpod", "kaambaan", "org-plane"] as const;
+/**
+ * The one shape a grant value may have: a bare principal id.
+ *
+ * The same grammar the hub's writer enforces (`PrincipalId` in
+ * `@agentpod/contract`, pinned across both repos by
+ * `fixtures/ecosystem-identity/id_grammar.json`). Restated here rather than
+ * imported so this module stays free of a runtime dependency for one regex —
+ * and the server, not this, remains the authority: a value that gets past this
+ * is still refused with a 400.
+ */
+const PRINCIPAL_ID = /^prn_[0-9a-f]{20}$/;
 
 /**
  * Why a value would be rejected, or null when it is fine.
@@ -78,23 +117,29 @@ export const KNOWN_PLANES = ["agentpod", "kaambaan", "org-plane"] as const;
  * Checked here as well as on the server so a typo is answered while the person
  * is still looking at it. The server remains the authority — this only saves a
  * round trip and gives a better sentence than a 400 does.
+ *
+ * The retired forms are named in the message on purpose. `agentpod:*&#47;hermes:*`
+ * was the shape this box asked for until recently, it is still what is written
+ * down in older notes, and pasted in today it would be refused with no hint
+ * that the whole grammar has been replaced rather than tightened.
  */
 export function grantValueProblem(value: string): string | null {
   const trimmed = value.trim();
   if (trimmed === "") return "empty";
 
-  const plane = KNOWN_PLANES.find((p) => trimmed.startsWith(`${p}:`));
-  if (!plane) {
-    return `must name a plane: ${KNOWN_PLANES.map((p) => `${p}:…`).join(", ")}`;
+  if (/^(agentpod|kaambaan|org-plane):/.test(trimmed)) {
+    return "that form is gone — a grant now names one agent by its principal id (prn_…), with no plane prefix and no patterns";
   }
-  const rest = trimmed.slice(plane.length + 1);
-  if (rest === "") return "names a plane but nothing in it";
 
-  if (plane === "agentpod" && !rest.includes("/")) {
-    // The trap worth catching early: `agentpod:hermes:*` looks right and matches
-    // nothing, because station keys repeat across nodes and it cannot say which
-    // node it meant.
-    return "must name a node too — agentpod:<node>/<stationKey>, e.g. agentpod:*/hermes:*";
+  if (trimmed.includes("*")) {
+    // Worth its own sentence: a wildcard is the value most likely to be typed
+    // by someone meaning "all of them", and stored it would match nothing at
+    // all — which reads exactly like a working grant.
+    return "wildcards match nothing — name each agent by its principal id (prn_…)";
+  }
+
+  if (!PRINCIPAL_ID.test(trimmed)) {
+    return "must be a principal id — prn_ followed by 20 hex characters";
   }
 
   return null;

--- a/apps/console/src/lib/components/admin/GrantDialog.svelte
+++ b/apps/console/src/lib/components/admin/GrantDialog.svelte
@@ -5,12 +5,17 @@
    * Edits one principal's control pair — what they may dispatch, and whether
    * they may grant an agent its reach.
    *
-   * The form is deliberately a list of exact strings rather than a set of
-   * checkboxes over live stations. A grant outlives the station it names: nodes
-   * are reprovisioned, stations are re-adopted, and a permission that quietly
-   * disappeared with its station would be a silent widening or narrowing nobody
-   * ordered. Live stations appear as *suggestions* instead, so the common case is
-   * one click and the uncommon case is still expressible.
+   * The form is deliberately a list of exact ids rather than a set of checkboxes
+   * over the live directory. A grant outlives the thing it names — an agent can
+   * be retired, a principal can be deleted — and a permission that quietly
+   * disappeared with it would be a silent narrowing nobody ordered, just as a
+   * checkbox list would make a grant on an id this hub does not know
+   * unexpressible. Known agents appear as *suggestions* instead, so the common
+   * case is one click and the uncommon case is still typable.
+   *
+   * A value is one agent's principal id and nothing else. There are no
+   * wildcards and no plane prefixes; `agentpod:<node>/<stationKey>` is deleted,
+   * not deprecated (charter decisions/2026-08-30-an-agent-is-a-principal.md §3).
    */
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
@@ -31,8 +36,11 @@
     open: boolean;
     principal: GrantPrincipal | null;
     grant: Grant;
-    /** Live `agentpod:<node>/<stationKey>` values, offered as suggestions. */
-    stationValues: string[];
+    /**
+     * The agents this fleet knows, offered as suggestions — `id` is what goes
+     * into the grant, `label` is what a person can recognise.
+     */
+    agentOptions: Array<{ id: string; label: string }>;
     onSaved: () => void;
   }
 
@@ -40,7 +48,7 @@
     open = $bindable(false),
     principal,
     grant,
-    stationValues = [],
+    agentOptions = [],
     onSaved,
   }: Props = $props();
 
@@ -61,7 +69,16 @@
     }
   });
 
-  let unusedSuggestions = $derived(stationValues.filter((v) => !values.includes(v)).slice(0, 8));
+  let unusedSuggestions = $derived(agentOptions.filter((a) => !values.includes(a.id)).slice(0, 8));
+
+  /**
+   * A recognisable name for an id, when this hub knows one.
+   *
+   * The id itself is always shown, never replaced by the label: this is the
+   * exact string that will be stored and compared by equality, and a row that
+   * showed only "Quill" would hide a typo'd id that grants nothing.
+   */
+  let labelOf = $derived((id: string) => agentOptions.find((a) => a.id === id)?.label ?? null);
 
   function addValue(value: string): boolean {
     const trimmed = value.trim();
@@ -133,6 +150,9 @@
                 <li>
                   <Badge variant="outline" class="gap-1 font-mono text-xs">
                     {value}
+                    {#if labelOf(value)}
+                      <span class="font-sans text-muted-foreground">· {labelOf(value)}</span>
+                    {/if}
                     <button
                       type="button"
                       aria-label="Remove value {value}"
@@ -154,7 +174,7 @@
             <Input
               id="grant-value"
               bind:value={draft}
-              placeholder="agentpod:node/hermes:agent — or kaambaan:agt_…"
+              placeholder="prn_0123456789abcdef0123"
               class="font-mono text-xs"
               onkeydown={(e: KeyboardEvent) => {
                 if (e.key === "Enter") {
@@ -169,20 +189,22 @@
             <p class="text-xs text-destructive" role="alert">{problem}</p>
           {:else}
             <p class="text-xs text-muted-foreground">
-              An AgentPod value names a node as well as a station — station keys repeat across
-              nodes. Fleet-wide is written out: <code>agentpod:*/hermes:*</code>.
+              One agent per value, named by its principal id — <code>prn_</code> and 20 hex
+              characters. Matched by equality: there are no wildcards, so granting three agents
+              means three values.
             </p>
           {/if}
 
           {#if unusedSuggestions.length > 0}
             <div class="flex flex-wrap gap-1 pt-1">
-              {#each unusedSuggestions as suggestion (suggestion)}
+              {#each unusedSuggestions as suggestion (suggestion.id)}
                 <button
                   type="button"
-                  class="rounded border border-dashed px-2 py-0.5 font-mono text-[11px] text-muted-foreground hover:border-primary hover:text-primary"
-                  onclick={() => addValue(suggestion)}
+                  class="rounded border border-dashed px-2 py-0.5 text-[11px] text-muted-foreground hover:border-primary hover:text-primary"
+                  onclick={() => addValue(suggestion.id)}
+                  title={suggestion.id}
                 >
-                  + {suggestion}
+                  + {suggestion.label}
                 </button>
               {/each}
             </div>

--- a/apps/console/src/lib/components/admin/GrantDialog.svelte.test.ts
+++ b/apps/console/src/lib/components/admin/GrantDialog.svelte.test.ts
@@ -10,6 +10,12 @@
  * is narrowed when the value they typed narrowed nothing. So most of what is
  * asserted below is about **refusing** values, and about the save being a
  * replacement rather than a merge.
+ *
+ * A value is one agent's principal id. The namespaced, pattern-matched forms
+ * this dialog used to ask for — `agentpod:<node>/<stationKey>`,
+ * `kaambaan:<agentId>` — are deleted rather than deprecated, so they are
+ * asserted here as REFUSALS: they are still written down in older notes and
+ * still what someone would paste in first.
  */
 
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
@@ -25,7 +31,6 @@ vi.mock("$lib/api/grants", async () => {
     // The validator is pure and shared with the server's rule — mocking it would
     // test a stub instead of the thing that decides.
     grantValueProblem: actual.grantValueProblem,
-    KNOWN_PLANES: actual.KNOWN_PLANES,
     setGrant: vi.fn(),
     deleteGrant: vi.fn(),
   };
@@ -34,7 +39,9 @@ vi.mock("$lib/api/grants", async () => {
 import * as grantsApi from "$lib/api/grants";
 import GrantDialog from "./GrantDialog.svelte";
 
-const PRINCIPAL = { id: "user_abc", label: "jo@example.com" };
+const PRINCIPAL = { id: "prn_00000000000000000001", label: "jo@example.com" };
+const QUILL = "prn_0123456789abcdef0123";
+const ECHO = "prn_ffffffffffffffffffff";
 
 function open(props: Record<string, unknown> = {}) {
   return render(GrantDialog, {
@@ -42,7 +49,7 @@ function open(props: Record<string, unknown> = {}) {
       open: true,
       principal: PRINCIPAL,
       grant: { mayDispatch: [], mayGrantReach: false },
-      stationValues: [],
+      agentOptions: [],
       onSaved: vi.fn(),
       ...props,
     },
@@ -59,31 +66,52 @@ afterEach(cleanup);
 
 test("shows the values the principal already has", () => {
   const { getByText } = open({
-    grant: { mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_7abf"], mayGrantReach: true },
+    grant: { mayDispatch: [QUILL, ECHO], mayGrantReach: true },
   });
 
-  expect(getByText("agentpod:molt-bot/hermes:*")).toBeTruthy();
-  expect(getByText("kaambaan:agt_7abf")).toBeTruthy();
+  expect(getByText(QUILL)).toBeTruthy();
+  expect(getByText(ECHO)).toBeTruthy();
 });
 
-test("refuses an AgentPod value that names no node", async () => {
-  // The shape everyone writes first. Station keys repeat across nodes, so this
-  // matches nothing anywhere — and stored, it looks like a working grant.
+test("refuses the namespaced form this box used to ask for", async () => {
+  // The shape everyone still has written down, and the one that would be pasted
+  // in first. It is deleted, not narrowed — so the message has to say the
+  // grammar changed rather than that this particular value is malformed.
   const { getByLabelText, getByRole, findByText } = open();
 
-  await addValue(getByLabelText, getByRole, "agentpod:hermes:*");
+  await addValue(getByLabelText, getByRole, "agentpod:molt-bot/hermes:*");
 
-  expect(await findByText(/must name a node/i)).toBeTruthy();
+  expect(await findByText(/that form is gone/i)).toBeTruthy();
   await fireEvent.click(getByRole("button", { name: /save/i }));
   expect(grantsApi.setGrant).not.toHaveBeenCalled();
 });
 
-test("refuses a value that names no plane", async () => {
+test("refuses a wildcard, which would store happily and match nothing", async () => {
+  // The value someone types meaning "all of them". Matching is equality now, so
+  // stored it permits nobody while reading exactly like a working grant.
   const { getByLabelText, getByRole, findByText } = open();
 
-  await addValue(getByLabelText, getByRole, "hermes:*");
+  await addValue(getByLabelText, getByRole, "*");
 
-  expect(await findByText(/must name a plane/i)).toBeTruthy();
+  expect(await findByText(/wildcards match nothing/i)).toBeTruthy();
+});
+
+test("refuses anything that is not a well-formed principal id", async () => {
+  const { getByLabelText, getByRole, findByText } = open();
+
+  await addValue(getByLabelText, getByRole, "hermes");
+
+  expect(await findByText(/must be a principal id/i)).toBeTruthy();
+});
+
+test("refuses a principal id one character short of the grammar", async () => {
+  // The same length the mint site pins. A truncated id names nothing that was
+  // ever minted, and it is the typo a copy-paste actually produces.
+  const { getByLabelText, getByRole, findByText } = open();
+
+  await addValue(getByLabelText, getByRole, "prn_0123456789abcdef012");
+
+  expect(await findByText(/must be a principal id/i)).toBeTruthy();
 });
 
 test("saves the whole grant, so removing a value actually narrows it", async () => {
@@ -92,7 +120,7 @@ test("saves the whole grant, so removing a value actually narrows it", async () 
   const onSaved = vi.fn();
   const { getByRole, getAllByRole } = open({
     grant: {
-      mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_7abf"],
+      mayDispatch: [QUILL, ECHO],
       mayGrantReach: false,
     },
     onSaved,
@@ -102,8 +130,8 @@ test("saves the whole grant, so removing a value actually narrows it", async () 
   await fireEvent.click(getByRole("button", { name: /save/i }));
 
   await waitFor(() =>
-    expect(grantsApi.setGrant).toHaveBeenCalledWith("user_abc", {
-      mayDispatch: ["kaambaan:agt_7abf"],
+    expect(grantsApi.setGrant).toHaveBeenCalledWith(PRINCIPAL.id, {
+      mayDispatch: [ECHO],
       mayGrantReach: false,
     })
   );
@@ -113,12 +141,30 @@ test("saves the whole grant, so removing a value actually narrows it", async () 
 test("adds a valid value and carries it into the save", async () => {
   const { getByLabelText, getByRole } = open();
 
-  await addValue(getByLabelText, getByRole, "agentpod:*/hermes:*");
+  await addValue(getByLabelText, getByRole, QUILL);
   await fireEvent.click(getByRole("button", { name: /save/i }));
 
   await waitFor(() =>
-    expect(grantsApi.setGrant).toHaveBeenCalledWith("user_abc", {
-      mayDispatch: ["agentpod:*/hermes:*"],
+    expect(grantsApi.setGrant).toHaveBeenCalledWith(PRINCIPAL.id, {
+      mayDispatch: [QUILL],
+      mayGrantReach: false,
+    })
+  );
+});
+
+test("a suggested agent is added by its id, never by the name shown on it", async () => {
+  // The label is what a person recognises; the id is what is compared by
+  // equality. Storing the label would be a grant that matches nothing.
+  const { getByRole } = open({
+    agentOptions: [{ id: QUILL, label: "Quill" }],
+  });
+
+  await fireEvent.click(getByRole("button", { name: /\+ Quill/ }));
+  await fireEvent.click(getByRole("button", { name: /save/i }));
+
+  await waitFor(() =>
+    expect(grantsApi.setGrant).toHaveBeenCalledWith(PRINCIPAL.id, {
+      mayDispatch: [QUILL],
       mayGrantReach: false,
     })
   );
@@ -128,24 +174,24 @@ test("does not add the same value twice", async () => {
   // A duplicate grants nothing extra and makes the list harder to read, which is
   // how an over-wide grant hides in plain sight.
   const { getByLabelText, getByRole, getAllByText } = open({
-    grant: { mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+    grant: { mayDispatch: [QUILL], mayGrantReach: false },
   });
 
-  await addValue(getByLabelText, getByRole, "kaambaan:agt_7abf");
+  await addValue(getByLabelText, getByRole, QUILL);
 
-  expect(getAllByText("kaambaan:agt_7abf")).toHaveLength(1);
+  expect(getAllByText(QUILL)).toHaveLength(1);
 });
 
 test("an empty grant is savable, because 'permitted nothing' is a real decision", async () => {
   const { getByRole } = open({
-    grant: { mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+    grant: { mayDispatch: [QUILL], mayGrantReach: false },
   });
 
   await fireEvent.click(getByRole("button", { name: /remove value/i }));
   await fireEvent.click(getByRole("button", { name: /save/i }));
 
   await waitFor(() =>
-    expect(grantsApi.setGrant).toHaveBeenCalledWith("user_abc", {
+    expect(grantsApi.setGrant).toHaveBeenCalledWith(PRINCIPAL.id, {
       mayDispatch: [],
       mayGrantReach: false,
     })
@@ -158,10 +204,10 @@ test("a failed save keeps the dialog open with the edits intact", async () => {
   vi.mocked(grantsApi.setGrant).mockRejectedValueOnce(new Error("hub unreachable"));
   const { getByLabelText, getByRole, getByText } = open();
 
-  await addValue(getByLabelText, getByRole, "kaambaan:agt_7abf");
+  await addValue(getByLabelText, getByRole, QUILL);
   await fireEvent.click(getByRole("button", { name: /save/i }));
 
   const { toast } = await import("svelte-sonner");
   await waitFor(() => expect(toast.error).toHaveBeenCalled());
-  expect(getByText("kaambaan:agt_7abf")).toBeTruthy();
+  expect(getByText(QUILL)).toBeTruthy();
 });

--- a/apps/console/src/lib/components/fleet/AgentCreate.svelte
+++ b/apps/console/src/lib/components/fleet/AgentCreate.svelte
@@ -28,7 +28,7 @@
   import { Field } from "$lib/components/ui/field";
   import { Spinner } from "$lib/components/ui/spinner";
   import { toast } from "svelte-sonner";
-  import { createAgent, assignStationAgent, defaultHandleFromStationKey, type CreatedAgent } from "$lib/api/agents";
+  import { createAgent, assignStationAgent, defaultHandleFromStationKey, roomProblem, type CreatedAgent } from "$lib/api/agents";
 
   export interface StationOption {
     id: string;
@@ -103,8 +103,19 @@
       let stationId: string | null = null;
       if (selectedStationId) {
         try {
-          await assignStationAgent(selectedStationId, principal.id);
+          const result = await assignStationAgent(selectedStationId, principal.id);
           stationId = selectedStationId;
+          // Assigned, but with no room. A third state beside "created" and
+          // "created but not assigned", and it gets its own sentence for the
+          // same reason those do — the assignment stands, so it is not an
+          // error, and it is not nothing either.
+          const roomIssue = roomProblem(result.room);
+          if (roomIssue) {
+            toast.warning(`${principal.handle} created and assigned`, { description: roomIssue });
+            open = false;
+            onCreated({ principal, stationId });
+            return;
+          }
         } catch (assignErr) {
           // The principal exists now even though the assignment failed —
           // reporting this as a failed create would strand an identity the

--- a/apps/console/src/lib/components/fleet/AgentCreate.svelte
+++ b/apps/console/src/lib/components/fleet/AgentCreate.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  /**
+   * AgentCreate.svelte
+   *
+   * Mints an agent principal and, in the common case, puts it straight into
+   * a station — the two acts `apps/hub/src/routes/agents-admin.ts` keeps
+   * separate (a bad handle and a suspended assignee are different refusals)
+   * but that read as one action from here.
+   *
+   * Two shapes, one component:
+   *  - `station` fixed: "Create an agent for this station." There is
+   *    nothing to pick — the target is already decided, and the handle
+   *    pre-fills from the station key (`hermes:writer-quill` → `writer-quill`,
+   *    the part an operator would actually type).
+   *  - `station` absent, `stationOptions` given: the same action reached
+   *    from /agents, offered a pick among the stations that are currently
+   *    unassigned. Assigning stays optional even here — minting an agent
+   *    ahead of a station existing for it is a legitimate order of events.
+   *
+   * The handle field never implies it can be edited later — because it
+   * can't (`charter → decisions/2026-08-30-an-agent-is-a-principal.md`): it
+   * is what the agent's Matrix address is built from, fixed at mint time.
+   */
+  import * as Dialog from "$lib/components/ui/dialog";
+  import * as Select from "$lib/components/ui/select";
+  import { Input } from "$lib/components/ui/input";
+  import { Button } from "$lib/components/ui/button";
+  import { Field } from "$lib/components/ui/field";
+  import { Spinner } from "$lib/components/ui/spinner";
+  import { toast } from "svelte-sonner";
+  import { createAgent, assignStationAgent, defaultHandleFromStationKey, type CreatedAgent } from "$lib/api/agents";
+
+  export interface StationOption {
+    id: string;
+    stationKey: string;
+    displayName: string;
+    nodeName?: string;
+  }
+
+  interface Props {
+    open: boolean;
+    /** A fixed target — "Create an agent for this station." Nothing to pick. */
+    station?: StationOption | null;
+    /**
+     * Offered only when `station` is not fixed: currently-unassigned
+     * stations to optionally assign the new agent to.
+     */
+    stationOptions?: StationOption[];
+    onCreated: (result: { principal: CreatedAgent; stationId: string | null }) => void;
+  }
+
+  let { open = $bindable(false), station = null, stationOptions = [], onCreated }: Props = $props();
+
+  let handle = $state("");
+  let handleTouched = $state(false);
+  let displayName = $state("");
+  let selectedStationId = $state<string | null>(null);
+  let isCreating = $state(false);
+  let handleProblem = $state<string | null>(null);
+
+  function optionFor(id: string | null): StationOption | null {
+    if (station) return station;
+    return stationOptions.find((s) => s.id === id) ?? null;
+  }
+
+  // Reset — and re-derive the prefill — every time the dialog opens, not
+  // just once at mount: the same instance can be reused across stations.
+  $effect(() => {
+    if (open) {
+      selectedStationId = station?.id ?? null;
+      handle = station ? defaultHandleFromStationKey(station.stationKey) : "";
+      handleTouched = false;
+      displayName = "";
+      isCreating = false;
+      handleProblem = null;
+    }
+  });
+
+  function handleStationSelect(id: string | undefined) {
+    selectedStationId = id ?? null;
+    // Re-derive the suggested handle on selection — but only while the
+    // operator hasn't typed one themselves. Overwriting a typed handle
+    // because a picker changed would be the same silent-rewrite the hub
+    // itself refuses to do.
+    if (!station && !handleTouched) {
+      const opt = optionFor(selectedStationId);
+      handle = opt ? defaultHandleFromStationKey(opt.stationKey) : "";
+    }
+  }
+
+  async function handleSubmit() {
+    const trimmed = handle.trim();
+    if (!trimmed || isCreating) return;
+
+    isCreating = true;
+    handleProblem = null;
+    try {
+      const principal = await createAgent({
+        handle: trimmed,
+        displayName: displayName.trim() || undefined,
+      });
+
+      let stationId: string | null = null;
+      if (selectedStationId) {
+        try {
+          await assignStationAgent(selectedStationId, principal.id);
+          stationId = selectedStationId;
+        } catch (assignErr) {
+          // The principal exists now even though the assignment failed —
+          // reporting this as a failed create would strand an identity the
+          // operator would then try to create again and hit 409 on. It
+          // exists, unassigned; say so and let the list pick it up.
+          toast.error("Agent created, but couldn't be assigned", {
+            description: (assignErr as Error).message,
+          });
+          open = false;
+          onCreated({ principal, stationId: null });
+          return;
+        }
+      }
+
+      toast.success(stationId ? `${principal.handle} created and assigned` : `${principal.handle} created`);
+      open = false;
+      onCreated({ principal, stationId });
+    } catch (e) {
+      // The hub's own sentence — "handle already taken", "handle would be
+      // altered…" — not a generic failure. http-error.ts already turns it
+      // into a readable one.
+      handleProblem = (e as Error).message;
+    } finally {
+      isCreating = false;
+    }
+  }
+</script>
+
+<Dialog.Root {open} onOpenChange={(v) => (open = v)}>
+  <Dialog.Portal>
+    <Dialog.Overlay />
+    <Dialog.Content showCloseButton={false}>
+      <Dialog.Header>
+        <Dialog.Title>{station ? `Create an agent for ${station.displayName}` : "Create an agent"}</Dialog.Title>
+        <Dialog.Description>
+          {#if station}
+            Mints a new agent principal and puts it in this station — it is dispatchable by nobody
+            until then.
+          {:else}
+            Mints a new agent principal. Assign it to a station now, or leave it unassigned to
+            place later.
+          {/if}
+        </Dialog.Description>
+      </Dialog.Header>
+
+      <!-- novalidate: the Field-level error below owns this, not the browser's bubble. -->
+      <form
+        novalidate
+        onsubmit={(e) => {
+          e.preventDefault();
+          void handleSubmit();
+        }}
+        class="space-y-4 py-2"
+      >
+        <Field
+          label="Handle"
+          for="agent-handle"
+          error={handleProblem ?? undefined}
+          description={handleProblem
+            ? undefined
+            : "Becomes this agent's Matrix address. Can't be changed after it's created."}
+        >
+          <Input
+            id="agent-handle"
+            name="handle"
+            autocomplete="off"
+            spellcheck={false}
+            bind:value={handle}
+            oninput={() => (handleTouched = true)}
+            required
+            disabled={isCreating}
+          />
+        </Field>
+
+        <Field label="Display name (optional)" for="agent-display-name">
+          <Input id="agent-display-name" name="displayName" bind:value={displayName} disabled={isCreating} />
+        </Field>
+
+        {#if station}
+          <Field label="Station" for="agent-station-fixed">
+            <p id="agent-station-fixed" class="text-sm text-muted-foreground">
+              {station.displayName}{station.nodeName ? ` · ${station.nodeName}` : ""}
+            </p>
+          </Field>
+        {:else}
+          <Field label="Assign to station" for="agent-station">
+            {#if stationOptions.length === 0}
+              <p class="text-xs text-muted-foreground" data-testid="no-unassigned-stations">
+                No unassigned stations right now — this creates the agent without one; assign it
+                from the station once it's here.
+              </p>
+            {:else}
+              <Select.Root
+                type="single"
+                value={selectedStationId ?? ""}
+                onValueChange={(v) => handleStationSelect(v || undefined)}
+              >
+                <Select.Trigger class="w-full" id="agent-station">
+                  {selectedStationId ? (optionFor(selectedStationId)?.displayName ?? "Leave unassigned") : "Leave unassigned"}
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="">Leave unassigned</Select.Item>
+                  {#each stationOptions as opt (opt.id)}
+                    <Select.Item value={opt.id}>
+                      {opt.displayName}{opt.nodeName ? ` · ${opt.nodeName}` : ""}
+                    </Select.Item>
+                  {/each}
+                </Select.Content>
+              </Select.Root>
+            {/if}
+          </Field>
+        {/if}
+
+        <!-- Footer lives INSIDE the form so Enter in any field submits natively. -->
+        <Dialog.Footer>
+          <Button type="button" variant="outline" onclick={() => (open = false)} disabled={isCreating}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isCreating || !handle.trim()}>
+            {#if isCreating}<Spinner size="sm" class="text-primary-foreground" />{/if}
+            {isCreating ? "Creating…" : "Create agent"}
+          </Button>
+        </Dialog.Footer>
+      </form>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/console/src/lib/components/fleet/AgentCreate.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/AgentCreate.svelte.test.ts
@@ -109,6 +109,39 @@ test("creating for a locked station calls createAgent then assignStationAgent, a
   });
 });
 
+test("create succeeds but the assignment fails: the agent is reported created-but-unassigned, not lost", async () => {
+  vi.mocked(agentsApi.createAgent).mockResolvedValue({
+    id: "prn_abc",
+    kind: "agent",
+    handle: "writer-quill",
+    displayName: null,
+    suspendedAt: null,
+  });
+  vi.mocked(agentsApi.assignStationAgent).mockRejectedValue(new Error("Principal is suspended."));
+  const { toast } = await import("svelte-sonner");
+  const onCreated = vi.fn();
+
+  const { getByRole } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated },
+  });
+
+  await fireEvent.submit(getByRole("button", { name: /create/i }).closest("form")!);
+
+  await waitFor(() => {
+    // The principal was minted — losing that from the caller's view would
+    // strand an identity nobody can find again, and a retry would 409.
+    expect(onCreated).toHaveBeenCalledWith({
+      principal: expect.objectContaining({ id: "prn_abc" }),
+      stationId: null,
+    });
+    // The refusal itself — not a generic failure — is what's reported.
+    expect(toast.error).toHaveBeenCalledWith(
+      "Agent created, but couldn't be assigned",
+      expect.objectContaining({ description: "Principal is suspended." })
+    );
+  });
+});
+
 test("a taken handle surfaces the 409 as a readable message, not a generic failure", async () => {
   vi.mocked(agentsApi.createAgent).mockRejectedValue(new Error("Handle already taken."));
 

--- a/apps/console/src/lib/components/fleet/AgentCreate.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/AgentCreate.svelte.test.ts
@@ -1,0 +1,199 @@
+/**
+ * AgentCreate.svelte.test.ts
+ *
+ * TDD tests for the create-and-assign dialog — the write half of "a station
+ * with no principal is dispatchable by nobody, and today that is invisible".
+ * RED → implement AgentCreate.svelte → GREEN.
+ *
+ * Two invocation shapes are covered:
+ *  - a locked `station` prop ("Create an agent for this station"): the
+ *    handle is pre-filled from the station key and the target isn't a choice.
+ *  - `stationOptions` with no locked station (reachable from /agents):
+ *    a picker among currently-unassigned stations, editable handle, still
+ *    optional to assign at all.
+ *
+ * And the refusal this dialog exists to get right: a 409 must read as "that
+ * handle is taken", not a generic failure.
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+
+// bits-ui's Select opens on `pointerdown` (not `click`) and picks an item on
+// `pointerup`, and touches `hasPointerCapture`/`releasePointerCapture` along
+// the way — jsdom implements neither. Same polyfill as RoleDialog.svelte.test.ts.
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  // @ts-expect-error jsdom has no native PointerEvent
+  window.PointerEvent = PointerEventPolyfill;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+
+vi.mock("svelte-sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("$lib/api/agents", async () => {
+  const actual = await vi.importActual<typeof import("$lib/api/agents")>("$lib/api/agents");
+  return {
+    ...actual,
+    createAgent: vi.fn(),
+    assignStationAgent: vi.fn(),
+  };
+});
+
+import * as agentsApi from "$lib/api/agents";
+import AgentCreate from "./AgentCreate.svelte";
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(cleanup);
+
+const station = { id: "st_1", stationKey: "hermes:writer-quill", displayName: "Writer Quill", nodeName: "vps1" };
+
+test("a locked station pre-fills the handle from the station key", () => {
+  const { getByLabelText } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated: vi.fn() },
+  });
+
+  const handleInput = getByLabelText(/handle/i) as HTMLInputElement;
+  expect(handleInput.value).toBe("writer-quill");
+});
+
+test("the pre-filled handle stays editable before submitting", async () => {
+  const { getByLabelText } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated: vi.fn() },
+  });
+
+  const handleInput = getByLabelText(/handle/i) as HTMLInputElement;
+  await fireEvent.input(handleInput, { target: { value: "quill-2" } });
+  expect(handleInput.value).toBe("quill-2");
+});
+
+test("creating for a locked station calls createAgent then assignStationAgent, and reports the assignment", async () => {
+  vi.mocked(agentsApi.createAgent).mockResolvedValue({
+    id: "prn_abc",
+    kind: "agent",
+    handle: "writer-quill",
+    displayName: null,
+    suspendedAt: null,
+  });
+  vi.mocked(agentsApi.assignStationAgent).mockResolvedValue({ stationId: "st_1", principalId: "prn_abc" });
+  const onCreated = vi.fn();
+
+  const { getByRole } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated },
+  });
+
+  await fireEvent.submit(getByRole("button", { name: /create/i }).closest("form")!);
+
+  await waitFor(() => {
+    expect(agentsApi.createAgent).toHaveBeenCalledWith({ handle: "writer-quill", displayName: undefined });
+    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("st_1", "prn_abc");
+    expect(onCreated).toHaveBeenCalledWith({ principal: expect.objectContaining({ id: "prn_abc" }), stationId: "st_1" });
+  });
+});
+
+test("a taken handle surfaces the 409 as a readable message, not a generic failure", async () => {
+  vi.mocked(agentsApi.createAgent).mockRejectedValue(new Error("Handle already taken."));
+
+  const { getByLabelText, getByRole, getByText, queryByText } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated: vi.fn() },
+  });
+
+  await fireEvent.submit(getByRole("button", { name: /create/i }).closest("form")!);
+
+  await waitFor(() => {
+    expect(getByText("Handle already taken.")).toBeTruthy();
+  });
+  // The generic fallback copy must not be what the operator sees instead.
+  expect(queryByText(/something went wrong/i)).toBeNull();
+  // The dialog must not silently move on — the handle is still what's shown.
+  expect((getByLabelText(/handle/i) as HTMLInputElement).value).toBe("writer-quill");
+  expect(agentsApi.assignStationAgent).not.toHaveBeenCalled();
+});
+
+test("a mangled-handle 400 also surfaces the hub's own sentence", async () => {
+  vi.mocked(agentsApi.createAgent).mockRejectedValue(
+    new Error("Handle would be altered when built into a matrix address; choose one clean() leaves unchanged.")
+  );
+
+  const { getByRole, getByText } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated: vi.fn() },
+  });
+
+  await fireEvent.submit(getByRole("button", { name: /create/i }).closest("form")!);
+
+  await waitFor(() => {
+    expect(getByText(/choose one clean\(\) leaves unchanged/i)).toBeTruthy();
+  });
+});
+
+test("no station prop and no stationOptions: creates unassigned and explains there's nothing to assign to yet", async () => {
+  vi.mocked(agentsApi.createAgent).mockResolvedValue({
+    id: "prn_xyz",
+    kind: "agent",
+    handle: "quill",
+    displayName: null,
+    suspendedAt: null,
+  });
+  const onCreated = vi.fn();
+
+  const { getByLabelText, getByRole, getByText } = render(AgentCreate, {
+    props: { open: true, station: null, stationOptions: [], onCreated },
+  });
+
+  expect(getByText(/no unassigned station/i)).toBeTruthy();
+
+  await fireEvent.input(getByLabelText(/handle/i), { target: { value: "quill" } });
+  await fireEvent.submit(getByRole("button", { name: /create/i }).closest("form")!);
+
+  await waitFor(() => {
+    expect(agentsApi.createAgent).toHaveBeenCalledWith({ handle: "quill", displayName: undefined });
+    expect(agentsApi.assignStationAgent).not.toHaveBeenCalled();
+    expect(onCreated).toHaveBeenCalledWith({ principal: expect.objectContaining({ id: "prn_xyz" }), stationId: null });
+  });
+});
+
+test("picking a station from stationOptions pre-fills the handle from its key, and picking a different one replaces it while untouched", async () => {
+  const options = [
+    { id: "st_1", stationKey: "hermes:writer-quill", displayName: "Writer Quill", nodeName: "vps1" },
+    { id: "st_2", stationKey: "openclaw:kubera", displayName: "Kubera", nodeName: "vps1" },
+  ];
+
+  const { getByLabelText, getByRole } = render(AgentCreate, {
+    props: { open: true, station: null, stationOptions: options, onCreated: vi.fn() },
+  });
+
+  const trigger = getByRole("button", { name: /assign to station/i });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const kuberaOption = await waitFor(() => getByRole("option", { name: /kubera/i }));
+  await fireEvent.pointerUp(kuberaOption, { pointerId: 1, button: 0, pointerType: "mouse" });
+
+  await waitFor(() => {
+    expect((getByLabelText(/handle/i) as HTMLInputElement).value).toBe("kubera");
+  });
+});
+
+test("the handle field says it cannot be changed after creation", () => {
+  const { getByText } = render(AgentCreate, {
+    props: { open: true, station, stationOptions: [], onCreated: vi.fn() },
+  });
+
+  expect(getByText(/can.?t (be )?change/i)).toBeTruthy();
+});

--- a/apps/console/src/lib/components/fleet/AssignAgent.svelte
+++ b/apps/console/src/lib/components/fleet/AssignAgent.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  /**
+   * AssignAgent.svelte
+   *
+   * Puts an EXISTING principal into a station — the control this slice was
+   * missing until now. `AgentCreate.svelte` wires the only path that ever
+   * called `assignStationAgent`: minting a brand-new agent and handing it a
+   * station in the same click. There was no way to take a principal that
+   * already exists — most pointedly, one this same page just unassigned —
+   * and put it somewhere. An operator could strand an agent and never get it
+   * back without a database client, which is exactly the gap this slice
+   * exists to close.
+   *
+   * Reuses `GET /api/admin/principals` (via `$lib/api/grants`'s
+   * `listPrincipals`) rather than a second endpoint — the same list Task 3
+   * already loads to know which stations are suspended-not-dispatchable.
+   * The page passes in only the agent principals not already occupying a
+   * station; picking one already active elsewhere would silently orphan its
+   * current station, since the hub's assign endpoint has no opinion about
+   * where a principal was before.
+   *
+   * A suspended principal is still offered rather than filtered out — hiding
+   * it would look like it does not exist, when what is actually true is that
+   * assigning it is refused. The hub's own 403 is what tells the operator
+   * that, surfaced here exactly as AgentCreate.svelte surfaces its refusals,
+   * not swallowed into a generic failure.
+   */
+  import * as Dialog from "$lib/components/ui/dialog";
+  import * as Select from "$lib/components/ui/select";
+  import { Button } from "$lib/components/ui/button";
+  import { Field } from "$lib/components/ui/field";
+  import { Spinner } from "$lib/components/ui/spinner";
+  import { assignStationAgent } from "$lib/api/agents";
+  import type { PrincipalSummary } from "$lib/api/grants";
+
+  export interface AssignStationTarget {
+    id: string;
+    displayName: string;
+    nodeName?: string;
+  }
+
+  interface Props {
+    open: boolean;
+    station: AssignStationTarget | null;
+    /** Agent principals offered — the page decides which ones make sense. */
+    candidates: PrincipalSummary[];
+    onAssigned: (result: { principal: PrincipalSummary; stationId: string }) => void;
+  }
+
+  let { open = $bindable(false), station, candidates, onAssigned }: Props = $props();
+
+  let selectedId = $state<string | null>(null);
+  let isAssigning = $state(false);
+  let problem = $state<string | null>(null);
+
+  $effect(() => {
+    if (open) {
+      selectedId = null;
+      isAssigning = false;
+      problem = null;
+    }
+  });
+
+  function labelFor(p: PrincipalSummary): string {
+    return p.suspendedAt ? `${p.handle} (suspended)` : p.handle;
+  }
+
+  function selected(): PrincipalSummary | null {
+    return candidates.find((p) => p.id === selectedId) ?? null;
+  }
+
+  async function handleSubmit() {
+    const principal = selected();
+    if (!station || !principal || isAssigning) return;
+
+    isAssigning = true;
+    problem = null;
+    try {
+      await assignStationAgent(station.id, principal.id);
+      open = false;
+      onAssigned({ principal, stationId: station.id });
+    } catch (e) {
+      // The hub's own sentence — "principal is suspended", "no such
+      // principal" — reaches the operator here rather than being swallowed.
+      // A suspended principal stayed selectable on purpose; this is the
+      // refusal that makes it not silently offerable.
+      problem = (e as Error).message;
+    } finally {
+      isAssigning = false;
+    }
+  }
+</script>
+
+<Dialog.Root {open} onOpenChange={(v) => (open = v)}>
+  <Dialog.Portal>
+    <Dialog.Overlay />
+    <Dialog.Content showCloseButton={false}>
+      <Dialog.Header>
+        <Dialog.Title>{station ? `Assign an agent to ${station.displayName}` : "Assign an agent"}</Dialog.Title>
+        <Dialog.Description>
+          Puts an existing agent principal in this station — it becomes dispatchable as soon as
+          this is done.
+        </Dialog.Description>
+      </Dialog.Header>
+
+      <form
+        novalidate
+        onsubmit={(e) => {
+          e.preventDefault();
+          void handleSubmit();
+        }}
+        class="space-y-4 py-2"
+      >
+        <Field label="Agent to assign" for="assign-agent-principal" error={problem ?? undefined}>
+          {#if candidates.length === 0}
+            <p class="text-xs text-muted-foreground" data-testid="no-available-agents">
+              No unassigned agent principals right now — create a new one instead.
+            </p>
+          {:else}
+            <Select.Root
+              type="single"
+              value={selectedId ?? ""}
+              onValueChange={(v) => (selectedId = v || null)}
+            >
+              <Select.Trigger class="w-full" id="assign-agent-principal">
+                {selectedId ? labelFor(selected()!) : "Choose an agent"}
+              </Select.Trigger>
+              <Select.Content>
+                {#each candidates as p (p.id)}
+                  <Select.Item value={p.id}>{labelFor(p)}</Select.Item>
+                {/each}
+              </Select.Content>
+            </Select.Root>
+          {/if}
+        </Field>
+
+        <Dialog.Footer>
+          <Button type="button" variant="outline" onclick={() => (open = false)} disabled={isAssigning}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isAssigning || !selectedId}>
+            {#if isAssigning}<Spinner size="sm" class="text-primary-foreground" />{/if}
+            {isAssigning ? "Assigning…" : "Assign"}
+          </Button>
+        </Dialog.Footer>
+      </form>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/console/src/lib/components/fleet/AssignAgent.svelte
+++ b/apps/console/src/lib/components/fleet/AssignAgent.svelte
@@ -14,10 +14,17 @@
    * Reuses `GET /api/admin/principals` (via `$lib/api/grants`'s
    * `listPrincipals`) rather than a second endpoint — the same list Task 3
    * already loads to know which stations are suspended-not-dispatchable.
-   * The page passes in only the agent principals not already occupying a
-   * station; picking one already active elsewhere would silently orphan its
-   * current station, since the hub's assign endpoint has no opinion about
-   * where a principal was before.
+   *
+   * **Occupancy is exclusive — fix round.** `routes/agents-admin.ts`'s
+   * assign endpoint now vacates a principal's previous station in the same
+   * transaction it places it in a new one, which makes offering an
+   * ALREADY-occupied agent safe: picking one moves it, it does not leave two
+   * stations claiming it. The page therefore offers every agent principal,
+   * not only unoccupied ones — each candidate carries the station it
+   * currently occupies, if any, so its option reads "moving an agent" rather
+   * than "placing a spare one". The one candidate excluded here, not by the
+   * page, is the principal already at THIS station: reassigning it to
+   * itself is a real no-op the picker has no business offering.
    *
    * A suspended principal is still offered rather than filtered out — hiding
    * it would look like it does not exist, when what is actually true is that
@@ -39,11 +46,18 @@
     nodeName?: string;
   }
 
+  /** A candidate agent, and where it currently runs — if anywhere. */
+  export interface AssignCandidate {
+    principal: PrincipalSummary;
+    currentStation: { id: string; displayName: string } | null;
+  }
+
   interface Props {
     open: boolean;
     station: AssignStationTarget | null;
-    /** Agent principals offered — the page decides which ones make sense. */
-    candidates: PrincipalSummary[];
+    /** Every agent principal — occupied or not. The page decides nothing
+     *  here except which station each one is currently at. */
+    candidates: AssignCandidate[];
     onAssigned: (result: { principal: PrincipalSummary; stationId: string }) => void;
   }
 
@@ -53,6 +67,11 @@
   let isAssigning = $state(false);
   let problem = $state<string | null>(null);
 
+  // The one filter this component owns, rather than the page: whoever
+  // already occupies the TARGET station has nothing to move — offering it
+  // would be a picker option whose only effect is a no-op round trip.
+  let offered = $derived(candidates.filter((c) => c.currentStation?.id !== station?.id));
+
   $effect(() => {
     if (open) {
       selectedId = null;
@@ -61,24 +80,25 @@
     }
   });
 
-  function labelFor(p: PrincipalSummary): string {
-    return p.suspendedAt ? `${p.handle} (suspended)` : p.handle;
+  function labelFor(c: AssignCandidate): string {
+    const base = c.principal.suspendedAt ? `${c.principal.handle} (suspended)` : c.principal.handle;
+    return c.currentStation ? `${base} — moving from ${c.currentStation.displayName}` : base;
   }
 
-  function selected(): PrincipalSummary | null {
-    return candidates.find((p) => p.id === selectedId) ?? null;
+  function selected(): AssignCandidate | null {
+    return offered.find((c) => c.principal.id === selectedId) ?? null;
   }
 
   async function handleSubmit() {
-    const principal = selected();
-    if (!station || !principal || isAssigning) return;
+    const candidate = selected();
+    if (!station || !candidate || isAssigning) return;
 
     isAssigning = true;
     problem = null;
     try {
-      await assignStationAgent(station.id, principal.id);
+      await assignStationAgent(station.id, candidate.principal.id);
       open = false;
-      onAssigned({ principal, stationId: station.id });
+      onAssigned({ principal: candidate.principal, stationId: station.id });
     } catch (e) {
       // The hub's own sentence — "principal is suspended", "no such
       // principal" — reaches the operator here rather than being swallowed.
@@ -112,9 +132,9 @@
         class="space-y-4 py-2"
       >
         <Field label="Agent to assign" for="assign-agent-principal" error={problem ?? undefined}>
-          {#if candidates.length === 0}
+          {#if offered.length === 0}
             <p class="text-xs text-muted-foreground" data-testid="no-available-agents">
-              No unassigned agent principals right now — create a new one instead.
+              No other agent principals right now — create a new one instead.
             </p>
           {:else}
             <Select.Root
@@ -126,8 +146,8 @@
                 {selectedId ? labelFor(selected()!) : "Choose an agent"}
               </Select.Trigger>
               <Select.Content>
-                {#each candidates as p (p.id)}
-                  <Select.Item value={p.id}>{labelFor(p)}</Select.Item>
+                {#each offered as c (c.principal.id)}
+                  <Select.Item value={c.principal.id}>{labelFor(c)}</Select.Item>
                 {/each}
               </Select.Content>
             </Select.Root>

--- a/apps/console/src/lib/components/fleet/AssignAgent.svelte
+++ b/apps/console/src/lib/components/fleet/AssignAgent.svelte
@@ -37,7 +37,8 @@
   import { Button } from "$lib/components/ui/button";
   import { Field } from "$lib/components/ui/field";
   import { Spinner } from "$lib/components/ui/spinner";
-  import { assignStationAgent } from "$lib/api/agents";
+  import { toast } from "svelte-sonner";
+  import { assignStationAgent, roomProblem } from "$lib/api/agents";
   import type { PrincipalSummary } from "$lib/api/grants";
 
   export interface AssignStationTarget {
@@ -96,8 +97,17 @@
     isAssigning = true;
     problem = null;
     try {
-      await assignStationAgent(station.id, candidate.principal.id);
+      const result = await assignStationAgent(station.id, candidate.principal.id);
       open = false;
+      // Assigned, but the homeserver refused it a room. Deliberately not an
+      // error toast: the assignment stands, and calling it a failure would
+      // send the operator to retry something that already happened. It must
+      // still be said — the whole finding this came from is that a silent
+      // gap looked exactly like success.
+      const roomIssue = roomProblem(result.room);
+      if (roomIssue) {
+        toast.warning(`${candidate.principal.handle} was assigned`, { description: roomIssue });
+      }
       onAssigned({ principal: candidate.principal, stationId: station.id });
     } catch (e) {
       // The hub's own sentence — "principal is suspended", "no such

--- a/apps/console/src/lib/components/fleet/AssignAgent.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/AssignAgent.svelte.test.ts
@@ -37,6 +37,10 @@ if (!Element.prototype.setPointerCapture) {
   Element.prototype.setPointerCapture = () => {};
 }
 
+vi.mock("svelte-sonner", () => ({
+  toast: { warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
 vi.mock("$lib/api/agents", async () => {
   const actual = await vi.importActual<typeof import("$lib/api/agents")>("$lib/api/agents");
   return {
@@ -45,6 +49,7 @@ vi.mock("$lib/api/agents", async () => {
   };
 });
 
+import { toast } from "svelte-sonner";
 import * as agentsApi from "$lib/api/agents";
 import { apiError } from "$lib/api/http-error";
 import AssignAgent from "./AssignAgent.svelte";
@@ -103,6 +108,58 @@ test("picking an agent and submitting calls assignStationAgent and reports it, a
       stationId: "st_2",
     });
   });
+});
+
+test("assigned but with no room: the operator is told, and it is not reported as a failed assignment", async () => {
+  // The whole-branch review's Critical was that assignment never provisioned
+  // a room at all. It does now, and provisioning talks to a homeserver that
+  // can be down — so the remaining risk is the same one in a smaller shape:
+  // a partial success that reads as a whole one. The assignment stands (the
+  // hub does not roll it back), so this must NOT surface as an error, and it
+  // must not surface as nothing either.
+  vi.mocked(agentsApi.assignStationAgent).mockResolvedValue({
+    stationId: "st_2",
+    principalId: "prn_stranded",
+    room: { status: "failed", error: "homeserver unreachable" },
+  });
+  const onAssigned = vi.fn();
+
+  const { getByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates, onAssigned },
+  });
+
+  await pickAgent(getByRole, /stranded-writer/i);
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => {
+    expect(toast.warning).toHaveBeenCalledWith(
+      "stranded-writer was assigned",
+      expect.objectContaining({ description: expect.stringContaining("homeserver unreachable") })
+    );
+  });
+  expect(toast.error, "not an error — the assignment landed").not.toHaveBeenCalled();
+  expect(onAssigned, "and the station really is occupied").toHaveBeenCalledWith({
+    principal: expect.objectContaining({ id: "prn_stranded" }),
+    stationId: "st_2",
+  });
+});
+
+test("a provisioned room says nothing extra — an ordinary assignment is not an event", async () => {
+  vi.mocked(agentsApi.assignStationAgent).mockResolvedValue({
+    stationId: "st_2",
+    principalId: "prn_stranded",
+    room: { status: "provisioned" },
+  });
+
+  const { getByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates, onAssigned: vi.fn() },
+  });
+
+  await pickAgent(getByRole, /stranded-writer/i);
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => expect(agentsApi.assignStationAgent).toHaveBeenCalled());
+  expect(toast.warning).not.toHaveBeenCalled();
 });
 
 test("the submit button stays disabled until an agent is picked", () => {

--- a/apps/console/src/lib/components/fleet/AssignAgent.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/AssignAgent.svelte.test.ts
@@ -46,6 +46,7 @@ vi.mock("$lib/api/agents", async () => {
 });
 
 import * as agentsApi from "$lib/api/agents";
+import { apiError } from "$lib/api/http-error";
 import AssignAgent from "./AssignAgent.svelte";
 
 beforeEach(() => vi.clearAllMocks());
@@ -54,14 +55,20 @@ afterEach(cleanup);
 const station = { id: "st_2", displayName: "Kubera", nodeName: "vps1" };
 
 const candidates = [
-  { id: "prn_stranded", kind: "agent" as const, handle: "stranded-writer", displayName: null, userId: null, suspendedAt: null },
   {
-    id: "prn_suspended",
-    kind: "agent" as const,
-    handle: "suspended-writer",
-    displayName: null,
-    userId: null,
-    suspendedAt: "2026-08-30T00:00:00Z",
+    principal: { id: "prn_stranded", kind: "agent" as const, handle: "stranded-writer", displayName: null, userId: null, suspendedAt: null },
+    currentStation: null,
+  },
+  {
+    principal: {
+      id: "prn_suspended",
+      kind: "agent" as const,
+      handle: "suspended-writer",
+      displayName: null,
+      userId: null,
+      suspendedAt: "2026-08-30T00:00:00Z",
+    },
+    currentStation: null,
   },
 ];
 
@@ -106,8 +113,31 @@ test("the submit button stays disabled until an agent is picked", () => {
   expect((getByRole("button", { name: /^assign$/i }) as HTMLButtonElement).disabled).toBe(true);
 });
 
-test("a suspended principal is offered, not silently hidden — and the hub's 403 reaches the operator", async () => {
-  vi.mocked(agentsApi.assignStationAgent).mockRejectedValue(new Error("Principal is suspended."));
+test("a suspended principal is offered, not silently hidden — and the hub's real refusal reaches the operator", async () => {
+  // Fix-round correction: this used to mock a hand-written
+  // `new Error("Principal is suspended.")` directly on `assignStationAgent`,
+  // which proved nothing about whether the hub's actual wire body survives
+  // the API layer — it could have drifted from `apiError`/`asSentence` in
+  // `http-error.ts` (or from `agents-admin.ts`'s own sentence) without this
+  // test ever noticing. This runs the hub's REAL 403 body —
+  // `{ error: "principal is suspended" }`, lowercase, no punctuation, exactly
+  // as `agents-admin.ts:147` sends it — through the REAL `apiError()` this
+  // codebase's `http()` calls on every failed request, and uses THAT derived
+  // `ApiError` as what the mocked call rejects with. jsdom in this suite has
+  // no `window.localStorage` (the same gap `NodesOverview.svelte.test.ts`
+  // hits), which is what `http()` itself needs to resolve a base URL before
+  // it would ever reach `fetch` — so the pipeline is exercised directly
+  // rather than through a live `fetch` stub.
+  const hubResponse = new Response(JSON.stringify({ error: "principal is suspended" }), {
+    status: 403,
+    headers: { "content-type": "application/json" },
+  });
+  const refusal = await apiError(hubResponse, "PUT /api/admin/stations/st_2/agent");
+  // Drift guard: if `asSentence` ever changes how it reads a hub body, this
+  // fails here rather than silently agreeing with whatever it now produces.
+  expect(refusal.message).toBe("Principal is suspended.");
+
+  vi.mocked(agentsApi.assignStationAgent).mockRejectedValue(refusal);
   const onAssigned = vi.fn();
 
   const { getByRole, getByText } = render(AssignAgent, {
@@ -120,8 +150,7 @@ test("a suspended principal is offered, not silently hidden — and the hub's 40
   await fireEvent.click(getByRole("button", { name: /^assign$/i }));
 
   await waitFor(() => {
-    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("st_2", "prn_suspended");
-    expect(getByText("Principal is suspended.")).toBeTruthy();
+    expect(getByText(refusal.message)).toBeTruthy();
   });
   expect(onAssigned).not.toHaveBeenCalled();
 });
@@ -133,4 +162,55 @@ test("no available agents says so and offers no picker", () => {
 
   expect(getByTestId("no-available-agents")).toBeTruthy();
   expect(queryByRole("button", { name: /^agent to assign$/i })).toBeNull();
+});
+
+test("an already-occupied agent is offered too, labelled with the station it is moving from", async () => {
+  // Fix round: occupancy is exclusive now, so the hub's assign endpoint
+  // vacates a principal's previous station itself — offering an occupied
+  // agent is a real move, not a silent double-assignment.
+  const occupiedElsewhere = [
+    ...candidates,
+    {
+      principal: { id: "prn_busy", kind: "agent" as const, handle: "busy-writer", displayName: null, userId: null, suspendedAt: null },
+      currentStation: { id: "st_9", displayName: "Hanuman" },
+    },
+  ];
+  vi.mocked(agentsApi.assignStationAgent).mockResolvedValue({ stationId: "st_2", principalId: "prn_busy" });
+  const onAssigned = vi.fn();
+
+  const { getByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates: occupiedElsewhere, onAssigned },
+  });
+
+  // The label names where it is moving FROM — so the operator sees a move,
+  // not a spare agent conjured from nowhere.
+  await pickAgent(getByRole, /busy-writer — moving from hanuman/i);
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => {
+    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("st_2", "prn_busy");
+    expect(onAssigned).toHaveBeenCalledWith({
+      principal: expect.objectContaining({ id: "prn_busy" }),
+      stationId: "st_2",
+    });
+  });
+});
+
+test("the agent already at THIS station is not offered — reassigning it to itself is not a move", async () => {
+  const alreadyHere = [
+    ...candidates,
+    {
+      principal: { id: "prn_here", kind: "agent" as const, handle: "here-writer", displayName: null, userId: null, suspendedAt: null },
+      currentStation: { id: station.id, displayName: station.displayName },
+    },
+  ];
+
+  const { getByRole, queryByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates: alreadyHere, onAssigned: vi.fn() },
+  });
+
+  const trigger = getByRole("button", { name: /^agent to assign$/i });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await waitFor(() => expect(getByRole("option", { name: /stranded-writer/i })).toBeTruthy());
+  expect(queryByRole("option", { name: /here-writer/i })).toBeNull();
 });

--- a/apps/console/src/lib/components/fleet/AssignAgent.svelte.test.ts
+++ b/apps/console/src/lib/components/fleet/AssignAgent.svelte.test.ts
@@ -1,0 +1,136 @@
+/**
+ * AssignAgent.svelte.test.ts
+ *
+ * TDD tests for Ruling 6's control: putting an EXISTING agent principal into
+ * a station. `AgentCreate.svelte` wired `assignStationAgent`'s only caller —
+ * minting a brand-new agent and handing it a station in one click — leaving
+ * no way to put a previously-existing (or just-unassigned) principal
+ * anywhere. This is that way back.
+ */
+
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+
+// bits-ui's Select opens on `pointerdown` (not `click`) and picks an item on
+// `pointerup`, and touches `hasPointerCapture`/`releasePointerCapture` along
+// the way — jsdom implements neither. Same polyfill as AgentCreate.svelte.test.ts.
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  // @ts-expect-error jsdom has no native PointerEvent
+  window.PointerEvent = PointerEventPolyfill;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+
+vi.mock("$lib/api/agents", async () => {
+  const actual = await vi.importActual<typeof import("$lib/api/agents")>("$lib/api/agents");
+  return {
+    ...actual,
+    assignStationAgent: vi.fn(),
+  };
+});
+
+import * as agentsApi from "$lib/api/agents";
+import AssignAgent from "./AssignAgent.svelte";
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(cleanup);
+
+const station = { id: "st_2", displayName: "Kubera", nodeName: "vps1" };
+
+const candidates = [
+  { id: "prn_stranded", kind: "agent" as const, handle: "stranded-writer", displayName: null, userId: null, suspendedAt: null },
+  {
+    id: "prn_suspended",
+    kind: "agent" as const,
+    handle: "suspended-writer",
+    displayName: null,
+    userId: null,
+    suspendedAt: "2026-08-30T00:00:00Z",
+  },
+];
+
+async function pickAgent(
+  getByRole: (role: string, options: { name: RegExp }) => HTMLElement,
+  name: RegExp
+) {
+  // Accessible name comes from the Field's associated <label>, not the
+  // trigger's own placeholder text — same as AgentCreate.svelte.test.ts's
+  // station picker.
+  const trigger = getByRole("button", { name: /^agent to assign$/i });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const option = await waitFor(() => getByRole("option", { name }));
+  await fireEvent.pointerUp(option, { pointerId: 1, button: 0, pointerType: "mouse" });
+}
+
+test("picking an agent and submitting calls assignStationAgent and reports it, and the station ends up occupied", async () => {
+  vi.mocked(agentsApi.assignStationAgent).mockResolvedValue({ stationId: "st_2", principalId: "prn_stranded" });
+  const onAssigned = vi.fn();
+
+  const { getByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates, onAssigned },
+  });
+
+  await pickAgent(getByRole, /stranded-writer/i);
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => {
+    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("st_2", "prn_stranded");
+    expect(onAssigned).toHaveBeenCalledWith({
+      principal: expect.objectContaining({ id: "prn_stranded" }),
+      stationId: "st_2",
+    });
+  });
+});
+
+test("the submit button stays disabled until an agent is picked", () => {
+  const { getByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates, onAssigned: vi.fn() },
+  });
+
+  expect((getByRole("button", { name: /^assign$/i }) as HTMLButtonElement).disabled).toBe(true);
+});
+
+test("a suspended principal is offered, not silently hidden — and the hub's 403 reaches the operator", async () => {
+  vi.mocked(agentsApi.assignStationAgent).mockRejectedValue(new Error("Principal is suspended."));
+  const onAssigned = vi.fn();
+
+  const { getByRole, getByText } = render(AssignAgent, {
+    props: { open: true, station, candidates, onAssigned },
+  });
+
+  // It is selectable at all — that is the "not silently offerable" part:
+  // the refusal, not an absent option, is what tells the operator no.
+  await pickAgent(getByRole, /suspended-writer/i);
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => {
+    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("st_2", "prn_suspended");
+    expect(getByText("Principal is suspended.")).toBeTruthy();
+  });
+  expect(onAssigned).not.toHaveBeenCalled();
+});
+
+test("no available agents says so and offers no picker", () => {
+  const { getByTestId, queryByRole } = render(AssignAgent, {
+    props: { open: true, station, candidates: [], onAssigned: vi.fn() },
+  });
+
+  expect(getByTestId("no-available-agents")).toBeTruthy();
+  expect(queryByRole("button", { name: /^agent to assign$/i })).toBeNull();
+});

--- a/apps/console/src/lib/components/stations/StationTree.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/StationTree.svelte.test.ts
@@ -15,6 +15,7 @@ const parentStation: StationRow = {
   workspacePath: "/home/user/workspace",
   capabilities: ["health", "logs"],
   matrixId: null, purpose: null,
+  principalId: null,
   adoptedAt: new Date("2026-06-22T00:00:00Z"),
   createdAt: new Date("2026-06-22T00:00:00Z"),
 };
@@ -31,6 +32,7 @@ const childStation: StationRow = {
   workspacePath: "/home/user/workspace/sub",
   capabilities: ["health"],
   matrixId: null, purpose: null,
+  principalId: null,
   adoptedAt: new Date("2026-06-22T00:00:00Z"),
   createdAt: new Date("2026-06-22T00:00:00Z"),
 };

--- a/apps/console/src/lib/stores/stations.svelte.test.ts
+++ b/apps/console/src/lib/stores/stations.svelte.test.ts
@@ -29,6 +29,7 @@ const mockStationRow = {
   workspacePath: "/home/user/workspace",
   capabilities: ["health", "logs"],
   matrixId: null, purpose: null,
+  principalId: null,
   adoptedAt: new Date("2026-06-22T00:00:00Z"),
   createdAt: new Date("2026-06-22T00:00:00Z"),
 };

--- a/apps/console/src/routes/admin/grants/+page.svelte
+++ b/apps/console/src/routes/admin/grants/+page.svelte
@@ -12,12 +12,27 @@
    * server's own answer rather than a build flag. And it must not hide a grant
    * whose principal no longer exists: those still match tokens if that id is ever
    * reissued, and they are exactly what nobody goes looking for.
+   *
+   * **Keyed by principal, not by Better Auth user.** A grant's row is
+   * `principal_grants.principal_id`, a foreign key onto `principals.id`, and
+   * every value in `mayDispatch` is a principal id too. This page used to list
+   * Better Auth users and PUT to `/api/admin/grants/<user.id>`, which since
+   * that key moved is not a grant on the wrong principal — it is a write that
+   * cannot land, and every existing grant rendered as an orphan besides. The
+   * directory comes from `/api/admin/principals`; users are joined onto it only
+   * to put an email against a person.
    */
   import { onMount } from "svelte";
   import { toast } from "svelte-sonner";
   import { listUsers } from "$lib/api/admin";
-  import { listGrants, deleteGrant, type PrincipalGrant, type Grant } from "$lib/api/grants";
-  import { listNodes, listStations } from "$lib/api/client";
+  import {
+    listGrants,
+    listPrincipals,
+    deleteGrant,
+    type PrincipalGrant,
+    type PrincipalSummary,
+    type Grant,
+  } from "$lib/api/grants";
   import type { AdminUserView } from "@agentpod/types";
   import { Button } from "$lib/components/ui/button";
   import { Badge } from "$lib/components/ui/badge";
@@ -39,7 +54,7 @@
     sublabel: string | null;
     grant: Grant;
     granted: boolean;
-    /** A grant whose principal is not a user here — kept visible on purpose. */
+    /** A grant naming a principal this hub has no record of — kept visible. */
     orphan: boolean;
   }
 
@@ -47,42 +62,61 @@
   let error = $state<string | null>(null);
   let enforced = $state(false);
   let rows = $state<Row[]>([]);
-  let stationValues = $state<string[]>([]);
+  let agentOptions = $state<Array<{ id: string; label: string }>>([]);
 
   let showDialog = $state(false);
   let editing = $state<Row | null>(null);
   let showRemove = $state(false);
   let removing = $state<Row | null>(null);
 
+  /** What a principal is called, in the order a person would recognise it. */
+  function nameOf(p: PrincipalSummary, user: AdminUserView | undefined): string {
+    return p.displayName || user?.name || user?.email || p.handle;
+  }
+
   async function loadData() {
     isLoading = true;
     error = null;
     try {
-      const [usersResponse, grantsResponse] = await Promise.all([
-        listUsers({ limit: 200 }),
+      // `listGrants` is the only blocking call. The directory and the user list
+      // are what put a readable name on a row; without them the page still has
+      // to show every grant, because narrowing one is exactly what you do when
+      // something has gone wrong and a page that refused to load would be the
+      // one thing standing in the way.
+      const [grantsResponse, directory, usersResponse] = await Promise.all([
         listGrants(),
+        listPrincipals().catch(() => [] as PrincipalSummary[]),
+        listUsers({ limit: 200 }).catch(() => ({ users: [] as AdminUserView[] })),
       ]);
 
       enforced = grantsResponse.enforced;
       const byPrincipal = new Map<string, PrincipalGrant>(
         grantsResponse.grants.map((g) => [g.principalId, g])
       );
+      const byUserId = new Map<string, AdminUserView>(
+        usersResponse.users.map((u: AdminUserView) => [u.id, u])
+      );
 
-      const users: Row[] = usersResponse.users.map((u: AdminUserView) => {
-        const grant = byPrincipal.get(u.id);
-        byPrincipal.delete(u.id);
+      const known: Row[] = directory.map((p) => {
+        const user = p.userId ? byUserId.get(p.userId) : undefined;
+        const grant = byPrincipal.get(p.id);
+        byPrincipal.delete(p.id);
         return {
-          principalId: u.id,
-          label: u.name || u.email,
-          sublabel: u.name ? u.email : null,
+          principalId: p.id,
+          label: nameOf(p, user),
+          // The handle and the kind, because two principals can share a display
+          // name and only one of them is the agent you meant to grant.
+          sublabel: [p.kind, p.handle, user?.email].filter(Boolean).join(" · "),
           grant: grant ?? NO_GRANT,
           granted: grant !== undefined,
           orphan: false,
         };
       });
 
-      // Whatever is left names a principal this hub has no user for — a deleted
-      // account, or an id from another issuer. Shown last, and marked.
+      // Whatever is left names a principal this hub has no record of — a deleted
+      // one, or an id from another issuer. Shown last, and marked: it still
+      // matches a token carrying that id, and it is exactly what nobody goes
+      // looking for.
       const orphans: Row[] = [...byPrincipal.values()].map((g) => ({
         principalId: g.principalId,
         label: g.principalId,
@@ -92,7 +126,14 @@
         orphan: true,
       }));
 
-      rows = [...users, ...orphans];
+      // Agents are what a grant's VALUES name, so they are what the dialog
+      // suggests. People and services are grantees, not grantable.
+      agentOptions = directory
+        .filter((p) => p.kind === "agent")
+        .map((p) => ({ id: p.id, label: p.displayName || p.handle }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+      rows = [...known, ...orphans];
     } catch (e) {
       error = (e as Error).message || "Couldn’t load grants.";
     } finally {
@@ -100,35 +141,8 @@
     }
   }
 
-  /**
-   * Live stations, as grant values.
-   *
-   * Best-effort and non-blocking: these are suggestions, and a fleet that is
-   * unreachable must not stop someone editing a grant — narrowing one is exactly
-   * what you do when something has gone wrong.
-   */
-  async function loadStationValues() {
-    try {
-      const nodes = await listNodes();
-      const perNode = await Promise.all(
-        nodes.map(async (n) => {
-          try {
-            const stations = await listStations(n.id);
-            return stations.map((s) => `agentpod:${n.name}/${s.stationKey}`);
-          } catch {
-            return [];
-          }
-        })
-      );
-      stationValues = [...new Set(perNode.flat())].sort();
-    } catch {
-      stationValues = [];
-    }
-  }
-
   onMount(() => {
     loadData();
-    loadStationValues();
   });
 
   function openEdit(row: Row) {
@@ -224,7 +238,7 @@
               <div class="flex items-center gap-2">
                 <p class="text-sm font-medium">{row.label}</p>
                 {#if row.orphan}
-                  <Badge variant="outline" class="text-amber-600">No such user</Badge>
+                  <Badge variant="outline" class="text-amber-600">No such principal</Badge>
                 {/if}
                 {#if row.grant.mayGrantReach}
                   <Badge variant="outline">May grant reach</Badge>
@@ -279,7 +293,7 @@
   bind:open={showDialog}
   principal={editing ? { id: editing.principalId, label: editing.label } : null}
   grant={editing?.grant ?? NO_GRANT}
-  {stationValues}
+  {agentOptions}
   onSaved={loadData}
 />
 

--- a/apps/console/src/routes/admin/grants/+page.svelte
+++ b/apps/console/src/routes/admin/grants/+page.svelte
@@ -29,6 +29,8 @@
     listGrants,
     listPrincipals,
     deleteGrant,
+    suspendPrincipal,
+    restorePrincipal,
     type PrincipalGrant,
     type PrincipalSummary,
     type Grant,
@@ -45,6 +47,8 @@
   import ShieldOffIcon from "@lucide/svelte/icons/shield-off";
   import PencilIcon from "@lucide/svelte/icons/pencil";
   import Trash2Icon from "@lucide/svelte/icons/trash-2";
+  import BanIcon from "@lucide/svelte/icons/ban";
+  import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
 
   const NO_GRANT: Grant = { mayDispatch: [], mayGrantReach: false };
 
@@ -56,6 +60,12 @@
     granted: boolean;
     /** A grant naming a principal this hub has no record of — kept visible. */
     orphan: boolean;
+    /**
+     * When this principal was suspended, or null. Null for an orphan row too
+     * — there is no principal record to hold that state, so suspending one is
+     * not offered.
+     */
+    suspendedAt: string | null;
   }
 
   let isLoading = $state(true);
@@ -68,6 +78,10 @@
   let editing = $state<Row | null>(null);
   let showRemove = $state(false);
   let removing = $state<Row | null>(null);
+  let showSuspend = $state(false);
+  let suspending = $state<Row | null>(null);
+  /** The one row with a suspend/restore request in flight — disables its own buttons only. */
+  let pendingSuspendId = $state<string | null>(null);
 
   /** What a principal is called, in the order a person would recognise it. */
   function nameOf(p: PrincipalSummary, user: AdminUserView | undefined): string {
@@ -110,6 +124,7 @@
           grant: grant ?? NO_GRANT,
           granted: grant !== undefined,
           orphan: false,
+          suspendedAt: p.suspendedAt,
         };
       });
 
@@ -124,6 +139,7 @@
         grant: { mayDispatch: g.mayDispatch, mayGrantReach: g.mayGrantReach },
         granted: true,
         orphan: true,
+        suspendedAt: null,
       }));
 
       // Agents are what a grant's VALUES name, so they are what the dialog
@@ -167,6 +183,52 @@
     } finally {
       showRemove = false;
       removing = null;
+    }
+  }
+
+  function openSuspend(row: Row) {
+    suspending = row;
+    showSuspend = true;
+  }
+
+  /**
+   * Suspend a principal. This is the reason `/api/admin/principals` gained
+   * suspend/restore at all: `buildTokenPayload` already refuses a suspended
+   * principal on every path, but until this button existed that lever had no
+   * surface a person could reach without a database client.
+   */
+  async function handleSuspend() {
+    if (!suspending) return;
+    const target = suspending;
+    pendingSuspendId = target.principalId;
+    try {
+      await suspendPrincipal(target.principalId);
+      toast.success(`${target.label} suspended`);
+      await loadData();
+    } catch (e) {
+      toast.error("Couldn’t suspend", { description: (e as Error).message });
+    } finally {
+      pendingSuspendId = null;
+      showSuspend = false;
+      suspending = null;
+    }
+  }
+
+  /**
+   * Lift a suspension — reversible from the same row it was applied from, on
+   * purpose: a control that can only be applied and never undone is one
+   * people route around rather than use.
+   */
+  async function handleRestore(row: Row) {
+    pendingSuspendId = row.principalId;
+    try {
+      await restorePrincipal(row.principalId);
+      toast.success(`${row.label} restored`);
+      await loadData();
+    } catch (e) {
+      toast.error("Couldn’t restore", { description: (e as Error).message });
+    } finally {
+      pendingSuspendId = null;
     }
   }
 
@@ -225,6 +287,17 @@
       <p class="text-sm text-destructive">{error}</p>
       <Button variant="outline" size="sm" onclick={loadData}>Retry</Button>
     </div>
+  {:else if rows.length === 0}
+    <!-- An empty directory reads two ways — "nobody exists yet" and "the load
+         quietly returned nothing" — and a bare "0 of 0 principals" said neither.
+         This says what zero means. -->
+    <div class="rounded-lg border border-dashed p-8 text-center" data-testid="empty-state">
+      <p class="text-sm font-medium">No principals yet</p>
+      <p class="mt-1 text-xs text-muted-foreground">
+        Nobody — human or agent — is registered with this hub, so there is nothing to grant or
+        suspend.
+      </p>
+    </div>
   {:else}
     <p class="text-xs text-muted-foreground">
       {grantedCount} of {rows.length} principals have a grant.
@@ -239,6 +312,9 @@
                 <p class="text-sm font-medium">{row.label}</p>
                 {#if row.orphan}
                   <Badge variant="outline" class="text-amber-600">No such principal</Badge>
+                {/if}
+                {#if row.suspendedAt}
+                  <Badge variant="outline" class="text-destructive">Suspended</Badge>
                 {/if}
                 {#if row.grant.mayGrantReach}
                   <Badge variant="outline">May grant reach</Badge>
@@ -270,6 +346,32 @@
                 <PencilIcon class="mr-1 h-3.5 w-3.5" />
                 {row.granted ? "Edit" : "Grant"}
               </Button>
+              {#if !row.orphan}
+                {#if row.suspendedAt}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onclick={() => handleRestore(row)}
+                    disabled={pendingSuspendId === row.principalId}
+                    aria-label="Restore {row.label}"
+                  >
+                    <RotateCcwIcon class="mr-1 h-3.5 w-3.5" />
+                    Restore
+                  </Button>
+                {:else}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onclick={() => openSuspend(row)}
+                    disabled={pendingSuspendId === row.principalId}
+                    aria-label="Suspend {row.label}"
+                  >
+                    <BanIcon class="mr-1 h-3.5 w-3.5" />
+                    Suspend
+                  </Button>
+                {/if}
+              {/if}
               {#if row.granted}
                 <Button
                   variant="ghost"
@@ -307,5 +409,18 @@
   onCancel={() => {
     showRemove = false;
     removing = null;
+  }}
+/>
+
+<ConfirmDialog
+  open={showSuspend}
+  title="Suspend principal"
+  message="{suspending?.label} will be refused everywhere, on both planes — no token is minted for a suspended principal, session or agent alike. Reversible from this same page at any time."
+  confirmLabel="Suspend"
+  destructive
+  onConfirm={handleSuspend}
+  onCancel={() => {
+    showSuspend = false;
+    suspending = null;
   }}
 />

--- a/apps/console/src/routes/admin/grants/page.svelte.test.ts
+++ b/apps/console/src/routes/admin/grants/page.svelte.test.ts
@@ -9,8 +9,14 @@
  *    `ENFORCE_CONTROL_PAIR` unset every row here is decoration, and a narrow
  *    grant would read as a locked-down fleet.
  *  - that the list is complete when a grant names a principal this hub has no
- *    user for. Those still match if that id is ever reissued, and they are
+ *    record of. Those still match if that id is ever reissued, and they are
  *    exactly what nobody goes looking for.
+ *
+ * Everything below is keyed by PRINCIPAL. A grant's row is
+ * `principal_grants.principal_id`, a foreign key onto `principals.id`, and the
+ * values are principal ids too — a page keyed on Better Auth users PUT to an id
+ * that cannot exist in that column, so every save failed and every real grant
+ * rendered as an orphan.
  */
 
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
@@ -26,32 +32,30 @@ vi.mock("$lib/api/admin", () => ({
   listUsers: vi.fn(),
 }));
 
-vi.mock("$lib/api/client", () => ({
-  listNodes: vi.fn(),
-  listStations: vi.fn(),
-}));
-
 vi.mock("$lib/api/grants", async () => {
   const actual = await vi.importActual<typeof import("$lib/api/grants")>("$lib/api/grants");
   return {
     grantValueProblem: actual.grantValueProblem,
-    KNOWN_PLANES: actual.KNOWN_PLANES,
     listGrants: vi.fn(),
+    listPrincipals: vi.fn(),
     setGrant: vi.fn(),
     deleteGrant: vi.fn(),
   };
 });
 
 import * as adminApi from "$lib/api/admin";
-import * as clientApi from "$lib/api/client";
 import * as grantsApi from "$lib/api/grants";
+import type { PrincipalSummary } from "$lib/api/grants";
 import GrantsPage from "./+page.svelte";
 
-function user(id: string, email: string) {
+const JO = "prn_00000000000000000001";
+const QUILL = "prn_00000000000000000002";
+
+function user(id: string, email: string, name = "Jo") {
   return {
     id,
     email,
-    name: "",
+    name,
     image: null,
     emailVerified: true,
     role: "user",
@@ -63,14 +67,28 @@ function user(id: string, email: string) {
   };
 }
 
+const JO_PRINCIPAL: PrincipalSummary = {
+  id: JO,
+  kind: "human",
+  handle: "jo",
+  displayName: null,
+  userId: "user_1",
+};
+
 function setup({
   users = [user("user_1", "jo@example.com")],
+  principals = [JO_PRINCIPAL] as PrincipalSummary[],
   grants = [] as Array<{ principalId: string; mayDispatch: string[]; mayGrantReach: boolean }>,
   enforced = true,
+  directoryFails = false,
 } = {}) {
   vi.mocked(adminApi.listUsers).mockResolvedValue({ users, total: users.length } as never);
+  if (directoryFails) {
+    vi.mocked(grantsApi.listPrincipals).mockRejectedValue(new Error("directory unreachable"));
+  } else {
+    vi.mocked(grantsApi.listPrincipals).mockResolvedValue(principals as never);
+  }
   vi.mocked(grantsApi.listGrants).mockResolvedValue({ grants, enforced });
-  vi.mocked(clientApi.listNodes).mockResolvedValue([] as never);
   return render(GrantsPage);
 }
 
@@ -79,13 +97,25 @@ afterEach(cleanup);
 
 test("lists a principal's grant values", async () => {
   const { findByText } = setup({
-    grants: [
-      { principalId: "user_1", mayDispatch: ["agentpod:molt-bot/hermes:*"], mayGrantReach: false },
-    ],
+    grants: [{ principalId: JO, mayDispatch: [QUILL], mayGrantReach: false }],
   });
 
-  expect(await findByText("jo@example.com")).toBeTruthy();
-  expect(await findByText("agentpod:molt-bot/hermes:*")).toBeTruthy();
+  expect(await findByText("Jo")).toBeTruthy();
+  expect(await findByText(QUILL)).toBeTruthy();
+});
+
+test("keys a row on the principal, not on the Better Auth user behind it", async () => {
+  // The bug this replaces: a grant keyed by `user.id` is not a grant on the
+  // wrong principal, it is an INSERT that violates a foreign key — so every
+  // save failed and every real grant showed up as an orphan.
+  const { findByRole } = setup({
+    grants: [{ principalId: JO, mayDispatch: [], mayGrantReach: false }],
+  });
+
+  await fireEvent.click(await findByRole("button", { name: /remove grant for/i }));
+  await fireEvent.click(await findByRole("button", { name: /^remove grant$/i }));
+
+  await waitFor(() => expect(grantsApi.deleteGrant).toHaveBeenCalledWith(JO));
 });
 
 test("says so loudly when nothing is enforcing these grants", async () => {
@@ -105,28 +135,40 @@ test("shows a principal with no grant rather than hiding them", async () => {
   // thing to discover by having dispatch fail.
   const { findByText } = setup({ grants: [] });
 
-  expect(await findByText("jo@example.com")).toBeTruthy();
+  expect(await findByText("Jo")).toBeTruthy();
   // Exact: the enforced banner also explains what having no grant costs.
   expect(await findByText("No grant.")).toBeTruthy();
 });
 
-test("keeps a grant whose principal is not a user here, and marks it", async () => {
+test("shows an agent, because an agent is a principal and can hold a grant too", async () => {
+  // The directory is not a user list. An agent has no Better Auth login and
+  // would never have appeared on this page before.
+  const { findByText } = setup({
+    principals: [
+      JO_PRINCIPAL,
+      { id: QUILL, kind: "agent", handle: "quill", displayName: "Quill", userId: null },
+    ] satisfies PrincipalSummary[],
+  });
+
+  expect(await findByText("Quill")).toBeTruthy();
+});
+
+test("keeps a grant whose principal this hub has no record of, and marks it", async () => {
   const { findByText } = setup({
     grants: [
-      { principalId: "user_gone", mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
+      { principalId: "prn_0000000000000000dead", mayDispatch: [QUILL], mayGrantReach: false },
     ],
   });
 
-  expect(await findByText("user_gone")).toBeTruthy();
-  expect(await findByText(/no such user/i)).toBeTruthy();
+  expect(await findByText("prn_0000000000000000dead")).toBeTruthy();
+  expect(await findByText(/no such principal/i)).toBeTruthy();
 });
 
 test("distinguishes granted-nothing from never-granted", async () => {
   // Both deny. They read differently to whoever comes next, and the difference
   // is the only record of whether anyone considered this principal at all.
   const { findByText } = setup({
-    users: [user("user_1", "jo@example.com")],
-    grants: [{ principalId: "user_1", mayDispatch: [], mayGrantReach: false }],
+    grants: [{ principalId: JO, mayDispatch: [], mayGrantReach: false }],
   });
 
   expect(await findByText(/considered, and permitted nothing/i)).toBeTruthy();
@@ -134,29 +176,26 @@ test("distinguishes granted-nothing from never-granted", async () => {
 
 test("removing a grant asks first, then reloads", async () => {
   const { findByRole, getByRole } = setup({
-    grants: [
-      { principalId: "user_1", mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
-    ],
+    grants: [{ principalId: JO, mayDispatch: [QUILL], mayGrantReach: false }],
   });
 
   await fireEvent.click(await findByRole("button", { name: /remove grant for/i }));
   await fireEvent.click(getByRole("button", { name: /^remove grant$/i }));
 
-  await waitFor(() => expect(grantsApi.deleteGrant).toHaveBeenCalledWith("user_1"));
+  await waitFor(() => expect(grantsApi.deleteGrant).toHaveBeenCalledWith(JO));
   // Reloaded rather than patched locally: the server is the authority on what a
   // grant is now, and a stale row here is a wrong belief about permission.
   await waitFor(() => expect(grantsApi.listGrants).toHaveBeenCalledTimes(2));
 });
 
-test("an unreachable fleet does not stop grant editing", async () => {
+test("an unreachable directory does not stop grant editing", async () => {
   // Narrowing a grant is exactly what you do when something has gone wrong, so
-  // station suggestions failing must not take the page with them.
-  vi.mocked(clientApi.listNodes).mockRejectedValue(new Error("nodes unreachable"));
+  // the directory that supplies readable names must not take the page with it.
+  // Every grant still has to be shown; it just shows the bare id.
   const { findByText } = setup({
-    grants: [
-      { principalId: "user_1", mayDispatch: ["kaambaan:agt_7abf"], mayGrantReach: false },
-    ],
+    directoryFails: true,
+    grants: [{ principalId: JO, mayDispatch: [QUILL], mayGrantReach: false }],
   });
 
-  expect(await findByText("kaambaan:agt_7abf")).toBeTruthy();
+  expect(await findByText(QUILL)).toBeTruthy();
 });

--- a/apps/console/src/routes/admin/grants/page.svelte.test.ts
+++ b/apps/console/src/routes/admin/grants/page.svelte.test.ts
@@ -40,6 +40,8 @@ vi.mock("$lib/api/grants", async () => {
     listPrincipals: vi.fn(),
     setGrant: vi.fn(),
     deleteGrant: vi.fn(),
+    suspendPrincipal: vi.fn(),
+    restorePrincipal: vi.fn(),
   };
 });
 
@@ -73,6 +75,7 @@ const JO_PRINCIPAL: PrincipalSummary = {
   handle: "jo",
   displayName: null,
   userId: "user_1",
+  suspendedAt: null,
 };
 
 function setup({
@@ -146,7 +149,14 @@ test("shows an agent, because an agent is a principal and can hold a grant too",
   const { findByText } = setup({
     principals: [
       JO_PRINCIPAL,
-      { id: QUILL, kind: "agent", handle: "quill", displayName: "Quill", userId: null },
+      {
+        id: QUILL,
+        kind: "agent",
+        handle: "quill",
+        displayName: "Quill",
+        userId: null,
+        suspendedAt: null,
+      },
     ] satisfies PrincipalSummary[],
   });
 
@@ -198,4 +208,52 @@ test("an unreachable directory does not stop grant editing", async () => {
   });
 
   expect(await findByText(QUILL)).toBeTruthy();
+});
+
+test("says what an empty directory means, rather than a bare '0 of 0'", async () => {
+  // Regression guard: a bare "0 of 0 principals have a grant" reads as a
+  // loading glitch, not as "nobody is registered here yet".
+  const { findByTestId, queryByText } = setup({ principals: [] });
+
+  const empty = await findByTestId("empty-state");
+  expect(empty.textContent).toMatch(/no principals yet/i);
+  expect(queryByText(/0 of 0 principals/i)).toBeNull();
+});
+
+test("suspending a principal asks first, calls the endpoint, then reloads", async () => {
+  const { findByRole, getByRole } = setup();
+  vi.mocked(grantsApi.suspendPrincipal).mockResolvedValue({ id: JO, suspendedAt: "now" });
+
+  await fireEvent.click(await findByRole("button", { name: /^suspend jo$/i }));
+  await fireEvent.click(getByRole("button", { name: /^suspend$/i }));
+
+  await waitFor(() => expect(grantsApi.suspendPrincipal).toHaveBeenCalledWith(JO));
+  // Reloaded rather than patched locally — the server, not this button, is the
+  // authority on whether the principal is actually suspended now.
+  await waitFor(() => expect(grantsApi.listPrincipals).toHaveBeenCalledTimes(2));
+});
+
+test("a suspended principal shows Restore in place of Suspend, and it is reversible with one click — no confirmation needed to undo", async () => {
+  const { findByRole, findByText } = setup({
+    principals: [{ ...JO_PRINCIPAL, suspendedAt: "2026-08-30T00:00:00.000Z" }],
+  });
+  vi.mocked(grantsApi.restorePrincipal).mockResolvedValue({ id: JO, suspendedAt: null });
+
+  expect(await findByText("Suspended")).toBeTruthy();
+
+  await fireEvent.click(await findByRole("button", { name: /^restore jo$/i }));
+
+  await waitFor(() => expect(grantsApi.restorePrincipal).toHaveBeenCalledWith(JO));
+  await waitFor(() => expect(grantsApi.listPrincipals).toHaveBeenCalledTimes(2));
+});
+
+test("an orphaned grant offers no suspend control — there is no principal row to suspend", async () => {
+  const { findByText, queryByRole } = setup({
+    grants: [
+      { principalId: "prn_0000000000000000dead", mayDispatch: [QUILL], mayGrantReach: false },
+    ],
+  });
+
+  expect(await findByText("prn_0000000000000000dead")).toBeTruthy();
+  expect(queryByRole("button", { name: /suspend prn_0000000000000000dead/i })).toBeNull();
 });

--- a/apps/console/src/routes/agents/+page.svelte
+++ b/apps/console/src/routes/agents/+page.svelte
@@ -3,6 +3,8 @@
   import { startPolling } from "$lib/utils/poll";
   import { page } from "$app/state";
   import { getFleet, listStations } from "$lib/api/client";
+  import { listPrincipals, type PrincipalSummary } from "$lib/api/grants";
+  import { unassignStationAgent } from "$lib/api/agents";
   import type { FleetAgent } from "@agentpod/contract";
   import PageHeader from "$lib/components/page-header.svelte";
   import AgentTable from "$lib/components/fleet/AgentTable.svelte";
@@ -10,9 +12,13 @@
   import StatusRibbon from "$lib/components/fleet/StatusRibbon.svelte";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Button } from "$lib/components/ui/button";
+  import { Badge } from "$lib/components/ui/badge";
+  import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
+  import { toast } from "svelte-sonner";
   import UserPlusIcon from "@lucide/svelte/icons/user-plus";
   import UserXIcon from "@lucide/svelte/icons/user-x";
   import UserCheckIcon from "@lucide/svelte/icons/user-check";
+  import BanIcon from "@lucide/svelte/icons/ban";
 
   interface ExternalFilter {
     stationId?: string;
@@ -25,10 +31,10 @@
   let error = $state<string | null>(null);
 
   /**
-   * stationId → occupying principal, or null. Built from `listStations` (the
-   * DB row already carries `principalId`; `getFleet`'s aggregate doesn't) —
-   * this is what turns "healthy" into "healthy AND dispatchable" or
-   * "healthy but nobody can dispatch it".
+   * stationId → occupying principal id, or null. Built from `listStations`
+   * (the DB row already carries `principalId`; `getFleet`'s aggregate
+   * doesn't) — this is the first half of turning "healthy" into "healthy AND
+   * dispatchable" or "healthy but nobody can dispatch it".
    *
    * A station with no principal is *correct*, deliberate behaviour
    * (`charter → decisions/2026-08-30-an-agent-is-a-principal.md`), not a
@@ -39,6 +45,17 @@
   let assignments = $state<Map<string, { stationKey: string; principalId: string | null }>>(new Map());
   let assignmentsError = $state<string | null>(null);
   let assignedNodeIds: string[] = [];
+
+  /**
+   * The second half: a station can carry a principal id and still be
+   * dispatchable by nobody, because that principal is suspended. Only
+   * `principalId !== null` was checked before this — which reads a
+   * suspended agent's station as "assigned", i.e. healthy, which is exactly
+   * the invisibility this task exists to remove, just arriving through a
+   * different door. `GET /api/admin/principals` already carries `suspendedAt`.
+   */
+  let principalsById = $state<Map<string, PrincipalSummary>>(new Map());
+  let principalsError = $state<string | null>(null);
 
   // Derive the external filter from the URL query params reactively.
   // ?station=<id> → filter by stationId; ?status=<s> → filter by status
@@ -58,16 +75,65 @@
     return filter;
   });
 
-  /** Every adopted station this fleet page knows about that has no occupying agent. */
-  let unassignedStations = $derived.by((): StationOption[] =>
-    agents
-      .filter((a) => assignments.get(a.stationId)?.principalId === null)
-      .map((a) => ({
-        id: a.stationId,
-        stationKey: assignments.get(a.stationId)!.stationKey,
-        displayName: a.agentName,
-        nodeName: a.nodeName,
-      }))
+  type StationStatus =
+    | { id: string; stationKey: string; displayName: string; nodeName: string; kind: "unassigned" }
+    | {
+        id: string;
+        stationKey: string;
+        displayName: string;
+        nodeName: string;
+        kind: "suspended";
+        principal: PrincipalSummary;
+      }
+    | {
+        id: string;
+        stationKey: string;
+        displayName: string;
+        nodeName: string;
+        kind: "active";
+        principal: PrincipalSummary;
+      };
+
+  /**
+   * Every adopted station this page knows about, classified by whether it
+   * can actually be dispatched right now — not merely whether a principal id
+   * is on the row. Omits stations `assignments` hasn't resolved yet (still
+   * loading, or the lookup failed) rather than guessing either way.
+   */
+  let stationStatuses = $derived.by((): StationStatus[] =>
+    agents.flatMap((a): StationStatus[] => {
+      const info = assignments.get(a.stationId);
+      if (!info) return [];
+      const base = { id: a.stationId, stationKey: info.stationKey, displayName: a.agentName, nodeName: a.nodeName };
+      if (info.principalId === null) {
+        return [{ ...base, kind: "unassigned" }];
+      }
+      const principal = principalsById.get(info.principalId);
+      // A principal id on the row that the directory doesn't (yet) know is
+      // treated as active rather than flagged — the directory can lag the
+      // assignment on first load, and there is no path today for a
+      // principal to be deleted out from under a station.
+      if (!principal || !principal.suspendedAt) {
+        return [{ ...base, kind: "active", principal: principal ?? { id: info.principalId, kind: "agent", handle: info.principalId, displayName: null, userId: null, suspendedAt: null } }];
+      }
+      return [{ ...base, kind: "suspended", principal }];
+    })
+  );
+
+  let unassignedStations = $derived(
+    stationStatuses.filter((s): s is Extract<StationStatus, { kind: "unassigned" }> => s.kind === "unassigned")
+  );
+  let suspendedStations = $derived(
+    stationStatuses.filter((s): s is Extract<StationStatus, { kind: "suspended" }> => s.kind === "suspended")
+  );
+  let activeStations = $derived(
+    stationStatuses.filter((s): s is Extract<StationStatus, { kind: "active" }> => s.kind === "active")
+  );
+  /** Stations that cannot be dispatched right now, for any reason. */
+  let blockedStations = $derived([...unassignedStations, ...suspendedStations]);
+
+  let unassignedOptions = $derived<StationOption[]>(
+    unassignedStations.map((s) => ({ id: s.id, stationKey: s.stationKey, displayName: s.displayName, nodeName: s.nodeName }))
   );
 
   async function loadAssignments(nodeIds: string[]) {
@@ -89,6 +155,16 @@
     }
   }
 
+  async function loadPrincipals() {
+    try {
+      principalsById = new Map((await listPrincipals()).map((p) => [p.id, p]));
+      principalsError = null;
+    } catch (e) {
+      principalsError =
+        e instanceof Error ? e.message : "Couldn't check which agents are suspended.";
+    }
+  }
+
   async function loadFleet(background = false) {
     if (!background) {
       isLoading = true;
@@ -98,7 +174,10 @@
       const result = await getFleet();
       agents = result.agents;
       error = null;
-      await loadAssignments([...new Set(result.agents.map((a) => a.nodeId))]);
+      await Promise.all([
+        loadAssignments([...new Set(result.agents.map((a) => a.nodeId))]),
+        loadPrincipals(),
+      ]);
     } catch (e) {
       // Background refreshes keep the last good data on screen; the shell's
       // hub-unreachable banner carries the staleness signal.
@@ -132,6 +211,40 @@
 
   function handleAgentCreated() {
     void loadFleet();
+  }
+
+  // ── Unassign — the other half of the pair, and a real control ────────────
+  //
+  // Task 2 built DELETE .../agent; until this, nothing in the console ever
+  // called it, so a mis-assignment (or a since-suspended agent left sitting
+  // in a station) could only be undone with SQL — the exact thing this
+  // slice exists to end.
+
+  let showUnassign = $state(false);
+  let unassignTarget = $state<Extract<StationStatus, { kind: "suspended" | "active" }> | null>(null);
+  let isUnassigning = $state(false);
+
+  function openUnassign(station: Extract<StationStatus, { kind: "suspended" | "active" }>) {
+    unassignTarget = station;
+    showUnassign = true;
+  }
+
+  async function handleUnassign() {
+    if (!unassignTarget) return;
+    isUnassigning = true;
+    try {
+      await unassignStationAgent(unassignTarget.id);
+      toast.success(`${unassignTarget.displayName} unassigned`);
+      showUnassign = false;
+      unassignTarget = null;
+      await loadFleet();
+    } catch (e) {
+      toast.error("Couldn't unassign", {
+        description: e instanceof Error ? e.message : "Something went wrong.",
+      });
+    } finally {
+      isUnassigning = false;
+    }
   }
 </script>
 
@@ -174,31 +287,42 @@
     </div>
 
   {:else}
-    {#if assignmentsError}
+    {#if assignmentsError || principalsError}
       <div
         class="flex items-start justify-between gap-3 rounded-lg border border-amber-500/50 bg-amber-500/5 p-3"
         role="alert"
       >
-        <p class="text-xs text-amber-700 dark:text-amber-400">{assignmentsError}</p>
-        <Button variant="outline" size="sm" onclick={() => loadAssignments(assignedNodeIds)}>Retry</Button>
+        <p class="text-xs text-amber-700 dark:text-amber-400">{assignmentsError ?? principalsError}</p>
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={() => {
+            void loadAssignments(assignedNodeIds);
+            void loadPrincipals();
+          }}
+        >
+          Retry
+        </Button>
       </div>
     {:else if agents.length > 0}
-      {#if unassignedStations.length > 0}
-        <!-- The point of this task: a station with no occupying agent must read
-             as unassigned, not merely healthy — a fleet-wide refusal to
-             dispatch otherwise produces no signal anywhere in this console. -->
+      {#if blockedStations.length > 0}
+        <!-- The point of this task: a station that cannot be dispatched must
+             read that way, not merely healthy — whether because nobody has
+             assigned it an agent, or because the agent it has is suspended.
+             Either way a fleet-wide refusal to dispatch otherwise produces no
+             signal anywhere in this console. -->
         <div class="rounded-lg border border-amber-500/40 bg-amber-500/5 p-4" data-testid="unassigned-stations">
           <div class="flex items-start gap-2">
             <UserXIcon class="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
             <div class="space-y-1">
               <p class="text-sm font-medium">
-                {unassignedStations.length}
-                {unassignedStations.length === 1 ? "station has" : "stations have"} no agent
+                {blockedStations.length}
+                {blockedStations.length === 1 ? "station can't" : "stations can't"} be dispatched
               </p>
               <p class="text-xs text-muted-foreground">
-                A station with no occupying agent is dispatchable by nobody — correct behaviour
-                for a station nobody has assigned yet, but indistinguishable from a fault unless
-                it's shown. Give one a principal to make it dispatchable.
+                A station with no agent, or whose agent is suspended, is dispatchable by nobody —
+                correct behaviour for a station nobody has assigned yet, but indistinguishable
+                from a fault unless it's shown here.
               </p>
             </div>
           </div>
@@ -213,9 +337,39 @@
                   variant="outline"
                   size="sm"
                   class="shrink-0"
-                  onclick={() => openCreateForStation(station)}
+                  onclick={() =>
+                    openCreateForStation({
+                      id: station.id,
+                      stationKey: station.stationKey,
+                      displayName: station.displayName,
+                      nodeName: station.nodeName,
+                    })}
                 >
                   Create an agent for this station
+                </Button>
+              </li>
+            {/each}
+            {#each suspendedStations as station (station.id)}
+              <li class="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2">
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-medium">{station.displayName}</p>
+                  <p class="flex items-center gap-1 text-xs text-destructive">
+                    <BanIcon class="h-3 w-3 shrink-0" aria-hidden="true" />
+                    {station.nodeName} · agent suspended — {station.principal.handle}
+                  </p>
+                  <p class="text-xs text-muted-foreground">
+                    Suspended principals are refused everywhere. Unassign to free the station, or
+                    <a href="/admin/grants" class="underline hover:text-foreground">restore it in Grants</a>.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  class="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="Unassign {station.displayName}"
+                  onclick={() => openUnassign(station)}
+                >
+                  Unassign
                 </Button>
               </li>
             {/each}
@@ -224,8 +378,38 @@
       {:else}
         <p class="flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="all-assigned">
           <UserCheckIcon class="h-3.5 w-3.5" aria-hidden="true" />
-          Every adopted station has an agent assigned.
+          Every adopted station has an active agent assigned.
         </p>
+      {/if}
+
+      {#if activeStations.length > 0}
+        <!-- The other half of "wire unassign to a real control": even a
+             correctly-assigned station needs a way off, or a mis-assignment
+             can only be undone with SQL. -->
+        <div class="rounded-lg border p-3" data-testid="assigned-stations">
+          <p class="mb-2 text-xs font-medium text-muted-foreground">
+            {activeStations.length} {activeStations.length === 1 ? "station is" : "stations are"} assigned
+          </p>
+          <ul class="space-y-1.5">
+            {#each activeStations as station (station.id)}
+              <li class="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 hover:bg-muted/50">
+                <div class="flex min-w-0 items-center gap-2">
+                  <span class="truncate text-sm">{station.displayName}</span>
+                  <Badge variant="outline" class="shrink-0 font-mono text-[11px]">{station.principal.handle}</Badge>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  class="shrink-0 text-muted-foreground hover:text-destructive"
+                  aria-label="Unassign {station.displayName}"
+                  onclick={() => openUnassign(station)}
+                >
+                  Unassign
+                </Button>
+              </li>
+            {/each}
+          </ul>
+        </div>
       {/if}
     {/if}
 
@@ -236,6 +420,22 @@
 <AgentCreate
   bind:open={createOpen}
   station={createForStation}
-  stationOptions={createForStation ? [] : unassignedStations}
+  stationOptions={createForStation ? [] : unassignedOptions}
   onCreated={handleAgentCreated}
+/>
+
+<ConfirmDialog
+  open={showUnassign}
+  title="Unassign agent"
+  message={unassignTarget
+    ? `${unassignTarget.displayName}'s agent (${unassignTarget.principal.handle}) will be removed from this station. It becomes dispatchable by nobody until an agent is assigned again.`
+    : ""}
+  confirmLabel="Unassign"
+  destructive
+  onConfirm={handleUnassign}
+  onCancel={() => {
+    if (isUnassigning) return;
+    showUnassign = false;
+    unassignTarget = null;
+  }}
 />

--- a/apps/console/src/routes/agents/+page.svelte
+++ b/apps/console/src/routes/agents/+page.svelte
@@ -2,13 +2,17 @@
   import { onMount } from "svelte";
   import { startPolling } from "$lib/utils/poll";
   import { page } from "$app/state";
-  import { getFleet } from "$lib/api/client";
+  import { getFleet, listStations } from "$lib/api/client";
   import type { FleetAgent } from "@agentpod/contract";
   import PageHeader from "$lib/components/page-header.svelte";
   import AgentTable from "$lib/components/fleet/AgentTable.svelte";
+  import AgentCreate, { type StationOption } from "$lib/components/fleet/AgentCreate.svelte";
   import StatusRibbon from "$lib/components/fleet/StatusRibbon.svelte";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Button } from "$lib/components/ui/button";
+  import UserPlusIcon from "@lucide/svelte/icons/user-plus";
+  import UserXIcon from "@lucide/svelte/icons/user-x";
+  import UserCheckIcon from "@lucide/svelte/icons/user-check";
 
   interface ExternalFilter {
     stationId?: string;
@@ -19,6 +23,22 @@
   let agents = $state<FleetAgent[]>([]);
   let isLoading = $state(true);
   let error = $state<string | null>(null);
+
+  /**
+   * stationId → occupying principal, or null. Built from `listStations` (the
+   * DB row already carries `principalId`; `getFleet`'s aggregate doesn't) —
+   * this is what turns "healthy" into "healthy AND dispatchable" or
+   * "healthy but nobody can dispatch it".
+   *
+   * A station with no principal is *correct*, deliberate behaviour
+   * (`charter → decisions/2026-08-30-an-agent-is-a-principal.md`), not a
+   * fault — and until this page existed it had no signal at all: the fleet
+   * table shows process health, which is unrelated to whether anything may
+   * dispatch the station.
+   */
+  let assignments = $state<Map<string, { stationKey: string; principalId: string | null }>>(new Map());
+  let assignmentsError = $state<string | null>(null);
+  let assignedNodeIds: string[] = [];
 
   // Derive the external filter from the URL query params reactively.
   // ?station=<id> → filter by stationId; ?status=<s> → filter by status
@@ -38,6 +58,37 @@
     return filter;
   });
 
+  /** Every adopted station this fleet page knows about that has no occupying agent. */
+  let unassignedStations = $derived.by((): StationOption[] =>
+    agents
+      .filter((a) => assignments.get(a.stationId)?.principalId === null)
+      .map((a) => ({
+        id: a.stationId,
+        stationKey: assignments.get(a.stationId)!.stationKey,
+        displayName: a.agentName,
+        nodeName: a.nodeName,
+      }))
+  );
+
+  async function loadAssignments(nodeIds: string[]) {
+    assignedNodeIds = nodeIds;
+    try {
+      const rows = await Promise.all(nodeIds.map((id) => listStations(id)));
+      const map = new Map<string, { stationKey: string; principalId: string | null }>();
+      for (const stations of rows) {
+        for (const s of stations) map.set(s.id, { stationKey: s.stationKey, principalId: s.principalId });
+      }
+      assignments = map;
+      assignmentsError = null;
+    } catch (e) {
+      // Non-fatal to the page — the fleet table itself still renders. Losing
+      // this specific check must say so rather than silently claiming every
+      // station has an agent.
+      assignmentsError =
+        e instanceof Error ? e.message : "Couldn't check which stations have an agent.";
+    }
+  }
+
   async function loadFleet(background = false) {
     if (!background) {
       isLoading = true;
@@ -47,6 +98,7 @@
       const result = await getFleet();
       agents = result.agents;
       error = null;
+      await loadAssignments([...new Set(result.agents.map((a) => a.nodeId))]);
     } catch (e) {
       // Background refreshes keep the last good data on screen; the shell's
       // hub-unreachable banner carries the staleness signal.
@@ -60,6 +112,27 @@
     void loadFleet();
     return startPolling(() => void loadFleet(true), 30_000);
   });
+
+  // ── Create-and-assign dialog ──────────────────────────────────────────────
+
+  let createOpen = $state(false);
+  /** Set when opened from a specific station's "Create an agent for this
+   *  station" action — the target is fixed rather than picked. */
+  let createForStation = $state<StationOption | null>(null);
+
+  function openCreateForStation(station: StationOption) {
+    createForStation = station;
+    createOpen = true;
+  }
+
+  function openCreateGeneric() {
+    createForStation = null;
+    createOpen = true;
+  }
+
+  function handleAgentCreated() {
+    void loadFleet();
+  }
 </script>
 
 <svelte:head>
@@ -75,9 +148,15 @@
       />
     {/if}
   {/snippet}
+  {#snippet actions()}
+    <Button variant="outline" size="sm" onclick={openCreateGeneric}>
+      <UserPlusIcon class="mr-1 h-3.5 w-3.5" />
+      Create agent
+    </Button>
+  {/snippet}
 </PageHeader>
 
-<div class="container mx-auto px-4 sm:px-6 max-w-7xl py-6">
+<div class="container mx-auto px-4 sm:px-6 max-w-7xl py-6 space-y-4">
   {#if isLoading}
     <div class="space-y-3">
       {#each [1, 2, 3] as _}
@@ -95,6 +174,68 @@
     </div>
 
   {:else}
+    {#if assignmentsError}
+      <div
+        class="flex items-start justify-between gap-3 rounded-lg border border-amber-500/50 bg-amber-500/5 p-3"
+        role="alert"
+      >
+        <p class="text-xs text-amber-700 dark:text-amber-400">{assignmentsError}</p>
+        <Button variant="outline" size="sm" onclick={() => loadAssignments(assignedNodeIds)}>Retry</Button>
+      </div>
+    {:else if agents.length > 0}
+      {#if unassignedStations.length > 0}
+        <!-- The point of this task: a station with no occupying agent must read
+             as unassigned, not merely healthy — a fleet-wide refusal to
+             dispatch otherwise produces no signal anywhere in this console. -->
+        <div class="rounded-lg border border-amber-500/40 bg-amber-500/5 p-4" data-testid="unassigned-stations">
+          <div class="flex items-start gap-2">
+            <UserXIcon class="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
+            <div class="space-y-1">
+              <p class="text-sm font-medium">
+                {unassignedStations.length}
+                {unassignedStations.length === 1 ? "station has" : "stations have"} no agent
+              </p>
+              <p class="text-xs text-muted-foreground">
+                A station with no occupying agent is dispatchable by nobody — correct behaviour
+                for a station nobody has assigned yet, but indistinguishable from a fault unless
+                it's shown. Give one a principal to make it dispatchable.
+              </p>
+            </div>
+          </div>
+          <ul class="mt-3 space-y-2">
+            {#each unassignedStations as station (station.id)}
+              <li class="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2">
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-medium">{station.displayName}</p>
+                  <p class="text-xs text-muted-foreground">{station.nodeName} · no agent</p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  class="shrink-0"
+                  onclick={() => openCreateForStation(station)}
+                >
+                  Create an agent for this station
+                </Button>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {:else}
+        <p class="flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="all-assigned">
+          <UserCheckIcon class="h-3.5 w-3.5" aria-hidden="true" />
+          Every adopted station has an agent assigned.
+        </p>
+      {/if}
+    {/if}
+
     <AgentTable {agents} {externalFilter} />
   {/if}
 </div>
+
+<AgentCreate
+  bind:open={createOpen}
+  station={createForStation}
+  stationOptions={createForStation ? [] : unassignedStations}
+  onCreated={handleAgentCreated}
+/>

--- a/apps/console/src/routes/agents/+page.svelte
+++ b/apps/console/src/routes/agents/+page.svelte
@@ -9,6 +9,7 @@
   import PageHeader from "$lib/components/page-header.svelte";
   import AgentTable from "$lib/components/fleet/AgentTable.svelte";
   import AgentCreate, { type StationOption } from "$lib/components/fleet/AgentCreate.svelte";
+  import AssignAgent, { type AssignStationTarget } from "$lib/components/fleet/AssignAgent.svelte";
   import StatusRibbon from "$lib/components/fleet/StatusRibbon.svelte";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Button } from "$lib/components/ui/button";
@@ -136,6 +137,22 @@
     unassignedStations.map((s) => ({ id: s.id, stationKey: s.stationKey, displayName: s.displayName, nodeName: s.nodeName }))
   );
 
+  /**
+   * Agent principals nothing currently occupies a station with — the pool
+   * Ruling 6's "assign an existing agent" control offers. Filtered on
+   * currently-known occupancy (`assignments`, the same map `stationStatuses`
+   * reads) rather than on the principal directory alone: offering one that
+   * is already active elsewhere would silently orphan its current station,
+   * since the hub's assign endpoint has no opinion about where a principal
+   * was before this call.
+   */
+  let availableAgentPrincipals = $derived.by((): PrincipalSummary[] => {
+    const occupied = new Set(
+      [...assignments.values()].map((a) => a.principalId).filter((id): id is string => id !== null)
+    );
+    return [...principalsById.values()].filter((p) => p.kind === "agent" && !occupied.has(p.id));
+  });
+
   async function loadAssignments(nodeIds: string[]) {
     assignedNodeIds = nodeIds;
     try {
@@ -210,6 +227,25 @@
   }
 
   function handleAgentCreated() {
+    void loadFleet();
+  }
+
+  // ── Assign an existing agent — Ruling 6: the way back for a stranded one ──
+  //
+  // AgentCreate wires `assignStationAgent`'s only caller before this: minting
+  // a brand-new principal and handing it a station in one click. An operator
+  // who unassigns one (below) had no way to put it — or any other existing
+  // principal — into a station again, short of SQL.
+
+  let assignOpen = $state(false);
+  let assignTarget = $state<AssignStationTarget | null>(null);
+
+  function openAssign(station: AssignStationTarget) {
+    assignTarget = station;
+    assignOpen = true;
+  }
+
+  function handleAgentAssigned() {
     void loadFleet();
   }
 
@@ -333,20 +369,30 @@
                   <p class="truncate text-sm font-medium">{station.displayName}</p>
                   <p class="text-xs text-muted-foreground">{station.nodeName} · no agent</p>
                 </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  class="shrink-0"
-                  onclick={() =>
-                    openCreateForStation({
-                      id: station.id,
-                      stationKey: station.stationKey,
-                      displayName: station.displayName,
-                      nodeName: station.nodeName,
-                    })}
-                >
-                  Create an agent for this station
-                </Button>
+                <div class="flex shrink-0 items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    aria-label="Assign an existing agent to {station.displayName}"
+                    onclick={() =>
+                      openAssign({ id: station.id, displayName: station.displayName, nodeName: station.nodeName })}
+                  >
+                    Assign an existing agent
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onclick={() =>
+                      openCreateForStation({
+                        id: station.id,
+                        stationKey: station.stationKey,
+                        displayName: station.displayName,
+                        nodeName: station.nodeName,
+                      })}
+                  >
+                    Create an agent for this station
+                  </Button>
+                </div>
               </li>
             {/each}
             {#each suspendedStations as station (station.id)}
@@ -422,6 +468,13 @@
   station={createForStation}
   stationOptions={createForStation ? [] : unassignedOptions}
   onCreated={handleAgentCreated}
+/>
+
+<AssignAgent
+  bind:open={assignOpen}
+  station={assignTarget}
+  candidates={availableAgentPrincipals}
+  onAssigned={handleAgentAssigned}
 />
 
 <ConfirmDialog

--- a/apps/console/src/routes/agents/+page.svelte
+++ b/apps/console/src/routes/agents/+page.svelte
@@ -9,7 +9,7 @@
   import PageHeader from "$lib/components/page-header.svelte";
   import AgentTable from "$lib/components/fleet/AgentTable.svelte";
   import AgentCreate, { type StationOption } from "$lib/components/fleet/AgentCreate.svelte";
-  import AssignAgent, { type AssignStationTarget } from "$lib/components/fleet/AssignAgent.svelte";
+  import AssignAgent, { type AssignStationTarget, type AssignCandidate } from "$lib/components/fleet/AssignAgent.svelte";
   import StatusRibbon from "$lib/components/fleet/StatusRibbon.svelte";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Button } from "$lib/components/ui/button";
@@ -138,20 +138,38 @@
   );
 
   /**
-   * Agent principals nothing currently occupies a station with — the pool
-   * Ruling 6's "assign an existing agent" control offers. Filtered on
-   * currently-known occupancy (`assignments`, the same map `stationStatuses`
-   * reads) rather than on the principal directory alone: offering one that
-   * is already active elsewhere would silently orphan its current station,
-   * since the hub's assign endpoint has no opinion about where a principal
-   * was before this call.
+   * stationId → occupied station's own {id, displayName} — from
+   * `stationStatuses`, which already carries a human-readable name per
+   * station (`assignments` alone only has `stationKey`). Occupancy is
+   * exclusive as of the fix round on Task 5 (`stations_principal_id_idx`,
+   * `routes/agents-admin.ts`'s assign-is-a-move), so a principal occupies at
+   * most one station and this map is unambiguous by construction.
    */
-  let availableAgentPrincipals = $derived.by((): PrincipalSummary[] => {
-    const occupied = new Set(
-      [...assignments.values()].map((a) => a.principalId).filter((id): id is string => id !== null)
-    );
-    return [...principalsById.values()].filter((p) => p.kind === "agent" && !occupied.has(p.id));
+  let occupiedStationByPrincipal = $derived.by((): Map<string, { id: string; displayName: string }> => {
+    const map = new Map<string, { id: string; displayName: string }>();
+    for (const s of stationStatuses) {
+      if (s.kind === "active" || s.kind === "suspended") {
+        map.set(s.principal.id, { id: s.id, displayName: s.displayName });
+      }
+    }
+    return map;
   });
+
+  /**
+   * Every agent principal, occupied or not — the pool Ruling 6's "assign an
+   * existing agent" control offers. Picking an already-occupied one is now
+   * safe rather than orphaning: `routes/agents-admin.ts`'s assign endpoint
+   * vacates a principal's previous station in the same transaction it
+   * places it in a new one. Each candidate carries where it currently runs,
+   * if anywhere, so the control can label a move as a move — not filtered
+   * down to unoccupied ones, which would hide the exact capability this
+   * ruling exists to add.
+   */
+  let assignCandidates = $derived.by((): AssignCandidate[] =>
+    [...principalsById.values()]
+      .filter((p) => p.kind === "agent")
+      .map((p) => ({ principal: p, currentStation: occupiedStationByPrincipal.get(p.id) ?? null }))
+  );
 
   async function loadAssignments(nodeIds: string[]) {
     assignedNodeIds = nodeIds;
@@ -408,15 +426,25 @@
                     <a href="/admin/grants" class="underline hover:text-foreground">restore it in Grants</a>.
                   </p>
                 </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  class="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  aria-label="Unassign {station.displayName}"
-                  onclick={() => openUnassign(station)}
-                >
-                  Unassign
-                </Button>
+                <div class="flex shrink-0 items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    aria-label="Assign a different agent to {station.displayName}"
+                    onclick={() => openAssign({ id: station.id, displayName: station.displayName, nodeName: station.nodeName })}
+                  >
+                    Assign a different agent
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    aria-label="Unassign {station.displayName}"
+                    onclick={() => openUnassign(station)}
+                  >
+                    Unassign
+                  </Button>
+                </div>
               </li>
             {/each}
           </ul>
@@ -443,15 +471,26 @@
                   <span class="truncate text-sm">{station.displayName}</span>
                   <Badge variant="outline" class="shrink-0 font-mono text-[11px]">{station.principal.handle}</Badge>
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  class="shrink-0 text-muted-foreground hover:text-destructive"
-                  aria-label="Unassign {station.displayName}"
-                  onclick={() => openUnassign(station)}
-                >
-                  Unassign
-                </Button>
+                <div class="flex shrink-0 items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="text-muted-foreground hover:text-foreground"
+                    aria-label="Assign a different agent to {station.displayName}"
+                    onclick={() => openAssign({ id: station.id, displayName: station.displayName, nodeName: station.nodeName })}
+                  >
+                    Assign a different agent
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="text-muted-foreground hover:text-destructive"
+                    aria-label="Unassign {station.displayName}"
+                    onclick={() => openUnassign(station)}
+                  >
+                    Unassign
+                  </Button>
+                </div>
               </li>
             {/each}
           </ul>
@@ -473,7 +512,7 @@
 <AssignAgent
   bind:open={assignOpen}
   station={assignTarget}
-  candidates={availableAgentPrincipals}
+  candidates={assignCandidates}
   onAssigned={handleAgentAssigned}
 />
 

--- a/apps/console/src/routes/agents/page.svelte.test.ts
+++ b/apps/console/src/routes/agents/page.svelte.test.ts
@@ -7,6 +7,9 @@
  *  - renders the AgentTable once agents are loaded
  *  - ?status=running derives externalFilter { status: "running" }
  *  - ?station=<id> derives externalFilter { stationId: <id> }
+ *  - an unassigned station (no occupying principal) reads as unassigned,
+ *    not merely healthy — the console previously had no signal for this at
+ *    all, and a station with no principal is dispatchable by nobody
  */
 
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
@@ -51,8 +54,32 @@ import AgentsPage from "./+page.svelte";
 beforeEach(() => {
   vi.restoreAllMocks();
   resetReactivePageState();
+  // Default: no stations to cross-reference, so tests that don't care about
+  // assignment never make a real network call for it.
+  vi.spyOn(api, "listStations").mockResolvedValue([]);
 });
 afterEach(cleanup);
+
+function stationRow(overrides: Partial<api.StationRow>): api.StationRow {
+  return {
+    id: "s1",
+    userId: "u1",
+    nodeId: "n1",
+    harness: "openclaw",
+    stationKey: "hermes:agent",
+    kind: "agent",
+    parentStationId: null,
+    displayName: "agent",
+    workspacePath: null,
+    capabilities: [],
+    matrixId: null,
+    purpose: null,
+    principalId: null,
+    adoptedAt: "2026-01-01T00:00:00Z",
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
 
 const mockAgents = [
   {
@@ -143,6 +170,43 @@ test("calls getFleet on mount", async () => {
   await waitFor(() => {
     expect(spy).toHaveBeenCalledOnce();
   });
+});
+
+test("an unassigned station renders as unassigned, not merely healthy", async () => {
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  vi.spyOn(api, "listStations").mockResolvedValue([
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", displayName: "hanuman", principalId: "prn_abc123" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", displayName: "kubera", principalId: null }),
+  ]);
+
+  const { getByTestId, getAllByText, queryByText } = render(AgentsPage);
+
+  await waitFor(() => {
+    // kubera's FleetAgent row already says "stopped" (a health status) —
+    // that alone must not be the only signal. A dedicated, explained section
+    // says it has no occupying agent.
+    expect(getByTestId("unassigned-stations")).toBeTruthy();
+    expect(getAllByText(/no agent/i).length).toBeGreaterThan(0);
+  });
+  const section = getByTestId("unassigned-stations");
+  expect(section.textContent).toContain("kubera");
+  // hanuman IS assigned — it must not appear as if it needs one too.
+  expect(queryByText(/hanuman/, { selector: '[data-testid="unassigned-stations"] *' })).toBeNull();
+});
+
+test("when every station has an agent, the page says so instead of staying silent", async () => {
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  vi.spyOn(api, "listStations").mockResolvedValue([
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", principalId: "prn_a" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", principalId: "prn_b" }),
+  ]);
+
+  const { getByTestId, queryByTestId } = render(AgentsPage);
+
+  await waitFor(() => {
+    expect(getByTestId("all-assigned")).toBeTruthy();
+  });
+  expect(queryByTestId("unassigned-stations")).toBeNull();
 });
 
 test("?updates=1 seeds the updates-only pill pressed and shows only update-available agents", async () => {

--- a/apps/console/src/routes/agents/page.svelte.test.ts
+++ b/apps/console/src/routes/agents/page.svelte.test.ts
@@ -13,8 +13,10 @@
  */
 
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, waitFor, cleanup } from "@testing-library/svelte";
+import { render, waitFor, cleanup, fireEvent } from "@testing-library/svelte";
 import * as api from "$lib/api/client";
+import * as grantsApi from "$lib/api/grants";
+import * as agentsApi from "$lib/api/agents";
 import { setSearchParam, resetReactivePageState } from "../../mocks/reactive-page-state.svelte";
 
 // ---------------------------------------------------------------------------
@@ -57,6 +59,7 @@ beforeEach(() => {
   // Default: no stations to cross-reference, so tests that don't care about
   // assignment never make a real network call for it.
   vi.spyOn(api, "listStations").mockResolvedValue([]);
+  vi.spyOn(grantsApi, "listPrincipals").mockResolvedValue([]);
 });
 afterEach(cleanup);
 
@@ -207,6 +210,88 @@ test("when every station has an agent, the page says so instead of staying silen
     expect(getByTestId("all-assigned")).toBeTruthy();
   });
   expect(queryByTestId("unassigned-stations")).toBeNull();
+});
+
+test("a suspended agent's station reads as not dispatchable, and says why — not merely healthy", async () => {
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  vi.spyOn(api, "listStations").mockResolvedValue([
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", principalId: "prn_active" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", principalId: "prn_suspended" }),
+  ]);
+  vi.spyOn(grantsApi, "listPrincipals").mockResolvedValue([
+    { id: "prn_active", kind: "agent", handle: "hanuman", displayName: null, userId: null, suspendedAt: null },
+    {
+      id: "prn_suspended",
+      kind: "agent",
+      handle: "kubera-agent",
+      displayName: null,
+      userId: null,
+      suspendedAt: "2026-08-30T00:00:00Z",
+    },
+  ]);
+
+  const { getByTestId, queryByTestId } = render(AgentsPage);
+
+  await waitFor(() => {
+    // A principalId being present is not enough — kubera's row would have
+    // read as "assigned" (i.e. healthy) under the old, principalId-only check.
+    const panel = getByTestId("unassigned-stations");
+    expect(panel.textContent).toMatch(/suspended/i);
+    expect(panel.textContent).toContain("kubera-agent");
+  });
+  // hanuman's agent is active — it must not appear as blocked.
+  expect(queryByTestId("all-assigned")).toBeNull();
+});
+
+test("unassigning a suspended station's agent asks first, calls the endpoint, then reloads", async () => {
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  const listStationsSpy = vi.spyOn(api, "listStations").mockResolvedValue([
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", principalId: "prn_active" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", principalId: "prn_suspended" }),
+  ]);
+  vi.spyOn(grantsApi, "listPrincipals").mockResolvedValue([
+    { id: "prn_active", kind: "agent", handle: "hanuman", displayName: null, userId: null, suspendedAt: null },
+    {
+      id: "prn_suspended",
+      kind: "agent",
+      handle: "kubera-agent",
+      displayName: null,
+      userId: null,
+      suspendedAt: "2026-08-30T00:00:00Z",
+    },
+  ]);
+  vi.spyOn(agentsApi, "unassignStationAgent").mockResolvedValue({ stationId: "s2", principalId: null });
+
+  const { findByRole, getByRole } = render(AgentsPage);
+
+  await fireEvent.click(await findByRole("button", { name: /unassign kubera/i }));
+  await fireEvent.click(getByRole("button", { name: /^unassign$/i }));
+
+  await waitFor(() => expect(agentsApi.unassignStationAgent).toHaveBeenCalledWith("s2"));
+  // Reloaded rather than patched locally — same convention as the grants page.
+  await waitFor(() => expect(listStationsSpy).toHaveBeenCalledTimes(2));
+});
+
+test("an actively-assigned station offers a real Unassign control — not SQL", async () => {
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  vi.spyOn(api, "listStations").mockResolvedValue([
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", principalId: "prn_a" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", principalId: "prn_b" }),
+  ]);
+  vi.spyOn(grantsApi, "listPrincipals").mockResolvedValue([
+    { id: "prn_a", kind: "agent", handle: "hanuman", displayName: null, userId: null, suspendedAt: null },
+    { id: "prn_b", kind: "agent", handle: "kubera", displayName: null, userId: null, suspendedAt: null },
+  ]);
+  vi.spyOn(agentsApi, "unassignStationAgent").mockResolvedValue({ stationId: "s1", principalId: null });
+
+  const { findByRole, getByRole, getByTestId } = render(AgentsPage);
+
+  await waitFor(() => expect(getByTestId("assigned-stations")).toBeTruthy());
+
+  await fireEvent.click(await findByRole("button", { name: /unassign hanuman/i }));
+  await fireEvent.click(getByRole("button", { name: /^unassign$/i }));
+
+  await waitFor(() => expect(agentsApi.unassignStationAgent).toHaveBeenCalledWith("s1"));
 });
 
 test("?updates=1 seeds the updates-only pill pressed and shows only update-available agents", async () => {

--- a/apps/console/src/routes/agents/page.svelte.test.ts
+++ b/apps/console/src/routes/agents/page.svelte.test.ts
@@ -10,6 +10,8 @@
  *  - an unassigned station (no occupying principal) reads as unassigned,
  *    not merely healthy — the console previously had no signal for this at
  *    all, and a station with no principal is dispatchable by nobody
+ *  - Ruling 6: an unassigned station offers a way to put an EXISTING agent
+ *    in it, and driving that control actually leaves the station occupied
  */
 
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
@@ -18,6 +20,33 @@ import * as api from "$lib/api/client";
 import * as grantsApi from "$lib/api/grants";
 import * as agentsApi from "$lib/api/agents";
 import { setSearchParam, resetReactivePageState } from "../../mocks/reactive-page-state.svelte";
+
+// bits-ui's Select opens on `pointerdown` (not `click`) and picks an item on
+// `pointerup`, and touches `hasPointerCapture`/`releasePointerCapture` along
+// the way — jsdom implements neither. Needed once the "assign an existing
+// agent" dialog's picker is actually opened, below.
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  // @ts-expect-error jsdom has no native PointerEvent
+  window.PointerEvent = PointerEventPolyfill;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
 
 // ---------------------------------------------------------------------------
 // SvelteKit stubs
@@ -292,6 +321,50 @@ test("an actively-assigned station offers a real Unassign control — not SQL", 
   await fireEvent.click(getByRole("button", { name: /^unassign$/i }));
 
   await waitFor(() => expect(agentsApi.unassignStationAgent).toHaveBeenCalledWith("s1"));
+});
+
+test("Ruling 6: assigning an existing agent to an unassigned station leaves it occupied", async () => {
+  // Task 3 wired `unassignStationAgent`; `assignStationAgent`'s only caller
+  // was AgentCreate's mint-and-assign flow. This is the way back for a
+  // principal that already exists — most pointedly, one this same page just
+  // unassigned above — with no database client required.
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  const rows = [
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", displayName: "hanuman", principalId: "prn_a" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", displayName: "kubera", principalId: null }),
+  ];
+  const listStationsSpy = vi.spyOn(api, "listStations").mockImplementation(async () => rows.map((r) => ({ ...r })));
+  vi.spyOn(grantsApi, "listPrincipals").mockResolvedValue([
+    { id: "prn_a", kind: "agent", handle: "hanuman", displayName: null, userId: null, suspendedAt: null },
+    { id: "prn_stranded", kind: "agent", handle: "stranded-writer", displayName: null, userId: null, suspendedAt: null },
+  ]);
+  vi.spyOn(agentsApi, "assignStationAgent").mockImplementation(async (stationId, principalId) => {
+    // What the hub actually does: the NEXT read reflects the write.
+    rows.find((r) => r.id === stationId)!.principalId = principalId;
+    return { stationId, principalId };
+  });
+
+  const { findByRole, getByRole, getByTestId } = render(AgentsPage);
+
+  await waitFor(() => expect(getByTestId("unassigned-stations")).toBeTruthy());
+
+  await fireEvent.click(await findByRole("button", { name: /assign an existing agent to kubera/i }));
+  const trigger = await findByRole("button", { name: /^agent to assign$/i });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  const option = await waitFor(() => getByRole("option", { name: /stranded-writer/i }));
+  await fireEvent.pointerUp(option, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => {
+    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("s2", "prn_stranded");
+  });
+  // Reloaded rather than patched locally, and the station now reads as
+  // occupied — proving the control actually worked, not merely that the
+  // endpoint was invoked.
+  await waitFor(() => {
+    expect(listStationsSpy).toHaveBeenCalledTimes(2);
+    expect(getByTestId("all-assigned")).toBeTruthy();
+  });
 });
 
 test("?updates=1 seeds the updates-only pill pressed and shows only update-available agents", async () => {

--- a/apps/console/src/routes/agents/page.svelte.test.ts
+++ b/apps/console/src/routes/agents/page.svelte.test.ts
@@ -367,6 +367,54 @@ test("Ruling 6: assigning an existing agent to an unassigned station leaves it o
   });
 });
 
+test("Ruling 6, fix round: an already-occupied station can be given a DIFFERENT existing agent — the room follows the move", async () => {
+  // Occupancy is exclusive now, so this is safe: assigning hanuman's agent
+  // to kubera's station moves it there and leaves hanuman's station empty,
+  // rather than the hub refusing or silently double-occupying.
+  vi.spyOn(api, "getFleet").mockResolvedValue({ stats: mockStats, agents: mockAgents });
+  const rows = [
+    stationRow({ id: "s1", stationKey: "hermes:hanuman", displayName: "hanuman", principalId: "prn_mover" }),
+    stationRow({ id: "s2", stationKey: "hermes:kubera", displayName: "kubera", principalId: "prn_b" }),
+  ];
+  const listStationsSpy = vi.spyOn(api, "listStations").mockImplementation(async () => rows.map((r) => ({ ...r })));
+  vi.spyOn(grantsApi, "listPrincipals").mockResolvedValue([
+    { id: "prn_mover", kind: "agent", handle: "mover-writer", displayName: null, userId: null, suspendedAt: null },
+    { id: "prn_b", kind: "agent", handle: "kubera-agent", displayName: null, userId: null, suspendedAt: null },
+  ]);
+  vi.spyOn(agentsApi, "assignStationAgent").mockImplementation(async (stationId, principalId) => {
+    // What the hub's transaction actually does: vacate the principal's old
+    // station, then place it — reflected on the NEXT read, same as above.
+    for (const r of rows) {
+      if (r.principalId === principalId) r.principalId = null;
+    }
+    rows.find((r) => r.id === stationId)!.principalId = principalId;
+    return { stationId, principalId };
+  });
+
+  const { findByRole, getByRole, getByTestId } = render(AgentsPage);
+
+  await waitFor(() => expect(getByTestId("assigned-stations")).toBeTruthy());
+
+  await fireEvent.click(await findByRole("button", { name: /assign a different agent to kubera/i }));
+  const trigger = await findByRole("button", { name: /^agent to assign$/i });
+  await fireEvent.pointerDown(trigger, { pointerId: 1, button: 0, pointerType: "mouse" });
+  // Labelled with where it is moving FROM — an operator picking this sees a
+  // move, not a spare agent conjured from nowhere.
+  const option = await waitFor(() => getByRole("option", { name: /mover-writer — moving from hanuman/i }));
+  await fireEvent.pointerUp(option, { pointerId: 1, button: 0, pointerType: "mouse" });
+  await fireEvent.click(getByRole("button", { name: /^assign$/i }));
+
+  await waitFor(() => {
+    expect(agentsApi.assignStationAgent).toHaveBeenCalledWith("s2", "prn_mover");
+  });
+  // Reloaded, and hanuman's OWN station now reads as unassigned — the agent
+  // actually moved, it was not merely handed a second station.
+  await waitFor(() => {
+    expect(listStationsSpy).toHaveBeenCalledTimes(2);
+    expect(getByTestId("unassigned-stations")).toBeTruthy();
+  });
+});
+
 test("?updates=1 seeds the updates-only pill pressed and shows only update-available agents", async () => {
   setSearchParam("updates", "1");
   vi.spyOn(api, "getFleet").mockResolvedValue({

--- a/apps/console/src/routes/nodes/[id]/page.svelte.test.ts
+++ b/apps/console/src/routes/nodes/[id]/page.svelte.test.ts
@@ -98,6 +98,7 @@ const adoptedStation: StationRow = {
   workspacePath: "/home/user/workspace",
   capabilities: ["health"],
   matrixId: null, purpose: null,
+  principalId: null,
   adoptedAt: "2026-06-22T00:00:00Z",
   createdAt: "2026-06-22T00:00:00Z",
 };

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/page.svelte.test.ts
@@ -99,6 +99,7 @@ function station(capabilities: StationRow["capabilities"]): StationRow {
     workspacePath: "/home/user/workspace",
     capabilities,
     matrixId: null, purpose: null,
+    principalId: null,
     adoptedAt: "2026-06-22T00:00:00Z",
     createdAt: "2026-06-22T00:00:00Z",
   };

--- a/apps/hub/scripts/migrate-agent-mxids-run.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.test.ts
@@ -2,18 +2,19 @@
  * The caller `migrateAgentMxids` never had — proved against fakes only.
  *
  * Nothing here reaches a database or a homeserver: `describeRooms` is fed a
- * fake `rows()` and a fake `isJoined`, and `runMigration` is fed a fake
+ * fake `rows()` and a fake `client`, and `runMigration` is fed a fake
  * `DirectClient`. That is deliberate — this suite exists to prove the
  * ordering and the read-modify-write in isolation, exactly like
  * `migrate-agent-mxids.test.ts` does for the pure function underneath it.
  */
-import { beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import {
   buildMigrationDeps,
   describeRooms,
   formatReport,
   runMigration,
+  type DescribeClient,
   type DescribeDeps,
   type DirectClient,
   type StationRoomRow,
@@ -30,22 +31,37 @@ const ROW: StationRoomRow = {
   ownerUserId: "usr_rakesh",
 };
 
-/** A `describeRooms` deps object with everything overridable. */
-function describeDeps(overrides: Partial<DescribeDeps> & { joined?: Set<string> } = {}): DescribeDeps {
-  const joined = overrides.joined ?? new Set<string>();
+const OLD_USER = "@agent_guild_hermes-writer-quill:id.agentpod.dev";
+const NEW_USER = "@agent_writer-quill:id.agentpod.dev";
+const OWNER = "@rakesh:id.agentpod.dev";
+
+/** A fake `DescribeClient`: live membership plus a fake `m.direct` store. */
+function fakeClient(opts: {
+  joined?: Set<string>;
+  direct?: Record<string, Record<string, string[]>>; // ownerMxid -> m.direct content
+  onGetAccountData?: (userId: string, type: string) => Promise<Record<string, unknown> | null>;
+} = {}): DescribeClient {
+  const joined = opts.joined ?? new Set<string>();
+  const direct = opts.direct ?? {};
   return {
-    domain: DOMAIN,
-    rows: overrides.rows ?? (async () => [ROW]),
-    isJoined: overrides.isJoined ?? (async (userId, roomId) => joined.has(`${userId}|${roomId}`)),
-    principalHandle: overrides.principalHandle ?? (async () => "writer-quill"),
-    ownerMxidFor: overrides.ownerMxidFor ?? (async () => "@rakesh:id.agentpod.dev"),
+    isJoined: async (userId, roomId) => joined.has(`${userId}|${roomId}`),
+    getAccountData:
+      opts.onGetAccountData ?? (async (userId) => (direct[userId] as Record<string, unknown>) ?? null),
   };
 }
 
-const OLD_USER = "@agent_guild_hermes-writer-quill:id.agentpod.dev";
-const NEW_USER = "@agent_writer-quill:id.agentpod.dev";
+/** A `describeRooms` deps object with everything overridable. */
+function describeDeps(overrides: Partial<DescribeDeps> = {}): DescribeDeps {
+  return {
+    domain: DOMAIN,
+    rows: overrides.rows ?? (async () => [ROW]),
+    client: overrides.client ?? fakeClient(),
+    principalHandle: overrides.principalHandle ?? (async () => "writer-quill"),
+    ownerMxidFor: overrides.ownerMxidFor ?? (async () => OWNER),
+  };
+}
 
-describe("describeRooms — live membership, not a flag", () => {
+describe("describeRooms — live membership and a live m.direct read, never a flag", () => {
   test("a room where nothing has happened yet is reported with all three steps outstanding", async () => {
     const rooms = await describeRooms(describeDeps());
 
@@ -55,7 +71,7 @@ describe("describeRooms — live membership, not a flag", () => {
       oldUserId: OLD_USER,
       newUserId: NEW_USER,
       joinOutstanding: true,
-      leaveOutstanding: false, // the OLD user was never reported joined by this fake either
+      leaveOutstanding: false,
       directOutstanding: true,
     });
   });
@@ -65,22 +81,61 @@ describe("describeRooms — live membership, not a flag", () => {
     // leave. Detected from membership, because nothing wrote a flag for it.
     const joined = new Set([`${NEW_USER}|${ROW.roomId}`, `${OLD_USER}|${ROW.roomId}`]);
 
-    const rooms = await describeRooms(describeDeps({ joined }));
+    const rooms = await describeRooms(describeDeps({ client: fakeClient({ joined }) }));
+
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]).toMatchObject({ joinOutstanding: false, leaveOutstanding: true });
+  });
+
+  test("a room fully done — joined, left, and m.direct already naming the new user — is omitted", async () => {
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old is NOT in this set — it left
+    const direct = { [OWNER]: { [NEW_USER]: [ROW.roomId] } };
+
+    const rooms = await describeRooms(describeDeps({ client: fakeClient({ joined, direct }) }));
+
+    expect(rooms).toEqual([]);
+  });
+
+  test("join and leave done but m.direct never confirmed is STILL reported — the refusal case", async () => {
+    // The critical fix: a refused m.direct write no longer blocks `leave`, so
+    // membership can finish moving while m.direct never gets fixed. That must
+    // stay visible forever, not vanish once the coupling would have hidden it.
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old left, m.direct never written
+    const rooms = await describeRooms(describeDeps({ client: fakeClient({ joined, direct: {} }) }));
 
     expect(rooms).toHaveLength(1);
     expect(rooms[0]).toMatchObject({
       joinOutstanding: false,
-      leaveOutstanding: true,
+      leaveOutstanding: false,
       directOutstanding: true,
     });
   });
 
-  test("a room where the new user has joined and the old has left is fully done, and omitted", async () => {
-    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old is NOT in this set — it left
+  test("no linked owner keeps the room visible even once join and leave are both done", async () => {
+    // The bug named "Important": ownerMxid null must not make the room
+    // silently disappear once membership finishes moving.
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]);
+    const rooms = await describeRooms(
+      describeDeps({ client: fakeClient({ joined }), ownerMxidFor: async () => null })
+    );
 
-    const rooms = await describeRooms(describeDeps({ joined }));
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]).toMatchObject({ ownerMxid: null, directOutstanding: true });
+  });
 
-    expect(rooms).toEqual([]);
+  test("a failure reading m.direct is reported as outstanding, not treated as fixed", async () => {
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]);
+    const client = fakeClient({
+      joined,
+      onGetAccountData: async () => {
+        throw new Error("M_FORBIDDEN");
+      },
+    });
+
+    const rooms = await describeRooms(describeDeps({ client }));
+
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]!.directOutstanding).toBe(true);
   });
 
   test("a station with no occupying principal is omitted, not migrated to a guessed address", async () => {
@@ -106,27 +161,41 @@ describe("describeRooms — live membership, not a flag", () => {
   });
 });
 
-describe("buildMigrationDeps — m.direct is read-modify-write", () => {
-  function client(overrides: Partial<DirectClient> = {}, accountData: Record<string, unknown> = {}): DirectClient & { written: Record<string, unknown> | null } {
+const ROOM_STATUS_BASE = {
+  roomId: "!r:id.agentpod.dev",
+  stationKey: ROW.stationKey,
+  nodeName: ROW.nodeName,
+  handle: "writer-quill",
+  oldUserId: OLD_USER,
+  newUserId: NEW_USER,
+  ownerMxid: OWNER,
+  joinOutstanding: true,
+  leaveOutstanding: false,
+  directOutstanding: true,
+};
+
+describe("buildMigrationDeps — m.direct is read-modify-write, and never fatal", () => {
+  function client(overrides: Partial<DirectClient> = {}, accountData: Record<string, unknown> = {}) {
     const state = { written: null as Record<string, unknown> | null };
-    return {
+    const c: DirectClient = {
       join: overrides.join ?? (async () => {}),
       leave: overrides.leave ?? (async () => {}),
-      getAccountData: overrides.getAccountData ?? (async () => (Object.keys(accountData).length ? accountData : null)),
-      setAccountData: overrides.setAccountData ?? (async (_u, _t, content) => {
-        state.written = content;
-      }),
-      get written() {
-        return state.written;
-      },
+      getAccountData:
+        overrides.getAccountData ?? (async () => (Object.keys(accountData).length ? accountData : null)),
+      setAccountData:
+        overrides.setAccountData ??
+        (async (_u, _t, content) => {
+          state.written = content;
+        }),
     };
+    return { c, state };
   }
 
   test("every other DM in m.direct survives untouched", async () => {
     // The single most destructive thing available in this task: blindly
     // writing one entry would discard every other conversation the operator
     // has. This is the test that would catch it.
-    const c = client(
+    const { c, state } = client(
       {},
       {
         [OLD_USER]: ["!r:id.agentpod.dev"],
@@ -134,97 +203,68 @@ describe("buildMigrationDeps — m.direct is read-modify-write", () => {
       }
     );
 
-    const deps = buildMigrationDeps(
-      [
-        {
-          roomId: "!r:id.agentpod.dev",
-          stationKey: ROW.stationKey,
-          nodeName: ROW.nodeName,
-          handle: "writer-quill",
-          oldUserId: OLD_USER,
-          newUserId: NEW_USER,
-          ownerMxid: "@rakesh:id.agentpod.dev",
-          joinOutstanding: true,
-          leaveOutstanding: false,
-          directOutstanding: true,
-        },
-      ],
-      c
-    );
-
+    const { deps } = buildMigrationDeps([ROOM_STATUS_BASE], c);
     await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
 
-    expect(c.written).toEqual({
-      // The old key is gone because this room was its only entry...
-      "@some-other-agent:id.agentpod.dev": ["!unrelated:id.agentpod.dev"], // ...and this one was never touched.
+    expect(state.written).toEqual({
+      "@some-other-agent:id.agentpod.dev": ["!unrelated:id.agentpod.dev"],
       [NEW_USER]: ["!r:id.agentpod.dev"],
     });
   });
 
   test("the old key survives if it still names another room", async () => {
-    const c = client(
-      {},
-      { [OLD_USER]: ["!r:id.agentpod.dev", "!other-room:id.agentpod.dev"] }
-    );
+    const { c, state } = client({}, { [OLD_USER]: ["!r:id.agentpod.dev", "!other-room:id.agentpod.dev"] });
 
-    const deps = buildMigrationDeps(
-      [
-        {
-          roomId: "!r:id.agentpod.dev",
-          stationKey: ROW.stationKey,
-          nodeName: ROW.nodeName,
-          handle: "writer-quill",
-          oldUserId: OLD_USER,
-          newUserId: NEW_USER,
-          ownerMxid: "@rakesh:id.agentpod.dev",
-          joinOutstanding: true,
-          leaveOutstanding: false,
-          directOutstanding: true,
-        },
-      ],
-      c
-    );
-
+    const { deps } = buildMigrationDeps([ROOM_STATUS_BASE], c);
     await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
 
-    expect(c.written).toEqual({
+    expect(state.written).toEqual({
       [OLD_USER]: ["!other-room:id.agentpod.dev"],
       [NEW_USER]: ["!r:id.agentpod.dev"],
     });
   });
 
-  test("a room with no linked owner is logged and left alone, not guessed at", async () => {
-    const c = client();
+  test("a room with no linked owner is logged and left alone, not guessed at, and recorded as no-owner", async () => {
+    const { c } = client();
     let setCalled = false;
     c.setAccountData = async () => {
       setCalled = true;
     };
 
-    const deps = buildMigrationDeps(
-      [
-        {
-          roomId: "!r:id.agentpod.dev",
-          stationKey: ROW.stationKey,
-          nodeName: ROW.nodeName,
-          handle: "writer-quill",
-          oldUserId: OLD_USER,
-          newUserId: NEW_USER,
-          ownerMxid: null,
-          joinOutstanding: true,
-          leaveOutstanding: false,
-          directOutstanding: true,
-        },
-      ],
-      c
-    );
-
+    const { deps, directOutcomes } = buildMigrationDeps([{ ...ROOM_STATUS_BASE, ownerMxid: null }], c);
     await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
 
     expect(setCalled).toBe(false);
+    expect(directOutcomes.get("!r:id.agentpod.dev")).toEqual({ status: "no-owner" });
+  });
+
+  test("a refused write is caught, recorded as failed, and does not throw", async () => {
+    // The critical fix. If this threw, migrateAgentMxids would never reach
+    // `leave`, and the room would be stuck with both agents present forever.
+    const { c } = client();
+    c.setAccountData = async () => {
+      throw new Error("M_FORBIDDEN: cannot act as another user's account data");
+    };
+
+    const { deps, directOutcomes } = buildMigrationDeps([ROOM_STATUS_BASE], c);
+
+    await expect(deps.setDirect(NEW_USER, "!r:id.agentpod.dev")).resolves.toBeUndefined();
+    expect(directOutcomes.get("!r:id.agentpod.dev")).toEqual({
+      status: "failed",
+      error: "M_FORBIDDEN: cannot act as another user's account data",
+    });
+  });
+
+  test("a successful write is recorded as fixed", async () => {
+    const { c } = client();
+    const { deps, directOutcomes } = buildMigrationDeps([ROOM_STATUS_BASE], c);
+    await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
+
+    expect(directOutcomes.get("!r:id.agentpod.dev")).toEqual({ status: "fixed" });
   });
 });
 
-describe("runMigration — dry run changes nothing, apply isolates failures", () => {
+describe("runMigration — a refused m.direct still lets leave run, and failures isolate per room", () => {
   test("dry run reports the room and calls no client method at all", async () => {
     let calls = 0;
     const c: DirectClient = {
@@ -239,6 +279,7 @@ describe("runMigration — dry run changes nothing, apply isolates failures", ()
     expect(result.applied).toBe(false);
     expect(result.rooms).toHaveLength(1);
     expect(result.migrated).toBe(0);
+    expect(result.results).toEqual([]);
     expect(calls).toBe(0);
   });
 
@@ -257,10 +298,36 @@ describe("runMigration — dry run changes nothing, apply isolates failures", ()
     expect(result.migrated).toBe(1);
     expect(acts).toEqual([
       `join ${NEW_USER} ${ROW.roomId}`,
-      // setAccountData is called as the OWNER, not the agent — m.direct is the
-      // human's own account data, not the agent's.
-      `direct @rakesh:id.agentpod.dev`,
+      // setAccountData is called as the OWNER, not the agent — m.direct is
+      // the human's own account data, not the agent's.
+      `direct ${OWNER}`,
       `leave ${OLD_USER} ${ROW.roomId}`,
+    ]);
+    expect(result.results).toEqual([
+      { roomId: ROW.roomId, stationKey: ROW.stationKey, direct: { status: "fixed" } },
+    ]);
+  });
+
+  test("a refused m.direct write does not stop leave from running, and is reported per room", async () => {
+    const acts: string[] = [];
+    const c: DirectClient = {
+      join: async (u, r) => { acts.push(`join ${u} ${r}`); },
+      leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
+      getAccountData: async () => null,
+      setAccountData: async () => {
+        throw new Error("M_FORBIDDEN");
+      },
+    };
+
+    const result = await runMigration(describeDeps(), c, { apply: true });
+
+    // leave still ran, and the room still counts as migrated: membership
+    // moved correctly even though the DM flag could not be fixed.
+    expect(acts).toEqual([`join ${NEW_USER} ${ROW.roomId}`, `leave ${OLD_USER} ${ROW.roomId}`]);
+    expect(result.migrated).toBe(1);
+    expect(result.failures).toEqual([]);
+    expect(result.results).toEqual([
+      { roomId: ROW.roomId, stationKey: ROW.stationKey, direct: { status: "failed", error: "M_FORBIDDEN" } },
     ]);
   });
 
@@ -289,6 +356,14 @@ describe("runMigration — dry run changes nothing, apply isolates failures", ()
     expect(result.failures).toEqual([
       { roomId: ROW.roomId, stationKey: ROW.stationKey, error: "rate limited" },
     ]);
+    // The failed room's result carries the error and no direct outcome —
+    // setDirect never ran because join threw first.
+    expect(result.results.find((r) => r.roomId === ROW.roomId)).toEqual({
+      roomId: ROW.roomId,
+      stationKey: ROW.stationKey,
+      error: "rate limited",
+      direct: null,
+    });
   });
 });
 
@@ -299,20 +374,8 @@ describe("formatReport — what an operator reads before deciding", () => {
       migrated: 0,
       skipped: 0,
       failures: [],
-      rooms: [
-        {
-          roomId: ROW.roomId,
-          stationKey: ROW.stationKey,
-          nodeName: ROW.nodeName,
-          handle: "writer-quill",
-          oldUserId: OLD_USER,
-          newUserId: NEW_USER,
-          ownerMxid: "@rakesh:id.agentpod.dev",
-          joinOutstanding: true,
-          leaveOutstanding: false,
-          directOutstanding: true,
-        },
-      ],
+      results: [],
+      rooms: [ROOM_STATUS_BASE],
     });
 
     expect(report).toContain("DRY RUN");
@@ -323,9 +386,29 @@ describe("formatReport — what an operator reads before deciding", () => {
     expect(report).toContain("join, m.direct");
   });
 
+  test("a room whose m.direct write was refused shows that plainly in an apply report", () => {
+    const report = formatReport({
+      applied: true,
+      migrated: 1,
+      skipped: 0,
+      failures: [],
+      results: [
+        {
+          roomId: ROW.roomId,
+          stationKey: ROW.stationKey,
+          direct: { status: "failed", error: "M_FORBIDDEN" },
+        },
+      ],
+      rooms: [{ ...ROOM_STATUS_BASE, joinOutstanding: false, leaveOutstanding: false }],
+    });
+
+    expect(report).toContain("membership updated");
+    expect(report).toContain("m.direct: skipped — M_FORBIDDEN");
+  });
+
   test("no outstanding rooms is reported plainly", () => {
-    expect(formatReport({ applied: false, migrated: 0, skipped: 0, failures: [], rooms: [] })).toContain(
-      "No rooms need migration"
-    );
+    expect(
+      formatReport({ applied: false, migrated: 0, skipped: 0, failures: [], results: [], rooms: [] })
+    ).toContain("No rooms need migration");
   });
 });

--- a/apps/hub/scripts/migrate-agent-mxids-run.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
+import { MatrixExclusiveNamespace } from "../src/services/matrix-as/client";
 import {
   buildMigrationDeps,
   describeRooms,
@@ -63,7 +64,7 @@ function describeDeps(overrides: Partial<DescribeDeps> = {}): DescribeDeps {
 
 describe("describeRooms — live membership and a live m.direct read, never a flag", () => {
   test("a room where nothing has happened yet is reported with all three steps outstanding", async () => {
-    const rooms = await describeRooms(describeDeps());
+    const { rooms } = await describeRooms(describeDeps());
 
     expect(rooms).toHaveLength(1);
     expect(rooms[0]).toMatchObject({
@@ -81,7 +82,7 @@ describe("describeRooms — live membership and a live m.direct read, never a fl
     // leave. Detected from membership, because nothing wrote a flag for it.
     const joined = new Set([`${NEW_USER}|${ROW.roomId}`, `${OLD_USER}|${ROW.roomId}`]);
 
-    const rooms = await describeRooms(describeDeps({ client: fakeClient({ joined }) }));
+    const { rooms } = await describeRooms(describeDeps({ client: fakeClient({ joined }) }));
 
     expect(rooms).toHaveLength(1);
     expect(rooms[0]).toMatchObject({ joinOutstanding: false, leaveOutstanding: true });
@@ -91,7 +92,7 @@ describe("describeRooms — live membership and a live m.direct read, never a fl
     const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old is NOT in this set — it left
     const direct = { [OWNER]: { [NEW_USER]: [ROW.roomId] } };
 
-    const rooms = await describeRooms(describeDeps({ client: fakeClient({ joined, direct }) }));
+    const { rooms } = await describeRooms(describeDeps({ client: fakeClient({ joined, direct }) }));
 
     expect(rooms).toEqual([]);
   });
@@ -101,7 +102,7 @@ describe("describeRooms — live membership and a live m.direct read, never a fl
     // membership can finish moving while m.direct never gets fixed. That must
     // stay visible forever, not vanish once the coupling would have hidden it.
     const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old left, m.direct never written
-    const rooms = await describeRooms(describeDeps({ client: fakeClient({ joined, direct: {} }) }));
+    const { rooms } = await describeRooms(describeDeps({ client: fakeClient({ joined, direct: {} }) }));
 
     expect(rooms).toHaveLength(1);
     expect(rooms[0]).toMatchObject({
@@ -115,7 +116,7 @@ describe("describeRooms — live membership and a live m.direct read, never a fl
     // The bug named "Important": ownerMxid null must not make the room
     // silently disappear once membership finishes moving.
     const joined = new Set([`${NEW_USER}|${ROW.roomId}`]);
-    const rooms = await describeRooms(
+    const { rooms } = await describeRooms(
       describeDeps({ client: fakeClient({ joined }), ownerMxidFor: async () => null })
     );
 
@@ -132,14 +133,55 @@ describe("describeRooms — live membership and a live m.direct read, never a fl
       },
     });
 
-    const rooms = await describeRooms(describeDeps({ client }));
+    const { rooms, mDirectExcluded } = await describeRooms(describeDeps({ client }));
 
     expect(rooms).toHaveLength(1);
     expect(rooms[0]!.directOutstanding).toBe(true);
+    // A genuine, retriable failure is not the permanent M_EXCLUSIVE case: it
+    // must not trip the "cannot ever be fixed through this bridge" note.
+    expect(rooms[0]!.directExcluded).toBe(false);
+    expect(mDirectExcluded).toBe(false);
+  });
+
+  test("m.direct refused with M_EXCLUSIVE is reported not-applicable, not outstanding", async () => {
+    // The permanent case, settled by a live probe: the appservice can never
+    // act as the human operator, so this must read differently from a
+    // transient failure — it must not sit in `outstanding` forever.
+    const client = fakeClient({
+      onGetAccountData: async () => {
+        throw new MatrixExclusiveNamespace("account_data GET m.direct", OWNER);
+      },
+    });
+
+    const { rooms, mDirectExcluded } = await describeRooms(describeDeps({ client }));
+
+    expect(rooms).toHaveLength(1); // join is still outstanding, so the room stays listed
+    expect(rooms[0]).toMatchObject({ directOutstanding: false, directExcluded: true });
+    expect(mDirectExcluded).toBe(true);
+  });
+
+  test("a room whose join and leave are both done is omitted even though m.direct is permanently excluded", async () => {
+    // Requirement 3: completion is join + leave. A step that is structurally
+    // impossible through this bridge must not keep a finished room reported
+    // forever.
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old left
+    const client = fakeClient({
+      joined,
+      onGetAccountData: async () => {
+        throw new MatrixExclusiveNamespace("account_data GET m.direct", OWNER);
+      },
+    });
+
+    const { rooms, mDirectExcluded } = await describeRooms(describeDeps({ client }));
+
+    expect(rooms).toEqual([]);
+    // The exclusion is still a fact worth surfacing once, even though no
+    // room is left in the list to attach it to.
+    expect(mDirectExcluded).toBe(true);
   });
 
   test("a station with no occupying principal is omitted, not migrated to a guessed address", async () => {
-    const rooms = await describeRooms(
+    const { rooms } = await describeRooms(
       describeDeps({ rows: async () => [{ ...ROW, principalId: null }] })
     );
 
@@ -147,13 +189,13 @@ describe("describeRooms — live membership and a live m.direct read, never a fl
   });
 
   test("a principal with no handle is omitted the same way", async () => {
-    const rooms = await describeRooms(describeDeps({ principalHandle: async () => null }));
+    const { rooms } = await describeRooms(describeDeps({ principalHandle: async () => null }));
 
     expect(rooms).toEqual([]);
   });
 
   test("the old address is derived from the station's own (node, key), not guessed from membership", async () => {
-    const rooms = await describeRooms(
+    const { rooms } = await describeRooms(
       describeDeps({ rows: async () => [{ ...ROW, nodeName: "Box!", stationKey: "OpenCode:C52DDF65" }] })
     );
 
@@ -172,6 +214,7 @@ const ROOM_STATUS_BASE = {
   joinOutstanding: true,
   leaveOutstanding: false,
   directOutstanding: true,
+  directExcluded: false,
 };
 
 describe("buildMigrationDeps — m.direct is read-modify-write, and never fatal", () => {
@@ -365,6 +408,24 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
       direct: null,
     });
   });
+
+  test("mDirectExcluded carries through from describeRooms into the run result", async () => {
+    const excludedClient = fakeClient({
+      onGetAccountData: async () => {
+        throw new MatrixExclusiveNamespace("account_data GET m.direct", OWNER);
+      },
+    });
+    const c: DirectClient = {
+      join: async () => {},
+      leave: async () => {},
+      getAccountData: async () => null,
+      setAccountData: async () => {},
+    };
+
+    const result = await runMigration(describeDeps({ client: excludedClient }), c, { apply: false });
+
+    expect(result.mDirectExcluded).toBe(true);
+  });
 });
 
 describe("formatReport — what an operator reads before deciding", () => {
@@ -376,6 +437,7 @@ describe("formatReport — what an operator reads before deciding", () => {
       failures: [],
       results: [],
       rooms: [ROOM_STATUS_BASE],
+      mDirectExcluded: false,
     });
 
     expect(report).toContain("DRY RUN");
@@ -400,6 +462,7 @@ describe("formatReport — what an operator reads before deciding", () => {
         },
       ],
       rooms: [{ ...ROOM_STATUS_BASE, joinOutstanding: false, leaveOutstanding: false }],
+      mDirectExcluded: false,
     });
 
     expect(report).toContain("membership updated");
@@ -408,7 +471,71 @@ describe("formatReport — what an operator reads before deciding", () => {
 
   test("no outstanding rooms is reported plainly", () => {
     expect(
-      formatReport({ applied: false, migrated: 0, skipped: 0, failures: [], results: [], rooms: [] })
+      formatReport({
+        applied: false,
+        migrated: 0,
+        skipped: 0,
+        failures: [],
+        results: [],
+        rooms: [],
+        mDirectExcluded: false,
+      })
     ).toContain("No rooms need migration");
+  });
+
+  test("mDirectExcluded prints one plain explanation at the top, naming M_EXCLUSIVE and the fix", () => {
+    const report = formatReport({
+      applied: false,
+      migrated: 0,
+      skipped: 0,
+      failures: [],
+      results: [],
+      rooms: [{ ...ROOM_STATUS_BASE, directOutstanding: false, directExcluded: true }],
+      mDirectExcluded: true,
+    });
+
+    expect(report).toContain("M_EXCLUSIVE");
+    expect(report).toContain("m.direct");
+    // The honest fix: whoever reads this needs to know it takes the
+    // operator's own token, not the bridge's.
+    expect(report).toContain("operator's own");
+    // Reported once — not repeated as a full explanation for every room.
+    expect(report.split("M_EXCLUSIVE")).toHaveLength(2);
+  });
+
+  test("a room whose m.direct is excluded reads as not applicable, not as outstanding work", () => {
+    const report = formatReport({
+      applied: false,
+      migrated: 0,
+      skipped: 0,
+      failures: [],
+      results: [],
+      rooms: [{ ...ROOM_STATUS_BASE, directOutstanding: false, directExcluded: true }],
+      mDirectExcluded: true,
+    });
+
+    // "m.direct" must not be listed among this room's outstanding steps...
+    expect(report).not.toContain("outstanding: join, m.direct");
+    expect(report).toContain("outstanding: join");
+    // ...but the room's own line still says plainly that it is excluded, not
+    // silently finished.
+    expect(report).toContain("not applicable");
+  });
+
+  test("the exclusion note still prints even when every room's join and leave are done", () => {
+    // Requirement 4: a reader must know m.direct was excluded deliberately,
+    // not forgotten — even once no room is left needing membership work.
+    const report = formatReport({
+      applied: false,
+      migrated: 0,
+      skipped: 0,
+      failures: [],
+      results: [],
+      rooms: [],
+      mDirectExcluded: true,
+    });
+
+    expect(report).toContain("M_EXCLUSIVE");
+    expect(report).toContain("No rooms need migration");
   });
 });

--- a/apps/hub/scripts/migrate-agent-mxids-run.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.test.ts
@@ -1,0 +1,331 @@
+/**
+ * The caller `migrateAgentMxids` never had — proved against fakes only.
+ *
+ * Nothing here reaches a database or a homeserver: `describeRooms` is fed a
+ * fake `rows()` and a fake `isJoined`, and `runMigration` is fed a fake
+ * `DirectClient`. That is deliberate — this suite exists to prove the
+ * ordering and the read-modify-write in isolation, exactly like
+ * `migrate-agent-mxids.test.ts` does for the pure function underneath it.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildMigrationDeps,
+  describeRooms,
+  formatReport,
+  runMigration,
+  type DescribeDeps,
+  type DirectClient,
+  type StationRoomRow,
+} from "./migrate-agent-mxids-run";
+
+const DOMAIN = "id.agentpod.dev";
+
+const ROW: StationRoomRow = {
+  roomId: "!r:id.agentpod.dev",
+  stationId: "stn_1",
+  stationKey: "hermes:writer-quill",
+  nodeName: "guild",
+  principalId: "prn_writer",
+  ownerUserId: "usr_rakesh",
+};
+
+/** A `describeRooms` deps object with everything overridable. */
+function describeDeps(overrides: Partial<DescribeDeps> & { joined?: Set<string> } = {}): DescribeDeps {
+  const joined = overrides.joined ?? new Set<string>();
+  return {
+    domain: DOMAIN,
+    rows: overrides.rows ?? (async () => [ROW]),
+    isJoined: overrides.isJoined ?? (async (userId, roomId) => joined.has(`${userId}|${roomId}`)),
+    principalHandle: overrides.principalHandle ?? (async () => "writer-quill"),
+    ownerMxidFor: overrides.ownerMxidFor ?? (async () => "@rakesh:id.agentpod.dev"),
+  };
+}
+
+const OLD_USER = "@agent_guild_hermes-writer-quill:id.agentpod.dev";
+const NEW_USER = "@agent_writer-quill:id.agentpod.dev";
+
+describe("describeRooms — live membership, not a flag", () => {
+  test("a room where nothing has happened yet is reported with all three steps outstanding", async () => {
+    const rooms = await describeRooms(describeDeps());
+
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]).toMatchObject({
+      roomId: ROW.roomId,
+      oldUserId: OLD_USER,
+      newUserId: NEW_USER,
+      joinOutstanding: true,
+      leaveOutstanding: false, // the OLD user was never reported joined by this fake either
+      directOutstanding: true,
+    });
+  });
+
+  test("a room where the new user has joined but the old has not left is still reported — half-migrated", async () => {
+    // The exact crash Task 9's review named: a run that died between join and
+    // leave. Detected from membership, because nothing wrote a flag for it.
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`, `${OLD_USER}|${ROW.roomId}`]);
+
+    const rooms = await describeRooms(describeDeps({ joined }));
+
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]).toMatchObject({
+      joinOutstanding: false,
+      leaveOutstanding: true,
+      directOutstanding: true,
+    });
+  });
+
+  test("a room where the new user has joined and the old has left is fully done, and omitted", async () => {
+    const joined = new Set([`${NEW_USER}|${ROW.roomId}`]); // old is NOT in this set — it left
+
+    const rooms = await describeRooms(describeDeps({ joined }));
+
+    expect(rooms).toEqual([]);
+  });
+
+  test("a station with no occupying principal is omitted, not migrated to a guessed address", async () => {
+    const rooms = await describeRooms(
+      describeDeps({ rows: async () => [{ ...ROW, principalId: null }] })
+    );
+
+    expect(rooms).toEqual([]);
+  });
+
+  test("a principal with no handle is omitted the same way", async () => {
+    const rooms = await describeRooms(describeDeps({ principalHandle: async () => null }));
+
+    expect(rooms).toEqual([]);
+  });
+
+  test("the old address is derived from the station's own (node, key), not guessed from membership", async () => {
+    const rooms = await describeRooms(
+      describeDeps({ rows: async () => [{ ...ROW, nodeName: "Box!", stationKey: "OpenCode:C52DDF65" }] })
+    );
+
+    expect(rooms[0]!.oldUserId).toBe("@agent_box-_opencode-c52ddf65:id.agentpod.dev");
+  });
+});
+
+describe("buildMigrationDeps — m.direct is read-modify-write", () => {
+  function client(overrides: Partial<DirectClient> = {}, accountData: Record<string, unknown> = {}): DirectClient & { written: Record<string, unknown> | null } {
+    const state = { written: null as Record<string, unknown> | null };
+    return {
+      join: overrides.join ?? (async () => {}),
+      leave: overrides.leave ?? (async () => {}),
+      getAccountData: overrides.getAccountData ?? (async () => (Object.keys(accountData).length ? accountData : null)),
+      setAccountData: overrides.setAccountData ?? (async (_u, _t, content) => {
+        state.written = content;
+      }),
+      get written() {
+        return state.written;
+      },
+    };
+  }
+
+  test("every other DM in m.direct survives untouched", async () => {
+    // The single most destructive thing available in this task: blindly
+    // writing one entry would discard every other conversation the operator
+    // has. This is the test that would catch it.
+    const c = client(
+      {},
+      {
+        [OLD_USER]: ["!r:id.agentpod.dev"],
+        "@some-other-agent:id.agentpod.dev": ["!unrelated:id.agentpod.dev"],
+      }
+    );
+
+    const deps = buildMigrationDeps(
+      [
+        {
+          roomId: "!r:id.agentpod.dev",
+          stationKey: ROW.stationKey,
+          nodeName: ROW.nodeName,
+          handle: "writer-quill",
+          oldUserId: OLD_USER,
+          newUserId: NEW_USER,
+          ownerMxid: "@rakesh:id.agentpod.dev",
+          joinOutstanding: true,
+          leaveOutstanding: false,
+          directOutstanding: true,
+        },
+      ],
+      c
+    );
+
+    await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
+
+    expect(c.written).toEqual({
+      // The old key is gone because this room was its only entry...
+      "@some-other-agent:id.agentpod.dev": ["!unrelated:id.agentpod.dev"], // ...and this one was never touched.
+      [NEW_USER]: ["!r:id.agentpod.dev"],
+    });
+  });
+
+  test("the old key survives if it still names another room", async () => {
+    const c = client(
+      {},
+      { [OLD_USER]: ["!r:id.agentpod.dev", "!other-room:id.agentpod.dev"] }
+    );
+
+    const deps = buildMigrationDeps(
+      [
+        {
+          roomId: "!r:id.agentpod.dev",
+          stationKey: ROW.stationKey,
+          nodeName: ROW.nodeName,
+          handle: "writer-quill",
+          oldUserId: OLD_USER,
+          newUserId: NEW_USER,
+          ownerMxid: "@rakesh:id.agentpod.dev",
+          joinOutstanding: true,
+          leaveOutstanding: false,
+          directOutstanding: true,
+        },
+      ],
+      c
+    );
+
+    await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
+
+    expect(c.written).toEqual({
+      [OLD_USER]: ["!other-room:id.agentpod.dev"],
+      [NEW_USER]: ["!r:id.agentpod.dev"],
+    });
+  });
+
+  test("a room with no linked owner is logged and left alone, not guessed at", async () => {
+    const c = client();
+    let setCalled = false;
+    c.setAccountData = async () => {
+      setCalled = true;
+    };
+
+    const deps = buildMigrationDeps(
+      [
+        {
+          roomId: "!r:id.agentpod.dev",
+          stationKey: ROW.stationKey,
+          nodeName: ROW.nodeName,
+          handle: "writer-quill",
+          oldUserId: OLD_USER,
+          newUserId: NEW_USER,
+          ownerMxid: null,
+          joinOutstanding: true,
+          leaveOutstanding: false,
+          directOutstanding: true,
+        },
+      ],
+      c
+    );
+
+    await deps.setDirect(NEW_USER, "!r:id.agentpod.dev");
+
+    expect(setCalled).toBe(false);
+  });
+});
+
+describe("runMigration — dry run changes nothing, apply isolates failures", () => {
+  test("dry run reports the room and calls no client method at all", async () => {
+    let calls = 0;
+    const c: DirectClient = {
+      join: async () => { calls++; },
+      leave: async () => { calls++; },
+      getAccountData: async () => { calls++; return null; },
+      setAccountData: async () => { calls++; },
+    };
+
+    const result = await runMigration(describeDeps(), c, { apply: false });
+
+    expect(result.applied).toBe(false);
+    expect(result.rooms).toHaveLength(1);
+    expect(result.migrated).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  test("applying runs join, then setDirect, then leave, in that order", async () => {
+    const acts: string[] = [];
+    const c: DirectClient = {
+      join: async (u, r) => { acts.push(`join ${u} ${r}`); },
+      leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
+      getAccountData: async () => null,
+      setAccountData: async (u) => { acts.push(`direct ${u}`); },
+    };
+
+    const result = await runMigration(describeDeps(), c, { apply: true });
+
+    expect(result.applied).toBe(true);
+    expect(result.migrated).toBe(1);
+    expect(acts).toEqual([
+      `join ${NEW_USER} ${ROW.roomId}`,
+      // setAccountData is called as the OWNER, not the agent — m.direct is the
+      // human's own account data, not the agent's.
+      `direct @rakesh:id.agentpod.dev`,
+      `leave ${OLD_USER} ${ROW.roomId}`,
+    ]);
+  });
+
+  test("a failure on one room does not stop the rest, and is reported", async () => {
+    const rows: StationRoomRow[] = [
+      ROW,
+      { ...ROW, roomId: "!r2:id.agentpod.dev", stationId: "stn_2", stationKey: "hermes:second" },
+    ];
+    let joinCalls = 0;
+    const c: DirectClient = {
+      join: async (_u, roomId) => {
+        joinCalls++;
+        if (roomId === ROW.roomId) throw new Error("rate limited");
+      },
+      leave: async () => {},
+      getAccountData: async () => null,
+      setAccountData: async () => {},
+    };
+
+    const result = await runMigration(describeDeps({ rows: async () => rows }), c, { apply: true });
+
+    // Both rooms were attempted, sequentially — the failure on the first did
+    // not abandon the second.
+    expect(joinCalls).toBe(2);
+    expect(result.migrated).toBe(1);
+    expect(result.failures).toEqual([
+      { roomId: ROW.roomId, stationKey: ROW.stationKey, error: "rate limited" },
+    ]);
+  });
+});
+
+describe("formatReport — what an operator reads before deciding", () => {
+  test("a dry run names the room, both addresses, and the outstanding steps, and says nothing changed", () => {
+    const report = formatReport({
+      applied: false,
+      migrated: 0,
+      skipped: 0,
+      failures: [],
+      rooms: [
+        {
+          roomId: ROW.roomId,
+          stationKey: ROW.stationKey,
+          nodeName: ROW.nodeName,
+          handle: "writer-quill",
+          oldUserId: OLD_USER,
+          newUserId: NEW_USER,
+          ownerMxid: "@rakesh:id.agentpod.dev",
+          joinOutstanding: true,
+          leaveOutstanding: false,
+          directOutstanding: true,
+        },
+      ],
+    });
+
+    expect(report).toContain("DRY RUN");
+    expect(report).toContain("Nothing has been changed");
+    expect(report).toContain(ROW.roomId);
+    expect(report).toContain(OLD_USER);
+    expect(report).toContain(NEW_USER);
+    expect(report).toContain("join, m.direct");
+  });
+
+  test("no outstanding rooms is reported plainly", () => {
+    expect(formatReport({ applied: false, migrated: 0, skipped: 0, failures: [], rooms: [] })).toContain(
+      "No rooms need migration"
+    );
+  });
+});

--- a/apps/hub/scripts/migrate-agent-mxids-run.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.ts
@@ -44,6 +44,39 @@
  * dropping out of People — traded against the charter principle that this
  * bridge holds no human credential, and that trade is reported here, not
  * made here.
+ *
+ * ## `M_EXCLUSIVE` is permanent, not transient — settled 2026-08-30
+ *
+ * A probe against the live homeserver answered the question the paragraph
+ * above only speculated about: `GET account_data` as the operator comes back
+ * `400 M_EXCLUSIVE — User is not in namespace.` The AS's exclusive namespace
+ * is `@agent_.*`; the operator's own mxid is outside it; no retry, backoff,
+ * or re-run changes that. This is why `describeRooms` tells `M_EXCLUSIVE`
+ * apart from every other read failure (`isMatrixExclusiveNamespace`, from
+ * `client.ts`): a genuine transient error must still fail closed and read as
+ * `directOutstanding`, but `M_EXCLUSIVE` must not — reporting it as
+ * outstanding forever, on every run, for all 32 rooms, is worse than a known
+ * limitation, because it buries the rooms that actually need attention under
+ * noise that can never clear. Such a room's `m.direct` reads as
+ * `directExcluded`, not outstanding, and — per "completion is join + leave"
+ * below — stops being reported at all once its membership has moved. The
+ * fact itself is not lost: `describeRooms` also returns `mDirectExcluded`,
+ * and `formatReport` states it once, at the top, in every report where it
+ * was true this run. The honest close for the DM mapping is a one-off run
+ * using the OPERATOR'S OWN access token, not the bridge's — that token is
+ * inside no `@agent_.*` namespace restriction, because it is not the
+ * bridge's credential to hold. This script cannot do that run; it can only
+ * say, plainly, that the remaining work exists and whose token closes it.
+ *
+ * ## Completion is join + leave
+ *
+ * `M_EXCLUSIVE` means `m.direct` can never be fixed through this bridge, and
+ * a room whose join and leave are both done is, for this migration's
+ * purposes, done — it must not stay on the report forever over a step that
+ * is structurally impossible here. `directExcluded` is what keeps that
+ * honest instead of silent: it says the step was excluded on purpose, not
+ * forgotten, which is why `formatReport` still names it once even once no
+ * room is left outstanding.
  */
 import { and, eq } from "drizzle-orm";
 
@@ -54,7 +87,7 @@ import { matrixRooms } from "../src/db/schema/matrix";
 import { principalIdentities } from "../src/db/schema/identities";
 import { principalHandle, principalForUser } from "../src/services/principals";
 import { bridgeUserId, localpartFor } from "../src/services/matrix-as/names";
-import { createMatrixClient } from "../src/services/matrix-as/client";
+import { createMatrixClient, isMatrixExclusiveNamespace } from "../src/services/matrix-as/client";
 import { matrixBridgeConfig } from "../src/services/matrix-as/index";
 import { migrateAgentMxids, type MxidMigrationDeps } from "./migrate-agent-mxids";
 import { createLogger } from "../src/utils/logger";
@@ -87,12 +120,24 @@ export interface RoomStatus {
   leaveOutstanding: boolean;
   /**
    * True until `m.direct` is actually read back naming the new user for this
-   * room. Not inferred from `joinOutstanding`/`leaveOutstanding` — a refused
-   * `m.direct` write no longer blocks `leave` (see the file doc), so a room
-   * can have finished moving membership while this stays true forever, and
-   * that must stay visible rather than making the room vanish from the report.
+   * room, UNLESS `directExcluded` is true (see below) — a permanently
+   * excluded room reads as not-applicable, never as outstanding, no matter
+   * how many times this is checked. Not inferred from
+   * `joinOutstanding`/`leaveOutstanding` — a refused `m.direct` write no
+   * longer blocks `leave` (see the file doc), so a room can have finished
+   * moving membership while this stays true forever, and that must stay
+   * visible rather than making the room vanish from the report.
    */
   directOutstanding: boolean;
+  /**
+   * True when reading `m.direct` for this room's owner failed with
+   * `M_EXCLUSIVE` — the appservice acting as a user outside its own
+   * namespace, confirmed permanent (see the file doc). Mutually exclusive
+   * with `directOutstanding`: this is the "not applicable" reading, not the
+   * "still needs work" one, and it is what lets a room whose join and leave
+   * are both done stop being reported at all.
+   */
+  directExcluded: boolean;
 }
 
 /** What `describeRooms` needs to ask a Matrix client. */
@@ -109,39 +154,78 @@ export interface DescribeDeps {
   ownerMxidFor(userId: string): Promise<string | null>;
 }
 
-/** Whether the owner's `m.direct` already names `newUserId` for this room. */
-async function directAlreadyFixed(
+/** The three things a room's `m.direct` state can turn out to be. */
+type DirectCheck = "done" | "outstanding" | "excluded";
+
+/**
+ * Whether the owner's `m.direct` already names `newUserId` for this room —
+ * or, if it can never be read at all, whether that is a real, retriable
+ * failure or the permanent `M_EXCLUSIVE` case (see the file doc).
+ *
+ * These three outcomes must not collapse into two: `"excluded"` is a fact
+ * about this bridge's reach, settled once and for all by a live probe, and
+ * conflating it with `"outstanding"` is exactly the defect this function
+ * exists to avoid — 32 rooms reported as needing work that can never be
+ * done, forever, on every run.
+ */
+async function checkDirect(
   client: DescribeClient,
   ownerMxid: string | null,
   newUserId: string,
   roomId: string
-): Promise<boolean> {
-  if (!ownerMxid) return false; // nothing this script can do is still "not done"
+): Promise<DirectCheck> {
+  if (!ownerMxid) return "outstanding"; // nothing this script can do is still "not done"
   try {
     const current = await client.getAccountData(ownerMxid, "m.direct");
     const rooms = current && Array.isArray(current[newUserId]) ? (current[newUserId] as unknown[]) : [];
-    return rooms.includes(roomId);
+    return rooms.includes(roomId) ? "done" : "outstanding";
   } catch (err) {
-    // A read failure is reported as outstanding, not silently treated as
-    // fixed — the same "fail closed" stance `setDirect` takes on a write.
+    if (isMatrixExclusiveNamespace(err)) {
+      // Permanent, not transient — confirmed live. Reported as excluded, not
+      // outstanding, so a room whose membership has fully moved is not kept
+      // on the report forever over a step that can never be done here.
+      log.warn(
+        "m.direct cannot be read as the owner — outside the appservice's namespace; reporting as not applicable, not outstanding",
+        { roomId }
+      );
+      return "excluded";
+    }
+    // A genuine, retriable failure is reported as outstanding, not silently
+    // treated as fixed — the same "fail closed" stance `setDirect` takes on
+    // a write. This must stay a different fact from `M_EXCLUSIVE` above: a
+    // transient error deserves a re-run, not a permanent write-off.
     log.warn("could not read m.direct while describing this room; reporting it as outstanding", {
       roomId,
       error: err instanceof Error ? err.message : String(err),
     });
-    return false;
+    return "outstanding";
   }
+}
+
+/** What `describeRooms` reports: the outstanding rooms, and one run-wide fact. */
+export interface DescribeRoomsResult {
+  rooms: RoomStatus[];
+  /**
+   * True when at least one room's `m.direct` read failed with `M_EXCLUSIVE`
+   * this run. The one fact `formatReport` states at the top, once — never
+   * per room — because it is the same fact for all 32 rooms: this bridge
+   * cannot act as the operator, permanently, and no re-run changes it.
+   */
+  mDirectExcluded: boolean;
 }
 
 /**
  * Every room that still needs some of this migration, and nothing else.
  *
- * A room is left out only once join, leave, AND `m.direct` are all
- * confirmed — the last one by reading it back, never inferred from the
- * other two, because a refused `m.direct` write must keep the room visible
- * even after membership has fully moved.
+ * A room is left out once join, leave, AND `m.direct` are all settled —
+ * `m.direct` either confirmed fixed by reading it back, or `excluded`
+ * (`M_EXCLUSIVE`, permanent — see the file doc). A refused-but-retriable
+ * `m.direct` read is the one case that must keep a room visible even after
+ * membership has fully moved; `excluded` deliberately is not that case.
  */
-export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
+export async function describeRooms(deps: DescribeDeps): Promise<DescribeRoomsResult> {
   const out: RoomStatus[] = [];
+  let mDirectExcluded = false;
 
   for (const row of await deps.rows()) {
     if (!row.principalId) {
@@ -170,13 +254,15 @@ export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
 
     const newJoined = await deps.client.isJoined(newUserId, row.roomId);
     const oldStillJoined = await deps.client.isJoined(oldUserId, row.roomId);
-    const directDone = await directAlreadyFixed(deps.client, ownerMxid, newUserId, row.roomId);
+    const direct = await checkDirect(deps.client, ownerMxid, newUserId, row.roomId);
+    if (direct === "excluded") mDirectExcluded = true;
 
     const joinOutstanding = !newJoined;
     const leaveOutstanding = oldStillJoined;
-    const directOutstanding = !directDone;
+    const directOutstanding = direct === "outstanding";
+    const directExcluded = direct === "excluded";
 
-    if (!joinOutstanding && !leaveOutstanding && !directOutstanding) continue; // truly nothing left
+    if (!joinOutstanding && !leaveOutstanding && !directOutstanding) continue; // truly nothing left — completion is join + leave, and m.direct is done or excluded
 
     out.push({
       roomId: row.roomId,
@@ -189,10 +275,11 @@ export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
       joinOutstanding,
       leaveOutstanding,
       directOutstanding,
+      directExcluded,
     });
   }
 
-  return out;
+  return { rooms: out, mDirectExcluded };
 }
 
 /** What `buildMigrationDeps` needs from a live (or fake) Matrix client. */
@@ -285,6 +372,8 @@ export interface RoomResult {
 export interface RunResult {
   applied: boolean;
   rooms: RoomStatus[];
+  /** See `DescribeRoomsResult` — the one run-wide fact `formatReport` states once. */
+  mDirectExcluded: boolean;
   migrated: number;
   skipped: number;
   failures: Array<{ roomId: string; stationKey: string; error: string }>;
@@ -307,10 +396,10 @@ export async function runMigration(
   client: DirectClient,
   opts: { apply: boolean }
 ): Promise<RunResult> {
-  const rooms = await describeRooms(describeDeps);
+  const { rooms, mDirectExcluded } = await describeRooms(describeDeps);
 
   if (!opts.apply) {
-    return { applied: false, rooms, migrated: 0, skipped: 0, failures: [], results: [] };
+    return { applied: false, rooms, mDirectExcluded, migrated: 0, skipped: 0, failures: [], results: [] };
   }
 
   const { deps, directOutcomes } = buildMigrationDeps(rooms, client);
@@ -351,7 +440,7 @@ export async function runMigration(
     }
   }
 
-  return { applied: true, rooms, migrated, skipped, failures, results };
+  return { applied: true, rooms, mDirectExcluded, migrated, skipped, failures, results };
 }
 
 function describeDirectOutcome(outcome: DirectOutcome | null): string {
@@ -361,9 +450,27 @@ function describeDirectOutcome(outcome: DirectOutcome | null): string {
   return `m.direct: skipped — ${outcome.error}`;
 }
 
+/**
+ * The `M_EXCLUSIVE` note — stated once, at the top, never per room. See the
+ * file doc's "`M_EXCLUSIVE` is permanent, not transient" section for the
+ * full story; this is the short form an operator reads before anything else.
+ */
+const M_DIRECT_EXCLUDED_NOTE =
+  "NOTE: m.direct (the operator's own DM mapping) cannot be updated through this bridge. " +
+  "Reading it as the operator gets 400 M_EXCLUSIVE — the operator's own mxid sits outside " +
+  "the appservice's exclusive @agent_.* namespace, confirmed live, and that is permanent, " +
+  "not a bug here. Room membership (join and leave) still moves in full for every room below; " +
+  "closing the DM mapping needs a one-off run using the operator's OWN access token, not the " +
+  "bridge's. Rooms below show this step as 'not applicable', not outstanding.";
+
 /** What an operator reads, whether this was a dry run or a real one. */
 export function formatReport(result: RunResult): string {
   const lines: string[] = [];
+
+  if (result.mDirectExcluded) {
+    lines.push(M_DIRECT_EXCLUDED_NOTE);
+    lines.push("");
+  }
 
   if (result.rooms.length === 0) {
     lines.push("No rooms need migration — every room already carries its new address.");
@@ -390,6 +497,9 @@ export function formatReport(result: RunResult): string {
     lines.push(`    old: ${r.oldUserId}`);
     lines.push(`    new: ${r.newUserId}`);
     lines.push(`    outstanding: ${steps || "none"}`);
+    if (r.directExcluded) {
+      lines.push(`    m.direct: not applicable — see note above`);
+    }
     if (!r.ownerMxid) {
       lines.push(`    warning: owner has no linked Matrix identity — m.direct cannot be fixed`);
     }

--- a/apps/hub/scripts/migrate-agent-mxids-run.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.ts
@@ -1,0 +1,360 @@
+/**
+ * The caller `migrateAgentMxids` never had.
+ *
+ * Task 9 built the pure function and its ordering; nothing implemented
+ * `rooms()`, `join()`, `leave()` or `setDirect()`, so the migration could not
+ * be run at all. This wires live dependencies for the 32 rooms this fleet
+ * actually has — and, on top of that, is the only place that decides which
+ * rooms still need it.
+ *
+ * **Dry run is the default.** `bun run scripts/migrate-agent-mxids-run.ts`
+ * prints exactly what would happen and changes nothing; only `--apply` does
+ * anything to a homeserver. The report is what an operator reads before
+ * deciding, so it names every room, both addresses, and which of the three
+ * steps are still outstanding.
+ *
+ * ## Detecting a half-migrated room
+ *
+ * A run across 32 rooms is expected to die partway through, and the question
+ * "does this room still need anything" cannot be answered from a database
+ * flag — nothing writes `matrix_rooms.principal_id` today, so a flag-based
+ * check would silently skip a room that is only half done. It is answered
+ * from live membership instead, with `client.isJoined`.
+ *
+ * `migrateAgentMxids`'s own steps run in a fixed order — join, then
+ * `setDirect`, then leave — so a room whose OLD user has already left proves,
+ * by that ordering alone, that `setDirect` already succeeded on some earlier
+ * pass: leave is unreachable otherwise. So this only has to ask two
+ * questions, not three: is the new user joined, and has the old user left.
+ * Both true together is the only state this omits from its report.
+ */
+import { and, eq } from "drizzle-orm";
+
+import { db } from "../src/db/drizzle";
+import { stations } from "../src/db/schema/stations";
+import { nodes } from "../src/db/schema/nodes";
+import { matrixRooms } from "../src/db/schema/matrix";
+import { principalIdentities } from "../src/db/schema/identities";
+import { principalHandle } from "../src/services/principals";
+import { bridgeUserId, localpartFor } from "../src/services/matrix-as/names";
+import { createMatrixClient } from "../src/services/matrix-as/client";
+import { matrixBridgeConfig } from "../src/services/matrix-as/index";
+import { migrateAgentMxids, type MxidMigrationDeps } from "./migrate-agent-mxids";
+import { createLogger } from "../src/utils/logger";
+
+const log = createLogger("migrate-agent-mxids-run");
+
+/** One room, as read off `matrix_rooms` joined through its station and node. */
+export interface StationRoomRow {
+  roomId: string;
+  stationId: string;
+  stationKey: string;
+  nodeName: string;
+  /** Null when the station has no occupying agent — see requirement 4. */
+  principalId: string | null;
+  /** The Better Auth id of the human this room belongs to. */
+  ownerUserId: string;
+}
+
+/** One room's migration status, as reported to an operator and to the migration itself. */
+export interface RoomStatus {
+  roomId: string;
+  stationKey: string;
+  nodeName: string;
+  handle: string;
+  oldUserId: string;
+  newUserId: string;
+  /** Null when the owner has no Matrix identity mapped — `m.direct` cannot be fixed then. */
+  ownerMxid: string | null;
+  joinOutstanding: boolean;
+  leaveOutstanding: boolean;
+  /** See the file doc: coupled to the other two by `migrateAgentMxids`'s own step order. */
+  directOutstanding: boolean;
+}
+
+export interface DescribeDeps {
+  domain: string;
+  rows(): Promise<StationRoomRow[]>;
+  isJoined(userId: string, roomId: string): Promise<boolean>;
+  principalHandle(id: string): Promise<string | null>;
+  ownerMxidFor(userId: string): Promise<string | null>;
+}
+
+/**
+ * Every room that still needs some of this migration, and nothing else.
+ *
+ * A room whose new user has joined and whose old user has left is left out
+ * entirely — not because a flag says it is done, but because those two live
+ * facts, together, are the only way this migration itself is capable of
+ * reaching that state (see the file doc).
+ */
+export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
+  const out: RoomStatus[] = [];
+
+  for (const row of await deps.rows()) {
+    if (!row.principalId) {
+      log.warn(
+        "station has no occupying agent, so its room has no address to migrate to — omitted",
+        { stationId: row.stationId, stationKey: row.stationKey, nodeName: row.nodeName }
+      );
+      continue;
+    }
+
+    const handle = await deps.principalHandle(row.principalId);
+    if (!handle) {
+      log.warn(
+        "principal has no handle, so its room has no address to migrate to — omitted",
+        { stationId: row.stationId, principalId: row.principalId }
+      );
+      continue;
+    }
+
+    // Derived, not read back from anywhere: the old address is what
+    // `provision.ts` minted from the station's own (node, key) pair, and
+    // nothing today stores it. See requirement 3.
+    const oldUserId = `@agent_${localpartFor(row.nodeName, row.stationKey)}:${deps.domain}`;
+    const newUserId = bridgeUserId(handle, deps.domain);
+
+    const newJoined = await deps.isJoined(newUserId, row.roomId);
+    const oldStillJoined = await deps.isJoined(oldUserId, row.roomId);
+
+    const joinOutstanding = !newJoined;
+    const leaveOutstanding = oldStillJoined;
+    const directOutstanding = joinOutstanding || leaveOutstanding;
+
+    if (!joinOutstanding && !leaveOutstanding) continue; // every step is already done
+
+    out.push({
+      roomId: row.roomId,
+      stationKey: row.stationKey,
+      nodeName: row.nodeName,
+      handle,
+      oldUserId,
+      newUserId,
+      ownerMxid: await deps.ownerMxidFor(row.ownerUserId),
+      joinOutstanding,
+      leaveOutstanding,
+      directOutstanding,
+    });
+  }
+
+  return out;
+}
+
+/** What `buildMigrationDeps` needs from a live (or fake) Matrix client. */
+export interface DirectClient {
+  join(userId: string, roomId: string): Promise<void>;
+  leave(userId: string, roomId: string): Promise<void>;
+  getAccountData(userId: string, type: string): Promise<Record<string, unknown> | null>;
+  setAccountData(userId: string, type: string, content: Record<string, unknown>): Promise<void>;
+}
+
+/**
+ * Wire `RoomStatus[]` into the deps shape `migrateAgentMxids` consumes.
+ *
+ * `setDirect` is where the read-modify-write lives: `m.direct` is every DM
+ * the owner has, not just this one, so this reads the map, changes only the
+ * two keys this room touches, and writes the whole thing back. A room whose
+ * owner has no linked Matrix identity is logged and left alone rather than
+ * guessed at.
+ */
+export function buildMigrationDeps(rooms: RoomStatus[], client: DirectClient): MxidMigrationDeps {
+  const byRoom = new Map(rooms.map((r) => [r.roomId, r]));
+
+  return {
+    rooms: async () => rooms.map((r) => ({ roomId: r.roomId, handle: r.handle, oldUserId: r.oldUserId })),
+    join: (userId, roomId) => client.join(userId, roomId),
+    leave: (userId, roomId) => client.leave(userId, roomId),
+    async setDirect(newUserId, roomId) {
+      const room = byRoom.get(roomId);
+      if (!room?.ownerMxid) {
+        log.warn("cannot fix m.direct: the room's owner has no linked Matrix identity", {
+          roomId,
+        });
+        return;
+      }
+
+      const current = (await client.getAccountData(room.ownerMxid, "m.direct")) ?? {};
+      const next: Record<string, unknown> = { ...current };
+
+      const oldRooms = Array.isArray(next[room.oldUserId]) ? (next[room.oldUserId] as unknown[]) : [];
+      const remaining = oldRooms.filter((r) => r !== roomId);
+      if (remaining.length > 0) next[room.oldUserId] = remaining;
+      else delete next[room.oldUserId];
+
+      const newRooms = Array.isArray(next[newUserId]) ? (next[newUserId] as unknown[]) : [];
+      if (!newRooms.includes(roomId)) next[newUserId] = [...newRooms, roomId];
+
+      await client.setAccountData(room.ownerMxid, "m.direct", next);
+    },
+  };
+}
+
+export interface RunResult {
+  applied: boolean;
+  rooms: RoomStatus[];
+  migrated: number;
+  skipped: number;
+  failures: Array<{ roomId: string; stationKey: string; error: string }>;
+}
+
+/**
+ * Describe every outstanding room, and — only when `apply` is true — migrate
+ * each one, sequentially, one room at a time.
+ *
+ * One room per `migrateAgentMxids` call rather than the whole batch, so one
+ * room's failure cannot abort the rest: a timeout or a rate limit on room 17
+ * is caught, logged, and counted, and rooms 18 through 32 are still attempted.
+ * A re-run is always the right response to a failure, because `describeRooms`
+ * will find the same room still outstanding.
+ */
+export async function runMigration(
+  describeDeps: DescribeDeps,
+  client: DirectClient,
+  opts: { apply: boolean }
+): Promise<RunResult> {
+  const rooms = await describeRooms(describeDeps);
+
+  if (!opts.apply) {
+    return { applied: false, rooms, migrated: 0, skipped: 0, failures: [] };
+  }
+
+  const deps = buildMigrationDeps(rooms, client);
+  let migrated = 0;
+  let skipped = 0;
+  const failures: RunResult["failures"] = [];
+
+  for (const room of rooms) {
+    try {
+      const r = await migrateAgentMxids({
+        rooms: async () => [{ roomId: room.roomId, handle: room.handle, oldUserId: room.oldUserId }],
+        join: deps.join,
+        leave: deps.leave,
+        setDirect: deps.setDirect,
+      });
+      migrated += r.migrated;
+      skipped += r.skipped;
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      failures.push({ roomId: room.roomId, stationKey: room.stationKey, error });
+      log.error("a room's migration failed; continuing with the rest", {
+        roomId: room.roomId,
+        stationKey: room.stationKey,
+        error,
+      });
+    }
+  }
+
+  return { applied: true, rooms, migrated, skipped, failures };
+}
+
+/** What an operator reads, whether this was a dry run or a real one. */
+export function formatReport(result: RunResult): string {
+  const lines: string[] = [];
+
+  if (result.rooms.length === 0) {
+    lines.push("No rooms need migration — every room already carries its new address.");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    result.applied
+      ? `Applying the migration to ${result.rooms.length} room(s).`
+      : `DRY RUN — ${result.rooms.length} room(s) would be touched. Nothing has been changed.`
+  );
+  if (!result.applied) lines.push("Pass --apply to run this for real.");
+  lines.push("");
+
+  for (const r of result.rooms) {
+    const steps = [
+      r.joinOutstanding ? "join" : null,
+      r.directOutstanding ? "m.direct" : null,
+      r.leaveOutstanding ? "leave" : null,
+    ]
+      .filter((s): s is string => s !== null)
+      .join(", ");
+    lines.push(`  ${r.stationKey} @ ${r.nodeName}  (${r.roomId})`);
+    lines.push(`    old: ${r.oldUserId}`);
+    lines.push(`    new: ${r.newUserId}`);
+    lines.push(`    outstanding: ${steps}`);
+    if (!r.ownerMxid) {
+      lines.push(`    warning: owner has no linked Matrix identity — m.direct cannot be fixed`);
+    }
+  }
+
+  if (result.applied) {
+    lines.push("");
+    lines.push(`migrated ${result.migrated}, skipped ${result.skipped}, failed ${result.failures.length}`);
+    for (const f of result.failures) {
+      lines.push(`  FAILED ${f.stationKey} (${f.roomId}): ${f.error} — re-run to retry`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ─── Live wiring — everything below touches the database and, with --apply, ───
+// ─── the homeserver. None of it runs under `bun test`.                      ───
+
+async function listRoomStations(): Promise<StationRoomRow[]> {
+  return db
+    .select({
+      roomId: matrixRooms.roomId,
+      stationId: stations.id,
+      stationKey: stations.stationKey,
+      nodeName: nodes.name,
+      principalId: stations.principalId,
+      ownerUserId: stations.userId,
+    })
+    .from(matrixRooms)
+    .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId));
+}
+
+/**
+ * The owner's Matrix id, resolved exactly as `provision.ts`'s own `ownerMxid`
+ * does — so the address this migration fixes `m.direct` for is the same one
+ * provisioning invited in the first place.
+ */
+async function ownerMxidFor(userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(principalIdentities)
+    .where(
+      and(eq(principalIdentities.principalId, userId), eq(principalIdentities.system, "matrix"))
+    );
+  return row?.externalId ?? null;
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  const cfg = matrixBridgeConfig();
+  const client = createMatrixClient({
+    homeserverUrl: cfg.homeserverUrl,
+    asToken: cfg.asToken,
+    domain: cfg.domain,
+  });
+
+  const result = await runMigration(
+    {
+      domain: cfg.domain,
+      rows: listRoomStations,
+      isJoined: client.isJoined,
+      principalHandle,
+      ownerMxidFor,
+    },
+    client,
+    { apply }
+  );
+
+  console.log(formatReport(result));
+
+  if (result.failures.length > 0) process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    log.error("migration run crashed", { error: err instanceof Error ? err.message : String(err) });
+    process.exitCode = 1;
+  });
+}

--- a/apps/hub/scripts/migrate-agent-mxids-run.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.ts
@@ -18,15 +18,32 @@
  * A run across 32 rooms is expected to die partway through, and the question
  * "does this room still need anything" cannot be answered from a database
  * flag — nothing writes `matrix_rooms.principal_id` today, so a flag-based
- * check would silently skip a room that is only half done. It is answered
- * from live membership instead, with `client.isJoined`.
+ * check would silently skip a room that is only half done. Membership is
+ * checked live with `client.isJoined`, and `m.direct` is checked live too, by
+ * reading it back rather than inferring it from the other two: join and leave
+ * no longer imply anything about `m.direct` (see below), so its own state has
+ * to be read directly for a room to ever stop being reported.
  *
- * `migrateAgentMxids`'s own steps run in a fixed order — join, then
- * `setDirect`, then leave — so a room whose OLD user has already left proves,
- * by that ordering alone, that `setDirect` already succeeded on some earlier
- * pass: leave is unreachable otherwise. So this only has to ask two
- * questions, not three: is the new user joined, and has the old user left.
- * Both true together is the only state this omits from its report.
+ * ## `m.direct` is optional, and never blocks the membership move
+ *
+ * `client.ts`'s own note on `ensureRoom`'s `isDirect` — written before this
+ * file existed — already concluded that writing a human's account data needs
+ * a credential this bridge exists to stop keeping; the tuwunel spike never
+ * tested `account_data` at all, and only ever proved `?user_id=` masquerading
+ * for identities *inside* `@agent_.*`. So a refusal here is the expected case,
+ * not a bug, and it must never be the thing that leaves a room stuck: if
+ * `setDirect` were allowed to throw, `migrateAgentMxids`'s own join-then-
+ * setDirect-then-leave order would abort before the old user ever leaves,
+ * and every room refused this way would end up with BOTH agents present,
+ * `m.direct` untouched, and an identical refusal on every re-run. `setDirect`
+ * therefore catches its own failure, records it, and always returns
+ * normally — membership always finishes moving, whether or not this bridge
+ * turns out to be allowed to fix the DM flag. Whether to pursue `m.direct` by
+ * some other route (a one-time use of a human's own token, say) is the
+ * operator's call, not this script's: it is a real cost — 32 rooms silently
+ * dropping out of People — traded against the charter principle that this
+ * bridge holds no human credential, and that trade is reported here, not
+ * made here.
  */
 import { and, eq } from "drizzle-orm";
 
@@ -68,25 +85,60 @@ export interface RoomStatus {
   ownerMxid: string | null;
   joinOutstanding: boolean;
   leaveOutstanding: boolean;
-  /** See the file doc: coupled to the other two by `migrateAgentMxids`'s own step order. */
+  /**
+   * True until `m.direct` is actually read back naming the new user for this
+   * room. Not inferred from `joinOutstanding`/`leaveOutstanding` — a refused
+   * `m.direct` write no longer blocks `leave` (see the file doc), so a room
+   * can have finished moving membership while this stays true forever, and
+   * that must stay visible rather than making the room vanish from the report.
+   */
   directOutstanding: boolean;
+}
+
+/** What `describeRooms` needs to ask a Matrix client. */
+export interface DescribeClient {
+  isJoined(userId: string, roomId: string): Promise<boolean>;
+  getAccountData(userId: string, type: string): Promise<Record<string, unknown> | null>;
 }
 
 export interface DescribeDeps {
   domain: string;
   rows(): Promise<StationRoomRow[]>;
-  isJoined(userId: string, roomId: string): Promise<boolean>;
+  client: DescribeClient;
   principalHandle(id: string): Promise<string | null>;
   ownerMxidFor(userId: string): Promise<string | null>;
+}
+
+/** Whether the owner's `m.direct` already names `newUserId` for this room. */
+async function directAlreadyFixed(
+  client: DescribeClient,
+  ownerMxid: string | null,
+  newUserId: string,
+  roomId: string
+): Promise<boolean> {
+  if (!ownerMxid) return false; // nothing this script can do is still "not done"
+  try {
+    const current = await client.getAccountData(ownerMxid, "m.direct");
+    const rooms = current && Array.isArray(current[newUserId]) ? (current[newUserId] as unknown[]) : [];
+    return rooms.includes(roomId);
+  } catch (err) {
+    // A read failure is reported as outstanding, not silently treated as
+    // fixed — the same "fail closed" stance `setDirect` takes on a write.
+    log.warn("could not read m.direct while describing this room; reporting it as outstanding", {
+      roomId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
 }
 
 /**
  * Every room that still needs some of this migration, and nothing else.
  *
- * A room whose new user has joined and whose old user has left is left out
- * entirely — not because a flag says it is done, but because those two live
- * facts, together, are the only way this migration itself is capable of
- * reaching that state (see the file doc).
+ * A room is left out only once join, leave, AND `m.direct` are all
+ * confirmed — the last one by reading it back, never inferred from the
+ * other two, because a refused `m.direct` write must keep the room visible
+ * even after membership has fully moved.
  */
 export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
   const out: RoomStatus[] = [];
@@ -114,15 +166,17 @@ export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
     // nothing today stores it. See requirement 3.
     const oldUserId = `@agent_${localpartFor(row.nodeName, row.stationKey)}:${deps.domain}`;
     const newUserId = bridgeUserId(handle, deps.domain);
+    const ownerMxid = await deps.ownerMxidFor(row.ownerUserId);
 
-    const newJoined = await deps.isJoined(newUserId, row.roomId);
-    const oldStillJoined = await deps.isJoined(oldUserId, row.roomId);
+    const newJoined = await deps.client.isJoined(newUserId, row.roomId);
+    const oldStillJoined = await deps.client.isJoined(oldUserId, row.roomId);
+    const directDone = await directAlreadyFixed(deps.client, ownerMxid, newUserId, row.roomId);
 
     const joinOutstanding = !newJoined;
     const leaveOutstanding = oldStillJoined;
-    const directOutstanding = joinOutstanding || leaveOutstanding;
+    const directOutstanding = !directDone;
 
-    if (!joinOutstanding && !leaveOutstanding) continue; // every step is already done
+    if (!joinOutstanding && !leaveOutstanding && !directOutstanding) continue; // truly nothing left
 
     out.push({
       roomId: row.roomId,
@@ -131,7 +185,7 @@ export async function describeRooms(deps: DescribeDeps): Promise<RoomStatus[]> {
       handle,
       oldUserId,
       newUserId,
-      ownerMxid: await deps.ownerMxidFor(row.ownerUserId),
+      ownerMxid,
       joinOutstanding,
       leaveOutstanding,
       directOutstanding,
@@ -149,19 +203,31 @@ export interface DirectClient {
   setAccountData(userId: string, type: string, content: Record<string, unknown>): Promise<void>;
 }
 
+/** How `m.direct` went for one room, once `setDirect` has run for it. */
+export type DirectOutcome =
+  | { status: "fixed" }
+  | { status: "no-owner" }
+  | { status: "failed"; error: string };
+
 /**
  * Wire `RoomStatus[]` into the deps shape `migrateAgentMxids` consumes.
  *
  * `setDirect` is where the read-modify-write lives: `m.direct` is every DM
  * the owner has, not just this one, so this reads the map, changes only the
- * two keys this room touches, and writes the whole thing back. A room whose
- * owner has no linked Matrix identity is logged and left alone rather than
- * guessed at.
+ * two keys this room touches, and writes the whole thing back. It is also
+ * where a refusal is caught rather than thrown — `migrateAgentMxids` calls
+ * `leave` right after this returns, and that call must still happen whether
+ * or not the write above succeeded. `directOutcomes` is how the caller finds
+ * out which happened, since `setDirect`'s own return type carries nothing.
  */
-export function buildMigrationDeps(rooms: RoomStatus[], client: DirectClient): MxidMigrationDeps {
+export function buildMigrationDeps(
+  rooms: RoomStatus[],
+  client: DirectClient
+): { deps: MxidMigrationDeps; directOutcomes: Map<string, DirectOutcome> } {
   const byRoom = new Map(rooms.map((r) => [r.roomId, r]));
+  const directOutcomes = new Map<string, DirectOutcome>();
 
-  return {
+  const deps: MxidMigrationDeps = {
     rooms: async () => rooms.map((r) => ({ roomId: r.roomId, handle: r.handle, oldUserId: r.oldUserId })),
     join: (userId, roomId) => client.join(userId, roomId),
     leave: (userId, roomId) => client.leave(userId, roomId),
@@ -171,23 +237,49 @@ export function buildMigrationDeps(rooms: RoomStatus[], client: DirectClient): M
         log.warn("cannot fix m.direct: the room's owner has no linked Matrix identity", {
           roomId,
         });
+        directOutcomes.set(roomId, { status: "no-owner" });
         return;
       }
 
-      const current = (await client.getAccountData(room.ownerMxid, "m.direct")) ?? {};
-      const next: Record<string, unknown> = { ...current };
+      try {
+        const current = (await client.getAccountData(room.ownerMxid, "m.direct")) ?? {};
+        const next: Record<string, unknown> = { ...current };
 
-      const oldRooms = Array.isArray(next[room.oldUserId]) ? (next[room.oldUserId] as unknown[]) : [];
-      const remaining = oldRooms.filter((r) => r !== roomId);
-      if (remaining.length > 0) next[room.oldUserId] = remaining;
-      else delete next[room.oldUserId];
+        const oldRooms = Array.isArray(next[room.oldUserId]) ? (next[room.oldUserId] as unknown[]) : [];
+        const remaining = oldRooms.filter((r) => r !== roomId);
+        if (remaining.length > 0) next[room.oldUserId] = remaining;
+        else delete next[room.oldUserId];
 
-      const newRooms = Array.isArray(next[newUserId]) ? (next[newUserId] as unknown[]) : [];
-      if (!newRooms.includes(roomId)) next[newUserId] = [...newRooms, roomId];
+        const newRooms = Array.isArray(next[newUserId]) ? (next[newUserId] as unknown[]) : [];
+        if (!newRooms.includes(roomId)) next[newUserId] = [...newRooms, roomId];
 
-      await client.setAccountData(room.ownerMxid, "m.direct", next);
+        await client.setAccountData(room.ownerMxid, "m.direct", next);
+        directOutcomes.set(roomId, { status: "fixed" });
+      } catch (err) {
+        // Not fatal, and deliberately so: see the file doc. The membership
+        // move must complete regardless of whether this bridge turns out to
+        // be allowed to touch the owner's account data.
+        const error = err instanceof Error ? err.message : String(err);
+        log.warn(
+          "could not fix m.direct for this room; leaving membership to move anyway",
+          { roomId, error }
+        );
+        directOutcomes.set(roomId, { status: "failed", error });
+      }
     },
   };
+
+  return { deps, directOutcomes };
+}
+
+/** One room's outcome after an apply run has actually touched it. */
+export interface RoomResult {
+  roomId: string;
+  stationKey: string;
+  /** Set only when `join` or `leave` threw and aborted this room's migration. */
+  error?: string;
+  /** Null when the room's migration failed before `setDirect` ever ran. */
+  direct: DirectOutcome | null;
 }
 
 export interface RunResult {
@@ -196,6 +288,8 @@ export interface RunResult {
   migrated: number;
   skipped: number;
   failures: Array<{ roomId: string; stationKey: string; error: string }>;
+  /** Per-room detail for an apply run; empty for a dry run. */
+  results: RoomResult[];
 }
 
 /**
@@ -216,13 +310,14 @@ export async function runMigration(
   const rooms = await describeRooms(describeDeps);
 
   if (!opts.apply) {
-    return { applied: false, rooms, migrated: 0, skipped: 0, failures: [] };
+    return { applied: false, rooms, migrated: 0, skipped: 0, failures: [], results: [] };
   }
 
-  const deps = buildMigrationDeps(rooms, client);
+  const { deps, directOutcomes } = buildMigrationDeps(rooms, client);
   let migrated = 0;
   let skipped = 0;
   const failures: RunResult["failures"] = [];
+  const results: RoomResult[] = [];
 
   for (const room of rooms) {
     try {
@@ -234,9 +329,20 @@ export async function runMigration(
       });
       migrated += r.migrated;
       skipped += r.skipped;
+      results.push({
+        roomId: room.roomId,
+        stationKey: room.stationKey,
+        direct: directOutcomes.get(room.roomId) ?? null,
+      });
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       failures.push({ roomId: room.roomId, stationKey: room.stationKey, error });
+      results.push({
+        roomId: room.roomId,
+        stationKey: room.stationKey,
+        error,
+        direct: directOutcomes.get(room.roomId) ?? null,
+      });
       log.error("a room's migration failed; continuing with the rest", {
         roomId: room.roomId,
         stationKey: room.stationKey,
@@ -245,7 +351,14 @@ export async function runMigration(
     }
   }
 
-  return { applied: true, rooms, migrated, skipped, failures };
+  return { applied: true, rooms, migrated, skipped, failures, results };
+}
+
+function describeDirectOutcome(outcome: DirectOutcome | null): string {
+  if (!outcome) return "m.direct: not attempted";
+  if (outcome.status === "fixed") return "m.direct: fixed";
+  if (outcome.status === "no-owner") return "m.direct: skipped — owner has no linked Matrix identity";
+  return `m.direct: skipped — ${outcome.error}`;
 }
 
 /** What an operator reads, whether this was a dry run or a real one. */
@@ -276,7 +389,7 @@ export function formatReport(result: RunResult): string {
     lines.push(`  ${r.stationKey} @ ${r.nodeName}  (${r.roomId})`);
     lines.push(`    old: ${r.oldUserId}`);
     lines.push(`    new: ${r.newUserId}`);
-    lines.push(`    outstanding: ${steps}`);
+    lines.push(`    outstanding: ${steps || "none"}`);
     if (!r.ownerMxid) {
       lines.push(`    warning: owner has no linked Matrix identity — m.direct cannot be fixed`);
     }
@@ -285,8 +398,13 @@ export function formatReport(result: RunResult): string {
   if (result.applied) {
     lines.push("");
     lines.push(`migrated ${result.migrated}, skipped ${result.skipped}, failed ${result.failures.length}`);
-    for (const f of result.failures) {
-      lines.push(`  FAILED ${f.stationKey} (${f.roomId}): ${f.error} — re-run to retry`);
+    lines.push("");
+    for (const r of result.results) {
+      lines.push(
+        r.error
+          ? `  FAILED ${r.stationKey} (${r.roomId}): ${r.error} — re-run to retry`
+          : `  ${r.stationKey} (${r.roomId}): membership updated, ${describeDirectOutcome(r.direct)}`
+      );
     }
   }
 
@@ -339,7 +457,7 @@ async function main(): Promise<void> {
     {
       domain: cfg.domain,
       rows: listRoomStations,
-      isJoined: client.isJoined,
+      client,
       principalHandle,
       ownerMxidFor,
     },

--- a/apps/hub/scripts/migrate-agent-mxids-run.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.ts
@@ -52,7 +52,7 @@ import { stations } from "../src/db/schema/stations";
 import { nodes } from "../src/db/schema/nodes";
 import { matrixRooms } from "../src/db/schema/matrix";
 import { principalIdentities } from "../src/db/schema/identities";
-import { principalHandle } from "../src/services/principals";
+import { principalHandle, principalForUser } from "../src/services/principals";
 import { bridgeUserId, localpartFor } from "../src/services/matrix-as/names";
 import { createMatrixClient } from "../src/services/matrix-as/client";
 import { matrixBridgeConfig } from "../src/services/matrix-as/index";
@@ -433,13 +433,27 @@ async function listRoomStations(): Promise<StationRoomRow[]> {
  * The owner's Matrix id, resolved exactly as `provision.ts`'s own `ownerMxid`
  * does — so the address this migration fixes `m.direct` for is the same one
  * provisioning invited in the first place.
+ *
+ * That parity claim was written while both functions were wrong in the same
+ * way, which is the worst thing a parity claim can be: `stations.userId` is a
+ * Better Auth id, `principal_identities.principal_id` holds `prn_…` values,
+ * and querying that column with a user id resolved null for every room in the
+ * fleet — so `m.direct` was never written and every room reported its DM flag
+ * outstanding forever. Both now resolve the principal first, and the parity is
+ * a fact rather than a hope: change one and this must change with it.
  */
 async function ownerMxidFor(userId: string): Promise<string | null> {
+  const principal = await principalForUser(userId);
+  if (!principal) return null;
+
   const [row] = await db
     .select({ externalId: principalIdentities.externalId })
     .from(principalIdentities)
     .where(
-      and(eq(principalIdentities.principalId, userId), eq(principalIdentities.system, "matrix"))
+      and(
+        eq(principalIdentities.principalId, principal.id),
+        eq(principalIdentities.system, "matrix")
+      )
     );
   return row?.externalId ?? null;
 }

--- a/apps/hub/scripts/migrate-agent-mxids.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The one irreversible step in slice A: re-addressing the fleet's DM rooms.
+ *
+ * Every dependency here is a fake. This proves the ordering and the `m.direct`
+ * fix-up in isolation — it does not, and must not, touch a homeserver.
+ */
+
+import { expect, test } from "bun:test";
+
+import { migrateAgentMxids } from "./migrate-agent-mxids";
+
+const fail = async () => {
+  throw new Error("must not be called");
+};
+
+test("the new user joins the existing room and the old one leaves", async () => {
+  const acts: string[] = [];
+  await migrateAgentMxids({
+    rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
+    join: async (u, r) => { acts.push(`join ${u} ${r}`); },
+    leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
+    setDirect: async (u, r) => { acts.push(`direct ${u} ${r}`); },
+  });
+  // Join BEFORE leave: the reverse leaves the room briefly with no agent in it.
+  expect(acts).toEqual([
+    "join @agent_writer-quill:h !r:h",
+    "direct @agent_writer-quill:h !r:h",
+    "leave @agent_guild_hermes-writer-quill:h !r:h",
+  ]);
+});
+
+test("is idempotent — a room already migrated is skipped", async () => {
+  const r = await migrateAgentMxids({ rooms: async () => [], join: fail, leave: fail, setDirect: fail });
+  expect(r.migrated).toBe(0);
+});
+
+test("a room whose new address matches its recorded one is skipped, not re-sent", async () => {
+  const r = await migrateAgentMxids({
+    rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_writer-quill:h" }],
+    join: fail,
+    leave: fail,
+    setDirect: fail,
+  });
+  expect(r).toEqual({ migrated: 0, skipped: 1 });
+});

--- a/apps/hub/scripts/migrate-agent-mxids.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.ts
@@ -55,10 +55,17 @@
  * `bridgeUserId(handle, domain) === oldUserId` is skipped.
  *
  * `rooms()` establishes that fact by ASKING THE HOMESERVER, not by reading a
- * column. `matrix_rooms.principal_id` exists and is reserved ahead of its
- * first writer — nothing populates it — so a check keyed on it would report
- * every one of the 32 rooms as untouched forever, including the ones a
- * previous run half-finished. `migrate-agent-mxids-run.ts` therefore derives
+ * column. `matrix_rooms.principal_id` has a writer now (Task 5's admin
+ * assign endpoint, and the migration that backfilled it) — but that column
+ * answers a different question than the one this skip condition needs. It
+ * records which principal is SUPPOSED to occupy a room, not whether the
+ * Matrix-side rename this script performs has actually happened. A room's
+ * `principal_id` can already name the right principal while its membership
+ * still answers to the old, station-derived address — closing that gap is
+ * this script's own job, so checking the column instead of the homeserver
+ * would report a room done before it is, and a previous run's half-finished
+ * rooms would read as untouched forever right alongside it.
+ * `migrate-agent-mxids-run.ts` therefore still derives
  * `oldUserId` from `(nodeName, stationKey)` and settles each of the three
  * steps against live membership and a live `m.direct` read.
  *

--- a/apps/hub/scripts/migrate-agent-mxids.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.ts
@@ -1,0 +1,100 @@
+/**
+ * Re-address 32 DM rooms from station-derived users to principal-derived ones.
+ *
+ * `charter → decisions/2026-08-30-an-agent-is-a-principal.md`. Before this, an
+ * agent's Matrix identity was `bridgeUserId(nodeName, stationKey)`; after Task
+ * 8 it is `bridgeUserId(principal.handle, domain)`. The 32 rooms `provision.ts`
+ * already created are still addressed to the old, station-derived user, and
+ * this is what moves them — the only irreversible step in slice A.
+ *
+ * **No room is deleted and no history is lost.** A room id is stable; only its
+ * membership changes. The new virtual user joins the existing room and the old
+ * one leaves; Matrix keeps every message from a member who has departed. The
+ * AS owns the whole `@agent_.*` namespace, so the new user joins without an
+ * invite.
+ *
+ * ## Join before leave
+ *
+ * The reverse order briefly leaves the room with no agent in it, and a crash
+ * between the two steps — the process killed, the homeserver rejecting the
+ * second call — would leave it that way permanently: a DM with a human on one
+ * side and nobody on the other. Joining first means the worst a crash can do
+ * is leave both users briefly in the room together, which is recoverable by
+ * simply running this again.
+ *
+ * ## `m.direct` is the step that is easy to miss
+ *
+ * `provision.ts` creates these rooms with `isDirect: true`, and that flag
+ * rides on the OWNER's own invite — Matrix records it in the owner's account
+ * data as `m.direct: { <old mxid>: [roomId] }`, keyed on the correspondent's
+ * OLD address. Move the membership and stop there, and the room is still a
+ * room, still readable, still exactly as functional — it has simply stopped
+ * being a DM in the operator's client: no longer listed under People, with
+ * nothing in the room itself to explain why. That is a quiet, confusing
+ * regression, so the account-data update is folded into the same pass rather
+ * than left as a follow-up.
+ *
+ * ## Idempotency is real, not decorative
+ *
+ * A run across 32 rooms is expected to fail partway through — a timeout, a
+ * rate limit, an operator's Ctrl-C — and a second run must pick up exactly
+ * where the first left off. The skip condition is a fact about the room, not
+ * a flag this script writes: a room whose already-correct address is what
+ * `rooms()` reports as `oldUserId` needs nothing done to it, so
+ * `bridgeUserId(handle, domain) === oldUserId` is skipped. `rooms()` itself is
+ * expected to source `oldUserId` from the newly-added `matrix_rooms.principal_id`
+ * (falling back to the station-derived address only for a room that has never
+ * been migrated), so a room this script has already touched is simply absent
+ * from the next run's list, or present with its new address already in place.
+ *
+ * ## A station with no occupying principal
+ *
+ * `rooms()` is the boundary that owns this decision, not this function: a
+ * station whose `principalId` is null has no handle, and therefore no address
+ * to migrate to. `rooms()` must leave such a room out of the list it returns
+ * rather than invent one — this function never falls back to the station-
+ * derived address, because doing so would silently keep the very identity
+ * this migration exists to retire.
+ */
+import { bridgeUserId } from "../src/services/matrix-as/names";
+
+export interface MxidMigrationDeps {
+  /** Every room still needing this, or already done — see the skip rule above. */
+  rooms(): Promise<Array<{ roomId: string; handle: string; oldUserId: string }>>;
+  /** Join as the new user. The AS owns `@agent_.*`, so no invite is needed. */
+  join(userId: string, roomId: string): Promise<void>;
+  /** Leave as the old user, once the new one is in and `m.direct` points at it. */
+  leave(userId: string, roomId: string): Promise<void>;
+  /** Fix up the owner's `m.direct` account data to name the new user. */
+  setDirect(userId: string, roomId: string): Promise<void>;
+}
+
+export async function migrateAgentMxids(
+  deps: MxidMigrationDeps
+): Promise<{ migrated: number; skipped: number }> {
+  let migrated = 0;
+  let skipped = 0;
+  for (const room of await deps.rooms()) {
+    // The domain comes from the room's own old address, not from a configured
+    // default: it is already known, per room, from data `rooms()` supplied —
+    // asking `process.env.MATRIX_DOMAIN` instead would silently disagree with
+    // it the day this ever runs against more than one homeserver.
+    const domain = room.oldUserId.slice(room.oldUserId.lastIndexOf(":") + 1);
+    const next = bridgeUserId(room.handle, domain);
+    if (next === room.oldUserId) {
+      // Already this room's address — a prior run got here, or it never
+      // needed to move. Nothing to do, and nothing to redo.
+      skipped++;
+      continue;
+    }
+    // Join first. Leaving first would leave the room with no agent in it, and
+    // a crash between the two would leave it that way permanently.
+    await deps.join(next, room.roomId);
+    // Before the old user leaves: `m.direct` naming the old mxid is what makes
+    // this room quietly stop being a DM once that member is gone.
+    await deps.setDirect(next, room.roomId);
+    await deps.leave(room.oldUserId, room.roomId);
+    migrated++;
+  }
+  return { migrated, skipped };
+}

--- a/apps/hub/scripts/migrate-agent-mxids.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.ts
@@ -41,11 +41,15 @@
  * where the first left off. The skip condition is a fact about the room, not
  * a flag this script writes: a room whose already-correct address is what
  * `rooms()` reports as `oldUserId` needs nothing done to it, so
- * `bridgeUserId(handle, domain) === oldUserId` is skipped. `rooms()` itself is
- * expected to source `oldUserId` from the newly-added `matrix_rooms.principal_id`
- * (falling back to the station-derived address only for a room that has never
- * been migrated), so a room this script has already touched is simply absent
- * from the next run's list, or present with its new address already in place.
+ * `bridgeUserId(handle, domain) === oldUserId` is skipped.
+ *
+ * `rooms()` establishes that fact by ASKING THE HOMESERVER, not by reading a
+ * column. `matrix_rooms.principal_id` exists and is reserved ahead of its
+ * first writer — nothing populates it — so a check keyed on it would report
+ * every one of the 32 rooms as untouched forever, including the ones a
+ * previous run half-finished. `migrate-agent-mxids-run.ts` therefore derives
+ * `oldUserId` from `(nodeName, stationKey)` and settles each of the three
+ * steps against live membership and a live `m.direct` read.
  *
  * ## A station with no occupying principal
  *

--- a/apps/hub/scripts/migrate-agent-mxids.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.ts
@@ -34,6 +34,17 @@
  * regression, so the account-data update is folded into the same pass rather
  * than left as a follow-up.
  *
+ * A live probe on 2026-08-30 settled that the fold cannot actually reach the
+ * operator's account data: the AS's exclusive namespace is `@agent_.*`, the
+ * operator's own mxid sits outside it, and `GET account_data` as the
+ * operator answers `400 M_EXCLUSIVE`, permanently. `setDirect` below is
+ * still attempted and still non-fatal on any failure, `M_EXCLUSIVE`
+ * included — see `migrate-agent-mxids-run.ts` for how the report tells that
+ * permanent case apart from a real, retriable one, and for who has to close
+ * it (the operator's own access token, in a one-off run this script cannot
+ * make).
+ *
+
  * ## Idempotency is real, not decorative
  *
  * A run across 32 rooms is expected to fail partway through — a timeout, a

--- a/apps/hub/scripts/seed-agent-principals.test.ts
+++ b/apps/hub/scripts/seed-agent-principals.test.ts
@@ -9,8 +9,9 @@
  * all — this spawns the real script as a subprocess, the way the runbook
  * does, and checks what an operator would actually see.
  */
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { ensurePgMigrations } from "../tests/helpers/pg-migrations";
 
 const HUB_ROOT = join(import.meta.dir, "..");
 
@@ -30,6 +31,17 @@ async function runScript(env: Record<string, string | undefined> = process.env) 
 }
 
 describe("scripts/seed-agent-principals.ts, run as a script", () => {
+  // The script is spawned as its own process, so it finds whatever schema the
+  // database already has — it does not build one. Every other integration suite
+  // here migrates in `beforeAll`; this file did not, and so it passed only when
+  // some other suite happened to migrate first. That is invisible on a
+  // developer's machine, whose database was migrated weeks ago, and decided by
+  // file ordering on a fresh CI database — where it failed, twice, while the
+  // test asserting the script FAILS kept passing for the same reason.
+  beforeAll(async () => {
+    await ensurePgMigrations();
+  });
+
   test("runs, seeds, and reports what it did", async () => {
     const { stdout, stderr, exitCode } = await runScript();
 

--- a/apps/hub/scripts/seed-agent-principals.test.ts
+++ b/apps/hub/scripts/seed-agent-principals.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Proves the script is *invocable*, not just that `seedAgentPrincipals()`
+ * works — those are different claims, and the gap between them was the whole
+ * defect. The function has been well tested from day one (see
+ * `../src/services/principals.test.ts`), which is exactly how a missing entry
+ * point slipped through: `bun run scripts/seed-agent-principals.ts` used to
+ * run, print nothing, and exit 0 without seeding a single station. A test
+ * that only calls the exported function would still pass with no `main()` at
+ * all — this spawns the real script as a subprocess, the way the runbook
+ * does, and checks what an operator would actually see.
+ */
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const HUB_ROOT = join(import.meta.dir, "..");
+
+async function runScript(env: Record<string, string | undefined> = process.env) {
+  const proc = Bun.spawn(["bun", "run", "scripts/seed-agent-principals.ts"], {
+    cwd: HUB_ROOT,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("scripts/seed-agent-principals.ts, run as a script", () => {
+  test("runs, seeds, and reports what it did", async () => {
+    const { stdout, stderr, exitCode } = await runScript();
+
+    expect(exitCode).toBe(0);
+    // The defect was silence: a seed that prints nothing is indistinguishable
+    // from a seed that did nothing. An operator reading this output must be
+    // able to tell how many stations were seeded and how many were already
+    // done.
+    expect(stdout).toMatch(/seeded \d+/i);
+    expect(stdout).toMatch(/skipped \d+/i);
+    expect(stderr).not.toMatch(/error/i);
+  });
+
+  test("running it again reports everything already done — idempotent as a script, not just as a function", async () => {
+    await runScript();
+    const { stdout, exitCode } = await runScript();
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/seeded 0\b/i);
+  });
+
+  test("exits non-zero when it fails, so a runbook step can be trusted", async () => {
+    const { exitCode } = await runScript({
+      ...process.env,
+      DATABASE_URL: "postgres://baduser:badpass@127.0.0.1:1/nonexistent",
+    });
+
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/apps/hub/scripts/seed-agent-principals.ts
+++ b/apps/hub/scripts/seed-agent-principals.ts
@@ -6,13 +6,16 @@
  * After this, creating an agent is a deliberate act and station adoption LINKS
  * to an existing principal rather than implying one.
  */
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
-import { db } from "../src/db/drizzle";
+import { closeDatabase, db } from "../src/db/drizzle";
 import { nodes } from "../src/db/schema/nodes";
 import { BOOTSTRAP_ORG_ID, principals } from "../src/db/schema/organization";
 import { stations } from "../src/db/schema/stations";
 import { createPrincipal } from "../src/services/principals";
+import { createLogger } from "../src/utils/logger";
+
+const log = createLogger("seed-agent-principals");
 
 /** `guild` + `hermes:writer-quill` → `writer-quill`; falls back to the whole key. */
 const handleFor = (stationKey: string): string => {
@@ -38,12 +41,20 @@ async function claimedByAnotherStation(principalId: string, stationId: string): 
   return row !== undefined && row.id !== stationId;
 }
 
-export async function seedAgentPrincipals(): Promise<{ created: number }> {
+export async function seedAgentPrincipals(): Promise<{ created: number; skipped: number }> {
+  const [totalRow] = await db.select({ count: sql<number>`count(*)::int` }).from(stations);
+  const totalStations = totalRow?.count ?? 0;
+
   const rows = await db
     .select({ id: stations.id, key: stations.stationKey, node: nodes.name })
     .from(stations)
     .innerJoin(nodes, eq(nodes.id, stations.nodeId))
     .where(isNull(stations.principalId));
+
+  // Stations that already had a principal before this run started — the ones
+  // this run has nothing to do for. Computed up front so a second run, which
+  // seeds nothing, still reports a real number instead of silence.
+  const skipped = totalStations - rows.length;
 
   let created = 0;
   for (const s of rows) {
@@ -66,5 +77,30 @@ export async function seedAgentPrincipals(): Promise<{ created: number }> {
     await db.update(stations).set({ principalId }).where(eq(stations.id, s.id));
     created++;
   }
-  return { created };
+  return { created, skipped };
+}
+
+// ─── Entry point — everything below runs only when this file is executed  ───
+// ─── directly (`bun run scripts/seed-agent-principals.ts`), not under      ───
+// ─── `bun test`, which imports `seedAgentPrincipals` on its own.           ───
+
+async function main(): Promise<void> {
+  try {
+    const { created, skipped } = await seedAgentPrincipals();
+    // A seed that prints nothing is indistinguishable from a seed that did
+    // nothing — which is exactly the defect this entry point exists to close.
+    console.log(`seeded ${created} station(s) with a new agent principal, skipped ${skipped} (already had one)`);
+  } finally {
+    // Without this the pool's idle connection holds the process open until
+    // its own timeout, so a script that already finished still doesn't
+    // return control to the operator (or a test) for up to twenty seconds.
+    await closeDatabase();
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    log.error("seed run crashed", { error: err instanceof Error ? err.message : String(err) });
+    process.exitCode = 1;
+  });
 }

--- a/apps/hub/scripts/seed-agent-principals.ts
+++ b/apps/hub/scripts/seed-agent-principals.ts
@@ -1,0 +1,70 @@
+/**
+ * One agent principal per adopted station — the one-time backfill for a fleet
+ * that predates principals. Idempotent: a station that already has one is left
+ * alone, so this is safe to re-run after adopting more stations.
+ *
+ * After this, creating an agent is a deliberate act and station adoption LINKS
+ * to an existing principal rather than implying one.
+ */
+import { and, eq, isNull } from "drizzle-orm";
+
+import { db } from "../src/db/drizzle";
+import { nodes } from "../src/db/schema/nodes";
+import { BOOTSTRAP_ORG_ID, principals } from "../src/db/schema/organization";
+import { stations } from "../src/db/schema/stations";
+import { createPrincipal } from "../src/services/principals";
+
+/** `guild` + `hermes:writer-quill` → `writer-quill`; falls back to the whole key. */
+const handleFor = (stationKey: string): string => {
+  const tail = stationKey.includes(":") ? stationKey.slice(stationKey.indexOf(":") + 1) : stationKey;
+  return tail.toLowerCase().replace(/[^a-z0-9._=/-]/g, "-");
+};
+
+/** The id of an existing principal on this handle, if one was already minted. */
+async function findByHandle(handle: string): Promise<string | null> {
+  const [row] = await db
+    .select({ id: principals.id })
+    .from(principals)
+    .where(and(eq(principals.orgId, BOOTSTRAP_ORG_ID), eq(principals.handle, handle)));
+  return row?.id ?? null;
+}
+
+/** Whether some OTHER station already occupies this principal. */
+async function claimedByAnotherStation(principalId: string, stationId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: stations.id })
+    .from(stations)
+    .where(eq(stations.principalId, principalId));
+  return row !== undefined && row.id !== stationId;
+}
+
+export async function seedAgentPrincipals(): Promise<{ created: number }> {
+  const rows = await db
+    .select({ id: stations.id, key: stations.stationKey, node: nodes.name })
+    .from(stations)
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .where(isNull(stations.principalId));
+
+  let created = 0;
+  for (const s of rows) {
+    // Two nodes can carry the same station key — `opencode:c52ddf65` did — so
+    // the handle is qualified when the bare one is taken by a DIFFERENT
+    // station. When it was minted for THIS station on an earlier, partial
+    // run — createPrincipal succeeded but the update to link it crashed
+    // before landing — the bare handle is still this station's own, and
+    // re-running must link it rather than mint a second, orphaned principal.
+    let handle = handleFor(s.key);
+    let principalId = await findByHandle(handle);
+    if (principalId && (await claimedByAnotherStation(principalId, s.id))) {
+      handle = `${s.node}-${handle}`;
+      principalId = await findByHandle(handle);
+    }
+    if (!principalId) {
+      principalId = await createPrincipal({ kind: "agent", handle, displayName: s.key });
+    }
+
+    await db.update(stations).set({ principalId }).where(eq(stations.id, s.id));
+    created++;
+  }
+  return { created };
+}

--- a/apps/hub/src/auth/jwt-claims.test.ts
+++ b/apps/hub/src/auth/jwt-claims.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildTokenPayload } from "./jwt-claims";
+
+/**
+ * `principalKind` stops being the literal `"human"`, and `sub` stops being a
+ * Better Auth user id — both become whatever the resolved principal actually
+ * is. These inject `resolvePrincipal` so they need no database
+ * (see `hub-tests-need-a-database`): the point under test is what
+ * `buildTokenPayload` does with a resolved principal, not how one gets
+ * resolved.
+ */
+describe("buildTokenPayload names its principal", () => {
+  test("an agent's token says it is an agent, and names the principal", async () => {
+    const payload = await buildTokenPayload({
+      user: { id: "usr-uuid" },
+      resolvePrincipal: async () => ({ id: "prn_0123456789abcdef0123", kind: "agent" }),
+      resolveTenant: async () => "fleet_00000000000000000000",
+      loadGrant: async () => ({ mayDispatch: [], mayGrantReach: false }),
+    });
+    expect(payload.principalKind).toBe("agent");
+    expect(payload.sub).toBe("prn_0123456789abcdef0123");
+  });
+
+  test("refuses to mint for a caller with no principal", async () => {
+    // Same shape as the no-tenant refusal below it: a token that verifies but
+    // names nobody is not a weaker caller, it is an unattributable one.
+    expect(
+      buildTokenPayload({ user: { id: "usr-unmapped" }, resolvePrincipal: async () => null })
+    ).rejects.toThrow(/no principal/);
+  });
+});

--- a/apps/hub/src/auth/jwt-claims.test.ts
+++ b/apps/hub/src/auth/jwt-claims.test.ts
@@ -30,3 +30,35 @@ describe("buildTokenPayload names its principal", () => {
     ).rejects.toThrow(/no principal/);
   });
 });
+
+/**
+ * A caller that already holds a principal id — e.g. a Matrix sender resolved
+ * through `principal_identities` — must never have that id re-resolved
+ * through Better Auth. `mintPrincipalAssertion` (service-signing.ts) is
+ * exactly this caller: it hands `buildTokenPayload` a `prn_…` id it already
+ * trusts, and `defaultResolvePrincipal` (keyed on a Better Auth external id)
+ * cannot answer for it — every gate approval minted this way threw before
+ * this fix.
+ */
+describe("buildTokenPayload for a caller that already holds a principal id", () => {
+  test("mints without re-resolving through Better Auth, and names the right kind", async () => {
+    const payload = await buildTokenPayload({
+      principalId: "prn_0123456789abcdef0123",
+      resolvePrincipalById: async (id) =>
+        id === "prn_0123456789abcdef0123" ? { id, kind: "agent" } : null,
+      resolveTenant: async () => "fleet_00000000000000000000",
+      loadGrant: async () => ({ mayDispatch: [], mayGrantReach: false }),
+    });
+    expect(payload.sub).toBe("prn_0123456789abcdef0123");
+    expect(payload.principalKind).toBe("agent");
+  });
+
+  test("refuses to mint for a principal id that does not exist, rather than falling back", async () => {
+    expect(
+      buildTokenPayload({
+        principalId: "prn_doesnotexist00000000",
+        resolvePrincipalById: async () => null,
+      })
+    ).rejects.toThrow(/no principal/);
+  });
+});

--- a/apps/hub/src/auth/jwt-claims.ts
+++ b/apps/hub/src/auth/jwt-claims.ts
@@ -83,9 +83,13 @@ export type BuildPayloadInput = BuildPayloadSubject & {
     principalId: string
   ) => Promise<{ mayDispatch: string[]; mayGrantReach: boolean } | null>;
   /** Injectable for the same reason. Defaults to `principalForUser`. Used only on the `user` path. */
-  resolvePrincipal?: (userId: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
+  resolvePrincipal?: (
+    userId: string
+  ) => Promise<{ id: string; kind: PrincipalKind; suspendedAt?: Date | null } | null>;
   /** Injectable for the same reason. Defaults to `principalById`. Used only on the `principalId` path. */
-  resolvePrincipalById?: (id: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
+  resolvePrincipalById?: (
+    id: string
+  ) => Promise<{ id: string; kind: PrincipalKind; suspendedAt?: Date | null } | null>;
 };
 
 /**
@@ -130,7 +134,7 @@ export type BuildPayloadInput = BuildPayloadSubject & {
  * old issuer silently authorise everything.
  */
 export async function buildTokenPayload(input: BuildPayloadInput): Promise<TokenPayload> {
-  let principal: { id: string; kind: PrincipalKind } | null;
+  let principal: { id: string; kind: PrincipalKind; suspendedAt?: Date | null } | null;
   let who: string;
 
   if (input.principalId !== undefined) {
@@ -145,6 +149,16 @@ export async function buildTokenPayload(input: BuildPayloadInput): Promise<Token
 
   if (!principal) {
     throw new Error(`refusing to mint a token for ${who}: no principal resolved`);
+  }
+
+  // Distinguishable from the no-principal refusal above on purpose: an
+  // operator debugging a refusal needs to tell "this caller maps to
+  // nobody" apart from "this caller maps to somebody who has been shut
+  // off" — the same fail-closed reasoning applies on both subject paths, a
+  // session caller included, since a session's principal being suspended
+  // makes it exactly as suspended as an agent's.
+  if (principal.suspendedAt) {
+    throw new Error(`refusing to mint a token for ${who}: principal ${principal.id} is suspended`);
   }
 
   const resolve = input.resolveTenant ?? resolveTenantForUser;

--- a/apps/hub/src/auth/jwt-claims.ts
+++ b/apps/hub/src/auth/jwt-claims.ts
@@ -15,7 +15,7 @@
 
 import { resolveTenantForUser } from "./tenant";
 import { getGrant } from "../services/grants";
-import { principalForUser } from "../services/principals";
+import { principalById, principalForUser } from "../services/principals";
 import type { PrincipalKind } from "../db/schema/organization";
 
 export type { PrincipalKind };
@@ -28,6 +28,14 @@ export type { PrincipalKind };
  */
 const defaultResolvePrincipal = principalForUser;
 
+/**
+ * The default `resolvePrincipalById`, for a caller that already holds a
+ * principal id and must not have it re-resolved through Better Auth (see
+ * `principalById`'s doc comment for why `defaultResolvePrincipal` cannot
+ * stand in for this).
+ */
+const defaultResolvePrincipalById = principalById;
+
 export interface TokenPayload extends Record<string, unknown> {
   sub: string;
   principalKind: PrincipalKind;
@@ -38,19 +46,48 @@ export interface TokenPayload extends Record<string, unknown> {
 }
 
 export interface BuildPayloadInput {
-  user: { id: string };
+  /**
+   * A caller with a Better Auth session. Resolved to a principal via
+   * `resolvePrincipal`. Mutually exclusive with `principalId` below — pass
+   * exactly one.
+   */
+  user?: { id: string };
+  /**
+   * A caller that already holds a principal id, obtained by an explicit
+   * lookup elsewhere (e.g. `principal_identities` by mxid). Trusted as-is:
+   * this id is checked to exist via `resolvePrincipalById`, never
+   * re-resolved through `resolvePrincipal`/Better Auth. This is the path
+   * `mintPrincipalAssertion` uses — its subject is never a session, and
+   * treating it as one would silently answer "no principal" for a principal
+   * that does exist.
+   */
+  principalId?: string;
   /** Injectable so the claim shape is testable without a database. */
   resolveTenant?: (userId: string) => Promise<string | null>;
   /** Injectable for the same reason. Keyed by principal id, not user id. */
   loadGrant?: (
     principalId: string
   ) => Promise<{ mayDispatch: string[]; mayGrantReach: boolean } | null>;
-  /** Injectable for the same reason. Defaults to `principalForUser`. */
+  /** Injectable for the same reason. Defaults to `principalForUser`. Used only on the `user` path. */
   resolvePrincipal?: (userId: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
+  /** Injectable for the same reason. Defaults to `principalById`. Used only on the `principalId` path. */
+  resolvePrincipalById?: (id: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
 }
 
 /**
  * Build the claims for a principal.
+ *
+ * Takes exactly one of two callers. `user: { id }` is a Better Auth session:
+ * its id is resolved to a principal via `resolvePrincipal`
+ * (`principalForUser` by default), which looks the id up as a Better Auth
+ * external id and can therefore only ever answer for a session. `principalId`
+ * is a caller that already holds a principal id from elsewhere —
+ * `mintPrincipalAssertion` asserting a Matrix sender it looked up in
+ * `principal_identities` — and that id is trusted as-is: it is checked to
+ * exist via `resolvePrincipalById` (`principalById` by default, a lookup by
+ * primary key) and used directly as `sub`, never pushed back through
+ * `resolvePrincipal` where it would read as an unmapped Better Auth id and
+ * fail closed for a principal that is very much real.
  *
  * Resolves the principal FIRST, and refuses to mint when none resolves. A
  * token that verifies but names nobody is not a weaker caller, it is an
@@ -79,22 +116,30 @@ export interface BuildPayloadInput {
  * old issuer silently authorise everything.
  */
 export async function buildTokenPayload(input: BuildPayloadInput): Promise<TokenPayload> {
-  const resolvePrincipal = input.resolvePrincipal ?? defaultResolvePrincipal;
-  const principal = await resolvePrincipal(input.user.id);
+  let principal: { id: string; kind: PrincipalKind } | null;
+  let who: string;
+
+  if (input.principalId !== undefined) {
+    who = input.principalId;
+    const resolveById = input.resolvePrincipalById ?? defaultResolvePrincipalById;
+    principal = await resolveById(input.principalId);
+  } else if (input.user) {
+    who = input.user.id;
+    const resolvePrincipal = input.resolvePrincipal ?? defaultResolvePrincipal;
+    principal = await resolvePrincipal(input.user.id);
+  } else {
+    throw new Error("buildTokenPayload requires either `user` or `principalId`");
+  }
 
   if (!principal) {
-    throw new Error(
-      `refusing to mint a token for ${input.user.id}: no principal resolved`
-    );
+    throw new Error(`refusing to mint a token for ${who}: no principal resolved`);
   }
 
   const resolve = input.resolveTenant ?? resolveTenantForUser;
-  const tenant = await resolve(input.user.id);
+  const tenant = await resolve(who);
 
   if (!tenant) {
-    throw new Error(
-      `refusing to mint a token for ${input.user.id}: no tenant resolved`
-    );
+    throw new Error(`refusing to mint a token for ${who}: no tenant resolved`);
   }
 
   const loadGrant = input.loadGrant ?? getGrant;

--- a/apps/hub/src/auth/jwt-claims.ts
+++ b/apps/hub/src/auth/jwt-claims.ts
@@ -45,23 +45,37 @@ export interface TokenPayload extends Record<string, unknown> {
   mayGrantReach: boolean;
 }
 
-export interface BuildPayloadInput {
-  /**
-   * A caller with a Better Auth session. Resolved to a principal via
-   * `resolvePrincipal`. Mutually exclusive with `principalId` below — pass
-   * exactly one.
-   */
-  user?: { id: string };
-  /**
-   * A caller that already holds a principal id, obtained by an explicit
-   * lookup elsewhere (e.g. `principal_identities` by mxid). Trusted as-is:
-   * this id is checked to exist via `resolvePrincipalById`, never
-   * re-resolved through `resolvePrincipal`/Better Auth. This is the path
-   * `mintPrincipalAssertion` uses — its subject is never a session, and
-   * treating it as one would silently answer "no principal" for a principal
-   * that does exist.
-   */
-  principalId?: string;
+/**
+ * Exactly one subject. A discriminated union rather than two optional
+ * fields: two optionals would let a caller pass both, and would need a
+ * runtime rule (and a comment) to say which wins. Making it a compile error
+ * to pass both means the ambiguity cannot exist rather than merely being
+ * documented not to.
+ */
+type BuildPayloadSubject =
+  | {
+      /**
+       * A caller with a Better Auth session. Resolved to a principal via
+       * `resolvePrincipal`.
+       */
+      user: { id: string };
+      principalId?: never;
+    }
+  | {
+      /**
+       * A caller that already holds a principal id, obtained by an explicit
+       * lookup elsewhere (e.g. `principal_identities` by mxid). Trusted
+       * as-is: this id is checked to exist via `resolvePrincipalById`,
+       * never re-resolved through `resolvePrincipal`/Better Auth. This is
+       * the path `mintPrincipalAssertion` uses — its subject is never a
+       * session, and treating it as one would silently answer "no
+       * principal" for a principal that does exist.
+       */
+      principalId: string;
+      user?: never;
+    };
+
+export type BuildPayloadInput = BuildPayloadSubject & {
   /** Injectable so the claim shape is testable without a database. */
   resolveTenant?: (userId: string) => Promise<string | null>;
   /** Injectable for the same reason. Keyed by principal id, not user id. */
@@ -72,7 +86,7 @@ export interface BuildPayloadInput {
   resolvePrincipal?: (userId: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
   /** Injectable for the same reason. Defaults to `principalById`. Used only on the `principalId` path. */
   resolvePrincipalById?: (id: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
-}
+};
 
 /**
  * Build the claims for a principal.
@@ -123,12 +137,10 @@ export async function buildTokenPayload(input: BuildPayloadInput): Promise<Token
     who = input.principalId;
     const resolveById = input.resolvePrincipalById ?? defaultResolvePrincipalById;
     principal = await resolveById(input.principalId);
-  } else if (input.user) {
+  } else {
     who = input.user.id;
     const resolvePrincipal = input.resolvePrincipal ?? defaultResolvePrincipal;
     principal = await resolvePrincipal(input.user.id);
-  } else {
-    throw new Error("buildTokenPayload requires either `user` or `principalId`");
   }
 
   if (!principal) {

--- a/apps/hub/src/auth/jwt-claims.ts
+++ b/apps/hub/src/auth/jwt-claims.ts
@@ -15,9 +15,18 @@
 
 import { resolveTenantForUser } from "./tenant";
 import { getGrant } from "../services/grants";
+import { principalForUser } from "../services/principals";
+import type { PrincipalKind } from "../db/schema/organization";
 
-/** The kinds of principal this suite has. Humans and agents are both first-class. */
-export type PrincipalKind = "human" | "agent" | "service";
+export type { PrincipalKind };
+
+/**
+ * The default `resolvePrincipal`: `principalForUser` from one joined query
+ * (`principal_identities` ⋈ `principals`), returning the id AND the kind
+ * together — a second query for kind would be two round trips answering one
+ * question.
+ */
+const defaultResolvePrincipal = principalForUser;
 
 export interface TokenPayload extends Record<string, unknown> {
   sub: string;
@@ -31,13 +40,27 @@ export interface TokenPayload extends Record<string, unknown> {
 export interface BuildPayloadInput {
   user: { id: string };
   /** Injectable so the claim shape is testable without a database. */
-  resolveTenant?: (userId: string) => Promise<string>;
-  /** Injectable for the same reason. */
-  loadGrant?: (userId: string) => Promise<{ mayDispatch: string[]; mayGrantReach: boolean } | null>;
+  resolveTenant?: (userId: string) => Promise<string | null>;
+  /** Injectable for the same reason. Keyed by principal id, not user id. */
+  loadGrant?: (
+    principalId: string
+  ) => Promise<{ mayDispatch: string[]; mayGrantReach: boolean } | null>;
+  /** Injectable for the same reason. Defaults to `principalForUser`. */
+  resolvePrincipal?: (userId: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
 }
 
 /**
  * Build the claims for a principal.
+ *
+ * Resolves the principal FIRST, and refuses to mint when none resolves. A
+ * token that verifies but names nobody is not a weaker caller, it is an
+ * unattributable one — the same reasoning as the no-tenant refusal below, and
+ * it applies before the tenant lookup because a claim naming no one has
+ * nothing to attach a tenant to.
+ *
+ * `sub` and `principalKind` come from the resolved principal, not from the
+ * caller passed in — an agent's token says it is an agent because the
+ * principal it maps to is one, not because of a separate exchange path.
  *
  * Throws when no tenant resolves, rather than falling back to a default
  * boundary. A token that verifies but names no tenant is not a weaker caller,
@@ -56,6 +79,15 @@ export interface BuildPayloadInput {
  * old issuer silently authorise everything.
  */
 export async function buildTokenPayload(input: BuildPayloadInput): Promise<TokenPayload> {
+  const resolvePrincipal = input.resolvePrincipal ?? defaultResolvePrincipal;
+  const principal = await resolvePrincipal(input.user.id);
+
+  if (!principal) {
+    throw new Error(
+      `refusing to mint a token for ${input.user.id}: no principal resolved`
+    );
+  }
+
   const resolve = input.resolveTenant ?? resolveTenantForUser;
   const tenant = await resolve(input.user.id);
 
@@ -66,14 +98,11 @@ export async function buildTokenPayload(input: BuildPayloadInput): Promise<Token
   }
 
   const loadGrant = input.loadGrant ?? getGrant;
-  const grant = await loadGrant(input.user.id);
+  const grant = await loadGrant(principal.id);
 
   return {
-    sub: input.user.id,
-    // Every principal the hub can issue a token for today is a human with a
-    // session. An agent gets one by exchanging its own credential, which is a
-    // separate path and will set this to "agent".
-    principalKind: "human",
+    sub: principal.id,
+    principalKind: principal.kind,
     tenant,
     mayDispatch: grant?.mayDispatch ?? [],
     mayGrantReach: grant?.mayGrantReach ?? false,

--- a/apps/hub/src/auth/service-signing.test.ts
+++ b/apps/hub/src/auth/service-signing.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Service Test: service-signing (minting an assertion for a principal)
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ * DATABASE_URL must be set before any src/ modules are imported.
+ *
+ * This exercises `mintPrincipalAssertion` itself, not a copy of its logic —
+ * `jwt-claims.test.ts`'s injected-resolver tests prove `buildTokenPayload`
+ * handles a `principalId` correctly, but nothing there would notice if
+ * `service-signing.ts` stopped calling it that way. It did, once: it called
+ * `buildTokenPayload({ user: { id: input.principalId } })`, which pushed a
+ * `prn_…` id through the Better-Auth-session resolver and threw for every
+ * principal that had no session — which was every gate approval minted from
+ * a phone. This test fails the same way if that line ever comes back.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import { decodeJwt } from "jose";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { createPrincipal } from "../services/principals";
+import { mintPrincipalAssertion } from "./service-signing";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
+
+describe("mintPrincipalAssertion", () => {
+  test("asserts the principal it was handed, without a Better Auth session to fall back to", async () => {
+    // Deliberately no `userId`: this principal has no `principal_identities`
+    // row for Better Auth to find. If `mintPrincipalAssertion` ever again
+    // hands `buildTokenPayload` a `user: { id }` shaped input, resolving this
+    // id as a session subject finds nothing and throws — there is no other
+    // way for this principal to end up in a minted token.
+    const principalId = await createPrincipal({ kind: "agent", handle: "assertion-target" });
+
+    const token = await mintPrincipalAssertion({ principalId });
+    const claims = decodeJwt(token);
+
+    expect(claims.sub).toBe(principalId);
+    expect(claims.principalKind).toBe("agent");
+  });
+});

--- a/apps/hub/src/auth/service-signing.test.ts
+++ b/apps/hub/src/auth/service-signing.test.ts
@@ -21,11 +21,12 @@ process.env.DATABASE_URL =
 process.env.NODE_ENV = "test";
 
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { decodeJwt } from "jose";
+import { decodeJwt, decodeProtectedHeader } from "jose";
+import { config } from "../config";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
 import { rawSql } from "../db/drizzle";
 import { createPrincipal } from "../services/principals";
-import { mintPrincipalAssertion } from "./service-signing";
+import { BRIDGE_ACTOR, mintPrincipalAssertion, servicePublicJwks } from "./service-signing";
 
 // Fixed handle, cleaned up on both ends: running this suite twice against the
 // same database (no reset between runs, unlike CI) must not hit
@@ -54,8 +55,43 @@ describe("mintPrincipalAssertion", () => {
 
     const token = await mintPrincipalAssertion({ principalId });
     const claims = decodeJwt(token);
+    const header = decodeProtectedHeader(token);
 
     expect(claims.sub).toBe(principalId);
     expect(claims.principalKind).toBe("agent");
+
+    // The claim this whole module exists for: WHO minted it is recorded
+    // distinctly from WHO it is minted for. Asserting only sub/principalKind
+    // (as this test used to) stays green even if `act` is deleted entirely —
+    // that would silently make an assertion indistinguishable from the
+    // principal's own token, exactly the impersonation-without-a-trace this
+    // module's own doc comment says must not be possible.
+    expect(claims.act).toEqual({ sub: BRIDGE_ACTOR });
+
+    // iss/aud: this hub, both ends — a consumer verifies against a specific
+    // issuer/audience pair, and a drift here is a token nothing accepts.
+    expect(claims.iss).toBe(config.publicUrl);
+    expect(claims.aud).toBe(config.publicUrl);
+
+    // alg/kid: EdDSA, matching Better Auth's own jwt plugin and what
+    // kaambaan pins — a different algorithm here is a token no consumer's
+    // pinned verifier would even attempt.
+    expect(header.alg).toBe("EdDSA");
+    expect(header.kid).toBeTruthy();
+
+    // The kid must be one this hub actually publishes — otherwise a
+    // consumer's offline verification (the entire point of a separate
+    // service key) fails for a token that was, in fact, validly signed.
+    const published = await servicePublicJwks();
+    expect(published.some((k) => k.kid === header.kid)).toBe(true);
+
+    // TTL is what it claims to be: ~120s, not the 5-minute session TTL and
+    // not unbounded. A wide tolerance (not exact-equality) because iat/exp
+    // are wall-clock seconds and the assertion cost real time to mint.
+    expect(typeof claims.iat).toBe("number");
+    expect(typeof claims.exp).toBe("number");
+    const ttlSeconds = (claims.exp as number) - (claims.iat as number);
+    expect(ttlSeconds).toBeGreaterThan(100);
+    expect(ttlSeconds).toBeLessThanOrEqual(120);
   });
 });

--- a/apps/hub/src/auth/service-signing.test.ts
+++ b/apps/hub/src/auth/service-signing.test.ts
@@ -20,14 +20,27 @@ process.env.DATABASE_URL =
   "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
 process.env.NODE_ENV = "test";
 
-import { describe, expect, test, beforeAll } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { decodeJwt } from "jose";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { rawSql } from "../db/drizzle";
 import { createPrincipal } from "../services/principals";
 import { mintPrincipalAssertion } from "./service-signing";
 
+// Fixed handle, cleaned up on both ends: running this suite twice against the
+// same database (no reset between runs, unlike CI) must not hit
+// "principals_org_handle_idx" on the second pass.
 beforeAll(async () => {
   await ensurePgMigrations();
+  await rawSql`DELETE FROM principals WHERE handle = 'assertion-target'`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM principals WHERE handle = 'assertion-target'`;
+  } catch {
+    // cleanup only
+  }
 });
 
 describe("mintPrincipalAssertion", () => {

--- a/apps/hub/src/auth/service-signing.ts
+++ b/apps/hub/src/auth/service-signing.ts
@@ -37,7 +37,7 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import { config } from "../config";
 import { db } from "../db/drizzle";
 import { serviceSigningKeys } from "../db/schema/service-keys";
-import { buildTokenPayload } from "./jwt-claims";
+import { buildTokenPayload, type TokenPayload } from "./jwt-claims";
 import { createLogger } from "../utils/logger";
 
 const log = createLogger("service-signing");
@@ -109,6 +109,45 @@ export async function servicePublicJwks(): Promise<JWK[]> {
   return rows.map((r) => JSON.parse(r.publicJwk) as JWK);
 }
 
+export interface SignServiceTokenInput {
+  /**
+   * Already-built claims. Never assembled here — the one thing every caller
+   * of this function must share is that `buildTokenPayload` produced them,
+   * so nobody can carry authority its grant does not give.
+   */
+  payload: TokenPayload;
+  /** Becomes `sub`. Kept apart from `payload` so a caller cannot forget it. */
+  subject: string;
+  /** A `jose` duration string, e.g. `"120s"` or the shared `TOKEN_TTL`. */
+  ttl: string;
+  /** Merged on top of `payload` in the signed body — e.g. an `act` claim. */
+  extraClaims?: Record<string, unknown>;
+}
+
+/**
+ * Sign a set of claims with this hub's service signing key.
+ *
+ * Pulled out of `mintPrincipalAssertion` so a second caller — the
+ * station-token exchange (`routes/station-token.ts`), which mints an agent's
+ * OWN token rather than an assertion of an absent human — shares the same key
+ * management (`activeKey`, its lazy creation, `servicePublicJwks`) instead of
+ * re-deriving it. The two callers differ only in TTL and in whether
+ * `extraClaims` adds an `act`.
+ */
+export async function signServiceToken(input: SignServiceTokenInput): Promise<string> {
+  const key = await activeKey();
+  const privateKey = await importJWK(key.privateJwk, ALG);
+
+  return new SignJWT({ ...input.payload, ...(input.extraClaims ?? {}) })
+    .setProtectedHeader({ alg: ALG, kid: key.kid })
+    .setSubject(input.subject)
+    .setIssuedAt()
+    .setIssuer(config.publicUrl)
+    .setAudience(config.publicUrl)
+    .setExpirationTime(input.ttl)
+    .sign(privateKey);
+}
+
 export interface AssertionInput {
   /**
    * The principal being asserted.
@@ -133,18 +172,10 @@ export interface AssertionInput {
  */
 export async function mintPrincipalAssertion(input: AssertionInput): Promise<string> {
   const payload = await buildTokenPayload({ principalId: input.principalId });
-  const key = await activeKey();
-  const privateKey = await importJWK(key.privateJwk, ALG);
-
-  return new SignJWT({
-    ...payload,
-    act: { sub: input.actor ?? BRIDGE_ACTOR },
-  })
-    .setProtectedHeader({ alg: ALG, kid: key.kid })
-    .setSubject(input.principalId)
-    .setIssuedAt()
-    .setIssuer(config.publicUrl)
-    .setAudience(config.publicUrl)
-    .setExpirationTime(ASSERTION_TTL)
-    .sign(privateKey);
+  return signServiceToken({
+    payload,
+    subject: input.principalId,
+    ttl: ASSERTION_TTL,
+    extraClaims: { act: { sub: input.actor ?? BRIDGE_ACTOR } },
+  });
 }

--- a/apps/hub/src/auth/service-signing.ts
+++ b/apps/hub/src/auth/service-signing.ts
@@ -132,7 +132,7 @@ export interface AssertionInput {
  * token would not.
  */
 export async function mintPrincipalAssertion(input: AssertionInput): Promise<string> {
-  const payload = await buildTokenPayload({ user: { id: input.principalId } });
+  const payload = await buildTokenPayload({ principalId: input.principalId });
   const key = await activeKey();
   const privateKey = await importJWK(key.privateJwk, ALG);
 

--- a/apps/hub/src/auth/service-signing.ts
+++ b/apps/hub/src/auth/service-signing.ts
@@ -109,6 +109,18 @@ export async function servicePublicJwks(): Promise<JWK[]> {
   return rows.map((r) => JSON.parse(r.publicJwk) as JWK);
 }
 
+/**
+ * The only claim `signServiceToken`'s caller may add on top of a built
+ * payload. Narrowed to this one shape — not `Record<string, unknown>` — so
+ * that overwriting `principalKind`, `tenant`, `mayDispatch` or
+ * `mayGrantReach` is a compile error, not a convention a caller has to
+ * remember. RFC 8693's actor claim: who minted this token, distinct from
+ * `sub`, who it is minted for.
+ */
+export interface ActClaim {
+  act: { sub: string };
+}
+
 export interface SignServiceTokenInput {
   /**
    * Already-built claims. Never assembled here — the one thing every caller
@@ -120,8 +132,12 @@ export interface SignServiceTokenInput {
   subject: string;
   /** A `jose` duration string, e.g. `"120s"` or the shared `TOKEN_TTL`. */
   ttl: string;
-  /** Merged on top of `payload` in the signed body — e.g. an `act` claim. */
-  extraClaims?: Record<string, unknown>;
+  /**
+   * Adds `act` to the signed body — nothing else, and by type rather than by
+   * discipline: `payload` is spread LAST below, so even a widened caller in
+   * future could not make this override a built claim, only add to it.
+   */
+  extraClaims?: ActClaim;
 }
 
 /**
@@ -131,14 +147,16 @@ export interface SignServiceTokenInput {
  * station-token exchange (`routes/station-token.ts`), which mints an agent's
  * OWN token rather than an assertion of an absent human — shares the same key
  * management (`activeKey`, its lazy creation, `servicePublicJwks`) instead of
- * re-deriving it. The two callers differ only in TTL and in whether
- * `extraClaims` adds an `act`.
+ * re-deriving it. The two callers differ only in TTL and in `act.sub`.
  */
 export async function signServiceToken(input: SignServiceTokenInput): Promise<string> {
   const key = await activeKey();
   const privateKey = await importJWK(key.privateJwk, ALG);
 
-  return new SignJWT({ ...input.payload, ...(input.extraClaims ?? {}) })
+  // `payload` spread LAST: `extraClaims` can only ever add `act`, by type —
+  // this ordering means even a mistaken future widening of `ActClaim` could
+  // not let an extra claim overwrite a built one, only merge under it.
+  return new SignJWT({ ...(input.extraClaims ?? {}), ...input.payload })
     .setProtectedHeader({ alg: ALG, kid: key.kid })
     .setSubject(input.subject)
     .setIssuedAt()

--- a/apps/hub/src/db/drizzle-migrations/0055_spotty_namor.sql
+++ b/apps/hub/src/db/drizzle-migrations/0055_spotty_namor.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "organizations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "organizations_id_is_org" CHECK ("organizations"."id" LIKE 'org\_%')
+);
+--> statement-breakpoint
+CREATE TABLE "principals" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kind" text NOT NULL,
+	"org_id" text NOT NULL,
+	"handle" text NOT NULL,
+	"display_name" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "principals_id_is_prn" CHECK ("principals"."id" LIKE 'prn\_%'),
+	CONSTRAINT "principals_kind_known" CHECK ("principals"."kind" IN ('human','agent','service'))
+);
+--> statement-breakpoint
+ALTER TABLE "principals" ADD CONSTRAINT "principals_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "principals_org_handle_idx" ON "principals" USING btree ("org_id","handle");--> statement-breakpoint
+
+INSERT INTO organizations (id, name) VALUES ('org_00000000000000000000', 'Super Jackfruit Labs')
+  ON CONFLICT (id) DO NOTHING;
+
+UPDATE tenants
+   SET external_id = 'org_00000000000000000000', external_source = 'org-plane'
+ WHERE id = 'fleet_00000000000000000000' AND external_id IS NULL;

--- a/apps/hub/src/db/drizzle-migrations/0056_left_darwin.sql
+++ b/apps/hub/src/db/drizzle-migrations/0056_left_darwin.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "principal_identities" DROP CONSTRAINT "principal_identities_system_known";--> statement-breakpoint
+ALTER TABLE "principal_identities" DROP CONSTRAINT "principal_identities_principal_id_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "principal_grants" DROP CONSTRAINT "principal_grants_principal_id_user_id_fk";
+--> statement-breakpoint
+-- One row today. Mint a principal for each existing user and carry the
+-- identities and grants that pointed at it. Runs after the old FKs (into
+-- "user") and the old system-list check are dropped, and before the new FKs
+-- (into "principals") are added — those validate existing rows on add, so
+-- principal_id must already hold prn_ ids by the time they land.
+INSERT INTO principals (id, kind, org_id, handle, display_name)
+SELECT 'prn_' || substr(replace(gen_random_uuid()::text, '-', ''), 1, 20),
+       'human', 'org_00000000000000000000',
+       lower(regexp_replace(split_part(u.email, '@', 1), '[^a-z0-9._=/-]', '-', 'g')),
+       u.name
+  FROM "user" u;
+--> statement-breakpoint
+
+INSERT INTO principal_identities (id, principal_id, system, external_id)
+SELECT gen_random_uuid()::text, p.id, 'better-auth', u.id
+  FROM "user" u
+  JOIN principals p ON p.handle = lower(regexp_replace(split_part(u.email, '@', 1), '[^a-z0-9._=/-]', '-', 'g'));
+--> statement-breakpoint
+
+UPDATE principal_identities pi SET principal_id = p.id
+  FROM principal_identities bi JOIN principals p ON p.id = bi.principal_id
+ WHERE bi.system = 'better-auth' AND pi.principal_id = bi.external_id;
+--> statement-breakpoint
+
+UPDATE principal_grants g SET principal_id = p.id
+  FROM principal_identities bi JOIN principals p ON p.id = bi.principal_id
+ WHERE bi.system = 'better-auth' AND g.principal_id = bi.external_id;
+--> statement-breakpoint
+ALTER TABLE "principal_identities" ADD CONSTRAINT "principal_identities_principal_id_principals_id_fk" FOREIGN KEY ("principal_id") REFERENCES "public"."principals"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "principal_grants" ADD CONSTRAINT "principal_grants_principal_id_principals_id_fk" FOREIGN KEY ("principal_id") REFERENCES "public"."principals"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "principal_identities" ADD CONSTRAINT "principal_identities_system_known" CHECK ("principal_identities"."system" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane'));

--- a/apps/hub/src/db/drizzle-migrations/0056_left_darwin.sql
+++ b/apps/hub/src/db/drizzle-migrations/0056_left_darwin.sql
@@ -1,7 +1,7 @@
 ALTER TABLE "principal_identities" DROP CONSTRAINT "principal_identities_system_known";--> statement-breakpoint
-ALTER TABLE "principal_identities" DROP CONSTRAINT "principal_identities_principal_id_user_id_fk";
+ALTER TABLE "principal_identities" DROP CONSTRAINT "principal_identities_principal_id_fkey";
 --> statement-breakpoint
-ALTER TABLE "principal_grants" DROP CONSTRAINT "principal_grants_principal_id_user_id_fk";
+ALTER TABLE "principal_grants" DROP CONSTRAINT "principal_grants_principal_id_fkey";
 --> statement-breakpoint
 -- One row today. Mint a principal for each existing user and carry the
 -- identities and grants that pointed at it. Runs after the old FKs (into

--- a/apps/hub/src/db/drizzle-migrations/0057_motionless_professor_monster.sql
+++ b/apps/hub/src/db/drizzle-migrations/0057_motionless_professor_monster.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "stations" ADD COLUMN "principal_id" text;--> statement-breakpoint
+ALTER TABLE "stations" ADD CONSTRAINT "stations_principal_id_principals_id_fk" FOREIGN KEY ("principal_id") REFERENCES "public"."principals"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/hub/src/db/drizzle-migrations/0058_matrix_rooms_principal_id.sql
+++ b/apps/hub/src/db/drizzle-migrations/0058_matrix_rooms_principal_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "matrix_rooms" ADD COLUMN "principal_id" text;--> statement-breakpoint
+ALTER TABLE "matrix_rooms" ADD CONSTRAINT "matrix_rooms_principal_id_principals_id_fk" FOREIGN KEY ("principal_id") REFERENCES "public"."principals"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "matrix_rooms_principal_idx" ON "matrix_rooms" USING btree ("principal_id");

--- a/apps/hub/src/db/drizzle-migrations/0059_abandoned_frog_thor.sql
+++ b/apps/hub/src/db/drizzle-migrations/0059_abandoned_frog_thor.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "principals" ADD COLUMN "suspended_at" timestamp;

--- a/apps/hub/src/db/drizzle-migrations/0060-backfill-collision.test.ts
+++ b/apps/hub/src/db/drizzle-migrations/0060-backfill-collision.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Migration 0060's backfill, proved against the exact case it was
+ * hardened for — fix round on Task 5.
+ *
+ * The review's finding C: `0060_matrix_rooms_backfill_principal_id.sql`
+ * raises `23505` and fails the deploy if one principal ever holds two
+ * stations at the moment it runs, because its `UPDATE` would then try to
+ * write that principal onto two different `matrix_rooms` rows, and
+ * `matrix_rooms_principal_idx` refuses a repeat. Occupancy is exclusive as
+ * of this same fix round (`stations_principal_id_idx`), but that
+ * constraint's own migration (`0061`) runs AFTER this one — a fresh
+ * database applying every migration in order still reaches 0060 before
+ * anything has ever ruled the collision out. This is what makes 0060 safe
+ * on its own terms rather than hopeful about migration order.
+ *
+ * Run against temporary tables shaped like the real ones, not the real
+ * `stations` and `matrix_rooms` — the real `stations` table, on this very
+ * database, now REFUSES the collision this test needs to create
+ * (`stations_principal_id_idx`). Reproducing it requires a schema that
+ * predates that constraint, which is exactly what the migration itself had
+ * to survive.
+ */
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
+import { rawSql } from "../drizzle";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
+
+describe("migration 0060's backfill, against data where a principal would otherwise collide", () => {
+  test("skips a principal occupying more than one station instead of raising 23505, and still backfills a clean one", async () => {
+    const raw = readFileSync(join(__dirname, "0060_matrix_rooms_backfill_principal_id.sql"), "utf8");
+    // The one real statement in the file — everything else is comment —
+    // adapted onto temp tables so this exercises the migration's own SQL,
+    // not a hand-copied duplicate that could quietly drift from it.
+    const statement = raw
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("--"))
+      .join("\n")
+      .replace(/"matrix_rooms"/g, '"tmp_rooms"')
+      .replace(/"stations"/g, '"tmp_stations"')
+      .trim();
+    expect(statement.length, "the migration file's one real statement must still be there to adapt").toBeGreaterThan(0);
+
+    await rawSql.begin(async (tx) => {
+      // ON COMMIT DROP: cleaned up the instant this transaction ends,
+      // regardless of which pooled connection happens to run the next test.
+      await tx`CREATE TEMP TABLE tmp_stations (id text PRIMARY KEY, principal_id text) ON COMMIT DROP`;
+      await tx`CREATE TEMP TABLE tmp_rooms (room_id text PRIMARY KEY, station_id text, principal_id text) ON COMMIT DROP`;
+
+      await tx`
+        INSERT INTO tmp_stations (id, principal_id) VALUES
+          ('st_collide_1', 'prn_shared_collision'),
+          ('st_collide_2', 'prn_shared_collision'),
+          ('st_clean', 'prn_solo_occupant')
+      `;
+      await tx`
+        INSERT INTO tmp_rooms (room_id, station_id, principal_id) VALUES
+          ('!r-collide-1', 'st_collide_1', NULL),
+          ('!r-collide-2', 'st_collide_2', NULL),
+          ('!r-clean', 'st_clean', NULL)
+      `;
+
+      // The migration's own statement. Must not throw — against the real
+      // schema before this fix round, this exact shape of data would raise
+      // 23505 here.
+      await tx.unsafe(statement);
+
+      const rows = await tx`SELECT room_id, principal_id FROM tmp_rooms ORDER BY room_id`;
+      const byId = new Map(rows.map((r) => [r.room_id as string, r.principal_id as string | null]));
+
+      expect(byId.get("!r-collide-1"), "a colliding principal's rooms are left alone, not half-backfilled").toBeNull();
+      expect(byId.get("!r-collide-2")).toBeNull();
+      expect(byId.get("!r-clean"), "a principal with no collision is still backfilled").toBe("prn_solo_occupant");
+    });
+  });
+});

--- a/apps/hub/src/db/drizzle-migrations/0060_matrix_rooms_backfill_principal_id.sql
+++ b/apps/hub/src/db/drizzle-migrations/0060_matrix_rooms_backfill_principal_id.sql
@@ -8,13 +8,33 @@
 -- occupant already made it in practice — that occupant IS who the room has
 -- been speaking as all along, this simply makes the column agree.
 --
--- `WHERE r.principal_id IS NULL` makes this safe to run more than once, and
--- the column's own unique index (`matrix_rooms_principal_idx`) is what would
--- catch two rooms ever claiming the same principal — a state this backfill
--- does not expect to find, and does not need to guard against by hand.
+-- `WHERE r.principal_id IS NULL` makes this safe to run more than once.
+--
+-- Fix-round correction: the column's own unique index
+-- (`matrix_rooms_principal_idx`) does not merely "catch" two rooms ever
+-- claiming the same principal — it makes this UPDATE raise 23505 and fail
+-- the deploy outright, on a database where that had never been prevented.
+-- Occupancy is exclusive as of this fix round
+-- (`stations_principal_id_idx`), but that constraint's own migration runs
+-- AFTER this one in sequence, so it cannot be relied on to have already
+-- ruled this out on every database this runs against. The
+-- `NOT IN (SELECT ... GROUP BY ... HAVING COUNT(*) > 1)` clause below is
+-- this migration's own defence: a principal occupying more than one station
+-- at the moment this runs is skipped rather than backfilled, so the
+-- migration finishes instead of failing partway through leaving some rooms
+-- backfilled and others not. A skipped room is not silently wrong — its
+-- `principal_id` simply stays null until the operator resolves the
+-- double-occupancy and the write path (`routes/agents-admin.ts`, now the
+-- exclusive one) binds it going forward.
 UPDATE "matrix_rooms" AS r
 SET "principal_id" = s."principal_id"
 FROM "stations" AS s
 WHERE s."id" = r."station_id"
   AND s."principal_id" IS NOT NULL
-  AND r."principal_id" IS NULL;
+  AND r."principal_id" IS NULL
+  AND s."principal_id" NOT IN (
+    SELECT "principal_id" FROM "stations"
+    WHERE "principal_id" IS NOT NULL
+    GROUP BY "principal_id"
+    HAVING COUNT(*) > 1
+  );

--- a/apps/hub/src/db/drizzle-migrations/0060_matrix_rooms_backfill_principal_id.sql
+++ b/apps/hub/src/db/drizzle-migrations/0060_matrix_rooms_backfill_principal_id.sql
@@ -1,0 +1,20 @@
+-- Custom SQL migration file, put your code below! --
+
+-- `matrix_rooms.principal_id` gains its first writer alongside this
+-- migration — `routes/agents-admin.ts`'s assign endpoint binds it the first
+-- time a station's own room finds an occupant with no room of its own yet.
+-- This is the one-time half of that: every room that already exists, from
+-- before there was a writer, is exactly as "bound" as its station's current
+-- occupant already made it in practice — that occupant IS who the room has
+-- been speaking as all along, this simply makes the column agree.
+--
+-- `WHERE r.principal_id IS NULL` makes this safe to run more than once, and
+-- the column's own unique index (`matrix_rooms_principal_idx`) is what would
+-- catch two rooms ever claiming the same principal — a state this backfill
+-- does not expect to find, and does not need to guard against by hand.
+UPDATE "matrix_rooms" AS r
+SET "principal_id" = s."principal_id"
+FROM "stations" AS s
+WHERE s."id" = r."station_id"
+  AND s."principal_id" IS NOT NULL
+  AND r."principal_id" IS NULL;

--- a/apps/hub/src/db/drizzle-migrations/0061-occupancy-exclusive-collision.test.ts
+++ b/apps/hub/src/db/drizzle-migrations/0061-occupancy-exclusive-collision.test.ts
@@ -38,17 +38,26 @@ beforeAll(async () => {
 describe("migration 0061's dedupe, against data that would otherwise collide", () => {
   test("keeps the most recently adopted station for a colliding principal, clears the rest, and the unique index then creates cleanly", async () => {
     const raw = readFileSync(join(__dirname, "0061_occupancy_exclusive.sql"), "utf8");
-    // The dedupe UPDATE is the file's first statement — everything after the
-    // first `--> statement-breakpoint` is the schema change this proves is
-    // now safe to run, not what this test exercises directly.
-    const dedupeStatement = raw
-      .split("--> statement-breakpoint")[0]!
-      .split("\n")
-      .filter((line) => !line.trim().startsWith("--"))
-      .join("\n")
-      .replace(/"stations"/g, '"tmp_stations_0061"')
-      .trim();
-    expect(dedupeStatement.length, "the migration file's dedupe statement must still be there to adapt").toBeGreaterThan(0);
+    // Selected by CONTENT, not position — fix round 3 (Minor): the earlier
+    // version took `split("--> statement-breakpoint")[0]`, which is the
+    // dedupe UPDATE today only because it happens to come first in the
+    // file. If the statements were ever reordered, that slice would
+    // silently become a different one — a `DROP INDEX` for the real
+    // `matrix_rooms` table, since only `"stations"` is renamed away below,
+    // executed via `tx.unsafe()` inside a transaction this test COMMITS.
+    // Finding the statement whose own SQL starts `UPDATE "stations"` is
+    // immune to the file's statements ever being reordered.
+    const statements = raw.split("--> statement-breakpoint").map((stmt) =>
+      stmt
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("--"))
+        .join("\n")
+        .trim()
+    );
+    const dedupeStatement = statements
+      .find((stmt) => stmt.toUpperCase().startsWith('UPDATE "STATIONS"'))
+      ?.replace(/"stations"/g, '"tmp_stations_0061"');
+    expect(dedupeStatement, "the migration file's dedupe UPDATE must still be there to adapt").toBeTruthy();
 
     await rawSql.begin(async (tx) => {
       // ON COMMIT DROP: cleaned up the instant this transaction ends,
@@ -69,7 +78,7 @@ describe("migration 0061's dedupe, against data that would otherwise collide", (
       // Must not throw — against the real schema at this point in the
       // migration sequence, this exact shape of data would raise 23505 on
       // the very next statement without it.
-      await tx.unsafe(dedupeStatement);
+      await tx.unsafe(dedupeStatement!);
 
       const rows = await tx`SELECT id, principal_id FROM tmp_stations_0061 ORDER BY id`;
       const byId = new Map(rows.map((r) => [r.id as string, r.principal_id as string | null]));

--- a/apps/hub/src/db/drizzle-migrations/0061-occupancy-exclusive-collision.test.ts
+++ b/apps/hub/src/db/drizzle-migrations/0061-occupancy-exclusive-collision.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Migration 0061's dedupe, proved against the exact case it exists for —
+ * fix round 2 on Task 5.
+ *
+ * `stations_principal_id_idx` enforces "occupancy is exclusive" going
+ * forward, but creating a unique index against data that already violates
+ * it raises `23505` and kills the deploy — the review's finding: skipping
+ * the collision in `0060`'s backfill (an earlier migration) without also
+ * deduping it here just relocates that same failure one migration later.
+ * This is what proves the relocation was actually closed, not moved again.
+ *
+ * Same pattern as `0060-backfill-collision.test.ts`, which the review
+ * confirmed worked: read the migration's own SQL and adapt it onto a temp
+ * table, because the real `stations` table — once this migration has run on
+ * this very database — now enforces the constraint that makes the collision
+ * this needs to create impossible to insert directly.
+ */
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
+import { rawSql } from "../drizzle";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
+
+describe("migration 0061's dedupe, against data that would otherwise collide", () => {
+  test("keeps the most recently adopted station for a colliding principal, clears the rest, and the unique index then creates cleanly", async () => {
+    const raw = readFileSync(join(__dirname, "0061_occupancy_exclusive.sql"), "utf8");
+    // The dedupe UPDATE is the file's first statement — everything after the
+    // first `--> statement-breakpoint` is the schema change this proves is
+    // now safe to run, not what this test exercises directly.
+    const dedupeStatement = raw
+      .split("--> statement-breakpoint")[0]!
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("--"))
+      .join("\n")
+      .replace(/"stations"/g, '"tmp_stations_0061"')
+      .trim();
+    expect(dedupeStatement.length, "the migration file's dedupe statement must still be there to adapt").toBeGreaterThan(0);
+
+    await rawSql.begin(async (tx) => {
+      // ON COMMIT DROP: cleaned up the instant this transaction ends,
+      // regardless of which pooled connection runs the next test.
+      await tx`
+        CREATE TEMP TABLE tmp_stations_0061 (id text PRIMARY KEY, principal_id text, adopted_at timestamp)
+        ON COMMIT DROP
+      `;
+
+      await tx`
+        INSERT INTO tmp_stations_0061 (id, principal_id, adopted_at) VALUES
+          ('st_old', 'prn_collide', '2026-01-01T00:00:00Z'),
+          ('st_new', 'prn_collide', '2026-06-01T00:00:00Z'),
+          ('st_solo', 'prn_solo', '2026-01-01T00:00:00Z')
+      `;
+
+      // The migration's own statement, verbatim apart from the table name.
+      // Must not throw — against the real schema at this point in the
+      // migration sequence, this exact shape of data would raise 23505 on
+      // the very next statement without it.
+      await tx.unsafe(dedupeStatement);
+
+      const rows = await tx`SELECT id, principal_id FROM tmp_stations_0061 ORDER BY id`;
+      const byId = new Map(rows.map((r) => [r.id as string, r.principal_id as string | null]));
+
+      expect(byId.get("st_old"), "the older adoption is cleared").toBeNull();
+      expect(byId.get("st_new"), "the more recently adopted station keeps the principal").toBe("prn_collide");
+      expect(byId.get("st_solo"), "a principal with no collision is untouched").toBe("prn_solo");
+
+      // Prove the post-dedupe data actually satisfies the constraint the
+      // real migration creates next — not merely that the UPDATE ran
+      // without throwing.
+      await tx`
+        CREATE UNIQUE INDEX tmp_stations_0061_principal_idx
+        ON tmp_stations_0061 (principal_id) WHERE principal_id IS NOT NULL
+      `;
+    });
+  });
+});

--- a/apps/hub/src/db/drizzle-migrations/0061_occupancy_exclusive.sql
+++ b/apps/hub/src/db/drizzle-migrations/0061_occupancy_exclusive.sql
@@ -1,0 +1,3 @@
+DROP INDEX "matrix_rooms_station_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "stations_principal_id_idx" ON "stations" USING btree ("principal_id") WHERE "stations"."principal_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "matrix_rooms_station_idx" ON "matrix_rooms" USING btree ("station_id");

--- a/apps/hub/src/db/drizzle-migrations/0061_occupancy_exclusive.sql
+++ b/apps/hub/src/db/drizzle-migrations/0061_occupancy_exclusive.sql
@@ -1,3 +1,25 @@
+-- Fix round 2 on Task 5. The unique index below enforces "occupancy is
+-- exclusive" going forward, but creating it against data that already
+-- violates it raises 23505 and kills the deploy — exactly the failure
+-- `0060`'s own backfill was hardened to skip past, one migration earlier.
+-- Skipping there without deduping here just relocates the failure rather
+-- than removing it.
+--
+-- Deterministic, not "first row Postgres happens to return": for any
+-- principal already on more than one station, the station it adopted MOST
+-- RECENTLY keeps it, and every other one is cleared. `id DESC` breaks a tie
+-- on identical `adopted_at` timestamps (two stations adopted in the same
+-- transaction, mainly) so this is reproducible rather than order-dependent.
+UPDATE "stations" AS s
+SET "principal_id" = NULL
+WHERE s."principal_id" IS NOT NULL
+  AND s."id" <> (
+    SELECT s2."id" FROM "stations" AS s2
+    WHERE s2."principal_id" = s."principal_id"
+    ORDER BY s2."adopted_at" DESC, s2."id" DESC
+    LIMIT 1
+  );
+--> statement-breakpoint
 DROP INDEX "matrix_rooms_station_idx";--> statement-breakpoint
 CREATE UNIQUE INDEX "stations_principal_id_idx" ON "stations" USING btree ("principal_id") WHERE "stations"."principal_id" IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "matrix_rooms_station_idx" ON "matrix_rooms" USING btree ("station_id");

--- a/apps/hub/src/db/drizzle-migrations/0062-rebackfill-after-dedupe.test.ts
+++ b/apps/hub/src/db/drizzle-migrations/0062-rebackfill-after-dedupe.test.ts
@@ -21,6 +21,13 @@
  *  - **The behaviour**, on the real tables, because "the column got
  *    written" is not the thing that matters — `gates.ts`'s `roomAgentUser`
  *    answering again is.
+ *
+ * **Whole-branch review.** `0062` used to DECLINE for a station carrying two
+ * unbound rooms, while the live writer picked one arbitrarily — same data,
+ * opposite policy. The rule is now decided in one place (oldest
+ * `created_at`, tie-broken by `room_id`; see `station-room.ts`'s
+ * `unboundRoomsForStation`) and this file proves `0062` applies it,
+ * including the tie-break, while both of its 23505 guards still hold.
  */
 
 process.env.DATABASE_URL =
@@ -121,7 +128,7 @@ describe("migration 0062 re-runs the backfill 0061's dedupe left half-done", () 
         ON COMMIT DROP
       `;
       await tx`
-        CREATE TEMP TABLE tmp_rooms_0062 (room_id text PRIMARY KEY, station_id text, principal_id text)
+        CREATE TEMP TABLE tmp_rooms_0062 (room_id text PRIMARY KEY, station_id text, principal_id text, created_at timestamp)
         ON COMMIT DROP
       `;
       // The index that makes every "would raise 23505" claim in these three
@@ -138,10 +145,10 @@ describe("migration 0062 re-runs the backfill 0061's dedupe left half-done", () 
           ('st_solo', 'prn_solo',    '2026-01-01T00:00:00Z')
       `;
       await tx`
-        INSERT INTO tmp_rooms_0062 (room_id, station_id, principal_id) VALUES
-          ('!r-old',  'st_old',  NULL),
-          ('!r-new',  'st_new',  NULL),
-          ('!r-solo', 'st_solo', NULL)
+        INSERT INTO tmp_rooms_0062 (room_id, station_id, principal_id, created_at) VALUES
+          ('!r-old',  'st_old',  NULL, '2026-01-01T00:00:00Z'),
+          ('!r-new',  'st_new',  NULL, '2026-06-01T00:00:00Z'),
+          ('!r-solo', 'st_solo', NULL, '2026-01-01T00:00:00Z')
       `;
 
       await tx.unsafe(backfill0060);
@@ -175,17 +182,28 @@ describe("migration 0062 re-runs the backfill 0061's dedupe left half-done", () 
       await tx`
         INSERT INTO tmp_stations_0062 (id, principal_id, adopted_at) VALUES
           ('st_moved', 'prn_moved', '2026-02-01T00:00:00Z'),
-          ('st_ambig', 'prn_ambig', '2026-03-01T00:00:00Z')
+          ('st_ambig', 'prn_ambig', '2026-03-01T00:00:00Z'),
+          ('st_tie',   'prn_tie',   '2026-04-01T00:00:00Z')
       `;
       await tx`
-        INSERT INTO tmp_rooms_0062 (room_id, station_id, principal_id) VALUES
+        INSERT INTO tmp_rooms_0062 (room_id, station_id, principal_id, created_at) VALUES
           -- an agent that moved stations keeps its old room; its new
           -- station carries an unbound one it never lived in
-          ('!r-moved-own',    'st_elsewhere', 'prn_moved'),
-          ('!r-moved-orphan', 'st_moved',     NULL),
-          -- one station, two unbound rooms: nothing to pick between them
-          ('!r-ambig-1', 'st_ambig', NULL),
-          ('!r-ambig-2', 'st_ambig', NULL)
+          ('!r-moved-own',    'st_elsewhere', 'prn_moved', '2026-02-01T00:00:00Z'),
+          ('!r-moved-orphan', 'st_moved',     NULL,        '2026-02-01T00:00:00Z'),
+          -- one station, two unbound rooms. This used to be the case 0062
+          -- declined outright; the rule now says the OLDEST carries the
+          -- history, and the newer one stays unbound. Deliberately
+          -- inserted newest-first, so a statement that has lost its
+          -- ORDER BY and falls back to insertion order picks the wrong one.
+          ('!r-ambig-new', 'st_ambig', NULL, '2026-05-01T00:00:00Z'),
+          ('!r-ambig-old', 'st_ambig', NULL, '2026-03-01T00:00:00Z'),
+          -- two unbound rooms created in the SAME instant: created_at
+          -- cannot separate them, and room_id is what stops the rule from
+          -- being an arbitrary pick in nicer clothes. !r-tie-a sorts first
+          -- and is inserted second.
+          ('!r-tie-b', 'st_tie', NULL, '2026-04-01T00:00:00Z'),
+          ('!r-tie-a', 'st_tie', NULL, '2026-04-01T00:00:00Z')
       `;
 
       await tx.unsafe(rebackfill0062);
@@ -210,10 +228,18 @@ describe("migration 0062 re-runs the backfill 0061's dedupe left half-done", () 
       ).toBeNull();
       expect(after0062.get("!r-moved-own"), "and that occupant's own room is untouched").toBe("prn_moved");
       expect(
-        after0062.get("!r-ambig-1"),
-        "two unbound rooms at one station is a guess, so 0062 declines to make it"
+        after0062.get("!r-ambig-old"),
+        "two unbound rooms at one station: the OLDEST carries the history and gets bound"
+      ).toBe("prn_ambig");
+      expect(
+        after0062.get("!r-ambig-new"),
+        "and the newer one stays unbound — binding both would violate matrix_rooms_principal_idx"
       ).toBeNull();
-      expect(after0062.get("!r-ambig-2")).toBeNull();
+      expect(
+        after0062.get("!r-tie-a"),
+        "same created_at: room_id breaks the tie, deterministically"
+      ).toBe("prn_tie");
+      expect(after0062.get("!r-tie-b")).toBeNull();
       expect(after0062.get("!r-solo"), "already bound, so a no-op").toBe("prn_solo");
 
       // Idempotent: a re-deploy must change nothing.
@@ -254,10 +280,10 @@ describe("migration 0062 re-runs the backfill 0061's dedupe left half-done", () 
     ).toBeNull();
 
     // The shipped file, verbatim, against the real schema — the same
-    // statement a deploy runs. Safe to run suite-wide: its `NOT EXISTS` and
-    // single-candidate clauses mean it can only bind a room whose station's
-    // occupant holds no other room and has no other unbound room to be
-    // confused with.
+    // statement a deploy runs. Safe to run suite-wide: its `NOT EXISTS`
+    // clause means it can only bind a room whose station's occupant holds
+    // no other room, and its one-row subquery means at most one room per
+    // station is touched.
     const rebackfill = statementStartingWith(
       "0062_matrix_rooms_rebackfill_after_dedupe.sql",
       'UPDATE "matrix_rooms"'

--- a/apps/hub/src/db/drizzle-migrations/0062-rebackfill-after-dedupe.test.ts
+++ b/apps/hub/src/db/drizzle-migrations/0062-rebackfill-after-dedupe.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Migration 0062, proved against the exact regression it exists to repair —
+ * fix round 5 on Task 5.
+ *
+ * The chain the review found: `0060`'s backfill SKIPS both rooms of a
+ * doubly-occupied principal (its `HAVING COUNT(*) > 1` clause, so the
+ * deploy cannot die of 23505 partway through). `0061` then dedupes exactly
+ * those principals and leaves the most recently adopted station
+ * RIGHTFULLY occupied. Nothing re-runs the backfill, so that survivor's
+ * room stays `principal_id IS NULL` forever — and once fix round 4 removed
+ * `roomAgentUser`'s fallback to `stations.principal_id`, a room that used
+ * to be answered correctly by accident began answering nothing at all.
+ *
+ * Two halves, because the migration has to be right about two different
+ * things:
+ *
+ *  - **The chain**, on temp tables, running all three shipped files' own
+ *    SQL read from disk (`0060-backfill-collision.test.ts`'s pattern, with
+ *    `0061`'s content-based statement selection). A pasted copy of the SQL
+ *    could drift from the file the deploy actually runs; this cannot.
+ *  - **The behaviour**, on the real tables, because "the column got
+ *    written" is not the thing that matters — `gates.ts`'s `roomAgentUser`
+ *    answering again is.
+ */
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../../tests/helpers/database";
+import { rawSql } from "../drizzle";
+import { resolveTenantForUser } from "../../auth/tenant";
+import { createPrincipal } from "../../services/principals";
+import { roomAgentUser } from "../../services/matrix-as/gates";
+import { bridgeUserId } from "../../services/matrix-as/names";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * One shipped migration's real statements, comments stripped, selected by
+ * CONTENT rather than by position — a slice by index silently becomes a
+ * different statement the moment a file is reordered, and these are run
+ * through `tx.unsafe()`.
+ */
+function statementsOf(file: string): string[] {
+  return readFileSync(join(__dirname, file), "utf8")
+    .split("--> statement-breakpoint")
+    .map((stmt) =>
+      stmt
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("--"))
+        .join("\n")
+        .trim()
+    )
+    .filter((stmt) => stmt.length > 0);
+}
+
+function statementStartingWith(file: string, prefix: string): string {
+  const found = statementsOf(file).find((s) =>
+    s.toUpperCase().replace(/\s+/g, " ").startsWith(prefix.toUpperCase())
+  );
+  expect(found, `${file} must still contain a statement starting "${prefix}"`).toBeTruthy();
+  return found!;
+}
+
+const RUN = crypto.randomUUID().slice(0, 8);
+const USER = `test-user-0062-${RUN}`;
+const NODE = `node_0062_${RUN}`;
+const STATION = `st_0062_${RUN}`;
+const ROOM = `!room-0062-${RUN}:id.agentpod.dev`;
+const HANDLE = `rebackfill-survivor-${RUN}`;
+let PRINCIPAL: string;
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM principals WHERE handle = ${HANDLE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("migration 0062 re-runs the backfill 0061's dedupe left half-done", () => {
+  test("0060 skips a doubly-occupied principal, 0061 leaves one station rightfully occupied, and 0062 binds that survivor's room — without 23505 on either way a room can be unbindable", async () => {
+    const backfill0060 = statementStartingWith(
+      "0060_matrix_rooms_backfill_principal_id.sql",
+      'UPDATE "matrix_rooms"'
+    )
+      .replace(/"matrix_rooms"/g, '"tmp_rooms_0062"')
+      .replace(/"stations"/g, '"tmp_stations_0062"');
+    const dedupe0061 = statementStartingWith(
+      "0061_occupancy_exclusive.sql",
+      'UPDATE "stations"'
+    ).replace(/"stations"/g, '"tmp_stations_0062"');
+    const rebackfill0062 = statementStartingWith(
+      "0062_matrix_rooms_rebackfill_after_dedupe.sql",
+      'UPDATE "matrix_rooms"'
+    )
+      .replace(/"matrix_rooms"/g, '"tmp_rooms_0062"')
+      .replace(/"stations"/g, '"tmp_stations_0062"');
+
+    await rawSql.begin(async (tx) => {
+      // ON COMMIT DROP: gone the instant this transaction ends, whichever
+      // pooled connection runs the next test.
+      await tx`
+        CREATE TEMP TABLE tmp_stations_0062 (id text PRIMARY KEY, principal_id text, adopted_at timestamp)
+        ON COMMIT DROP
+      `;
+      await tx`
+        CREATE TEMP TABLE tmp_rooms_0062 (room_id text PRIMARY KEY, station_id text, principal_id text)
+        ON COMMIT DROP
+      `;
+      // The index that makes every "would raise 23505" claim in these three
+      // migrations' comments real. Without it this test proves nothing about
+      // the guards.
+      await tx`CREATE UNIQUE INDEX tmp_rooms_0062_principal_idx ON tmp_rooms_0062 (principal_id)`;
+
+      // The state at the moment 0060 runs: `principal_id` has no writer yet,
+      // so every room is unbound, and one principal is doubly occupied.
+      await tx`
+        INSERT INTO tmp_stations_0062 (id, principal_id, adopted_at) VALUES
+          ('st_old',  'prn_collide', '2026-01-01T00:00:00Z'),
+          ('st_new',  'prn_collide', '2026-06-01T00:00:00Z'),
+          ('st_solo', 'prn_solo',    '2026-01-01T00:00:00Z')
+      `;
+      await tx`
+        INSERT INTO tmp_rooms_0062 (room_id, station_id, principal_id) VALUES
+          ('!r-old',  'st_old',  NULL),
+          ('!r-new',  'st_new',  NULL),
+          ('!r-solo', 'st_solo', NULL)
+      `;
+
+      await tx.unsafe(backfill0060);
+      const after0060 = new Map(
+        (await tx`SELECT room_id, principal_id FROM tmp_rooms_0062`).map((r) => [
+          r.room_id as string,
+          r.principal_id as string | null,
+        ])
+      );
+      expect(after0060.get("!r-old"), "0060 skips the colliding principal's rooms").toBeNull();
+      expect(after0060.get("!r-new")).toBeNull();
+      expect(after0060.get("!r-solo"), "and backfills a clean one").toBe("prn_solo");
+
+      await tx.unsafe(dedupe0061);
+      const stations0061 = new Map(
+        (await tx`SELECT id, principal_id FROM tmp_stations_0062`).map((r) => [
+          r.id as string,
+          r.principal_id as string | null,
+        ])
+      );
+      expect(stations0061.get("st_old"), "0061 clears the older adoption").toBeNull();
+      expect(
+        stations0061.get("st_new"),
+        "and leaves the survivor RIGHTFULLY occupied — with its room still unbound"
+      ).toBe("prn_collide");
+
+      // Between 0061 and 0062, on the deployed box: `agents-admin.ts`'s
+      // bind-on-assign has been live, so bound rooms and unbound leftovers
+      // both exist now. Each of these would make a verbatim re-run of 0060
+      // raise 23505 here.
+      await tx`
+        INSERT INTO tmp_stations_0062 (id, principal_id, adopted_at) VALUES
+          ('st_moved', 'prn_moved', '2026-02-01T00:00:00Z'),
+          ('st_ambig', 'prn_ambig', '2026-03-01T00:00:00Z')
+      `;
+      await tx`
+        INSERT INTO tmp_rooms_0062 (room_id, station_id, principal_id) VALUES
+          -- an agent that moved stations keeps its old room; its new
+          -- station carries an unbound one it never lived in
+          ('!r-moved-own',    'st_elsewhere', 'prn_moved'),
+          ('!r-moved-orphan', 'st_moved',     NULL),
+          -- one station, two unbound rooms: nothing to pick between them
+          ('!r-ambig-1', 'st_ambig', NULL),
+          ('!r-ambig-2', 'st_ambig', NULL)
+      `;
+
+      await tx.unsafe(rebackfill0062);
+      const after0062 = new Map(
+        (await tx`SELECT room_id, principal_id FROM tmp_rooms_0062`).map((r) => [
+          r.room_id as string,
+          r.principal_id as string | null,
+        ])
+      );
+
+      expect(
+        after0062.get("!r-new"),
+        "the survivor's room is bound at last — the whole point of 0062"
+      ).toBe("prn_collide");
+      expect(
+        after0062.get("!r-old"),
+        "the cleared station's room is not: it has no occupant to be bound to"
+      ).toBeNull();
+      expect(
+        after0062.get("!r-moved-orphan"),
+        "a room its station's occupant never lived in stays unattributable, rather than raising 23505 against the room that occupant does hold"
+      ).toBeNull();
+      expect(after0062.get("!r-moved-own"), "and that occupant's own room is untouched").toBe("prn_moved");
+      expect(
+        after0062.get("!r-ambig-1"),
+        "two unbound rooms at one station is a guess, so 0062 declines to make it"
+      ).toBeNull();
+      expect(after0062.get("!r-ambig-2")).toBeNull();
+      expect(after0062.get("!r-solo"), "already bound, so a no-op").toBe("prn_solo");
+
+      // Idempotent: a re-deploy must change nothing.
+      await tx.unsafe(rebackfill0062);
+      const twice = new Map(
+        (await tx`SELECT room_id, principal_id FROM tmp_rooms_0062`).map((r) => [
+          r.room_id as string,
+          r.principal_id as string | null,
+        ])
+      );
+      expect([...twice.entries()].sort()).toEqual([...after0062.entries()].sort());
+    });
+  });
+
+  test("and the room answers again: roomAgentUser goes from silence to the station's rightful occupant", async () => {
+    // Behaviour, on the real tables, because the column is not the point.
+    // The state 0061 leaves behind, reproduced directly: a station with its
+    // rightful occupant and a room of its own that nothing ever bound.
+    await createTestUser({ id: USER, email: `rebackfill-${RUN}@example.com`, name: "RB" });
+    const tenant = await resolveTenantForUser(USER);
+    PRINCIPAL = await createPrincipal({ kind: "agent", handle: HANDLE });
+    await rawSql`
+      INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+      VALUES (${NODE}, ${tenant}, ${USER}, ${"rebackfill-box-" + RUN}, 'rb', 'linux', 'amd64', 2, 'online', 'x', now())`;
+    await rawSql`
+      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
+      VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'opencode', ${"opencode:" + RUN}, 'leaf', 'Survivor',
+              '["acp"]'::jsonb, ${PRINCIPAL}, now(), now())`;
+    await rawSql`
+      INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
+      VALUES (${ROOM}, ${tenant}, ${STATION}, ${"#rebackfill-" + RUN + ":id.agentpod.dev"}, now())`;
+
+    // The regression, stated as behaviour: the room's rightful occupant is
+    // sitting right there on the station, and the room answers nothing.
+    expect(
+      await roomAgentUser(ROOM, "id.agentpod.dev"),
+      "before the backfill re-runs, a rightfully occupied station's room is unattributable"
+    ).toBeNull();
+
+    // The shipped file, verbatim, against the real schema — the same
+    // statement a deploy runs. Safe to run suite-wide: its `NOT EXISTS` and
+    // single-candidate clauses mean it can only bind a room whose station's
+    // occupant holds no other room and has no other unbound room to be
+    // confused with.
+    const rebackfill = statementStartingWith(
+      "0062_matrix_rooms_rebackfill_after_dedupe.sql",
+      'UPDATE "matrix_rooms"'
+    );
+    await rawSql.unsafe(rebackfill);
+
+    expect(
+      await roomAgentUser(ROOM, "id.agentpod.dev"),
+      "afterwards it answers as its station's rightful occupant again"
+    ).toBe(bridgeUserId(HANDLE, "id.agentpod.dev"));
+  });
+});

--- a/apps/hub/src/db/drizzle-migrations/0062_matrix_rooms_rebackfill_after_dedupe.sql
+++ b/apps/hub/src/db/drizzle-migrations/0062_matrix_rooms_rebackfill_after_dedupe.sql
@@ -1,0 +1,61 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Fix round 5 on Task 5. `0060`'s backfill deliberately SKIPS both rooms of
+-- a principal that occupied more than one station at the moment it ran --
+-- its `NOT IN (SELECT ... HAVING COUNT(*) > 1)` clause, added so the
+-- migration could not raise 23505 against `matrix_rooms_principal_idx` and
+-- fail the deploy partway through. `0061` then deduped exactly those
+-- principals, clearing every station but the most recently adopted one --
+-- and the survivor is RIGHTFULLY occupied. Nothing re-ran the backfill
+-- afterwards, so that survivor's room sits at `principal_id IS NULL`
+-- forever.
+--
+-- That was survivable only while `gates.ts`'s `roomAgentUser` fell back to
+-- `stations.principal_id`, which answered such a room correctly by
+-- accident. Fix round 4 removed that fallback -- rightly, because it also
+-- answered rooms their station's occupant had never lived in, with the
+-- wrong agent's name. Failing closed is only defensible if the rows that
+-- legitimately deserve an answer are actually bound. This binds them.
+--
+-- **Not a verbatim re-run of `0060`.** By this point `0061`'s unique index
+-- guarantees one station per principal, so `0060`'s skip clause has nothing
+-- left to skip -- but two OTHER ways of violating
+-- `matrix_rooms_principal_idx` have opened up since `0060` ran, both of
+-- them reachable on the deployed box, and either would fail this deploy:
+--
+--  1. A principal that ALREADY holds a room. `matrix_rooms.principal_id`
+--     has had a live writer since `routes/agents-admin.ts`'s bind-on-assign
+--     shipped, and an agent that moved stations keeps its old room while
+--     its new station may carry an unbound one. Binding that second room to
+--     the same principal raises 23505. The `NOT EXISTS` clause below is the
+--     same guard the assign endpoint already applies, for the same reason
+--     -- and it is also correct on the merits: a room the station's
+--     occupant demonstrably never lived in is not that occupant's room.
+--
+--  2. A station carrying MORE THAN ONE unbound room. `station_id` stopped
+--     being unique in fix round 1 precisely so a departed occupant's room
+--     could sit beside its successor's. A set-wide UPDATE would bind the
+--     same principal onto every one of them in a single statement and raise
+--     23505 -- and even if it could pick one, picking is guessing. The
+--     `1 = (SELECT COUNT(*) ...)` clause binds only where there is exactly
+--     one candidate and therefore nothing to guess about; an ambiguous
+--     station is left alone, which `roomAgentUser` now reports honestly as
+--     "no answer" rather than as the wrong agent.
+--
+-- Idempotent: every row it touches stops matching `r."principal_id" IS
+-- NULL`, so a second run changes nothing.
+UPDATE "matrix_rooms" AS r
+SET "principal_id" = s."principal_id"
+FROM "stations" AS s
+WHERE s."id" = r."station_id"
+  AND s."principal_id" IS NOT NULL
+  AND r."principal_id" IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "matrix_rooms" AS held
+    WHERE held."principal_id" = s."principal_id"
+  )
+  AND 1 = (
+    SELECT COUNT(*) FROM "matrix_rooms" AS sibling
+    WHERE sibling."station_id" = s."id"
+      AND sibling."principal_id" IS NULL
+  );

--- a/apps/hub/src/db/drizzle-migrations/0062_matrix_rooms_rebackfill_after_dedupe.sql
+++ b/apps/hub/src/db/drizzle-migrations/0062_matrix_rooms_rebackfill_after_dedupe.sql
@@ -36,11 +36,27 @@
 --     being unique in fix round 1 precisely so a departed occupant's room
 --     could sit beside its successor's. A set-wide UPDATE would bind the
 --     same principal onto every one of them in a single statement and raise
---     23505 -- and even if it could pick one, picking is guessing. The
---     `1 = (SELECT COUNT(*) ...)` clause binds only where there is exactly
---     one candidate and therefore nothing to guess about; an ambiguous
---     station is left alone, which `roomAgentUser` now reports honestly as
---     "no answer" rather than as the wrong agent.
+--     23505. The subquery below picks exactly ONE room per station, so the
+--     statement can match at most one row per principal and the index has
+--     nothing to refuse.
+--
+--     **This clause used to decline instead** -- `1 = (SELECT COUNT(*) ...)`,
+--     on the reasoning that picking between siblings is guessing. The
+--     whole-branch review pointed out that the LIVE writer
+--     (`routes/agents-admin.ts`'s bind-on-assign) was picking anyway, with
+--     an unordered `LIMIT 1`: same data, opposite policy, and the arbitrary
+--     one was the one an operator actually hit. So the rule was decided
+--     rather than avoided -- **oldest `created_at`, tie-broken by
+--     `room_id`** -- and it is applied identically here, in that endpoint,
+--     in `station-room.ts`'s `roomForStation`, and in
+--     `roomAliasForStation`. Oldest, because the station's ORIGINAL room is
+--     the one carrying the history this whole slice exists to preserve;
+--     `room_id` breaks the tie because `created_at` is not unique and two
+--     rooms provisioned in one batch can share it.
+--
+--     Declining was not the safer option it looked like. It left exactly
+--     the rooms whose stations are rightfully occupied answering nothing,
+--     which is what this file exists to stop.
 --
 -- Idempotent: every row it touches stops matching `r."principal_id" IS
 -- NULL`, so a second run changes nothing.
@@ -54,8 +70,10 @@ WHERE s."id" = r."station_id"
     SELECT 1 FROM "matrix_rooms" AS held
     WHERE held."principal_id" = s."principal_id"
   )
-  AND 1 = (
-    SELECT COUNT(*) FROM "matrix_rooms" AS sibling
+  AND r."room_id" = (
+    SELECT sibling."room_id" FROM "matrix_rooms" AS sibling
     WHERE sibling."station_id" = s."id"
       AND sibling."principal_id" IS NULL
+    ORDER BY sibling."created_at" ASC, sibling."room_id" ASC
+    LIMIT 1
   );

--- a/apps/hub/src/db/drizzle-migrations/meta/0055_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0055_snapshot.json
@@ -1,0 +1,3699 @@
+{
+  "id": "f0f33877-c369-4f1e-88cd-a6f66ff154da",
+  "prevId": "15ad5cf4-2102-475b-92b5-af8d9687afc1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_user_id_fk": {
+          "name": "principal_identities_principal_id_user_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "user",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('matrix', 'kaambaan', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_user_id_fk": {
+          "name": "principal_grants_principal_id_user_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0056_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0056_snapshot.json
@@ -1,0 +1,3699 @@
+{
+  "id": "3ebc4f71-c64b-4321-94a2-5436945d7124",
+  "prevId": "f0f33877-c369-4f1e-88cd-a6f66ff154da",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0057_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0057_snapshot.json
@@ -1,0 +1,3718 @@
+{
+  "id": "4f2b430c-7ce6-4457-9787-f3e247093bad",
+  "prevId": "3ebc4f71-c64b-4321-94a2-5436945d7124",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_principal_id_principals_id_fk": {
+          "name": "stations_principal_id_principals_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0058_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0058_snapshot.json
@@ -1,0 +1,3752 @@
+{
+  "id": "f213794b-9b7e-4a06-b34b-9f1275cf77c6",
+  "prevId": "4f2b430c-7ce6-4457-9787-f3e247093bad",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_principal_id_principals_id_fk": {
+          "name": "stations_principal_id_principals_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_principal_idx": {
+          "name": "matrix_rooms_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_principal_id_principals_id_fk": {
+          "name": "matrix_rooms_principal_id_principals_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0059_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0059_snapshot.json
@@ -1,0 +1,3758 @@
+{
+  "id": "45745343-9cf4-4938-b431-f65979e2f954",
+  "prevId": "f213794b-9b7e-4a06-b34b-9f1275cf77c6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_principal_id_principals_id_fk": {
+          "name": "stations_principal_id_principals_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_principal_idx": {
+          "name": "matrix_rooms_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_principal_id_principals_id_fk": {
+          "name": "matrix_rooms_principal_id_principals_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0060_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0060_snapshot.json
@@ -1,0 +1,3758 @@
+{
+  "id": "095b3921-acc0-47ac-983e-3a43534cec30",
+  "prevId": "45745343-9cf4-4938-b431-f65979e2f954",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "tableTo": "provisioned_runtimes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "tableTo": "stations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "stations_principal_id_principals_id_fk": {
+          "name": "stations_principal_id_principals_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "tableTo": "principals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "acp_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "tableTo": "acp_sessions",
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "acp_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "tableTo": "acp_sessions",
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "tableTo": "acp_runs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "tableTo": "principals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "tableTo": "principals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "matrix_rooms_principal_idx": {
+          "name": "matrix_rooms_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "matrix_rooms_principal_id_principals_id_fk": {
+          "name": "matrix_rooms_principal_id_principals_id_fk",
+          "tableFrom": "matrix_rooms",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "tableTo": "principals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "tableTo": "stations",
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "tableTo": "tenants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0061_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0061_snapshot.json
@@ -1,0 +1,3774 @@
+{
+  "id": "1aa79361-2004-4709-a482-1cd495113422",
+  "prevId": "095b3921-acc0-47ac-983e-3a43534cec30",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_principal_id_idx": {
+          "name": "stations_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stations\".\"principal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_principal_id_principals_id_fk": {
+          "name": "stations_principal_id_principals_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_principal_idx": {
+          "name": "matrix_rooms_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_principal_id_principals_id_fk": {
+          "name": "matrix_rooms_principal_id_principals_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/0062_snapshot.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/0062_snapshot.json
@@ -1,0 +1,3774 @@
+{
+  "id": "8f7e80e4-5779-4de6-b298-63d5c6ffa1db",
+  "prevId": "1aa79361-2004-4709-a482-1cd495113422",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_external_idx": {
+          "name": "tenants_external_idx",
+          "columns": [
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_id_is_agentpod_fleet": {
+          "name": "tenants_id_is_agentpod_fleet",
+          "value": "\"tenants\".\"id\" LIKE 'fleet\\_%'"
+        },
+        "tenants_external_is_not_agentpod": {
+          "name": "tenants_external_is_not_agentpod",
+          "value": "\"tenants\".\"external_id\" IS NULL OR \"tenants\".\"external_id\" NOT LIKE 'fleet\\_%'"
+        },
+        "tenants_external_pair": {
+          "name": "tenants_external_pair",
+          "value": "(\"tenants\".\"external_id\" IS NULL) = (\"tenants\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_id_is_org": {
+          "name": "organizations_id_is_org",
+          "value": "\"organizations\".\"id\" LIKE 'org\\_%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "principals_org_handle_idx": {
+          "name": "principals_org_handle_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_org_id_organizations_id_fk": {
+          "name": "principals_org_id_organizations_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principals_id_is_prn": {
+          "name": "principals_id_is_prn",
+          "value": "\"principals\".\"id\" LIKE 'prn\\_%'"
+        },
+        "principals_kind_known": {
+          "name": "principals_kind_known",
+          "value": "\"principals\".\"kind\" IN ('human','agent','service')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_idx": {
+          "name": "account_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_type": {
+          "name": "target_resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_user_id_idx": {
+          "name": "admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_target_user_id_idx": {
+          "name": "admin_audit_log_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_action_idx": {
+          "name": "admin_audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_at_idx": {
+          "name": "admin_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_user_id_fk": {
+          "name": "admin_audit_log_admin_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_user_id_fk": {
+          "name": "admin_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_updated_by_user_id_fk": {
+          "name": "system_settings_updated_by_user_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_user_id_idx": {
+          "name": "agent_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_sandbox_id_idx": {
+          "name": "agent_tasks_sandbox_id_idx",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_created_at_idx": {
+          "name": "agent_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_tenant_id_idx": {
+          "name": "agent_tasks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_tenant_id_tenants_id_fk": {
+          "name": "agent_tasks_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_user_id_user_id_fk": {
+          "name": "agent_tasks_user_id_user_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_sandboxes": {
+      "name": "cloudflare_sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cloudflare_sandbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sleeping'"
+        },
+        "worker_url": {
+          "name": "worker_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_synced_at": {
+          "name": "workspace_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloudflare_sandboxes_user_id_idx": {
+          "name": "cloudflare_sandboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_status_idx": {
+          "name": "cloudflare_sandboxes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_sandboxes_tenant_id_idx": {
+          "name": "cloudflare_sandboxes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_sandboxes_tenant_id_tenants_id_fk": {
+          "name": "cloudflare_sandboxes_tenant_id_tenants_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cloudflare_sandboxes_user_id_user_id_fk": {
+          "name": "cloudflare_sandboxes_user_id_user_id_fk",
+          "tableFrom": "cloudflare_sandboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollment_tokens": {
+      "name": "enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provisioned_runtime_id": {
+          "name": "provisioned_runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrollment_tokens_user_id_idx": {
+          "name": "enrollment_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollment_tokens_tenant_id_idx": {
+          "name": "enrollment_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollment_tokens_tenant_id_tenants_id_fk": {
+          "name": "enrollment_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_user_id_user_id_fk": {
+          "name": "enrollment_tokens_user_id_user_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk": {
+          "name": "enrollment_tokens_provisioned_runtime_id_provisioned_runtimes_id_fk",
+          "tableFrom": "enrollment_tokens",
+          "tableTo": "provisioned_runtimes",
+          "columnsFrom": [
+            "provisioned_runtime_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_count": {
+          "name": "cpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_tenant_id_idx": {
+          "name": "nodes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_id_tenant_idx": {
+          "name": "nodes_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_tenant_id_tenants_id_fk": {
+          "name": "nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "nodes_user_id_user_id_fk": {
+          "name": "nodes_user_id_user_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provisioned_runtimes": {
+      "name": "provisioned_runtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_tier": {
+          "name": "resource_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'small'"
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_started_at": {
+          "name": "external_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioned_runtimes_user_id_idx": {
+          "name": "provisioned_runtimes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioned_runtimes_tenant_id_idx": {
+          "name": "provisioned_runtimes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provisioned_runtimes_tenant_id_tenants_id_fk": {
+          "name": "provisioned_runtimes_tenant_id_tenants_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_user_id_user_id_fk": {
+          "name": "provisioned_runtimes_user_id_user_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provisioned_runtimes_node_id_nodes_id_fk": {
+          "name": "provisioned_runtimes_node_id_nodes_id_fk",
+          "tableFrom": "provisioned_runtimes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_station_id": {
+          "name": "parent_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_id": {
+          "name": "matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bridge_matrix_id": {
+          "name": "bridge_matrix_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_identity_mode": {
+          "name": "matrix_identity_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_node_id_station_key_idx": {
+          "name": "stations_node_id_station_key_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_principal_id_idx": {
+          "name": "stations_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stations\".\"principal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_node_id_idx": {
+          "name": "stations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_user_id_idx": {
+          "name": "stations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stations_tenant_id_idx": {
+          "name": "stations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_tenant_id_tenants_id_fk": {
+          "name": "stations_tenant_id_tenants_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stations_user_id_user_id_fk": {
+          "name": "stations_user_id_user_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_node_id_nodes_id_fk": {
+          "name": "stations_node_id_nodes_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_parent_station_id_stations_id_fk": {
+          "name": "stations_parent_station_id_stations_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "parent_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stations_principal_id_principals_id_fk": {
+          "name": "stations_principal_id_principals_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stations_node_tenant_fk": {
+          "name": "stations_node_tenant_fk",
+          "tableFrom": "stations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_audit": {
+      "name": "station_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_key": {
+          "name": "station_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_summary": {
+          "name": "params_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_audit_user_id_idx": {
+          "name": "station_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_station_key_idx": {
+          "name": "station_audit_station_key_idx",
+          "columns": [
+            {
+              "expression": "station_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_node_id_idx": {
+          "name": "station_audit_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_created_at_idx": {
+          "name": "station_audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_audit_tenant_id_idx": {
+          "name": "station_audit_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_audit_tenant_id_tenants_id_fk": {
+          "name": "station_audit_tenant_id_tenants_id_fk",
+          "tableFrom": "station_audit",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_events": {
+      "name": "acp_events",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_events_created_at_idx": {
+          "name": "acp_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_events_tenant_id_idx": {
+          "name": "acp_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_events_session_id_acp_sessions_id_fk": {
+          "name": "acp_events_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_events_tenant_id_tenants_id_fk": {
+          "name": "acp_events_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_events_session_tenant_fk": {
+          "name": "acp_events_session_tenant_fk",
+          "tableFrom": "acp_events",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "acp_events_session_id_seq_pk": {
+          "name": "acp_events_session_id_seq_pk",
+          "columns": [
+            "session_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.acp_runs": {
+      "name": "acp_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_seq": {
+          "name": "start_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_seq": {
+          "name": "end_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acp_runs_session_idx": {
+          "name": "acp_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_station_started_idx": {
+          "name": "acp_runs_station_started_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_external_idx": {
+          "name": "acp_runs_external_idx",
+          "columns": [
+            {
+              "expression": "external_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_runs_tenant_id_idx": {
+          "name": "acp_runs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_runs_tenant_id_tenants_id_fk": {
+          "name": "acp_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_id_acp_sessions_id_fk": {
+          "name": "acp_runs_session_id_acp_sessions_id_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_runs_session_tenant_fk": {
+          "name": "acp_runs_session_tenant_fk",
+          "tableFrom": "acp_runs",
+          "tableTo": "acp_sessions",
+          "columnsFrom": [
+            "session_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_runs_id_is_agentpod_attempt": {
+          "name": "acp_runs_id_is_agentpod_attempt",
+          "value": "\"acp_runs\".\"id\" LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_is_not_agentpod": {
+          "name": "acp_runs_external_is_not_agentpod",
+          "value": "\"acp_runs\".\"external_run_id\" IS NULL OR \"acp_runs\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "acp_runs_external_pair": {
+          "name": "acp_runs_external_pair",
+          "value": "(\"acp_runs\".\"external_run_id\" IS NULL) = (\"acp_runs\".\"external_source\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.acp_sessions": {
+      "name": "acp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_session_id": {
+          "name": "node_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seq": {
+          "name": "last_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "acp_sessions_station_id_idx": {
+          "name": "acp_sessions_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_station_activity_idx": {
+          "name": "acp_sessions_station_activity_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_tenant_id_idx": {
+          "name": "acp_sessions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acp_sessions_id_tenant_idx": {
+          "name": "acp_sessions_id_tenant_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_sessions_tenant_id_tenants_id_fk": {
+          "name": "acp_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "acp_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_dispatches": {
+      "name": "bridge_dispatches",
+      "schema": "",
+      "columns": {
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_card_id": {
+          "name": "external_card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_key": {
+          "name": "agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_run_id": {
+          "name": "acp_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_received": {
+          "name": "events_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities_posted": {
+          "name": "activities_posted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bridge_dispatches_card_idx": {
+          "name": "bridge_dispatches_card_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_tenant_id_idx": {
+          "name": "bridge_dispatches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bridge_dispatches_attempt_idx": {
+          "name": "bridge_dispatches_attempt_idx",
+          "columns": [
+            {
+              "expression": "acp_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bridge_dispatches_tenant_id_tenants_id_fk": {
+          "name": "bridge_dispatches_tenant_id_tenants_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bridge_dispatches_acp_run_id_acp_runs_id_fk": {
+          "name": "bridge_dispatches_acp_run_id_acp_runs_id_fk",
+          "tableFrom": "bridge_dispatches",
+          "tableTo": "acp_runs",
+          "columnsFrom": [
+            "acp_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bridge_dispatches_external_source_external_run_id_pk": {
+          "name": "bridge_dispatches_external_source_external_run_id_pk",
+          "columns": [
+            "external_source",
+            "external_run_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bridge_dispatches_external_is_not_agentpod": {
+          "name": "bridge_dispatches_external_is_not_agentpod",
+          "value": "\"bridge_dispatches\".\"external_run_id\" NOT LIKE 'attempt\\_%'"
+        },
+        "bridge_dispatches_outcome": {
+          "name": "bridge_dispatches_outcome",
+          "value": "\"bridge_dispatches\".\"outcome\" IN ('working', 'produced', 'reported', 'released', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_identities": {
+      "name": "principal_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_identities_system_external_idx": {
+          "name": "principal_identities_system_external_idx",
+          "columns": [
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_system_idx": {
+          "name": "principal_identities_principal_system_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_identities_principal_idx": {
+          "name": "principal_identities_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_identities_principal_id_principals_id_fk": {
+          "name": "principal_identities_principal_id_principals_id_fk",
+          "tableFrom": "principal_identities",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_identities_system_known": {
+          "name": "principal_identities_system_known",
+          "value": "\"principal_identities\".\"system\" IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')"
+        },
+        "principal_identities_external_id_present": {
+          "name": "principal_identities_external_id_present",
+          "value": "length(\"principal_identities\".\"external_id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_grants": {
+      "name": "principal_grants",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "may_dispatch": {
+          "name": "may_dispatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "may_grant_reach": {
+          "name": "may_grant_reach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_grants_principal_id_principals_id_fk": {
+          "name": "principal_grants_principal_id_principals_id_fk",
+          "tableFrom": "principal_grants",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_grants_may_dispatch_is_array": {
+          "name": "principal_grants_may_dispatch_is_array",
+          "value": "\"principal_grants\".\"may_dispatch\" LIKE '[%]'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matrix_as_transactions": {
+      "name": "matrix_as_transactions",
+      "schema": "",
+      "columns": {
+        "txn_id": {
+          "name": "txn_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_gate_events": {
+      "name": "matrix_gate_events",
+      "schema": "",
+      "columns": {
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_gate_events_tenant_id_idx": {
+          "name": "matrix_gate_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_gate_events_event_idx": {
+          "name": "matrix_gate_events_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_gate_events_tenant_id_tenants_id_fk": {
+          "name": "matrix_gate_events_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_gate_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_mission_members": {
+      "name": "matrix_mission_members",
+      "schema": "",
+      "columns": {
+        "mission_id": {
+          "name": "mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_mission_members_tenant_id_idx": {
+          "name": "matrix_mission_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_mission_members_tenant_id_tenants_id_fk": {
+          "name": "matrix_mission_members_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_mission_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_missions": {
+      "name": "matrix_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_missions_tenant_id_idx": {
+          "name": "matrix_missions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_missions_alias_idx": {
+          "name": "matrix_missions_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_missions_tenant_id_tenants_id_fk": {
+          "name": "matrix_missions_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_missions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_rooms": {
+      "name": "matrix_rooms",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_room_id": {
+          "name": "space_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matrix_rooms_tenant_id_idx": {
+          "name": "matrix_rooms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_station_idx": {
+          "name": "matrix_rooms_station_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matrix_rooms_principal_idx": {
+          "name": "matrix_rooms_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matrix_rooms_tenant_id_tenants_id_fk": {
+          "name": "matrix_rooms_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_principal_id_principals_id_fk": {
+          "name": "matrix_rooms_principal_id_principals_id_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "matrix_rooms_station_tenant_fk": {
+          "name": "matrix_rooms_station_tenant_fk",
+          "tableFrom": "matrix_rooms",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matrix_spaces": {
+      "name": "matrix_spaces",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_key": {
+          "name": "space_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matrix_spaces_tenant_id_tenants_id_fk": {
+          "name": "matrix_spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "matrix_spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matrix_spaces_tenant_id_space_key_pk": {
+          "name": "matrix_spaces_tenant_id_space_key_pk",
+          "columns": [
+            "tenant_id",
+            "space_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_signing_keys": {
+      "name": "service_signing_keys",
+      "schema": "",
+      "columns": {
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_jwk": {
+          "name": "public_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_jwk": {
+          "name": "private_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_signing_keys_active_idx": {
+          "name": "service_signing_keys_active_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"service_signing_keys\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_task_status": {
+      "name": "agent_task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.cloudflare_sandbox_status": {
+      "name": "cloudflare_sandbox_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "running",
+        "sleeping",
+        "stopped",
+        "error"
+      ]
+    },
+    "public.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "public",
+      "values": [
+        "docker",
+        "cloudflare"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline"
+      ]
+    },
+    "public.runtime_status": {
+      "name": "runtime_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "starting",
+        "online",
+        "stopping",
+        "stopped",
+        "asleep",
+        "error",
+        "destroyed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1786687173202,
       "tag": "0054_service_signing_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1788110577341,
+      "tag": "0055_spotty_namor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1788112729533,
       "tag": "0057_motionless_professor_monster",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1788118319157,
+      "tag": "0058_matrix_rooms_principal_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1788167041109,
       "tag": "0061_occupancy_exclusive",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1788176000000,
+      "tag": "0062_matrix_rooms_rebackfill_after_dedupe",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1788165015180,
       "tag": "0060_matrix_rooms_backfill_principal_id",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1788167041109,
+      "tag": "0061_occupancy_exclusive",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1788141024903,
       "tag": "0059_abandoned_frog_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1788165015180,
+      "tag": "0060_matrix_rooms_backfill_principal_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1788110577341,
       "tag": "0055_spotty_namor",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1788111076830,
+      "tag": "0056_left_darwin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1788111076830,
       "tag": "0056_left_darwin",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1788112729533,
+      "tag": "0057_motionless_professor_monster",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/hub/src/db/drizzle-migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1788118319157,
       "tag": "0058_matrix_rooms_principal_id",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1788141024903,
+      "tag": "0059_abandoned_frog_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hub/src/db/schema/grants.ts
+++ b/apps/hub/src/db/schema/grants.ts
@@ -8,11 +8,11 @@
  * the eventual claim** — which it did (`CONTROL_PAIR_GRANTS`). This is the
  * eventual claim arriving.
  *
- * Values are namespaced per
- * decisions/2026-08-15-a-grant-names-an-agent-per-plane.md: `agentpod:<stationKey>`
- * is matched here, `kaambaan:<agentId>` is matched there, and a namespace a plane
- * does not recognise is ignored rather than refused — a claim is read by more
- * planes over time, not fewer.
+ * Values are bare principal ids (`prn_…`), matched by equality, per
+ * decisions/2026-08-30-an-agent-is-a-principal.md §3 — which replaced the two
+ * namespaced, pattern-matched forms this table used to carry with one
+ * enumeration. A value that is not a recognised principal id is ignored rather
+ * than refused — a claim is read by more planes over time, not fewer.
  *
  * **A grant is authority, unlike `principal_identities` next door, which is only
  * sameness.** The distinction is the whole reason they are two tables: reading
@@ -38,7 +38,7 @@ export const principalGrants = pgTable(
       .references(() => principals.id, { onDelete: "cascade" }),
 
     /**
-     * Namespaced agent patterns this principal may dispatch.
+     * The ids of the agents this principal may dispatch.
      *
      * Stored as JSON text rather than a Postgres array: the value travels into a
      * JWT claim verbatim, and a round trip through `text[]` adds a shape

--- a/apps/hub/src/db/schema/grants.ts
+++ b/apps/hub/src/db/schema/grants.ts
@@ -22,7 +22,7 @@
 
 import { sql } from "drizzle-orm";
 import { pgTable, text, boolean, timestamp, check } from "drizzle-orm/pg-core";
-import { user } from "./auth";
+import { principals } from "./organization";
 
 export const principalGrants = pgTable(
   "principal_grants",
@@ -35,7 +35,7 @@ export const principalGrants = pgTable(
      */
     principalId: text("principal_id")
       .primaryKey()
-      .references(() => user.id, { onDelete: "cascade" }),
+      .references(() => principals.id, { onDelete: "cascade" }),
 
     /**
      * Namespaced agent patterns this principal may dispatch.

--- a/apps/hub/src/db/schema/identities.ts
+++ b/apps/hub/src/db/schema/identities.ts
@@ -23,7 +23,7 @@
 
 import { sql } from "drizzle-orm";
 import { pgTable, text, timestamp, uniqueIndex, index, check } from "drizzle-orm/pg-core";
-import { user } from "./auth";
+import { principals } from "./organization";
 
 /**
  * The systems a principal can be known to.
@@ -31,9 +31,11 @@ import { user } from "./auth";
  * Deliberately a CHECK rather than a Postgres enum: adding a system should be a
  * one-line migration, and an enum makes removing one painful. `org-plane` is
  * listed before it exists, because the whole point is that adopting it is a
- * data move.
+ * data move. `better-auth` is here because Better Auth's user is now one
+ * identity of one kind of principal, reached like any other system rather than
+ * being what a principal structurally is.
  */
-export const IDENTITY_SYSTEMS = ["matrix", "kaambaan", "org-plane"] as const;
+export const IDENTITY_SYSTEMS = ["better-auth", "matrix", "kaambaan", "agentpod", "org-plane"] as const;
 export type IdentitySystem = (typeof IDENTITY_SYSTEMS)[number];
 
 export const principalIdentities = pgTable(
@@ -41,10 +43,10 @@ export const principalIdentities = pgTable(
   {
     id: text("id").primaryKey(),
 
-    /** The local principal. Today a Better Auth user; a canonical principal later. */
+    /** The principal this identity belongs to. */
     principalId: text("principal_id")
       .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
+      .references(() => principals.id, { onDelete: "cascade" }),
 
     /** Which system knows them. */
     system: text("system").notNull(),
@@ -85,7 +87,7 @@ export const principalIdentities = pgTable(
 
     check(
       "principal_identities_system_known",
-      sql`${t.system} IN ('matrix', 'kaambaan', 'org-plane')`
+      sql`${t.system} IN ('better-auth', 'matrix', 'kaambaan', 'agentpod', 'org-plane')`
     ),
 
     /** An empty external id is not a mapping; it is a row that looks like one. */

--- a/apps/hub/src/db/schema/index.ts
+++ b/apps/hub/src/db/schema/index.ts
@@ -9,6 +9,10 @@
 // First, because everything below references it.
 export * from "./tenants";
 
+// Organization plane — organizations and principals, living in the hub until
+// the plane is extracted (see the module doc in ./organization).
+export * from "./organization";
+
 // Authentication (Better Auth tables)
 export * from "./auth";
 

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -45,13 +45,32 @@ export const matrixRooms = pgTable(
      * The occupying agent this room speaks to — added, not swapped in for
      * `stationId`.
      *
-     * **Has a writer now.** `routes/agents-admin.ts`'s assign endpoint binds
-     * it once: the first time a station's own room finds an occupant that has
-     * no room of its own anywhere yet. It is never moved or cleared after
-     * that — an agent keeps the room it was first bound to for as long as it
-     * exists, however many stations it occupies afterward, which is the
-     * entire point of keying gates on the agent rather than on wherever it
-     * currently sits. Migration `0060_matrix_rooms_backfill_principal_id`
+     * **Has TWO writers, and they agree.** The whole-branch review found this
+     * comment still claiming one, which by then was false:
+     *
+     *  - `routes/agents-admin.ts`'s assign endpoint binds an EXISTING unbound
+     *    room — the oldest at the station, under the rule in
+     *    `matrix-as/station-room.ts` — and only under `NOT EXISTS (… WHERE
+     *    principal_id = …)`, because the row it is updating was created for
+     *    somebody else's benefit and it has no other way to know whether this
+     *    principal is already housed.
+     *  - `matrix-as/provision.ts` binds a room it is CREATING, at insert,
+     *    unconditionally.
+     *
+     * The two policies read as a disagreement and are not: provisioning only
+     * reaches its insert when `roomForStation` has already answered "this
+     * occupant has no room", which is the same predicate assign spells out as
+     * `NOT EXISTS`. One checks it by having asked a moment earlier; the other
+     * checks it in the statement, because it is racing other assigns.
+     * `matrix_rooms_principal_idx` is what makes the agreement enforced
+     * rather than merely intended — if either ever stopped holding, the
+     * second write raises 23505 instead of quietly giving an agent two rooms.
+     *
+     * Once bound, never moved or cleared — an agent keeps the room it was
+     * first bound to for as long as it exists, however many stations it
+     * occupies afterward, which is the entire point of keying gates on the
+     * agent rather than on wherever it currently sits.
+     * Migration `0060_matrix_rooms_backfill_principal_id`
      * backfilled every room that predates the writer from its station's
      * occupant at the time, so no pre-existing room reads null forever for
      * having existed before this column had one.

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -42,8 +42,19 @@ export const matrixRooms = pgTable(
       .references(() => tenants.id, { onDelete: "restrict" }),
     stationId: text("station_id").notNull(),
     /**
-     * The occupying agent this room now speaks to, once Task 9's migration has
-     * run — added, not swapped in for `stationId`.
+     * The occupying agent this room speaks to — added, not swapped in for
+     * `stationId`.
+     *
+     * **Reserved ahead of its first writer: nothing populates it today.** The
+     * same manoeuvre `IDENTITY_SYSTEMS` uses for `org-plane` in
+     * `identities.ts` — declared before there is anything to put in it, so
+     * that adopting it later is a data move rather than a migration. An
+     * earlier version of this note said Task 9's migration backfills it room
+     * by room; it does not. `scripts/migrate-agent-mxids-run.ts` derives a
+     * room's old address from `(nodeName, stationKey)` and its new one from
+     * the station's principal handle, and writes neither back here. Anything
+     * reading this column as a record of what has been migrated would read
+     * null for all 32 rooms and conclude nothing had happened.
      *
      * `gates.ts` (`roomForCard`, `roomAgentUser`) and `gate-sweep.ts` join on
      * `stationId`, and `gate-sweep.ts` is deployed in production today —
@@ -53,10 +64,10 @@ export const matrixRooms = pgTable(
      * not a replacement for it. Retiring `stationId` is a later slice's own
      * migration, once every reader has moved.
      *
-     * Nullable because it starts empty for every existing row — Task 9's
-     * migration backfills it room by room as each one is re-addressed — and
-     * because a station can lose its occupant (`stations.principalId` is
-     * itself nullable) after ever having had one.
+     * Nullable because it is empty for every row until something writes it,
+     * and because a station can lose its occupant (`stations.principalId` is
+     * itself nullable) after ever having had one — so it would stay nullable
+     * even once a writer exists.
      */
     principalId: text("principal_id").references(() => principals.id, { onDelete: "set null" }),
     alias: text("alias").notNull(),

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -9,6 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { tenants } from "./tenants";
 import { stations } from "./stations";
+import { principals } from "./organization";
 
 /**
  * Applied Application Service transactions.
@@ -40,6 +41,24 @@ export const matrixRooms = pgTable(
       .notNull()
       .references(() => tenants.id, { onDelete: "restrict" }),
     stationId: text("station_id").notNull(),
+    /**
+     * The occupying agent this room now speaks to, once Task 9's migration has
+     * run — added, not swapped in for `stationId`.
+     *
+     * `gates.ts` (`roomForCard`, `roomAgentUser`) and `gate-sweep.ts` join on
+     * `stationId`, and `gate-sweep.ts` is deployed in production today —
+     * re-keying this table onto `principalId` inside this slice would break
+     * the approvals chain that is this slice's own exit test. `stationId`
+     * stays the column every current reader uses; this is redundant with it,
+     * not a replacement for it. Retiring `stationId` is a later slice's own
+     * migration, once every reader has moved.
+     *
+     * Nullable because it starts empty for every existing row — Task 9's
+     * migration backfills it room by room as each one is re-addressed — and
+     * because a station can lose its occupant (`stations.principalId` is
+     * itself nullable) after ever having had one.
+     */
+    principalId: text("principal_id").references(() => principals.id, { onDelete: "set null" }),
     alias: text("alias").notNull(),
     /** The ACP session this room is talking to, if one is open. */
     acpSessionId: text("acp_session_id"),
@@ -57,6 +76,9 @@ export const matrixRooms = pgTable(
   (t) => [
     index("matrix_rooms_tenant_id_idx").on(t.tenantId),
     uniqueIndex("matrix_rooms_station_idx").on(t.stationId),
+    /** One room per occupying agent too, mirroring the station invariant
+     *  above — multiple NULLs are fine and expected before migration. */
+    uniqueIndex("matrix_rooms_principal_idx").on(t.principalId),
     foreignKey({
       columns: [t.stationId, t.tenantId],
       foreignColumns: [stations.id, stations.tenantId],

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -60,14 +60,24 @@ export const matrixRooms = pgTable(
      * `stationId` join precisely so a reassigned agent's gates keep landing
      * in its original room rather than in whatever room its new station
      * happens to have; `roomAgentUser` does the same for a room that already
-     * has a bound resident. Both still fall back to the `stationId` join when
-     * this is null — a room the backfill has not reached, or one whose
-     * occupant has simply never moved — which is what keeps `gate-sweep.ts`
-     * working exactly as it does today: it calls into `gates.ts` rather than
-     * querying this table itself, and it is deployed in production. `stationId`
-     * stays the column every current reader still needs; this is redundant
-     * with it, not a replacement for it. Retiring `stationId` is a later
-     * slice's own migration, once every reader has moved.
+     * has a bound resident.
+     *
+     * **The `stationId` fallback is scoped, not unconditional — fix round on
+     * Task 5.** The first cut fell back to the `stationId` join whenever this
+     * column was null, which included a station whose CURRENT occupant
+     * simply hadn't been bound yet — and since a departed principal's room
+     * keeps its `stationId`, that fallback could hand a new occupant's gates
+     * to the room, and the address, of whoever used to be there. `roomForCard`
+     * now falls back to `stationId` only when the station has NO occupant at
+     * all; an occupied station whose occupant has no room of its own answers
+     * "no room yet" instead of guessing. `gate-sweep.ts` — deployed in
+     * production, and unaware it depends on this — is unaffected: it calls
+     * into `gates.ts` rather than querying this table itself, and the
+     * fallback it actually exercises (an unoccupied station's own room) is
+     * untouched. `stationId` stays the column every current reader still
+     * needs; this is redundant with it, not a replacement for it. Retiring
+     * `stationId` is a later slice's own migration, once every reader has
+     * moved.
      *
      * Nullable because a room this hasn't reached is still nullable, and
      * because a station can lose its occupant (`stations.principalId` is
@@ -92,9 +102,17 @@ export const matrixRooms = pgTable(
   },
   (t) => [
     index("matrix_rooms_tenant_id_idx").on(t.tenantId),
-    uniqueIndex("matrix_rooms_station_idx").on(t.stationId),
-    /** One room per occupying agent too, mirroring the station invariant
-     *  above — multiple NULLs are fine and expected before migration. */
+    /**
+     * NOT unique, as of the fix round on Task 5 — deliberately. A station
+     * can now carry more than one room: a departed principal's, kept so it
+     * keeps its history and address, alongside its new occupant's own. A
+     * unique index here would refuse the second row outright, which is
+     * exactly what "the room follows the agent" requires being able to do.
+     */
+    index("matrix_rooms_station_idx").on(t.stationId),
+    /** One room per occupying agent — enforceable now that occupancy
+     *  itself is exclusive (`stations_principal_id_idx`); multiple NULLs
+     *  are still fine, for every room with no bound occupant. */
     uniqueIndex("matrix_rooms_principal_idx").on(t.principalId),
     foreignKey({
       columns: [t.stationId, t.tenantId],

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -56,28 +56,30 @@ export const matrixRooms = pgTable(
      * occupant at the time, so no pre-existing room reads null forever for
      * having existed before this column had one.
      *
-     * `gates.ts`'s `roomForCard` reads this in preference to the plain
-     * `stationId` join precisely so a reassigned agent's gates keep landing
-     * in its original room rather than in whatever room its new station
-     * happens to have; `roomAgentUser` does the same for a room that already
-     * has a bound resident.
+     * `matrix-as/station-room.ts`'s `roomForStation` is the ONE place this
+     * resolves for every reader now — `gates.ts`, `routes/station-say.ts`,
+     * and `provision.ts` all call into it rather than joining on `stationId`
+     * themselves, so a reassigned agent's gates, unprompted messages, and
+     * provisioning all keep landing in its original room rather than
+     * whatever room its new station happens to have.
      *
-     * **The `stationId` fallback is scoped, not unconditional — fix round on
-     * Task 5.** The first cut fell back to the `stationId` join whenever this
-     * column was null, which included a station whose CURRENT occupant
-     * simply hadn't been bound yet — and since a departed principal's room
-     * keeps its `stationId`, that fallback could hand a new occupant's gates
-     * to the room, and the address, of whoever used to be there. `roomForCard`
-     * now falls back to `stationId` only when the station has NO occupant at
-     * all; an occupied station whose occupant has no room of its own answers
-     * "no room yet" instead of guessing. `gate-sweep.ts` — deployed in
-     * production, and unaware it depends on this — is unaffected: it calls
-     * into `gates.ts` rather than querying this table itself, and the
-     * fallback it actually exercises (an unoccupied station's own room) is
-     * untouched. `stationId` stays the column every current reader still
-     * needs; this is redundant with it, not a replacement for it. Retiring
-     * `stationId` is a later slice's own migration, once every reader has
-     * moved.
+     * **The `stationId` fallback is scoped, not unconditional — fix round 1
+     * on Task 5, then centralised in fix round 2.** The first cut fell back
+     * to the `stationId` join whenever this column was null, which included
+     * a station whose CURRENT occupant simply hadn't been bound yet — and
+     * since a departed principal's room keeps its `stationId`, that fallback
+     * could hand a new occupant's gates (and, a second review found, its
+     * unprompted messages, and its provisioning) to the room, and the
+     * address, of whoever used to be there. `roomForStation` falls back to
+     * `stationId` only when the station has NO occupant at all; an occupied
+     * station whose occupant has no room of its own answers "no room yet"
+     * instead of guessing. `gate-sweep.ts` — deployed in production, and
+     * unaware it depends on this — is unaffected: it calls into `gates.ts`
+     * rather than querying this table itself, and the fallback it actually
+     * exercises (an unoccupied station's own room) is untouched. `stationId`
+     * stays the column every current reader still needs; this is redundant
+     * with it, not a replacement for it. Retiring `stationId` is a later
+     * slice's own migration, once every reader has moved.
      *
      * Nullable because a room this hasn't reached is still nullable, and
      * because a station can lose its occupant (`stations.principalId` is

--- a/apps/hub/src/db/schema/matrix.ts
+++ b/apps/hub/src/db/schema/matrix.ts
@@ -45,29 +45,35 @@ export const matrixRooms = pgTable(
      * The occupying agent this room speaks to — added, not swapped in for
      * `stationId`.
      *
-     * **Reserved ahead of its first writer: nothing populates it today.** The
-     * same manoeuvre `IDENTITY_SYSTEMS` uses for `org-plane` in
-     * `identities.ts` — declared before there is anything to put in it, so
-     * that adopting it later is a data move rather than a migration. An
-     * earlier version of this note said Task 9's migration backfills it room
-     * by room; it does not. `scripts/migrate-agent-mxids-run.ts` derives a
-     * room's old address from `(nodeName, stationKey)` and its new one from
-     * the station's principal handle, and writes neither back here. Anything
-     * reading this column as a record of what has been migrated would read
-     * null for all 32 rooms and conclude nothing had happened.
+     * **Has a writer now.** `routes/agents-admin.ts`'s assign endpoint binds
+     * it once: the first time a station's own room finds an occupant that has
+     * no room of its own anywhere yet. It is never moved or cleared after
+     * that — an agent keeps the room it was first bound to for as long as it
+     * exists, however many stations it occupies afterward, which is the
+     * entire point of keying gates on the agent rather than on wherever it
+     * currently sits. Migration `0060_matrix_rooms_backfill_principal_id`
+     * backfilled every room that predates the writer from its station's
+     * occupant at the time, so no pre-existing room reads null forever for
+     * having existed before this column had one.
      *
-     * `gates.ts` (`roomForCard`, `roomAgentUser`) and `gate-sweep.ts` join on
-     * `stationId`, and `gate-sweep.ts` is deployed in production today —
-     * re-keying this table onto `principalId` inside this slice would break
-     * the approvals chain that is this slice's own exit test. `stationId`
-     * stays the column every current reader uses; this is redundant with it,
-     * not a replacement for it. Retiring `stationId` is a later slice's own
-     * migration, once every reader has moved.
+     * `gates.ts`'s `roomForCard` reads this in preference to the plain
+     * `stationId` join precisely so a reassigned agent's gates keep landing
+     * in its original room rather than in whatever room its new station
+     * happens to have; `roomAgentUser` does the same for a room that already
+     * has a bound resident. Both still fall back to the `stationId` join when
+     * this is null — a room the backfill has not reached, or one whose
+     * occupant has simply never moved — which is what keeps `gate-sweep.ts`
+     * working exactly as it does today: it calls into `gates.ts` rather than
+     * querying this table itself, and it is deployed in production. `stationId`
+     * stays the column every current reader still needs; this is redundant
+     * with it, not a replacement for it. Retiring `stationId` is a later
+     * slice's own migration, once every reader has moved.
      *
-     * Nullable because it is empty for every row until something writes it,
-     * and because a station can lose its occupant (`stations.principalId` is
-     * itself nullable) after ever having had one — so it would stay nullable
-     * even once a writer exists.
+     * Nullable because a room this hasn't reached is still nullable, and
+     * because a station can lose its occupant (`stations.principalId` is
+     * itself nullable) without this column following it down — a room's own
+     * binding does not un-bind just because its station's current occupant
+     * changed — so it would stay nullable even with a writer in place.
      */
     principalId: text("principal_id").references(() => principals.id, { onDelete: "set null" }),
     alias: text("alias").notNull(),

--- a/apps/hub/src/db/schema/organization.test.ts
+++ b/apps/hub/src/db/schema/organization.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { prefixedId } from "../../utils/ids";
+import { BOOTSTRAP_ORG_ID, PRINCIPAL_KINDS } from "./organization";
+
+describe("principal ids and kinds", () => {
+  test("a minted principal id matches the shared grammar", () => {
+    // The corpus is the contract; a minter that drifts from it fails at the
+    // seam rather than here, which is far more expensive to diagnose.
+    expect(prefixedId("prn")).toMatch(/^prn_[0-9a-f]{20}$/);
+  });
+
+  test("the bootstrap organisation is a fixed id, not a random one", () => {
+    // Same reason tenants.BOOTSTRAP_TENANT_ID is a literal: a fresh deploy and
+    // the live hub must agree on it, which a random value cannot guarantee.
+    expect(BOOTSTRAP_ORG_ID).toBe("org_00000000000000000000");
+  });
+
+  test("kind is closed, and includes the one that did not exist", () => {
+    expect(PRINCIPAL_KINDS).toEqual(["human", "agent", "service"]);
+  });
+});

--- a/apps/hub/src/db/schema/organization.ts
+++ b/apps/hub/src/db/schema/organization.ts
@@ -47,6 +47,13 @@ export const principals = pgTable(
     handle: text("handle").notNull(),
     displayName: text("display_name"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
+    /**
+     * When this principal stopped being allowed to act, if it has.
+     *
+     * A timestamp rather than a boolean: "since when" is the first question asked
+     * of a suspension, and a boolean cannot answer it. NULL is the normal state.
+     */
+    suspendedAt: timestamp("suspended_at"),
   },
   (t) => [
     check("principals_id_is_prn", sql`${t.id} LIKE 'prn\\_%'`),

--- a/apps/hub/src/db/schema/organization.ts
+++ b/apps/hub/src/db/schema/organization.ts
@@ -1,0 +1,58 @@
+/**
+ * The Organization plane's tables, living in the hub until the plane is extracted.
+ *
+ * `charter → decisions/2026-08-30-an-agent-is-a-principal.md`. The hub already
+ * IS the issuer; it is the Organization plane on the same terms, and extraction
+ * moves these rows without changing their meaning. That is what
+ * `2026-08-15-one-issuer-and-offline-verification` meant by "only the issuer
+ * URL changes".
+ */
+import { sql } from "drizzle-orm";
+import { pgTable, text, timestamp, uniqueIndex, check } from "drizzle-orm/pg-core";
+
+/** Fixed, for the same reason `BOOTSTRAP_TENANT_ID` is: a fresh deploy and the
+ *  live hub must agree, and a random id cannot guarantee that. */
+export const BOOTSTRAP_ORG_ID = "org_00000000000000000000";
+
+export const PRINCIPAL_KINDS = ["human", "agent", "service"] as const;
+export type PrincipalKind = (typeof PRINCIPAL_KINDS)[number];
+
+export const organizations = pgTable(
+  "organizations",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [check("organizations_id_is_org", sql`${t.id} LIKE 'org\\_%'`)]
+);
+
+export const principals = pgTable(
+  "principals",
+  {
+    id: text("id").primaryKey(),
+    /**
+     * Explicit, never inferred from which identities exist. An agent with no
+     * identities linked yet is still an agent, and inference would default it
+     * to human — which is the one wrong answer that fails open.
+     */
+    kind: text("kind").notNull(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    /**
+     * Immutable, and what an agent's mxid is built from. `display_name` moves;
+     * this does not, exactly as Matrix separates an mxid from a displayname.
+     */
+    handle: text("handle").notNull(),
+    displayName: text("display_name"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    check("principals_id_is_prn", sql`${t.id} LIKE 'prn\\_%'`),
+    check("principals_kind_known", sql`${t.kind} IN ('human','agent','service')`),
+    /** One handle, one principal: it is an address, and two claimants make the
+     *  mxid it produces ambiguous. */
+    uniqueIndex("principals_org_handle_idx").on(t.orgId, t.handle),
+  ]
+);

--- a/apps/hub/src/db/schema/stations.ts
+++ b/apps/hub/src/db/schema/stations.ts
@@ -2,6 +2,7 @@ import { pgTable, text, timestamp, index, uniqueIndex, jsonb, foreignKey, AnyPgC
 import { user } from "./auth";
 import { nodes } from "./nodes";
 import { tenants } from "./tenants";
+import { principals } from "./organization";
 
 export const stations = pgTable("stations", {
   id: text("id").primaryKey(),
@@ -38,6 +39,17 @@ export const stations = pgTable("stations", {
    * has said, and an unlabelled station is filed under no Matrix space at all.
    */
   purpose: text("purpose"),
+  /**
+   * The agent that occupies this station, if any.
+   *
+   * Nullable and it stays nullable: a station nobody has assigned is a machine,
+   * not an agent, and it is dispatchable by nobody — which is the behaviour change
+   * charter decisions/2026-08-30-an-agent-is-a-principal.md §3 names.
+   *
+   * Here rather than in `principal_identities` because occupancy is not sameness.
+   * A principal's identities say who it also is; this says where it currently runs.
+   */
+  principalId: text("principal_id").references(() => principals.id, { onDelete: "set null" }),
   adoptedAt: timestamp("adopted_at").defaultNow().notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (t) => [

--- a/apps/hub/src/db/schema/stations.ts
+++ b/apps/hub/src/db/schema/stations.ts
@@ -1,4 +1,5 @@
 import { pgTable, text, timestamp, index, uniqueIndex, jsonb, foreignKey, AnyPgColumn } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user } from "./auth";
 import { nodes } from "./nodes";
 import { tenants } from "./tenants";
@@ -48,12 +49,23 @@ export const stations = pgTable("stations", {
    *
    * Here rather than in `principal_identities` because occupancy is not sameness.
    * A principal's identities say who it also is; this says where it currently runs.
+   *
+   * **Occupancy is exclusive.** Fix-round ruling on Task 5: a principal runs
+   * in one station at a time — `stations_principal_id_idx` below enforces it
+   * at the schema, and `routes/agents-admin.ts`'s assign endpoint vacates a
+   * principal's previous station in the same transaction it places it in a
+   * new one. Before this ruling nothing enforced it, while
+   * `matrix_rooms_principal_idx` already allowed a principal only one room —
+   * a contradiction the code silently carried both sides of.
    */
   principalId: text("principal_id").references(() => principals.id, { onDelete: "set null" }),
   adoptedAt: timestamp("adopted_at").defaultNow().notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (t) => [
   uniqueIndex("stations_node_id_station_key_idx").on(t.nodeId, t.stationKey),
+  // Partial: many stations share `principal_id IS NULL` (unoccupied is the
+  // default state), and only a non-null occupant needs to be unique.
+  uniqueIndex("stations_principal_id_idx").on(t.principalId).where(sql`${t.principalId} IS NOT NULL`),
   index("stations_node_id_idx").on(t.nodeId),
   index("stations_user_id_idx").on(t.userId),
   index("stations_tenant_id_idx").on(t.tenantId),

--- a/apps/hub/src/db/tenant-scope.ts
+++ b/apps/hub/src/db/tenant-scope.ts
@@ -53,6 +53,7 @@ import { agentTasks, cloudflareSandboxes } from "./schema/cloudflare";
 import { enrollmentTokens, nodes, provisionedRuntimes } from "./schema/nodes";
 import { stations } from "./schema/stations";
 import { tenants } from "./schema/tenants";
+import { organizations, principals } from "./schema/organization";
 
 export { BOOTSTRAP_TENANT_ID } from "./schema/tenants";
 
@@ -131,6 +132,31 @@ export const TENANT_EXEMPT_TABLES: Record<string, { table: Table; reason: string
     reason:
       "It IS the boundary. A tenant inside a tenant is the membership/hierarchy model the " +
       "Organization plane owns, and building it here is what MT-1 (#145) was rewritten to avoid.",
+  },
+
+  // ── The Organization plane, living in the hub before extraction ─────────────
+  //
+  // `tenants.externalId` maps a tenant to the organisation it stands for; these
+  // two tables ARE that organisation, not a tenant's contents. Scoping either by
+  // tenant_id would put the boundary's own referent inside the boundary — the
+  // same shape the `tenants` exemption above refuses, one level out.
+  organizations: {
+    table: organizations,
+    reason:
+      "The real thing `tenants.externalId` points at, not a row belonging to a tenant. An " +
+      "organisation is not inside a fleet — a fleet optionally names one via its external " +
+      "mapping — so a tenant_id column here would have the referent carry a pointer back to " +
+      "one of its own referrers, which is backwards. Same shape as the `tenants` exemption " +
+      "above, one level out.",
+  },
+  principals: {
+    table: principals,
+    reason:
+      "Belongs to an organization (orgId), not a fleet, for the same reason `user` and " +
+      "`principal_identities` are exempt above: a principal is not inside a tenant, it reaches " +
+      "one. This is the Organization-plane table `user`'s exemption comment already points at — " +
+      "'principals belong to the Organization plane, which owns Principal, Team, Role, " +
+      "identity mappings, authority' — now given a home instead of only a forward reference.",
   },
 
   // ── The Better Auth family ────────────────────────────────────────────────

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -61,7 +61,7 @@ import { enabledProviders } from './services/provisioner/registry.ts';
 import { startNodeSweeper } from './services/node-sweeper.ts';
 import { startKaambaanBridge } from './services/bridge/loop.ts';
 import { createMatrixBridge, startMatrixBridge } from './services/matrix-as/index.ts';
-import { onStationsAdopted } from './services/matrix-as/hooks.ts';
+import { onStationsAdopted, onProvisionStation } from './services/matrix-as/hooks.ts';
 import { createMatrixAsRoutes } from './routes/matrix-as.ts';
 import { createStationMatrixRoutes } from './routes/station-matrix.ts';
 import { createStationSayRoutes } from './routes/station-say.ts';
@@ -362,6 +362,12 @@ if (matrixBridge) {
   onStationsAdopted(async (stationIds) => {
     for (const id of stationIds) await matrixBridge.provision(id);
   });
+  // Nor must an agent assigned at noon. Adoption fires before a station has
+  // an occupant, and a bridge-mode station with none is exactly what
+  // `provision.ts` returns early from — so without this the console could
+  // create an agent, put it in a station, and leave it with no room at all
+  // until the next restart. `routes/agents-admin.ts` awaits this one.
+  onProvisionStation((stationId) => matrixBridge.provision(stationId));
   await startMatrixBridge(matrixBridge);
 } else {
   console.log('matrix bridge: (disabled)');

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -35,6 +35,8 @@ import { enrollmentTokenRoutes } from './routes/enrollment-tokens.ts';
 import { runtimeRoutes } from './routes/runtimes.ts';
 // Station routes (detect, adopt, list, unadopt)
 import { stationRoutes } from './routes/stations.ts';
+// A node exchanging its credential for a station-scoped agent token
+import { stationTokenRoutes } from './routes/station-token.ts';
 import { purposeRoutes } from './routes/purpose.ts';
 // Station terminal WebSocket bridge (fleet console ↔ node PTY)
 import { stationTerminalRoutes } from './routes/station-terminal.ts';
@@ -146,6 +148,18 @@ const app = new Hono()
   .on(['GET', 'POST'], '/api/auth/*', (c) => {
     return auth.handler(c.req.raw);
   })
+  /**
+   * POST /api/nodes/:nodeId/stations/:stationId/token — a node exchanging its
+   * long-term `<nodeId>:<nodeSecret>` credential for a short-lived agent
+   * token. `Bearer <nodeId>:<nodeSecret>` is not a Better Auth session and is
+   * never the static API_TOKEN either, so `authMiddleware` below would 401 it
+   * before the route's own credential check ever ran — the same reason the
+   * jwks route and `/api/auth/*` above are registered here, ahead of it. The
+   * route authenticates itself; `/api` is still right for it (Bearer passes
+   * CSRF, unlike the HMAC-signed `kaambaan-push` receiver under `/public`),
+   * it just cannot sit behind a middleware built for a session.
+   */
+  .route('/api', stationTokenRoutes)
   .use('/api/*', authMiddleware)
   .use('/api/*', banCheckMiddleware) // Block banned users
   .use('/api/*', csrfMiddleware)

--- a/apps/hub/src/middleware/rate-limit.test.ts
+++ b/apps/hub/src/middleware/rate-limit.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Which bucket a path falls in.
+ *
+ * `getLimitType` is the whole of the rate limiter's policy: everything else
+ * counts. The bucket a path lands in is a security decision — `auth` is 60/min
+ * because a credential-guessing surface should not get the 600/min an
+ * ordinary read gets — and it was made by a `startsWith("/api/auth")` prefix
+ * that no test held.
+ *
+ * The station-token exchange is the case that made this worth pinning. It
+ * takes a secret (`<nodeId>:<nodeSecret>`), it sits OUTSIDE the auth
+ * middleware chain by design (a node holds no session), and it is mounted
+ * under `/api/nodes/...` — so the prefix put it in the generic bucket, giving
+ * a guesser ten times the attempts the sign-in route allows.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { getLimitType } from "./rate-limit";
+
+describe("rate-limit buckets", () => {
+  test("the station-token exchange is auth traffic, not ordinary api traffic", () => {
+    // Real shape: concrete ids, not the `:param` pattern — `c.req.path` is the
+    // requested path.
+    expect(
+      getLimitType("/api/nodes/node_01H8XABCD/stations/stn_01H8XWXYZ/token")
+    ).toBe("auth");
+  });
+
+  test("still buckets sign-in and ordinary reads as before", () => {
+    expect(getLimitType("/api/auth/sign-in/email")).toBe("auth");
+    expect(getLimitType("/api/stations")).toBe("api");
+    expect(getLimitType("/api/nodes")).toBe("api");
+    // A node route that is not the token exchange stays ordinary — the
+    // stricter bucket is for the one that takes a secret, not for every path
+    // with `nodes` in it.
+    expect(getLimitType("/api/nodes/node_01H8XABCD/stations")).toBe("api");
+    expect(getLimitType("/api/missions/m_1/events")).toBe("sse");
+  });
+});

--- a/apps/hub/src/middleware/rate-limit.ts
+++ b/apps/hub/src/middleware/rate-limit.ts
@@ -37,8 +37,21 @@ function getClientIdentifier(c: Context): string {
   return `ip:${ip}`;
 }
 
-function getLimitType(path: string): keyof typeof LIMITS {
+/**
+ * The station-token exchange: `POST /api/nodes/:nodeId/stations/:stationId/token`.
+ *
+ * It is auth traffic that does not live under `/api/auth`. A node presents
+ * `<nodeId>:<nodeSecret>` to it (station-token.ts), so it is a
+ * credential-guessing surface exactly like a sign-in — and because a node
+ * holds no session it sits outside the auth middleware chain by design, which
+ * is what kept the prefix above from catching it. Left in the generic bucket
+ * it would allow ten times the attempts per minute the sign-in route allows.
+ */
+const STATION_TOKEN_EXCHANGE = /^\/api\/nodes\/[^/]+\/stations\/[^/]+\/token$/;
+
+export function getLimitType(path: string): keyof typeof LIMITS {
   if (path.startsWith("/api/auth")) return "auth";
+  if (STATION_TOKEN_EXCHANGE.test(path)) return "auth";
   if (path.includes("/event") || path.includes("/stream")) return "sse";
   return "api";
 }

--- a/apps/hub/src/routes/admin-grants.ts
+++ b/apps/hub/src/routes/admin-grants.ts
@@ -15,6 +15,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
+import { PrincipalId } from "@agentpod/contract";
 import { createLogger } from "../utils/logger";
 import { getGrant, setGrant, deleteGrant, listGrants, NO_GRANT } from "../services/grants";
 import { isControlPairEnforced } from "../services/control-pair";
@@ -22,46 +23,21 @@ import { isControlPairEnforced } from "../services/control-pair";
 const log = createLogger("admin-grants");
 
 /**
- * The planes a grant may name.
+ * A grant value: one principal id, and nothing else.
  *
- * An explicit list, not a shape. The obvious implementation — "anything before a
- * colon is a namespace" — accepts `hermes:*`, which is precisely the retired
- * `CONTROL_PAIR_GRANTS` format this is meant to stop: `hermes` looks exactly
- * like a plane name. It would store happily, match nothing anywhere, and read as
- * a working grant, which is the worst of the three outcomes.
- *
- * `org-plane` is here before it exists, for the same reason it is in the
- * identity systems: adopting it should be a data move.
+ * The same `PrincipalId` grammar the mint site and the cross-repo corpus pin
+ * (`fixtures/ecosystem-identity/id_grammar.json` → `agentpod.principal`), not a
+ * hand-rolled shape check — a second regex here would be a second place for the
+ * grammar to drift from the one that actually mints ids.
  *
  * Note the asymmetry with the reader, and that it is deliberate. A READER
- * ignores a namespace it does not recognise, because a claim is read by more
- * planes over time. A WRITER refuses one, because this is where a human types a
- * value and a typo should come back as an error rather than as silence.
+ * ignores a value it does not recognise, because a claim is read by more planes
+ * over time. A WRITER refuses one, because this is where a human types a value
+ * and a typo should come back as an error rather than as silence — `*` or
+ * `prn_*` would store happily and match nothing anywhere, which is the worst of
+ * the three outcomes.
  */
-const KNOWN_PLANES = ["agentpod", "kaambaan", "org-plane"] as const;
-
-const grantValue = z
-  .string()
-  .min(3)
-  .refine(
-    (v) => KNOWN_PLANES.some((p) => v.startsWith(`${p}:`) && v.length > p.length + 1),
-    `a grant value must name a known plane: ${KNOWN_PLANES.map((p) => `${p}:…`).join(", ")}`
-  )
-  /**
-   * An AgentPod value names a node as well as a station.
-   *
-   * `agentpod:hermes:*` is the shape everyone writes first and it matches no
-   * station on any node, because uniqueness is `(node, stationKey)`
-   * (`charter` → `decisions/2026-08-15-a-grant-names-an-agent-per-plane.md`,
-   * amended). The reader already ignores it; refusing it here is the difference
-   * between a typo answered in a form and a grant that looks live and permits
-   * nothing. Fleet-wide is still available — it just has to be said out loud,
-   * with an explicit wildcard in the node half.
-   */
-  .refine(
-    (v) => !v.startsWith("agentpod:") || v.slice("agentpod:".length).includes("/"),
-    "an agentpod value must name a node too: agentpod:<node>/<stationKey>, e.g. agentpod:*/hermes:*"
-  );
+const grantValue = PrincipalId;
 
 const grantBody = z.object({
   mayDispatch: z.array(grantValue),

--- a/apps/hub/src/routes/admin-principals.ts
+++ b/apps/hub/src/routes/admin-principals.ts
@@ -1,0 +1,27 @@
+/**
+ * The directory a grant is written against.
+ *
+ * A grant names one principal on each side now — the row is keyed by a `prn_`
+ * id and every value in `mayDispatch` is one — and nothing else in this API
+ * will tell you what those ids are. Without this the console's grants page can
+ * only offer a bare text box for a twenty-hex id, which is not a control an
+ * organisation can use: an authorization surface nobody can operate is one
+ * people route around, which is the same reason `/api/admin/grants` exists at
+ * all.
+ *
+ * **Read-only, and deliberately.** Minting a principal is how an agent comes
+ * into existence and is a decision with a handle attached — an immutable
+ * address other systems will hold — so it does not belong on a picker's
+ * convenience endpoint. This lists what is already there; nothing more.
+ *
+ * Mounted inside the same admin guard as the rest of `/api/admin`. This is the
+ * shape of the fleet's identities: who exists, what kind of thing each one is,
+ * and which of them is a person. That is not a public list.
+ */
+
+import { Hono } from "hono";
+import { listPrincipals } from "../services/principals";
+
+export const adminPrincipalsRouter = new Hono().get("/", async (c) => {
+  return c.json({ principals: await listPrincipals() });
+});

--- a/apps/hub/src/routes/admin-principals.ts
+++ b/apps/hub/src/routes/admin-principals.ts
@@ -1,5 +1,6 @@
 /**
- * The directory a grant is written against.
+ * The directory a grant is written against — and the one place a principal is
+ * suspended or restored.
  *
  * A grant names one principal on each side now — the row is keyed by a `prn_`
  * id and every value in `mayDispatch` is one — and nothing else in this API
@@ -9,19 +10,75 @@
  * people route around, which is the same reason `/api/admin/grants` exists at
  * all.
  *
- * **Read-only, and deliberately.** Minting a principal is how an agent comes
- * into existence and is a decision with a handle attached — an immutable
- * address other systems will hold — so it does not belong on a picker's
- * convenience endpoint. This lists what is already there; nothing more.
+ * Listing is **read-only**, and deliberately. Minting a principal is how an
+ * agent comes into existence and is a decision with a handle attached — an
+ * immutable address other systems will hold — so it does not belong on a
+ * picker's convenience endpoint. This lists what is already there; nothing
+ * more.
+ *
+ * Suspend and restore are the exception, and the reason to put them here
+ * rather than leave them as a database script: `buildTokenPayload` already
+ * refuses to mint for a suspended principal, on every subject path, but until
+ * now that lever had no operator surface — only a function reachable with a
+ * database client. `charter` →
+ * decisions/2026-08-15-granting-reach-is-changing-an-agent.md is why this is
+ * two small, boring, reversible endpoints rather than a new page: a control
+ * people route around because it is awkward to use is worse than no control
+ * at all.
  *
  * Mounted inside the same admin guard as the rest of `/api/admin`. This is the
  * shape of the fleet's identities: who exists, what kind of thing each one is,
- * and which of them is a person. That is not a public list.
+ * which of them is a person, and which of them may currently act. That is not
+ * a public list.
  */
 
 import { Hono } from "hono";
-import { listPrincipals } from "../services/principals";
+import {
+  listPrincipals,
+  principalById,
+  suspendPrincipal,
+  restorePrincipal,
+} from "../services/principals";
 
-export const adminPrincipalsRouter = new Hono().get("/", async (c) => {
-  return c.json({ principals: await listPrincipals() });
-});
+export const adminPrincipalsRouter = new Hono()
+  .get("/", async (c) => {
+    return c.json({ principals: await listPrincipals() });
+  })
+
+  /**
+   * Suspend a principal. Idempotent: suspending one that is already
+   * suspended succeeds again rather than erroring — an operator
+   * double-clicking is ordinary, not a fault.
+   *
+   * 404 for an id naming nobody, distinctly from that idempotent 200:
+   * `suspendPrincipal`'s `UPDATE … WHERE id = …` would otherwise touch zero
+   * rows and report success for a principal that was never suspended because
+   * it never existed — which is not "double-clicked", it is a typo, and
+   * should come back as one.
+   */
+  .post("/:id/suspend", async (c) => {
+    const id = c.req.param("id");
+    const existing = await principalById(id);
+    if (!existing) return c.json({ error: "no such principal" }, 404);
+
+    await suspendPrincipal(id);
+    const updated = await principalById(id);
+    return c.json({ id: updated!.id, suspendedAt: updated!.suspendedAt });
+  })
+
+  /**
+   * Lift a suspension — reversible from the same surface as suspending it,
+   * because a control that can only be applied and never undone is one
+   * people route around rather than use. Idempotent for the same reason as
+   * above: restoring a principal that is not suspended succeeds rather than
+   * erroring.
+   */
+  .post("/:id/restore", async (c) => {
+    const id = c.req.param("id");
+    const existing = await principalById(id);
+    if (!existing) return c.json({ error: "no such principal" }, 404);
+
+    await restorePrincipal(id);
+    const updated = await principalById(id);
+    return c.json({ id: updated!.id, suspendedAt: updated!.suspendedAt });
+  });

--- a/apps/hub/src/routes/admin.ts
+++ b/apps/hub/src/routes/admin.ts
@@ -15,6 +15,7 @@ import { adminMiddleware, getRequestContext } from "../auth/admin-middleware";
 import { authMiddleware } from "../auth/middleware";
 import { createLogger } from "../utils/logger";
 import { adminGrantsRouter } from "./admin-grants";
+import { adminPrincipalsRouter } from "./admin-principals";
 
 // Models
 import {
@@ -49,6 +50,11 @@ adminRouter.use("*", adminMiddleware);
 // surface the control is operable only by someone with a database client, and
 // an authorization system nobody can inspect is one people route around.
 adminRouter.route("/grants", adminGrantsRouter);
+
+// The vocabulary those grants are written in. A grant names a `prn_` id on both
+// sides and nothing else in this API says what those ids are, so without this
+// the console can offer only a text box for a twenty-hex string.
+adminRouter.route("/principals", adminPrincipalsRouter);
 
 // =============================================================================
 // Validation Schemas

--- a/apps/hub/src/routes/admin.ts
+++ b/apps/hub/src/routes/admin.ts
@@ -16,6 +16,7 @@ import { authMiddleware } from "../auth/middleware";
 import { createLogger } from "../utils/logger";
 import { adminGrantsRouter } from "./admin-grants";
 import { adminPrincipalsRouter } from "./admin-principals";
+import { agentsAdminRouter } from "./agents-admin";
 
 // Models
 import {
@@ -55,6 +56,11 @@ adminRouter.route("/grants", adminGrantsRouter);
 // sides and nothing else in this API says what those ids are, so without this
 // the console can offer only a text box for a twenty-hex string.
 adminRouter.route("/principals", adminPrincipalsRouter);
+
+// Creating an agent, and putting it in a station. Mounted at the root of
+// `/api/admin` because it owns two path families — `/agents` and
+// `/stations/:stationId/agent` — not one subtree.
+adminRouter.route("/", agentsAdminRouter);
 
 // =============================================================================
 // Validation Schemas

--- a/apps/hub/src/routes/agents-admin.test.ts
+++ b/apps/hub/src/routes/agents-admin.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Route test: creating and assigning an agent.
+ *
+ * `charter → decisions/2026-08-30-an-agent-is-a-principal.md` says creating an
+ * agent is "a deliberate act, not a side effect of a machine appearing" — until
+ * this file, the only way to mint an agent principal was a seed script. This
+ * proves the HTTP surface that replaces it, and what each of its refusals
+ * looks like:
+ *
+ *   1. A handle that would be silently mangled into a different mxid → 400,
+ *      not a quietly different address than the one typed.
+ *   2. A handle already claimed → 409, not the 500 a bare unique-index
+ *      violation would leak — `principals_org_handle_idx` exists because two
+ *      claimants make the mxid it produces ambiguous.
+ *   3. Assigning a suspended principal to a station → 403. A suspended agent
+ *      that can still be handed a station is a suspension that does not
+ *      suspend.
+ *   4. Every one of these, behind the real `adminMiddleware` — a non-admin
+ *      gets 403 from all three verbs.
+ *
+ * Uses the local Docker test-postgres (localhost:5434). Every fixture id is
+ * unique per run (`crypto.randomUUID()`), and `afterAll` deletes what it
+ * created — so this file passes on a fresh database AND on a second run
+ * against the same one, immediately after, with no reset in between.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../tests/helpers/database";
+import { db, rawSql } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
+import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { createPrincipal, suspendPrincipal } from "../services/principals";
+import { adminMiddleware } from "../auth/admin-middleware";
+import { agentsAdminRouter } from "./agents-admin";
+
+const RUN = crypto.randomUUID().slice(0, 8);
+const HANDLE_PREFIX = `agents-admin-it-${RUN}`;
+const ADMIN_ACTOR = `test-admin-actor-agents-admin-${RUN}`;
+const NON_ADMIN_ACTOR = `test-non-admin-actor-agents-admin-${RUN}`;
+
+let stationId: string;
+let principalId: string;
+let suspendedPrincipalId: string;
+
+/** The real guard, not a stub — "a non-admin can do none of it" is a claim
+ *  about `adminMiddleware`, not about the router in isolation. */
+function guardedApp(actorId: string) {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: actorId, authType: "api_key", tenantId: "default" });
+    await next();
+  });
+  a.use("*", adminMiddleware);
+  a.route("/", agentsAdminRouter);
+  return a;
+}
+
+const adminApp = guardedApp(ADMIN_ACTOR);
+const userApp = guardedApp(NON_ADMIN_ACTOR);
+
+async function stationRow(id: string): Promise<{ principalId: string | null } | undefined> {
+  const [row] = await db
+    .select({ principalId: stations.principalId })
+    .from(stations)
+    .where(eq(stations.id, id));
+  return row;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+
+  await createTestUser({
+    id: ADMIN_ACTOR,
+    email: `agents-admin-actor-${RUN}@example.com`,
+    name: "Actor",
+    role: "admin",
+  });
+  await createTestUser({
+    id: NON_ADMIN_ACTOR,
+    email: `agents-admin-nonactor-${RUN}@example.com`,
+    name: "Non-actor",
+  });
+
+  const { token } = await mintEnrollmentToken(ADMIN_ACTOR);
+  const { nodeId } = await enrollNode(token, {
+    hostname: `agents-admin-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 1,
+  });
+
+  stationId = `st_agtadm_${RUN}`;
+  await db.insert(stations).values({
+    id: stationId,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    userId: ADMIN_ACTOR,
+    nodeId,
+    harness: "opencode",
+    stationKey: `opencode:${RUN}`,
+    kind: "workspace",
+    displayName: "/workspace",
+  });
+
+  principalId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-assignee` });
+  suspendedPrincipalId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-suspended` });
+  await suspendPrincipal(suspendedPrincipalId);
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE user_id = ${ADMIN_ACTOR}`;
+    await rawSql`DELETE FROM nodes WHERE user_id = ${ADMIN_ACTOR}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${ADMIN_ACTOR}`;
+    await rawSql`DELETE FROM principals WHERE handle LIKE ${HANDLE_PREFIX + "%"}`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${ADMIN_ACTOR}, ${NON_ADMIN_ACTOR})`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("POST /api/admin/agents", () => {
+  test("creates an agent principal with the handle given", async () => {
+    const res = await adminApp.request("/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ handle: `${HANDLE_PREFIX}-writer`, displayName: "Writer Quill" }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string };
+    expect(body.id).toMatch(/^prn_[0-9a-f]{20}$/);
+  });
+
+  test("refuses a handle already taken", async () => {
+    // A handle becomes an mxid localpart. Two claimants make the address
+    // ambiguous, which is why principals_org_handle_idx exists — surfaced as
+    // a 409, not the 500 a bare constraint violation would leak.
+    const taken = `${HANDLE_PREFIX}-taken`;
+    await createPrincipal({ kind: "agent", handle: taken });
+
+    const res = await adminApp.request("/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ handle: taken }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  test("refuses a handle that cannot be an mxid localpart", async () => {
+    // Would be silently mangled by `clean()` in matrix-as/names.ts into a
+    // different address than the one typed — refused up front instead.
+    const res = await adminApp.request("/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ handle: "Writer Quill!" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("a non-admin cannot create an agent", async () => {
+    const res = await userApp.request("/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ handle: `${HANDLE_PREFIX}-forbidden` }),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("PUT/DELETE /api/admin/stations/:stationId/agent", () => {
+  test("assigning makes the station dispatchable, unassigning makes it nobody's", async () => {
+    const put = await adminApp.request(`/stations/${stationId}/agent`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId }),
+    });
+    expect(put.status).toBe(200);
+    expect((await stationRow(stationId))!.principalId).toBe(principalId);
+
+    const del = await adminApp.request(`/stations/${stationId}/agent`, { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect((await stationRow(stationId))!.principalId).toBeNull();
+  });
+
+  test("refuses to assign a suspended principal — a suspension that can still be given a station does not suspend", async () => {
+    const res = await adminApp.request(`/stations/${stationId}/agent`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: suspendedPrincipalId }),
+    });
+    expect(res.status).toBe(403);
+    expect((await stationRow(stationId))!.principalId).toBeNull();
+  });
+
+  test("refuses an unknown principal id", async () => {
+    const res = await adminApp.request(`/stations/${stationId}/agent`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "prn_ffffffffffffffffff00" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("refuses an unknown station id", async () => {
+    const res = await adminApp.request("/stations/st_doesnotexist/agent", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("a non-admin can assign or unassign none of it", async () => {
+    const put = await userApp.request(`/stations/${stationId}/agent`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId }),
+    });
+    expect(put.status).toBe(403);
+
+    const del = await userApp.request(`/stations/${stationId}/agent`, { method: "DELETE" });
+    expect(del.status).toBe(403);
+  });
+});

--- a/apps/hub/src/routes/agents-admin.ts
+++ b/apps/hub/src/routes/agents-admin.ts
@@ -1,0 +1,167 @@
+/**
+ * Creating an agent, and putting it somewhere.
+ *
+ * `charter → decisions/2026-08-30-an-agent-is-a-principal.md`: creating an
+ * agent is "a deliberate act, not a side effect of a machine appearing" — and
+ * until this file, the only way one came into existence was a seed script run
+ * by hand. This is the HTTP surface that replaces it: minting the principal,
+ * and putting it in a station so it becomes dispatchable.
+ *
+ * Mounted inside the same admin guard as the rest of `/api/admin`, no
+ * exemption carved: minting an identity other systems will address by its
+ * handle forever is at least as sensitive as the grants and suspensions that
+ * already live there.
+ *
+ * Two refusals this file exists to get right:
+ *
+ *   - A handle is what an agent's Matrix address is built from
+ *     (`services/matrix-as/names.ts`), and it is immutable once minted. A
+ *     handle `clean()` would alter — case, or a character outside its kept
+ *     set — must be refused here, not silently registered under a different
+ *     address than the one typed. The character class below is deliberately
+ *     the same one, kept in sync by hand rather than by import: `clean()` is
+ *     private to that module, and duplicating a five-character regex is a
+ *     smaller risk than reaching into a module this task does not otherwise
+ *     touch.
+ *   - Two principals cannot share a handle — `principals_org_handle_idx`
+ *     enforces it at the database — and a race between two admins hitting
+ *     this endpoint at once must still resolve to one winner and a 409, not
+ *     a 500 leaking a constraint name.
+ *
+ * Assigning a suspended principal to a station is refused for a third reason
+ * that belongs to the station side, not the handle side: a suspended agent
+ * that can still be handed a station is a suspension that does not suspend.
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+
+import { db } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { createPrincipal, principalById } from "../services/principals";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("agents-admin");
+
+/**
+ * The same character class `clean()` in `matrix-as/names.ts` cleans a
+ * localpart with. A handle outside it is not rejected there — it is
+ * rewritten, quietly, into a different address than the one an admin typed.
+ * Refusing it here is what makes the handle actually the address, rather
+ * than a suggestion for one.
+ */
+const ILLEGAL_HANDLE_CHARS = /[^a-z0-9.=/-]/g;
+
+function wouldBeMangled(handle: string): boolean {
+  return handle.toLowerCase().replace(ILLEGAL_HANDLE_CHARS, "-") !== handle;
+}
+
+/**
+ * `postgres`'s `PostgresError` isn't re-exported from its ESM entry point
+ * (only its CJS build carries it), so this checks shape rather than
+ * `instanceof` — the wire-protocol error code for a unique-violation, which
+ * is what `principals_org_handle_idx` raises for a repeated handle. Drizzle
+ * wraps the driver's error in its own `DrizzleQueryError`, with the original
+ * on `.cause`, so both layers are checked.
+ */
+function hasCode(err: unknown, code: string): boolean {
+  return typeof err === "object" && err !== null && "code" in err && (err as { code: unknown }).code === code;
+}
+
+function isHandleTaken(err: unknown): boolean {
+  if (hasCode(err, "23505")) return true;
+  const cause = err instanceof Error ? err.cause : undefined;
+  return hasCode(cause, "23505");
+}
+
+const createAgentBody = z.object({
+  handle: z.string().min(1),
+  displayName: z.string().min(1).optional(),
+});
+
+const assignBody = z.object({
+  principalId: z.string(),
+});
+
+export const agentsAdminRouter = new Hono()
+  /**
+   * Mint a new agent principal.
+   *
+   * 201 with the created principal — the id is the whole point of the call,
+   * since nothing else in the fleet can predict a `prn_` id in advance.
+   */
+  .post("/agents", zValidator("json", createAgentBody), async (c) => {
+    const { handle, displayName } = c.req.valid("json");
+
+    if (wouldBeMangled(handle)) {
+      return c.json(
+        { error: "handle would be altered when built into a Matrix address; choose one clean() leaves unchanged" },
+        400
+      );
+    }
+
+    let id: string;
+    try {
+      id = await createPrincipal({ kind: "agent", handle, displayName });
+    } catch (err) {
+      if (isHandleTaken(err)) {
+        return c.json({ error: "handle already taken" }, 409);
+      }
+      throw err;
+    }
+
+    const principal = await principalById(id);
+    log.info("agent principal created", { id, handle, by: c.get("user")?.id });
+    return c.json(
+      {
+        id,
+        kind: principal!.kind,
+        handle,
+        displayName: displayName ?? null,
+        suspendedAt: principal!.suspendedAt,
+      },
+      201
+    );
+  })
+
+  /**
+   * Assign an agent to a station, which is what makes the station
+   * dispatchable — an unoccupied station is a machine, not an agent.
+   *
+   * Refused for a suspended principal: a suspension that can still be handed
+   * a station is a suspension that does not suspend.
+   */
+  .put("/stations/:stationId/agent", zValidator("json", assignBody), async (c) => {
+    const stationId = c.req.param("stationId");
+    const { principalId } = c.req.valid("json");
+
+    const [station] = await db.select({ id: stations.id }).from(stations).where(eq(stations.id, stationId));
+    if (!station) return c.json({ error: "no such station" }, 404);
+
+    const principal = await principalById(principalId);
+    if (!principal) return c.json({ error: "no such principal" }, 404);
+    if (principal.suspendedAt) {
+      return c.json({ error: "principal is suspended" }, 403);
+    }
+
+    await db.update(stations).set({ principalId }).where(eq(stations.id, stationId));
+    log.info("station assigned", { stationId, principalId, by: c.get("user")?.id });
+    return c.json({ stationId, principalId });
+  })
+
+  /**
+   * Unassign — the station goes back to being nobody's, dispatchable by
+   * nobody, exactly the state an unoccupied station is already in.
+   */
+  .delete("/stations/:stationId/agent", async (c) => {
+    const stationId = c.req.param("stationId");
+
+    const [station] = await db.select({ id: stations.id }).from(stations).where(eq(stations.id, stationId));
+    if (!station) return c.json({ error: "no such station" }, 404);
+
+    await db.update(stations).set({ principalId: null }).where(eq(stations.id, stationId));
+    log.info("station unassigned", { stationId, by: c.get("user")?.id });
+    return c.json({ stationId, principalId: null });
+  });

--- a/apps/hub/src/routes/agents-admin.ts
+++ b/apps/hub/src/routes/agents-admin.ts
@@ -147,7 +147,10 @@ export const agentsAdminRouter = new Hono()
     const stationId = c.req.param("stationId");
     const { principalId } = c.req.valid("json");
 
-    const [station] = await db.select({ id: stations.id }).from(stations).where(eq(stations.id, stationId));
+    const [station] = await db
+      .select({ id: stations.id, principalId: stations.principalId })
+      .from(stations)
+      .where(eq(stations.id, stationId));
     if (!station) return c.json({ error: "no such station" }, 404);
 
     const principal = await principalById(principalId);
@@ -155,6 +158,15 @@ export const agentsAdminRouter = new Hono()
     if (principal.suspendedAt) {
       return c.json({ error: "principal is suspended" }, 403);
     }
+
+    // Read BEFORE the transaction overwrites it — fix round 2: assigning a
+    // NEW principal to a station that already holds a DIFFERENT one evicts
+    // that one silently otherwise. It is a legitimate operation (Ruling 6's
+    // "assign a different agent" reassigns exactly this way), but a silent
+    // one is how an operator loses track of an agent without ever seeing it
+    // happen — logged below once the eviction actually lands.
+    const evictedPrincipalId =
+      station.principalId && station.principalId !== principalId ? station.principalId : null;
 
     await db.transaction(async (tx) => {
       // Vacate wherever this principal already is — including this same
@@ -183,17 +195,37 @@ export const agentsAdminRouter = new Hono()
       // its new station happens to have. Conditioned on `NOT EXISTS` rather
       // than checked-then-written so two assignments racing each other cannot
       // both decide the room is free and violate `matrix_rooms_principal_idx`.
+      //
+      // Targets exactly ONE unbound row via a `LIMIT 1` subquery, not a bare
+      // `WHERE station_id = … AND principal_id IS NULL` — a station can carry
+      // more than one room since fix round 1 (`matrix_rooms_station_idx` is
+      // no longer unique), and a plain multi-row UPDATE binding the SAME
+      // principal onto every unbound row at this station in one statement
+      // would itself violate `matrix_rooms_principal_idx` the moment more
+      // than one existed — a real, reachable crash a fix-round-2 test found,
+      // not a hypothetical one.
       await tx.execute(sql`
         UPDATE matrix_rooms
         SET principal_id = ${principalId}
-        WHERE station_id = ${stationId}
-          AND principal_id IS NULL
-          AND NOT EXISTS (
-            SELECT 1 FROM matrix_rooms already_bound WHERE already_bound.principal_id = ${principalId}
-          )
+        WHERE room_id = (
+          SELECT room_id FROM matrix_rooms
+          WHERE station_id = ${stationId} AND principal_id IS NULL
+          LIMIT 1
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM matrix_rooms already_bound WHERE already_bound.principal_id = ${principalId}
+        )
       `);
     });
 
+    if (evictedPrincipalId) {
+      log.warn("assigning a new occupant evicted the station's previous one", {
+        stationId,
+        principalId,
+        evictedPrincipalId,
+        by: c.get("user")?.id,
+      });
+    }
     log.info("station assigned", { stationId, principalId, by: c.get("user")?.id });
     return c.json({ stationId, principalId });
   })

--- a/apps/hub/src/routes/agents-admin.ts
+++ b/apps/hub/src/routes/agents-admin.ts
@@ -36,7 +36,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
@@ -132,6 +132,16 @@ export const agentsAdminRouter = new Hono()
    *
    * Refused for a suspended principal: a suspension that can still be handed
    * a station is a suspension that does not suspend.
+   *
+   * **Occupancy is exclusive — a principal runs in one station at a time.**
+   * Fix-round ruling: nothing had ever decided this, so the code assumed
+   * both answers at once — `stations.principal_id` carried no constraint
+   * against a principal appearing twice, while `matrix_rooms_principal_idx`
+   * only ever allowed it one room. Assigning an already-placed principal is
+   * therefore a MOVE: its previous station (if any) is vacated in the same
+   * transaction this writes the new one, and `stations_principal_id_idx` (a
+   * partial unique index, not-null only) is what makes a principal in two
+   * stations impossible at the schema itself rather than merely unusual.
    */
   .put("/stations/:stationId/agent", zValidator("json", assignBody), async (c) => {
     const stationId = c.req.param("stationId");
@@ -146,30 +156,43 @@ export const agentsAdminRouter = new Hono()
       return c.json({ error: "principal is suspended" }, 403);
     }
 
-    await db.update(stations).set({ principalId }).where(eq(stations.id, stationId));
+    await db.transaction(async (tx) => {
+      // Vacate wherever this principal already is — including this same
+      // station, harmlessly — BEFORE placing it here. Done first and in the
+      // same transaction so a crash between the two steps cannot leave the
+      // principal occupying two stations, which `stations_principal_id_idx`
+      // would refuse anyway; doing it in this order is what makes that
+      // index's own errno the exception rather than the ordinary path.
+      await tx
+        .update(stations)
+        .set({ principalId: null })
+        .where(and(eq(stations.principalId, principalId), ne(stations.id, stationId)));
 
-    // `matrix_rooms.principal_id`'s one writer — `charter →
-    // decisions/2026-08-30-an-agent-is-a-principal.md`'s whole reason a
-    // room's identity comes from a handle rather than a station. Binds this
-    // station's own room to this principal EXACTLY ONCE: only when that room
-    // exists, has no binding yet, and this principal has no room bound
-    // anywhere else. Every later assignment — this principal moving to a
-    // different station, or a different principal taking this one — leaves
-    // the binding alone, which is what makes the room follow the agent
-    // rather than the station: `gates.ts`'s `roomForCard` finds THIS
-    // principal's room from wherever it is dispatched next, not a fresh room
-    // its new station happens to have. Conditioned on `NOT EXISTS` rather
-    // than checked-then-written so two assignments racing each other cannot
-    // both decide the room is free and violate `matrix_rooms_principal_idx`.
-    await db.execute(sql`
-      UPDATE matrix_rooms
-      SET principal_id = ${principalId}
-      WHERE station_id = ${stationId}
-        AND principal_id IS NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM matrix_rooms already_bound WHERE already_bound.principal_id = ${principalId}
-        )
-    `);
+      await tx.update(stations).set({ principalId }).where(eq(stations.id, stationId));
+
+      // `matrix_rooms.principal_id`'s one writer — `charter →
+      // decisions/2026-08-30-an-agent-is-a-principal.md`'s whole reason a
+      // room's identity comes from a handle rather than a station. Binds this
+      // station's own room to this principal EXACTLY ONCE: only when that room
+      // exists, has no binding yet, and this principal has no room bound
+      // anywhere else. Every later assignment — this principal moving to a
+      // different station, or a different principal taking this one — leaves
+      // the binding alone, which is what makes the room follow the agent
+      // rather than the station: `gates.ts`'s `roomForCard` finds THIS
+      // principal's room from wherever it is dispatched next, not a fresh room
+      // its new station happens to have. Conditioned on `NOT EXISTS` rather
+      // than checked-then-written so two assignments racing each other cannot
+      // both decide the room is free and violate `matrix_rooms_principal_idx`.
+      await tx.execute(sql`
+        UPDATE matrix_rooms
+        SET principal_id = ${principalId}
+        WHERE station_id = ${stationId}
+          AND principal_id IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM matrix_rooms already_bound WHERE already_bound.principal_id = ${principalId}
+          )
+      `);
+    });
 
     log.info("station assigned", { stationId, principalId, by: c.get("user")?.id });
     return c.json({ stationId, principalId });

--- a/apps/hub/src/routes/agents-admin.ts
+++ b/apps/hub/src/routes/agents-admin.ts
@@ -39,7 +39,10 @@ import { z } from "zod";
 import { and, eq, ne, sql } from "drizzle-orm";
 
 import { db } from "../db/drizzle";
+import { matrixRooms } from "../db/schema/matrix";
 import { stations } from "../db/schema/stations";
+import { provisionStationNow } from "../services/matrix-as/hooks";
+import { unboundRoomsForStation } from "../services/matrix-as/station-room";
 import { createPrincipal, principalById } from "../services/principals";
 import { createLogger } from "../utils/logger";
 
@@ -168,6 +171,12 @@ export const agentsAdminRouter = new Hono()
     const evictedPrincipalId =
       station.principalId && station.principalId !== principalId ? station.principalId : null;
 
+    // Read for the log line below, not for the write: the `UPDATE` picks its
+    // own row atomically. Held so that if the bind lands on one of several
+    // candidates, the choice is visible in the record — see
+    // `unboundRoomsForStation`.
+    const candidates = await unboundRoomsForStation(stationId);
+
     await db.transaction(async (tx) => {
       // Vacate wherever this principal already is — including this same
       // station, harmlessly — BEFORE placing it here. Done first and in the
@@ -204,12 +213,23 @@ export const agentsAdminRouter = new Hono()
       // would itself violate `matrix_rooms_principal_idx` the moment more
       // than one existed — a real, reachable crash a fix-round-2 test found,
       // not a hypothetical one.
+      //
+      // WHICH one is decided by the rule in `matrix-as/station-room.ts`'s
+      // `unboundRoomsForStation`: oldest `created_at`, tie-broken by
+      // `room_id`. Written out here as an inline `ORDER BY` rather than read
+      // through that function because this must stay ONE atomic statement —
+      // a select-then-update would reopen the race the `NOT EXISTS` clause
+      // exists to close. Until the whole-branch review this was an unordered
+      // `LIMIT 1`: the live writer guessed in exactly the state migration
+      // `0062` was declining to guess in, and could hand the agent a
+      // departed occupant's leftover room instead of the station's own.
       await tx.execute(sql`
         UPDATE matrix_rooms
         SET principal_id = ${principalId}
         WHERE room_id = (
           SELECT room_id FROM matrix_rooms
           WHERE station_id = ${stationId} AND principal_id IS NULL
+          ORDER BY created_at ASC, room_id ASC
           LIMIT 1
         )
         AND NOT EXISTS (
@@ -226,8 +246,58 @@ export const agentsAdminRouter = new Hono()
         by: c.get("user")?.id,
       });
     }
+
+    // Did the bind actually have to choose? Only worth a line when more than
+    // one unbound room was available AND one of them is now this principal's
+    // — a station with several unbound rooms whose occupant already held a
+    // room elsewhere made no choice at all, and saying it did would be the
+    // same sort of untrue record this branch has spent five rounds removing.
+    if (candidates.length > 1) {
+      const [bound] = await db
+        .select({ roomId: matrixRooms.roomId })
+        .from(matrixRooms)
+        .where(eq(matrixRooms.principalId, principalId));
+      if (bound && candidates.some((r) => r.roomId === bound.roomId)) {
+        log.warn("station carried more than one unbound room; bound the oldest", {
+          stationId,
+          principalId,
+          chose: bound.roomId,
+          among: candidates.map((r) => r.roomId),
+        });
+      }
+    }
+
     log.info("station assigned", { stationId, principalId, by: c.get("user")?.id });
-    return c.json({ stationId, principalId });
+
+    // **Provisioning runs here, and its failure does NOT undo the
+    // assignment.** The whole-branch review's Critical was that it did not
+    // run at all: the console reaches no other trigger, and a bridge-mode
+    // station with no occupant is exactly the case `provision.ts` returns
+    // early from — so adoption made no room, assignment made no room, and
+    // the first anyone heard of it was a gate that resolved to nowhere.
+    //
+    // Why the assignment stands when the homeserver does not:
+    //
+    //  - Occupancy is a fact in the organization plane; a Matrix room is
+    //    that plane's shadow on a system this hub does not own. Letting an
+    //    unreachable homeserver veto who occupies a station inverts which of
+    //    the two is authoritative.
+    //  - A rollback here could not be partial. Assignment is a MOVE — it has
+    //    already vacated wherever this principal was — so undoing it would
+    //    have to restore an occupancy the operator deliberately ended, or
+    //    leave the principal nowhere. Both are worse lies than a missing
+    //    room.
+    //  - `provisionStation` is idempotent and re-runs at boot and on every
+    //    later trigger, so a recorded assignment with no room self-heals. A
+    //    rolled-back assignment heals nothing, and the operator's retry is
+    //    the same call either way.
+    //
+    // What it must not do is read as success. The outcome is logged at error
+    // level by `provisionStationNow` and returned in the body, so the console
+    // can say "assigned, but it has no room yet" instead of nothing at all.
+    const room = await provisionStationNow(stationId);
+
+    return c.json({ stationId, principalId, room });
   })
 
   /**

--- a/apps/hub/src/routes/agents-admin.ts
+++ b/apps/hub/src/routes/agents-admin.ts
@@ -36,7 +36,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
@@ -147,6 +147,30 @@ export const agentsAdminRouter = new Hono()
     }
 
     await db.update(stations).set({ principalId }).where(eq(stations.id, stationId));
+
+    // `matrix_rooms.principal_id`'s one writer — `charter →
+    // decisions/2026-08-30-an-agent-is-a-principal.md`'s whole reason a
+    // room's identity comes from a handle rather than a station. Binds this
+    // station's own room to this principal EXACTLY ONCE: only when that room
+    // exists, has no binding yet, and this principal has no room bound
+    // anywhere else. Every later assignment — this principal moving to a
+    // different station, or a different principal taking this one — leaves
+    // the binding alone, which is what makes the room follow the agent
+    // rather than the station: `gates.ts`'s `roomForCard` finds THIS
+    // principal's room from wherever it is dispatched next, not a fresh room
+    // its new station happens to have. Conditioned on `NOT EXISTS` rather
+    // than checked-then-written so two assignments racing each other cannot
+    // both decide the room is free and violate `matrix_rooms_principal_idx`.
+    await db.execute(sql`
+      UPDATE matrix_rooms
+      SET principal_id = ${principalId}
+      WHERE station_id = ${stationId}
+        AND principal_id IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM matrix_rooms already_bound WHERE already_bound.principal_id = ${principalId}
+        )
+    `);
+
     log.info("station assigned", { stationId, principalId, by: c.get("user")?.id });
     return c.json({ stationId, principalId });
   })

--- a/apps/hub/src/routes/enrollment-tokens.ts
+++ b/apps/hub/src/routes/enrollment-tokens.ts
@@ -17,11 +17,18 @@ const log = createLogger("enrollment-tokens");
  * reach: "anyone who can register an agent and grant it production credentials
  * … they build the agent they want."
  *
- * It names no station, so there is no pattern to match against and the rule is
- * the narrower one — you may grow a fleet only if your authority already spans
- * it. Enforced on the route rather than in `mintEnrollmentToken`, because the
- * service is also how the *node* re-enrols itself and how tests build fixtures;
- * this is a check on a person asking, not on a token being made.
+ * It names no station, so there is nothing for a grant to be compared against.
+ * The rule used to be "you may grow a fleet only if your authority already
+ * spans it" — a dispatch value whose node half was `*`. With wildcards deleted
+ * (charter decisions/2026-08-30-an-agent-is-a-principal.md §3) there is no way
+ * to write "spans", and 2026-08-15-granting-reach-is-changing-an-agent
+ * explicitly rejected a second scoped list as the asymmetric-grant hazard
+ * restated. So `requireFleetGrantReach` asks whether the caller is an admin,
+ * which is what `/api/admin/grants` is already guarded by, and this route
+ * carries the same answer. Enforced on the route rather than in
+ * `mintEnrollmentToken`, because the service is also how the *node* re-enrols
+ * itself and how tests build fixtures; this is a check on a person asking, not
+ * on a token being made.
  *
  * `requireFleetGrantReach` takes a principal id, not a Better Auth user id, so
  * the caller is resolved to one here via `principalForUser` — the same lookup

--- a/apps/hub/src/routes/enrollment-tokens.ts
+++ b/apps/hub/src/routes/enrollment-tokens.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
 import { mintEnrollmentToken } from "../services/enrollment";
 import { requireFleetGrantReach } from "../services/grant-reach";
-import { isGrantReachDenied } from "../services/control-pair";
+import { isControlPairEnforced, isGrantReachDenied, GrantReachDenied } from "../services/control-pair";
+import { principalForUser } from "../services/principals";
 
 /**
  * POST /api/enrollment-tokens
@@ -18,12 +19,27 @@ import { isGrantReachDenied } from "../services/control-pair";
  * it. Enforced on the route rather than in `mintEnrollmentToken`, because the
  * service is also how the *node* re-enrols itself and how tests build fixtures;
  * this is a check on a person asking, not on a token being made.
+ *
+ * `requireFleetGrantReach` takes a principal id, not a Better Auth user id, so
+ * the caller is resolved to one here via `principalForUser` — the same lookup
+ * Task 4's default resolver uses — before the guard runs. Gated behind
+ * `isControlPairEnforced()` up front, not just inside the guard: resolving
+ * a principal and refusing an unmapped one must stay exactly as inert as the
+ * guard itself when the pair is off, or a deployment that never enabled the
+ * control pair would start rejecting enrollment for every caller with no
+ * principal row — which today is everyone. A caller the pair DOES enforce
+ * against and who has no linked principal is refused, the same as a
+ * non-admin one: fail closed on an unmapped identity, never fail open.
  */
 export const enrollmentTokenRoutes = new Hono().post("/", async (c) => {
   const user = c.get("user");
 
   try {
-    await requireFleetGrantReach(user.id);
+    if (isControlPairEnforced()) {
+      const principal = await principalForUser(user.id);
+      if (!principal) throw new GrantReachDenied(user.id, "fleet", null);
+      await requireFleetGrantReach(principal.id);
+    }
   } catch (e) {
     if (!isGrantReachDenied(e)) throw e;
     return c.json({ error: "You do not have permission to add machines to this fleet." }, 403);

--- a/apps/hub/src/routes/enrollment-tokens.ts
+++ b/apps/hub/src/routes/enrollment-tokens.ts
@@ -3,6 +3,9 @@ import { mintEnrollmentToken } from "../services/enrollment";
 import { requireFleetGrantReach } from "../services/grant-reach";
 import { isControlPairEnforced, isGrantReachDenied, GrantReachDenied } from "../services/control-pair";
 import { principalForUser } from "../services/principals";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("enrollment-tokens");
 
 /**
  * POST /api/enrollment-tokens
@@ -37,7 +40,10 @@ export const enrollmentTokenRoutes = new Hono().post("/", async (c) => {
   try {
     if (isControlPairEnforced()) {
       const principal = await principalForUser(user.id);
-      if (!principal) throw new GrantReachDenied(user.id, "fleet", null);
+      if (!principal) {
+        log.warn("fleet-level reach refused: no principal for this caller", { principalId: user.id });
+        throw new GrantReachDenied(user.id, "fleet", null);
+      }
       await requireFleetGrantReach(principal.id);
     }
   } catch (e) {

--- a/apps/hub/src/routes/matrix-as.ts
+++ b/apps/hub/src/routes/matrix-as.ts
@@ -17,11 +17,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { matrixAsTransactions } from "../db/schema/matrix";
 import { isBridgeUser } from "../services/matrix-as/names";
-import {
-  stationForLocalpart,
-  stationForAgentUserId,
-  localpartFromAlias,
-} from "../services/matrix-as/stations";
+import { stationForAgentUserId, stationForAlias } from "../services/matrix-as/stations";
 import { recordTransaction } from "../services/matrix-as/health";
 import { createLogger } from "../utils/logger";
 
@@ -202,9 +198,17 @@ export function createMatrixAsRoutes(deps: MatrixAsDeps) {
       .get("/rooms/:alias", async (c) => {
         if (!authorised(c, deps)) return c.json({ errcode: "M_FORBIDDEN" }, 403);
 
+        // Both alias shapes, through the one resolver `onProvisionAlias`
+        // uses — fix round 4. This gate used to ask `stationForLocalpart`
+        // alone, which knows only the station-derived form: an
+        // occupant-derived alias (`bridgeAliasForHandle`, the shape every
+        // occupied station's room carries now) was 404'd HERE, before
+        // `onProvisionAlias` and its two-shape lookup ever ran. Nothing live
+        // broke, because a legacy alias still resolved — but the path that
+        // creates a missing room for an agent addressed by its handle could
+        // never heal itself.
         const alias = decodeURIComponent(c.req.param("alias"));
-        const localpart = localpartFromAlias(alias, deps.domain);
-        const station = localpart ? await stationForLocalpart(localpart) : null;
+        const station = await stationForAlias(alias, deps.domain);
         if (!station) return c.json({ errcode: "M_NOT_FOUND" }, 404);
 
         if (deps.onProvisionAlias) await deps.onProvisionAlias(alias);

--- a/apps/hub/src/routes/matrix-as.ts
+++ b/apps/hub/src/routes/matrix-as.ts
@@ -19,7 +19,7 @@ import { matrixAsTransactions } from "../db/schema/matrix";
 import { isBridgeUser } from "../services/matrix-as/names";
 import {
   stationForLocalpart,
-  localpartFromUserId,
+  stationForAgentUserId,
   localpartFromAlias,
 } from "../services/matrix-as/stations";
 import { recordTransaction } from "../services/matrix-as/health";
@@ -183,11 +183,10 @@ export function createMatrixAsRoutes(deps: MatrixAsDeps) {
       .get("/users/:userId", async (c) => {
         if (!authorised(c, deps)) return c.json({ errcode: "M_FORBIDDEN" }, 403);
 
-        const localpart = localpartFromUserId(
-          decodeURIComponent(c.req.param("userId")),
-          deps.domain
-        );
-        const station = localpart ? await stationForLocalpart(localpart) : null;
+        // An agent's user id is built from its occupying principal's handle
+        // now, not from `(nodeName, stationKey)` — see `stationForAgentUserId`.
+        const userId = decodeURIComponent(c.req.param("userId"));
+        const station = await stationForAgentUserId(userId, deps.domain);
         if (!station) return c.json({ errcode: "M_NOT_FOUND" }, 404);
 
         return c.json({}, 200);

--- a/apps/hub/src/routes/missions.ts
+++ b/apps/hub/src/routes/missions.ts
@@ -19,7 +19,7 @@ import { nodes } from "../db/schema/nodes";
 import { matrixMissions, matrixMissionMembers } from "../db/schema/matrix";
 import { principalIdentities } from "../db/schema/identities";
 import { getGrant, grantAllowsPrincipal } from "../services/grants";
-import { principalForUser } from "../services/principals";
+import { principalForUser, principalHandle } from "../services/principals";
 import { isControlPairEnforced } from "../services/control-pair";
 import { bridgeUserId } from "../services/matrix-as/names";
 import { missionAlias } from "../services/matrix-as/missions";
@@ -159,11 +159,34 @@ export function createMissionRoutes(deps: MissionDeps) {
       return c.json({ id: existing.id, roomId: existing.roomId, alias: existing.alias });
     }
 
+    // A mission's members are addressed by their principal's handle now, not
+    // by where they run — resolved for every member before anything is
+    // created, because a half-made mission is worse than none. A station with
+    // no occupying agent has no handle and therefore no mxid to invite, and
+    // that must refuse the whole request rather than invent one from
+    // `(nodeName, stationKey)`, which is the station-derived identity this
+    // suite moved away from.
+    const handles = new Map<string, string>();
+    for (const m of members) {
+      const handle = m.principalId ? await principalHandle(m.principalId) : null;
+      if (!handle) {
+        return c.json(
+          {
+            error:
+              `${m.nodeName}/${m.stationKey} has no occupying agent, so it has no Matrix ` +
+              "identity to put in this mission.",
+          },
+          409
+        );
+      }
+      handles.set(m.id, handle);
+    }
+
     const tenantId = members[0]!.tenantId;
     // The mission speaks as the first agent in it: an appservice must act as
     // SOME user in its namespace, and a room created by one of its members reads
     // better than one created by a nameless bot.
-    const speaker = bridgeUserId(members[0]!.nodeName, members[0]!.stationKey, deps.domain);
+    const speaker = bridgeUserId(handles.get(members[0]!.id)!, deps.domain);
 
     const roomId = await deps.client.ensureRoom(alias, {
       creator: speaker,
@@ -221,7 +244,7 @@ export function createMissionRoutes(deps: MissionDeps) {
     );
 
     for (const m of members) {
-      const agent = bridgeUserId(m.nodeName, m.stationKey, deps.domain);
+      const agent = bridgeUserId(handles.get(m.id)!, deps.domain);
       if (agent === speaker) continue; // already in the room, having made it
       await deps.client.invite(speaker, roomId, agent).catch(() => {});
     }

--- a/apps/hub/src/routes/missions.ts
+++ b/apps/hub/src/routes/missions.ts
@@ -18,7 +18,8 @@ import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
 import { matrixMissions, matrixMissionMembers } from "../db/schema/matrix";
 import { principalIdentities } from "../db/schema/identities";
-import { getGrant, grantAllowsStation } from "../services/grants";
+import { getGrant, grantAllowsPrincipal } from "../services/grants";
+import { principalForUser } from "../services/principals";
 import { isControlPairEnforced } from "../services/control-pair";
 import { bridgeUserId } from "../services/matrix-as/names";
 import { missionAlias } from "../services/matrix-as/missions";
@@ -93,6 +94,7 @@ export function createMissionRoutes(deps: MissionDeps) {
         tenantId: stations.tenantId,
         stationKey: stations.stationKey,
         nodeName: nodes.name,
+        principalId: stations.principalId,
       })
       .from(stations)
       .innerJoin(nodes, eq(nodes.id, stations.nodeId))
@@ -108,17 +110,30 @@ export function createMissionRoutes(deps: MissionDeps) {
     // different day — and the room's creator is visible to everyone in it.
     members.sort((a, b) => stationIds.indexOf(a.id) - stationIds.indexOf(b.id));
 
+    // `getGrant` and `principal_identities` are both keyed by principal id now,
+    // never by the Better Auth user id a session carries — resolved once, up
+    // front, for the control-pair check below and the Matrix invite further
+    // down. A caller with no principal has no grant to hold and no identity to
+    // invite, so both must fail closed on it rather than querying a table with
+    // an id shaped like the wrong plane's.
+    const principal = await principalForUser(user.id);
+
     // Putting an agent in a room is putting it to work, so the grant that
     // governs dispatching it governs this too — checked for EVERY member before
     // anything is created, because a half-made mission is worse than none.
     if (isControlPairEnforced()) {
-      const grant = await getGrant(user.id);
-      const refused = members.filter(
-        (m) => !grantAllowsStation(grant, { nodeName: m.nodeName, stationKey: m.stationKey })
-      );
+      if (!principal) {
+        log.warn("mission refused: no principal for this caller", { userId: user.id });
+        return c.json(
+          { error: "You are not permitted to dispatch every agent in this mission." },
+          403
+        );
+      }
+      const grant = await getGrant(principal.id);
+      const refused = members.filter((m) => !grantAllowsPrincipal(grant, m.principalId));
       if (refused.length > 0) {
         log.warn("mission refused by the control pair", {
-          principalId: user.id,
+          principalId: principal.id,
           refused: refused.map((m) => `${m.nodeName}/${m.stationKey}`),
         });
         return c.json(
@@ -157,15 +172,20 @@ export function createMissionRoutes(deps: MissionDeps) {
     });
     if (!roomId) return c.json({ error: "Could not create the mission's room." }, 502);
 
-    const [identity] = await db
-      .select({ externalId: principalIdentities.externalId })
-      .from(principalIdentities)
-      .where(
-        and(
-          eq(principalIdentities.principalId, user.id),
-          eq(principalIdentities.system, "matrix")
-        )
-      );
+    // `principal_identities.principal_id` is a `prn_…` value — comparing it
+    // against the raw Better Auth `user.id` would find nothing for every
+    // caller, silently dropping them from their own mission's invite list.
+    const [identity] = principal
+      ? await db
+          .select({ externalId: principalIdentities.externalId })
+          .from(principalIdentities)
+          .where(
+            and(
+              eq(principalIdentities.principalId, principal.id),
+              eq(principalIdentities.system, "matrix")
+            )
+          )
+      : [];
 
     // Every mission goes in the one Missions space. Grouping is by NODE now,
     // and a mission that spans machines — which is most of them, since that is

--- a/apps/hub/src/routes/station-matrix.ts
+++ b/apps/hub/src/routes/station-matrix.ts
@@ -25,6 +25,7 @@ import { requireIssueCredentials } from "../services/grant-reach";
 import { isGrantReachDenied } from "../services/control-pair";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "../services/matrix-as/names";
 import { isMatrixUserInUse } from "../services/matrix-as/client";
+import { principalHandle } from "../services/principals";
 import type { AuthUser } from "../auth/middleware";
 
 export interface IssuedCredentials {
@@ -64,11 +65,25 @@ export function createStationMatrixRoutes(deps: StationMatrixDeps) {
         nodeName: nodes.name,
         stationKey: stations.stationKey,
         mode: stations.matrixIdentityMode,
+        principalId: stations.principalId,
       })
       .from(stations)
       .innerJoin(nodes, eq(nodes.id, stations.nodeId))
       .where(and(eq(stations.id, stationId), eq(stations.userId, userId)));
     return row ?? null;
+  }
+
+  /**
+   * The handle of the agent occupying a station, or null.
+   *
+   * A station with no occupying principal has no handle and therefore no
+   * agent mxid — never invented from `(nodeName, stationKey)`, which is
+   * exactly the station-derived identity this file stopped minting. Every
+   * caller treats null as a 409, failing visibly rather than building an
+   * address for nobody.
+   */
+  async function occupyingHandle(station: { principalId: string | null }): Promise<string | null> {
+    return station.principalId ? principalHandle(station.principalId) : null;
   }
 
   return new Hono()
@@ -86,8 +101,19 @@ export function createStationMatrixRoutes(deps: StationMatrixDeps) {
 
       await deps.provisionStation(station.id);
 
+      const handle = await occupyingHandle(station);
+      if (!handle) {
+        return c.json(
+          {
+            error:
+              "This station has no occupying agent, so it has no Matrix identity of its own.",
+          },
+          409
+        );
+      }
+
       return c.json({
-        mxid: bridgeUserId(station.nodeName, station.stationKey, deps.domain),
+        mxid: bridgeUserId(handle, deps.domain),
         alias: bridgeAlias(station.nodeName, station.stationKey, deps.domain),
         mode: station.mode,
       });
@@ -124,7 +150,18 @@ export function createStationMatrixRoutes(deps: StationMatrixDeps) {
         );
       }
 
-      const localpart = bridgeLocalpart(station.nodeName, station.stationKey);
+      const handle = await occupyingHandle(station);
+      if (!handle) {
+        return c.json(
+          {
+            error:
+              "This station has no occupying agent, so it has no Matrix identity to issue credentials for.",
+          },
+          409
+        );
+      }
+
+      const localpart = bridgeLocalpart(handle);
 
       // Register, and rotate if the identity turns out to already exist.
       //

--- a/apps/hub/src/routes/station-matrix.ts
+++ b/apps/hub/src/routes/station-matrix.ts
@@ -23,7 +23,8 @@ import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
 import { requireIssueCredentials } from "../services/grant-reach";
 import { isGrantReachDenied } from "../services/control-pair";
-import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "../services/matrix-as/names";
+import { bridgeUserId, bridgeLocalpart } from "../services/matrix-as/names";
+import { roomAliasForStation } from "../services/matrix-as/station-room";
 import { isMatrixUserInUse } from "../services/matrix-as/client";
 import { principalHandle } from "../services/principals";
 import type { AuthUser } from "../auth/middleware";
@@ -112,9 +113,19 @@ export function createStationMatrixRoutes(deps: StationMatrixDeps) {
         );
       }
 
+      // The address the room this endpoint just provisioned is ACTUALLY
+      // reachable at, read through the one resolver for that question — not
+      // `bridgeAlias(nodeName, stationKey)` re-derived here, which is what
+      // this returned until fix round 5. An occupied station's room is
+      // addressed by its occupant's handle, and this endpoint 409s below
+      // unless the station HAS an occupant, so the station-derived form was
+      // wrong for every station it can answer for: the AS route 200s on it
+      // through the legacy fallback and then creates nothing (the station
+      // already has a room), and the caller is left with a directory lookup
+      // that fails.
       return c.json({
         mxid: bridgeUserId(handle, deps.domain),
-        alias: bridgeAlias(station.nodeName, station.stationKey, deps.domain),
+        alias: await roomAliasForStation(station.id, deps.domain),
         mode: station.mode,
       });
     })

--- a/apps/hub/src/routes/station-say.test.ts
+++ b/apps/hub/src/routes/station-say.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Speaking unprompted — and never in the wrong room.
+ *
+ * Fix round 2 on Task 5. A review's second pass found this route making the
+ * identical mistake `gates.ts`'s `roomForCard` was fixed for in round 1: a
+ * bare `leftJoin(matrixRooms, eq(matrixRooms.stationId, stations.id))`, with
+ * no `ORDER BY`, handed back an ARBITRARY room at a station's `station_id` —
+ * which, once a station can carry more than one room, can belong to whoever
+ * occupied it before. This route then spoke as the station's CURRENT
+ * occupant into THAT room. P leaves a station, Q takes it: this route would
+ * post `@agent_Q`'s words into `@agent_P`'s room, a room whose Matrix
+ * membership belongs to P — a live route, unlike `roomForCard`, this was
+ * never previously covered by a test at all.
+ *
+ * `station-room.ts`'s `roomForStation` is now the one place this resolves,
+ * shared with `gates.ts` and `provision.ts`. This is the test that would have
+ * caught the bug, and the one that proves it stays caught.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../tests/helpers/database";
+import { db, rawSql } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { matrixRooms } from "../db/schema/matrix";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
+import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { createPrincipal } from "../services/principals";
+import { adminMiddleware } from "../auth/admin-middleware";
+import { agentsAdminRouter } from "./agents-admin";
+import { createStationSayRoutes } from "./station-say";
+import { bridgeUserId } from "../services/matrix-as/names";
+import type { AuthUser } from "../auth/middleware";
+
+const RUN = crypto.randomUUID().slice(0, 8);
+const HANDLE_PREFIX = `station-say-it-${RUN}`;
+const OWNER = `test-owner-station-say-${RUN}`;
+const DOMAIN = "id.agentpod.dev";
+
+let stationAId: string;
+let pId: string;
+let qId: string;
+const roomA1 = `!say-a1-${RUN}:id.agentpod.dev`;
+const roomA2 = `!say-a2-${RUN}:id.agentpod.dev`;
+
+function adminApp() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: OWNER, authType: "api_key", tenantId: "default" });
+    await next();
+  });
+  a.use("*", adminMiddleware);
+  a.route("/", agentsAdminRouter);
+  return a;
+}
+
+function sayApp(sent: Array<{ userId: string; roomId: string; body: string }>) {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: OWNER } as AuthUser);
+    await next();
+  });
+  a.route(
+    "/",
+    createStationSayRoutes({
+      domain: DOMAIN,
+      client: {
+        sendText: async (userId: string, roomId: string, body: string) => {
+          sent.push({ userId, roomId, body });
+          return `$evt-${sent.length}`;
+        },
+      },
+    })
+  );
+  return a;
+}
+
+const admin = adminApp();
+
+async function assign(stationId: string, principalId: string) {
+  const res = await admin.request(`/stations/${stationId}/agent`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ principalId }),
+  });
+  expect(res.status).toBe(200);
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+
+  await createTestUser({
+    id: OWNER,
+    email: `station-say-owner-${RUN}@example.com`,
+    name: "Owner",
+    role: "admin",
+  });
+
+  const { token } = await mintEnrollmentToken(OWNER);
+  const { nodeId } = await enrollNode(token, {
+    hostname: `station-say-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 1,
+  });
+
+  stationAId = `st_say_a_${RUN}`;
+  await db.insert(stations).values({
+    id: stationAId,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    userId: OWNER,
+    nodeId,
+    harness: "opencode",
+    stationKey: `opencode:${RUN}-a`,
+    kind: "workspace",
+    displayName: "Station A",
+  });
+
+  // P's own room — the ordinary case: a station provisioned once, for its
+  // first occupant.
+  await db.insert(matrixRooms).values({
+    roomId: roomA1,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    stationId: stationAId,
+    alias: `#say-a1-${RUN}:${DOMAIN}`,
+  });
+
+  pId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-p` });
+  qId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-q` });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE user_id = ${OWNER}`;
+    await rawSql`DELETE FROM nodes WHERE user_id = ${OWNER}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${OWNER}`;
+    await rawSql`DELETE FROM principals WHERE handle LIKE ${HANDLE_PREFIX + "%"}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("speaking unprompted reaches the CURRENT occupant's own room", () => {
+  test("P leaves the station, Q takes it: this route speaks as Q, into Q's own room — never P's", async () => {
+    // P occupies A first, binding room A1 — its OWN room, kept from here on.
+    await assign(stationAId, pId);
+    const [a1] = await db
+      .select({ principalId: matrixRooms.principalId })
+      .from(matrixRooms)
+      .where(eq(matrixRooms.roomId, roomA1));
+    expect(a1!.principalId).toBe(pId);
+
+    // A second room turns up at the SAME station — what provisioning gives
+    // the next occupant, since a departed occupant's room (A1) stays put
+    // rather than being reused. Station A now genuinely carries two rooms,
+    // the ordinary case since fix round 1 dropped uniqueness from
+    // `matrix_rooms_station_idx`.
+    await db.insert(matrixRooms).values({
+      roomId: roomA2,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      stationId: stationAId,
+      alias: `#say-a2-${RUN}:${DOMAIN}`,
+    });
+
+    // Q takes A — evicting P (a station holds one occupant at a time). Room
+    // A2, still unbound, is what binds to Q; room A1 stays P's, untouched.
+    await assign(stationAId, qId);
+    const [a1After, a2After] = await Promise.all([
+      db.select({ principalId: matrixRooms.principalId }).from(matrixRooms).where(eq(matrixRooms.roomId, roomA1)),
+      db.select({ principalId: matrixRooms.principalId }).from(matrixRooms).where(eq(matrixRooms.roomId, roomA2)),
+    ]);
+    expect(a1After[0]!.principalId, "P's room is untouched by Q's assignment").toBe(pId);
+    expect(a2After[0]!.principalId).toBe(qId);
+
+    const sent: Array<{ userId: string; roomId: string; body: string }> = [];
+    const app = sayApp(sent);
+
+    const res = await app.request(`/stations/${stationAId}/matrix/say`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: "good morning" }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { roomId: string; mxid: string };
+
+    const qMxid = bridgeUserId(`${HANDLE_PREFIX}-q`, DOMAIN);
+    const pMxid = bridgeUserId(`${HANDLE_PREFIX}-p`, DOMAIN);
+
+    // Q's OWN room — never P's, even though P's room still sits at this
+    // exact `station_id`.
+    expect(json.roomId).toBe(roomA2);
+    expect(json.roomId).not.toBe(roomA1);
+    expect(json.mxid).toBe(qMxid);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.roomId).toBe(roomA2);
+    expect(sent[0]!.userId).toBe(qMxid);
+    // The bug this test exists to catch: nothing sent as P, nowhere.
+    expect(sent.some((s) => s.userId === pMxid || s.roomId === roomA1)).toBe(false);
+  });
+});

--- a/apps/hub/src/routes/station-say.ts
+++ b/apps/hub/src/routes/station-say.ts
@@ -25,7 +25,7 @@ import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
 import { matrixRooms } from "../db/schema/matrix";
 import { getGrant, grantAllowsPrincipal } from "../services/grants";
-import { principalForUser } from "../services/principals";
+import { principalForUser, principalHandle } from "../services/principals";
 import { isControlPairEnforced } from "../services/control-pair";
 import { bridgeUserId } from "../services/matrix-as/names";
 import { createLogger } from "../utils/logger";
@@ -118,7 +118,22 @@ export function createStationSayRoutes(deps: StationSayDeps) {
       );
     }
 
-    const agentUser = bridgeUserId(station.nodeName, station.stationKey, deps.domain);
+    // A station with no occupying agent has no handle and therefore no mxid to
+    // speak as — refused rather than falling back to the retired
+    // `(nodeName, stationKey)` form, which would silently reinvent a
+    // station-derived identity.
+    const handle = station.principalId ? await principalHandle(station.principalId) : null;
+    if (!handle) {
+      return c.json(
+        {
+          error:
+            "This station has no occupying agent, so there is nobody to speak as here.",
+        },
+        409
+      );
+    }
+
+    const agentUser = bridgeUserId(handle, deps.domain);
     const eventId = await deps.client.sendText(agentUser, station.roomId, text);
 
     log.info("station spoke unprompted", {

--- a/apps/hub/src/routes/station-say.ts
+++ b/apps/hub/src/routes/station-say.ts
@@ -24,7 +24,8 @@ import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
 import { matrixRooms } from "../db/schema/matrix";
-import { getGrant, grantAllowsStation } from "../services/grants";
+import { getGrant, grantAllowsPrincipal } from "../services/grants";
+import { principalForUser } from "../services/principals";
 import { isControlPairEnforced } from "../services/control-pair";
 import { bridgeUserId } from "../services/matrix-as/names";
 import { createLogger } from "../utils/logger";
@@ -50,6 +51,7 @@ export function createStationSayRoutes(deps: StationSayDeps) {
         mode: stations.matrixIdentityMode,
         nodeName: nodes.name,
         roomId: matrixRooms.roomId,
+        principalId: stations.principalId,
       })
       .from(stations)
       .innerJoin(nodes, eq(nodes.id, stations.nodeId))
@@ -67,14 +69,19 @@ export function createStationSayRoutes(deps: StationSayDeps) {
     // The same question dispatching asks. Speaking as an agent is speaking AS
     // it, and a grant that does not cover this station does not cover this.
     if (isControlPairEnforced()) {
-      const grant = await getGrant(user.id);
-      const allowed = grantAllowsStation(grant, {
-        nodeName: station.nodeName,
-        stationKey: station.stationKey,
-      });
+      // `getGrant` is keyed by principal id now, not the Better Auth user id a
+      // session carries — a caller with no principal has no grant to hold and
+      // must be refused, not treated as unrestricted.
+      const principal = await principalForUser(user.id);
+      if (!principal) {
+        log.warn("unprompted message refused: no principal for this caller", { userId: user.id });
+        return c.json({ error: "You are not permitted to speak as this agent." }, 403);
+      }
+      const grant = await getGrant(principal.id);
+      const allowed = grantAllowsPrincipal(grant, station.principalId);
       if (!allowed) {
         log.warn("unprompted message refused by the control pair", {
-          principalId: user.id,
+          principalId: principal.id,
           node: station.nodeName,
           stationKey: station.stationKey,
         });

--- a/apps/hub/src/routes/station-say.ts
+++ b/apps/hub/src/routes/station-say.ts
@@ -23,11 +23,11 @@ import { eq, and } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
 import { nodes } from "../db/schema/nodes";
-import { matrixRooms } from "../db/schema/matrix";
 import { getGrant, grantAllowsPrincipal } from "../services/grants";
 import { principalForUser, principalHandle } from "../services/principals";
 import { isControlPairEnforced } from "../services/control-pair";
 import { bridgeUserId } from "../services/matrix-as/names";
+import { roomForStation } from "../services/matrix-as/station-room";
 import { createLogger } from "../utils/logger";
 import type { AuthUser } from "../auth/middleware";
 
@@ -50,12 +50,10 @@ export function createStationSayRoutes(deps: StationSayDeps) {
         stationKey: stations.stationKey,
         mode: stations.matrixIdentityMode,
         nodeName: nodes.name,
-        roomId: matrixRooms.roomId,
         principalId: stations.principalId,
       })
       .from(stations)
       .innerJoin(nodes, eq(nodes.id, stations.nodeId))
-      .leftJoin(matrixRooms, eq(matrixRooms.stationId, stations.id))
       .where(and(eq(stations.id, c.req.param("id")), eq(stations.userId, user.id)));
 
     if (!station) return c.json({ error: "Not Found" }, 404);
@@ -109,7 +107,16 @@ export function createStationSayRoutes(deps: StationSayDeps) {
       );
     }
 
-    if (!station.roomId) {
+    // The CURRENT occupant's own room — never a departed occupant's room
+    // that merely still sits at this `station_id`. A plain
+    // `leftJoin(matrixRooms, stationId)` here was finding 1 of a fix-round
+    // review's second pass: it would speak as `station.principalId` into
+    // whatever room that unordered join happened to return, which could
+    // belong to a predecessor — `@agent_Q` sent into `@agent_P`'s room, a
+    // room whose Matrix membership belongs to P. `station-room.ts` is the
+    // one place this resolves now.
+    const roomId = (await roomForStation(station.id)).room?.roomId ?? null;
+    if (!roomId) {
       // Provisioning may simply not have run yet. Saying which thing is missing
       // beats swallowing the message.
       return c.json(
@@ -134,7 +141,7 @@ export function createStationSayRoutes(deps: StationSayDeps) {
     }
 
     const agentUser = bridgeUserId(handle, deps.domain);
-    const eventId = await deps.client.sendText(agentUser, station.roomId, text);
+    const eventId = await deps.client.sendText(agentUser, roomId, text);
 
     log.info("station spoke unprompted", {
       principalId: user.id,
@@ -142,6 +149,6 @@ export function createStationSayRoutes(deps: StationSayDeps) {
       chars: text.length,
     });
 
-    return c.json({ eventId, roomId: station.roomId, mxid: agentUser });
+    return c.json({ eventId, roomId, mxid: agentUser });
   });
 }

--- a/apps/hub/src/routes/station-terminal.test.ts
+++ b/apps/hub/src/routes/station-terminal.test.ts
@@ -243,6 +243,12 @@ async function adoptStation(
 
 /** Put the test's agent in the station, so a grant naming it covers this one. */
 async function occupy(stationId: string): Promise<void> {
+  // Occupancy is exclusive as of the fix round on Task 5
+  // (`stations_principal_id_idx`) — this file reuses ONE `AGENT_PRINCIPAL`
+  // across many tests, each adopting its own fresh station, so it has to
+  // vacate wherever that principal already sits (an earlier test's station)
+  // before placing it here, exactly as the real assign endpoint now does.
+  await rawSql`UPDATE stations SET principal_id = NULL WHERE principal_id = ${AGENT_PRINCIPAL}`;
   await rawSql`UPDATE stations SET principal_id = ${AGENT_PRINCIPAL} WHERE id = ${stationId}`;
 }
 

--- a/apps/hub/src/routes/station-terminal.test.ts
+++ b/apps/hub/src/routes/station-terminal.test.ts
@@ -27,6 +27,7 @@ import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
 import { waitForNodeOnline } from "../../tests/helpers/wait";
 import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
 import { setGrant } from "../services/grants";
+import { createPrincipal } from "../services/principals";
 import { gatewayRoutes } from "./gateway";
 import { stationTerminalRoutes } from "./station-terminal";
 import { stationRoutes } from "./stations";
@@ -39,6 +40,22 @@ import type { StationRow } from "../services/station-registry";
 const TEST_USER = "test-user-sterm-001";
 const STATION_KEY = "sterm-station";
 const FAKE_SESSION_ID = "pty-session-abc123";
+
+/**
+ * The two principals the control-pair tests need.
+ *
+ * A grant is keyed by the CALLER's principal and its values are the principal
+ * ids of the agents that caller may dispatch — `principal_grants.principal_id`
+ * is a foreign key onto `principals.id`, so a grant keyed by a Better Auth id
+ * is not a wide grant, it is a failed INSERT. And the scope half compares the
+ * grant against the station's OCCUPANT, so a station with nobody in it is
+ * dispatchable by nobody: `AGENT_PRINCIPAL` is put on the station after adoption,
+ * which is the fixture standing in for an assignment nothing yet does.
+ */
+const USER_HANDLE = "sterm-it-user";
+const AGENT_HANDLE = "sterm-it-agent";
+let USER_PRINCIPAL: string;
+let AGENT_PRINCIPAL: string;
 
 // ─── Minimal test app ─────────────────────────────────────────────────────────
 
@@ -67,6 +84,12 @@ beforeAll(async () => {
     email: "sterm-test@example.com",
     name: "Station Terminal Test User",
   });
+  USER_PRINCIPAL = await createPrincipal({
+    kind: "human",
+    handle: USER_HANDLE,
+    userId: TEST_USER,
+  });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: AGENT_HANDLE });
 });
 
 afterAll(async () => {
@@ -74,6 +97,7 @@ afterAll(async () => {
     await rawSql`DELETE FROM stations          WHERE user_id = ${TEST_USER}`;
     await rawSql`DELETE FROM nodes             WHERE user_id = ${TEST_USER}`;
     await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM principals        WHERE handle IN (${USER_HANDLE}, ${AGENT_HANDLE})`;
     await rawSql`DELETE FROM "user"            WHERE id = ${TEST_USER}`;
   } catch {
     // Ignore cleanup errors
@@ -215,6 +239,11 @@ async function adoptStation(
   const rows = (await res.json()) as StationRow[];
   expect(rows).toHaveLength(1);
   return rows[0]!;
+}
+
+/** Put the test's agent in the station, so a grant naming it covers this one. */
+async function occupy(stationId: string): Promise<void> {
+  await rawSql`UPDATE stations SET principal_id = ${AGENT_PRINCIPAL} WHERE id = ${stationId}`;
 }
 
 // ─── Helpers (event-driven) ───────────────────────────────────────────────────
@@ -619,8 +648,10 @@ test(
       });
       const station = await adoptStation(baseUrl, nodeId);
 
-      // Dispatch as wide as it goes, and no reach.
-      await setGrant(TEST_USER, { mayDispatch: ["agentpod:*/sterm-station"], mayGrantReach: false });
+      // Dispatch over this very agent, and no reach — so the only thing that
+      // can refuse is the reach half.
+      await occupy(station.id);
+      await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
       await rawSql`DELETE FROM station_audit WHERE user_id = ${TEST_USER} AND verb = 'terminal'`;
 
       await new Promise<void>((resolve) => {
@@ -656,7 +687,7 @@ test(
       fakeNode.close();
     } finally {
       delete process.env.ENFORCE_CONTROL_PAIR;
-      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${TEST_USER}`;
+      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER_PRINCIPAL}`;
       server.stop(true);
     }
   },
@@ -685,7 +716,8 @@ test(
       });
       const station = await adoptStation(baseUrl, nodeId);
 
-      await setGrant(TEST_USER, { mayDispatch: ["agentpod:*/sterm-station"], mayGrantReach: true });
+      await occupy(station.id);
+      await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
 
       const clientWs = new WebSocket(
         `ws://localhost:${server.port}/api/stations/${station.id}/terminal`,
@@ -713,7 +745,7 @@ test(
       fakeNode.close();
     } finally {
       delete process.env.ENFORCE_CONTROL_PAIR;
-      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${TEST_USER}`;
+      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER_PRINCIPAL}`;
       server.stop(true);
     }
   },

--- a/apps/hub/src/routes/station-token.test.ts
+++ b/apps/hub/src/routes/station-token.test.ts
@@ -148,6 +148,11 @@ describe("a node exchanges for one of its stations", () => {
     const claims = decodeJwt(body.token);
     expect(claims.sub).toBe(agentPrincipalId);
     expect(claims.principalKind).toBe("agent");
+    // The node minted this, the agent did not present a credential of its
+    // own — act.sub names the node, so an auditor can tell "the agent
+    // acted" apart from "node N minted for the agent", the fact that scopes
+    // a compromised node's blast radius (service-signing.ts:19-25).
+    expect(claims.act).toEqual({ sub: nodeId });
   });
 
   test("refuses a station hosted by a different node", async () => {

--- a/apps/hub/src/routes/station-token.test.ts
+++ b/apps/hub/src/routes/station-token.test.ts
@@ -144,8 +144,20 @@ describe("a node exchanges for one of its stations", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { token: string; expiresIn: number };
     expect(typeof body.expiresIn).toBe("number");
-    expect(body.expiresIn).toBeGreaterThan(0);
+    // The ACTUAL bound, not its sign. TOKEN_TTL = "5m" is the revocation SLA
+    // (jwt-claims.ts: verification is offline, there is no revocation list,
+    // "the expiry IS the revocation SLA") — it is precisely how long a
+    // suspended principal's already-issued token keeps working. Asserting
+    // only `> 0` would let a drift to "5h" pass the whole suite in silence.
+    // Bounded rather than exact for the same reason service-signing.test.ts
+    // bounds its 120s: iat and exp are wall-clock seconds and minting costs
+    // real time.
+    expect(body.expiresIn).toBeGreaterThan(280);
+    expect(body.expiresIn).toBeLessThanOrEqual(300);
     const claims = decodeJwt(body.token);
+    // Same bound read off the token itself, since `expiresIn` is a number the
+    // response computes and a consumer verifying offline reads only these.
+    expect((claims.exp as number) - (claims.iat as number)).toBe(body.expiresIn);
     expect(claims.sub).toBe(agentPrincipalId);
     expect(claims.principalKind).toBe("agent");
     // The node minted this, the agent did not present a credential of its

--- a/apps/hub/src/routes/station-token.test.ts
+++ b/apps/hub/src/routes/station-token.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Route test: POST /api/nodes/:nodeId/stations/:stationId/token
+ *
+ * A node exchanges its long-term `<nodeId>:<nodeSecret>` credential for a
+ * short-lived token naming the principal occupying one of its stations. This
+ * is the endpoint a wrong subject would be minted from, so what is proven
+ * here is mostly refusal:
+ *
+ *   1. Success mints for the station's OCCUPANT, not the node — sub is the
+ *      agent principal, not the node id, and claims come from the same
+ *      `buildTokenPayload` a human's token uses.
+ *   2. A station hosted by a DIFFERENT node → 403. The node proves who it
+ *      is, not what it may reach.
+ *   3. A station with no occupying principal → 409, distinctly — the
+ *      ordinary state of an unassigned station, not a fault.
+ *   4. A suspended principal → 403 (`buildTokenPayload`'s refusal, surfaced
+ *      rather than re-implemented, but not left as the 500 it throws as).
+ *   5. A bad node credential → 401.
+ *
+ * Uses the local Docker test-postgres (localhost:5434). Every fixture id is
+ * unique per run (`crypto.randomUUID()`), and `afterAll` deletes what it
+ * created — so this file passes on a fresh database AND on a second run
+ * against the same one, immediately after, with no reset in between.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { decodeJwt } from "jose";
+
+import { db, rawSql } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../tests/helpers/database";
+import { mintEnrollmentToken, enrollNode } from "../services/enrollment";
+import { createPrincipal, suspendPrincipal } from "../services/principals";
+import { stationTokenRoutes } from "./station-token";
+
+const RUN = crypto.randomUUID().slice(0, 8);
+const TEST_USER = `test-user-station-token-${RUN}`;
+
+const app = new Hono().route("/api", stationTokenRoutes);
+
+let nodeId: string;
+let nodeSecret: string;
+let otherNodeId: string;
+let stationId: string;
+let otherNodesStation: string;
+let unoccupied: string;
+let agentPrincipalId: string;
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: TEST_USER,
+    email: `station-token-${RUN}@example.com`,
+    name: "Station Token Test User",
+  });
+
+  const { token } = await mintEnrollmentToken(TEST_USER);
+  ({ nodeId, nodeSecret } = await enrollNode(token, {
+    hostname: `station-token-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  }));
+
+  const { token: otherToken } = await mintEnrollmentToken(TEST_USER);
+  const other = await enrollNode(otherToken, {
+    hostname: `station-token-other-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 2,
+  });
+  otherNodeId = other.nodeId;
+
+  agentPrincipalId = await createPrincipal({
+    kind: "agent",
+    handle: `station-token-agent-${RUN}`,
+  });
+
+  stationId = `st_stt_${RUN}`;
+  await db.insert(stations).values({
+    id: stationId,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    userId: TEST_USER,
+    nodeId,
+    harness: "opencode",
+    stationKey: "opencode:ws",
+    kind: "workspace",
+    displayName: "/workspace",
+    principalId: agentPrincipalId,
+  });
+
+  otherNodesStation = `st_stt_other_${RUN}`;
+  await db.insert(stations).values({
+    id: otherNodesStation,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    userId: TEST_USER,
+    nodeId: otherNodeId,
+    harness: "opencode",
+    stationKey: "opencode:ws",
+    kind: "workspace",
+    displayName: "/workspace",
+  });
+
+  unoccupied = `st_stt_unocc_${RUN}`;
+  await db.insert(stations).values({
+    id: unoccupied,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    userId: TEST_USER,
+    nodeId,
+    harness: "opencode",
+    stationKey: "opencode:idle",
+    kind: "workspace",
+    displayName: "/idle",
+  });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM nodes WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${TEST_USER}`;
+    await rawSql`DELETE FROM principals WHERE id = ${agentPrincipalId}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${TEST_USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("a node exchanges for one of its stations", () => {
+  test("mints for the station's occupant, naming the principal and its kind", async () => {
+    const res = await app.request(`/api/nodes/${nodeId}/stations/${stationId}/token`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string; expiresIn: number };
+    expect(typeof body.expiresIn).toBe("number");
+    expect(body.expiresIn).toBeGreaterThan(0);
+    const claims = decodeJwt(body.token);
+    expect(claims.sub).toBe(agentPrincipalId);
+    expect(claims.principalKind).toBe("agent");
+  });
+
+  test("refuses a station hosted by a different node", async () => {
+    // The node proves who it is, not what it may reach. Without this check any
+    // node could mint for any agent in the fleet.
+    const res = await app.request(`/api/nodes/${nodeId}/stations/${otherNodesStation}/token`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("refuses a station with no occupying principal, distinctly", async () => {
+    const res = await app.request(`/api/nodes/${nodeId}/stations/${unoccupied}/token`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    });
+    expect(res.status).toBe(409);
+  });
+
+  test("refuses a suspended principal", async () => {
+    await suspendPrincipal(agentPrincipalId);
+    const res = await app.request(`/api/nodes/${nodeId}/stations/${stationId}/token`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("refuses a wrong node secret", async () => {
+    const res = await app.request(`/api/nodes/${nodeId}/stations/${stationId}/token`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${nodeId}:wrong` },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/hub/src/routes/station-token.ts
+++ b/apps/hub/src/routes/station-token.ts
@@ -1,0 +1,120 @@
+/**
+ * A node exchanges its long-term `<nodeId>:<nodeSecret>` credential for a
+ * short-lived token naming the principal occupying one of its stations.
+ *
+ * This is the endpoint that lets an agent hold no long-lived credential of
+ * its own — the node already proved itself once, at enrollment, and this is
+ * that proof spent again on a station's behalf
+ * (`charter → decisions/2026-08-30-an-agent-is-a-principal.md`). It is also
+ * the most sensitive thing in this slice: a token minted for the wrong
+ * subject makes every action the agent takes attribute to the wrong
+ * principal while looking exactly like it worked. Every refusal here fails
+ * closed, and each is distinct so an operator reading a 4xx knows which.
+ *
+ * **The credential.** A station holds no secret of its own — `stations.ts`
+ * carries `matrixId`, `bridgeMatrixId`, `principalId` and nothing that could
+ * authenticate a request. The node's `<nodeId>:<nodeSecret>` is what exists,
+ * so the node exchanges on the station's behalf, following the exact scheme
+ * `nodes.ts`'s credential-check uses — parsed the same way, verified with
+ * the same `verifyNodeCredential`.
+ *
+ * **Claims come from `buildTokenPayload` and nowhere else.** Hand-assembling
+ * a payload here would be exactly how an agent ends up carrying authority
+ * its grant does not give. `buildTokenPayload` also refuses to mint for a
+ * suspended principal — that refusal is let through rather than
+ * re-implemented, only translated from the 500 it throws as into the 403 it
+ * means.
+ *
+ * Mounted under `/api`, not `/public`: `Bearer` already passes the CSRF
+ * middleware (unlike the HMAC-signed `kaambaan-push` receiver, which needs
+ * `/public` because a signed body is not a bearer credential), so nothing
+ * here needs the exemption.
+ */
+
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { decodeJwt } from "jose";
+
+import { db } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { verifyNodeCredential } from "../services/enrollment";
+import { buildTokenPayload, TOKEN_TTL } from "../auth/jwt-claims";
+import { signServiceToken } from "../auth/service-signing";
+
+export const stationTokenRoutes = new Hono().post(
+  "/nodes/:nodeId/stations/:stationId/token",
+  async (c) => {
+    const nodeId = c.req.param("nodeId");
+    const stationId = c.req.param("stationId");
+
+    // Same scheme as nodes.ts:249-258 — Authorization: Bearer
+    // <nodeId>:<nodeSecret>. The credential must both verify AND name the
+    // node the URL claims to be: a credential that verifies for a different
+    // node is not this node's request, whatever the path says, so a
+    // mismatch here fails the same way a wrong secret does.
+    const auth = c.req.header("Authorization") ?? "";
+    const bearer = auth.replace(/^Bearer\s+/, "");
+    const idx = bearer.indexOf(":");
+    const credNodeId = idx !== -1 ? bearer.slice(0, idx) : "";
+    const nodeSecret = idx !== -1 ? bearer.slice(idx + 1) : "";
+
+    if (
+      !credNodeId ||
+      !nodeSecret ||
+      credNodeId !== nodeId ||
+      !(await verifyNodeCredential(credNodeId, nodeSecret))
+    ) {
+      return c.json({ error: "invalid node credential" }, 401);
+    }
+
+    const [station] = await db
+      .select()
+      .from(stations)
+      .where(eq(stations.id, stationId));
+
+    // The node proves who IT is, not what it may reach. A station that does
+    // not exist and a station hosted by a different node are
+    // indistinguishable to this credential and refused identically —
+    // otherwise this endpoint would let one node probe another's station
+    // ids by reading 403 apart from 404. Without this check any node could
+    // mint a token for any agent in the fleet just by naming its station.
+    if (!station || station.nodeId !== nodeId) {
+      return c.json({ error: "station not hosted by this node" }, 403);
+    }
+
+    // Not an error condition — the ordinary state of a station nobody has
+    // put an agent on. Said distinctly (409, not 403/404) so an operator
+    // reading it does not mistake an unassigned station for a fault.
+    if (!station.principalId) {
+      return c.json({ error: "station has no occupying principal" }, 409);
+    }
+
+    let payload;
+    try {
+      payload = await buildTokenPayload({ principalId: station.principalId });
+    } catch (e) {
+      // buildTokenPayload's own refusal for a suspended principal — let
+      // through rather than re-implemented, translated from the 500 a
+      // thrown Error becomes by default into the 403 it actually means.
+      // Anything else here would be a bug (a station's principalId is a
+      // live foreign key), so it is left to propagate as a 500.
+      if (/suspended/.test((e as Error).message)) {
+        return c.json({ error: "principal suspended" }, 403);
+      }
+      throw e;
+    }
+
+    const token = await signServiceToken({
+      payload,
+      subject: station.principalId,
+      ttl: TOKEN_TTL,
+    });
+
+    // Read back from the signed token rather than a second constant, so
+    // `expiresIn` can never drift from what the token itself says.
+    const { iat, exp } = decodeJwt(token);
+    const expiresIn = typeof iat === "number" && typeof exp === "number" ? exp - iat : undefined;
+
+    return c.json({ token, expiresIn });
+  }
+);

--- a/apps/hub/src/routes/station-token.ts
+++ b/apps/hub/src/routes/station-token.ts
@@ -25,6 +25,14 @@
  * re-implemented, only translated from the 500 it throws as into the 403 it
  * means.
  *
+ * **The token also carries `act: { sub: nodeId }`.** `sub` is the agent —
+ * this is its own token, not an assertion of someone else — but the agent
+ * did not present a credential; the node did, on its behalf. Recording that
+ * distinctly is what lets an auditor tell "the agent acted" apart from
+ * "node N minted a token for the agent", which is the fact that scopes a
+ * compromised node's blast radius to that node
+ * (`auth/service-signing.ts`:19-25).
+ *
  * Mounted under `/api`, not `/public`: `Bearer` already passes the CSRF
  * middleware (unlike the HMAC-signed `kaambaan-push` receiver, which needs
  * `/public` because a signed body is not a bearer credential), so nothing
@@ -108,6 +116,13 @@ export const stationTokenRoutes = new Hono().post(
       payload,
       subject: station.principalId,
       ttl: TOKEN_TTL,
+      // Delegation that cannot be seen in the record is impersonation with
+      // better manners (service-signing.ts:19-25). sub names the agent, but
+      // the agent is not the one presenting a credential here — the node is,
+      // on its behalf — so act.sub names the node. On a compromised node
+      // this is the fact that scopes the blast radius to that node instead
+      // of reading as "the agent acted" with nothing to tell the two apart.
+      extraClaims: { act: { sub: nodeId } },
     });
 
     // Read back from the signed token rather than a second constant, so

--- a/apps/hub/src/services/acp-sessions.ts
+++ b/apps/hub/src/services/acp-sessions.ts
@@ -48,9 +48,9 @@ import type {
 import { db } from "../db/drizzle";
 import { resolveTenantForUser } from "../auth/tenant";
 import { ControlPairDenied, isControlPairEnforced } from "./control-pair";
-import { getGrant, grantAllowsStation } from "./grants";
+import { getGrant, grantAllowsPrincipal } from "./grants";
+import { principalForUser } from "./principals";
 import { acpSessions, acpEvents } from "../db/schema/acp";
-import { nodes } from "../db/schema/nodes";
 import { stations } from "../db/schema/stations";
 import { createLogger } from "../utils/logger";
 import { getStation } from "./station-registry";
@@ -655,25 +655,18 @@ export async function createSession(
   // to someone who was never permitted leaks which stations exist.
   const station = await getStation(userId, stationId);
   if (station && isControlPairEnforced()) {
-    // The grant names a node as well as a station, because station keys repeat
-    // across nodes — `opencode:c52ddf65` exists on two of them in production.
-    const [node] = await db
-      .select({ name: nodes.name })
-      .from(nodes)
-      .where(eq(nodes.id, station.nodeId))
-      .limit(1);
-
+    // `getGrant` is keyed by principal id now, not the Better Auth user id
+    // `userId` is here — `getStation` above requires it to equal
+    // `stations.userId`, so this is always a session id, never one obtained
+    // elsewhere. A caller with no principal has no grant to hold.
+    const principal = await principalForUser(userId);
     const allowed =
-      node !== undefined &&
-      grantAllowsStation(await getGrant(userId), {
-        nodeName: node.name,
-        stationKey: station.stationKey,
-      });
+      principal !== null && grantAllowsPrincipal(await getGrant(principal.id), station.principalId);
 
     if (!allowed) {
       log.warn("dispatch refused by the control pair", {
-        principalId: userId,
-        node: node?.name,
+        userId,
+        principalId: principal?.id ?? null,
         stationKey: station.stationKey,
         stationId,
       });

--- a/apps/hub/src/services/enrollment.ts
+++ b/apps/hub/src/services/enrollment.ts
@@ -2,15 +2,12 @@ import { and, eq, gt, isNull } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { resolveTenantForUser } from "../auth/tenant";
 import { nodes, enrollmentTokens, provisionedRuntimes } from "../db/schema/nodes";
+import { prefixedId } from "../utils/ids";
 import type { HostInfo, EnrollResponse } from "@agentpod/contract";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
-
-/** Generate a prefixed ID: e.g. "node_a1b2c3d4e5f6..." */
-const prefixedId = (prefix: string) =>
-  `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
 
 /** SHA-256 hex digest of a string */
 const sha256 = async (s: string): Promise<string> =>

--- a/apps/hub/src/services/grant-reach.test.ts
+++ b/apps/hub/src/services/grant-reach.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Service Test: grant-reach — growing the fleet is an admin act
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ * DATABASE_URL must be set before any src/ modules are imported.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../tests/helpers/database";
+import { rawSql } from "../db/drizzle";
+import { createPrincipal } from "./principals";
+import { requireFleetGrantReach } from "./grant-reach";
+import { GrantReachDenied, isControlPairEnforced } from "./control-pair";
+
+const NON_ADMIN_USER = "test-user-grant-reach-nonadmin";
+const ADMIN_USER = "test-user-grant-reach-admin";
+
+let NON_ADMIN_PRINCIPAL: string;
+let ADMIN_PRINCIPAL: string;
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+
+  await createTestUser({
+    id: NON_ADMIN_USER,
+    email: "grant-reach-nonadmin@example.com",
+    name: "Non Admin",
+    role: "user",
+  });
+  await createTestUser({
+    id: ADMIN_USER,
+    email: "grant-reach-admin@example.com",
+    name: "Admin",
+    role: "admin",
+  });
+
+  NON_ADMIN_PRINCIPAL = await createPrincipal({
+    kind: "human",
+    handle: "grant-reach-nonadmin",
+    userId: NON_ADMIN_USER,
+  });
+  ADMIN_PRINCIPAL = await createPrincipal({
+    kind: "human",
+    handle: "grant-reach-admin",
+    userId: ADMIN_USER,
+  });
+
+  // The guard is a no-op unless the control pair is enforced.
+  process.env.ENFORCE_CONTROL_PAIR = "true";
+});
+
+afterAll(async () => {
+  delete process.env.ENFORCE_CONTROL_PAIR;
+  try {
+    await rawSql`DELETE FROM principal_identities WHERE external_id IN (${NON_ADMIN_USER}, ${ADMIN_USER})`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('grant-reach-nonadmin', 'grant-reach-admin')`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${NON_ADMIN_USER}, ${ADMIN_USER})`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("requireFleetGrantReach", () => {
+  test("a non-admin cannot mint an enrollment token, however wide their grant", async () => {
+    // The wildcard that encoded "your authority spans the fleet" no longer
+    // exists. A second scoped list was rejected by
+    // 2026-08-15-granting-reach-is-changing-an-agent, so this is admin.
+    await expect(requireFleetGrantReach(NON_ADMIN_PRINCIPAL)).rejects.toThrow(GrantReachDenied);
+  });
+
+  test("an admin may", async () => {
+    await expect(requireFleetGrantReach(ADMIN_PRINCIPAL)).resolves.toBeUndefined();
+  });
+
+  test("is a no-op when the pair is not enforced, admin or not", async () => {
+    const before = process.env.ENFORCE_CONTROL_PAIR;
+    expect(isControlPairEnforced()).toBe(true);
+    try {
+      process.env.ENFORCE_CONTROL_PAIR = "false";
+      await expect(requireFleetGrantReach(NON_ADMIN_PRINCIPAL)).resolves.toBeUndefined();
+    } finally {
+      if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;
+      else process.env.ENFORCE_CONTROL_PAIR = before;
+    }
+  });
+});

--- a/apps/hub/src/services/grant-reach.ts
+++ b/apps/hub/src/services/grant-reach.ts
@@ -12,11 +12,13 @@
  * Design: `docs/superpowers/specs/2026-08-15-granting-reach-design.md`.
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Capability } from "@agentpod/contract";
 import { db } from "../db/drizzle";
 import { nodes } from "../db/schema";
-import { getGrant, grantAllowsStation, AGENTPOD_NS } from "./grants";
+import { principalIdentities } from "../db/schema/identities";
+import { getGrant, grantAllowsStation } from "./grants";
+import { isUserAdmin } from "../models/admin-users";
 import { isControlPairEnforced, GrantReachDenied } from "./control-pair";
 import { createLogger } from "../utils/logger";
 
@@ -146,27 +148,44 @@ export async function requireIssueCredentials(
 }
 
 /**
- * Guard an act that names no station — minting an enrollment token today, the
- * credential broker later.
+ * Is this principal an admin?
  *
- * There is no station to match a pattern against, so the rule is narrower: you
- * may grow a fleet only if your authority already spans it. The alternative —
- * the boolean alone — would let a principal scoped to one node add machines
- * indefinitely, which is the "register an agent" half of Decision 4's threat
- * restated.
+ * Resolves through the same identity the login session came from —
+ * `principal_identities` where `system = "better-auth"` — and asks the
+ * question the Better Auth admin plugin already answers for `/api/admin/*`:
+ * is `role` on that `user` row `"admin"`. No second notion of admin is
+ * introduced here; a principal with no linked Better Auth identity (an agent,
+ * a service) is simply not an admin.
  */
-export async function requireFleetGrantReach(userId: string): Promise<void> {
+async function isAdminPrincipal(principalId: string): Promise<boolean> {
+  const [identity] = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(principalIdentities)
+    .where(
+      and(
+        eq(principalIdentities.principalId, principalId),
+        eq(principalIdentities.system, "better-auth")
+      )
+    )
+    .limit(1);
+
+  if (!identity) return false;
+  return isUserAdmin(identity.externalId);
+}
+
+/**
+ * Growing a fleet is an admin act.
+ *
+ * This used to require `mayGrantReach` plus a dispatch value whose node half was
+ * `*` — "you may grow a fleet only if your authority already spans it". With no
+ * wildcards there is no way to say "spans", and
+ * 2026-08-15-granting-reach-is-changing-an-agent explicitly rejected a second
+ * scoped list as the asymmetric-grant hazard restated. Admin is the honest
+ * remaining answer, and /api/admin/grants is already guarded that way.
+ */
+export async function requireFleetGrantReach(principalId: string): Promise<void> {
   if (!isControlPairEnforced()) return;
-
-  const grant = await getGrant(userId);
-  const fleetWide =
-    grant?.mayGrantReach === true &&
-    grant.mayDispatch.some(
-      (v) => v.startsWith(AGENTPOD_NS) && v.slice(AGENTPOD_NS.length).startsWith("*/")
-    );
-
-  if (!fleetWide) {
-    log.warn("fleet-level reach refused by the control pair", { principalId: userId });
-    throw new GrantReachDenied(userId, "fleet", null);
-  }
+  if (await isAdminPrincipal(principalId)) return;
+  log.warn("fleet-level reach refused: not an admin", { principalId });
+  throw new GrantReachDenied(principalId, "fleet", null);
 }

--- a/apps/hub/src/services/grant-reach.ts
+++ b/apps/hub/src/services/grant-reach.ts
@@ -15,9 +15,10 @@
 import { and, eq } from "drizzle-orm";
 import { Capability } from "@agentpod/contract";
 import { db } from "../db/drizzle";
-import { nodes } from "../db/schema";
+import { stations } from "../db/schema";
 import { principalIdentities } from "../db/schema/identities";
-import { getGrant, grantAllowsStation } from "./grants";
+import { getGrant, grantAllowsPrincipal } from "./grants";
+import { principalForUser } from "./principals";
 import { isUserAdmin } from "../models/admin-users";
 import { isControlPairEnforced, GrantReachDenied } from "./control-pair";
 import { createLogger } from "../utils/logger";
@@ -58,9 +59,14 @@ export function isReachBearing(cap: Capability): boolean {
  * Guard a station-scoped act.
  *
  * Two conditions, both required: the principal holds `mayGrantReach`, AND their
- * dispatch scope covers this station. One scope list, shared with dispatch, so
- * the two can never disagree about what a pattern means — `grantAllowsStation`
+ * dispatch scope covers this station. One scope check, shared with dispatch, so
+ * the two can never disagree about what a grant means — `grantAllowsPrincipal`
  * is the same function `acp.createSession` calls.
+ *
+ * `userId` is a Better Auth user id — every caller reaches this through a
+ * console route holding a session, never a principal id obtained elsewhere —
+ * and is resolved to a principal before either `getGrant` or the station scope
+ * check, both of which are keyed by principal id now.
  */
 export async function requireGrantReach(
   userId: string,
@@ -71,36 +77,44 @@ export async function requireGrantReach(
   if (!isControlPairEnforced()) return;
   if (effect === "read" || !isReachBearing(cap)) return;
 
-  const grant = await getGrant(userId);
-  if (!grant?.mayGrantReach) {
-    log.warn("reach refused by the control pair: principal may not change agents", {
-      principalId: userId,
+  const principal = await principalForUser(userId);
+  if (!principal) {
+    log.warn("reach refused by the control pair: no principal for this caller", {
+      userId,
       stationKey: station.stationKey,
       capability: cap,
     });
     throw new GrantReachDenied(userId, station.stationKey, cap);
   }
 
-  // The node name, because a grant names a node as well as a station — station
-  // keys repeat across the fleet.
-  const [node] = await db
-    .select({ name: nodes.name })
-    .from(nodes)
-    .where(eq(nodes.id, station.nodeId))
-    .limit(1);
-
-  const inScope =
-    node !== undefined &&
-    grantAllowsStation(grant, { nodeName: node.name, stationKey: station.stationKey });
-
-  if (!inScope) {
-    log.warn("reach refused by the control pair: station out of scope", {
-      principalId: userId,
-      node: node?.name,
+  const grant = await getGrant(principal.id);
+  if (!grant?.mayGrantReach) {
+    log.warn("reach refused by the control pair: principal may not change agents", {
+      principalId: principal.id,
       stationKey: station.stationKey,
       capability: cap,
     });
-    throw new GrantReachDenied(userId, station.stationKey, cap);
+    throw new GrantReachDenied(principal.id, station.stationKey, cap);
+  }
+
+  // The station's OCCUPYING PRINCIPAL, not the station itself — a grant names
+  // an agent, and (nodeId, stationKey) is the unique index that gets there
+  // without a second copy of the id in every caller's hands.
+  const [row] = await db
+    .select({ principalId: stations.principalId })
+    .from(stations)
+    .where(and(eq(stations.nodeId, station.nodeId), eq(stations.stationKey, station.stationKey)))
+    .limit(1);
+
+  const inScope = row !== undefined && grantAllowsPrincipal(grant, row.principalId);
+
+  if (!inScope) {
+    log.warn("reach refused by the control pair: station out of scope", {
+      principalId: principal.id,
+      stationKey: station.stationKey,
+      capability: cap,
+    });
+    throw new GrantReachDenied(principal.id, station.stationKey, cap);
   }
 }
 
@@ -119,31 +133,38 @@ export async function requireIssueCredentials(
 ): Promise<void> {
   if (!isControlPairEnforced()) return;
 
-  const grant = await getGrant(userId);
-  if (!grant?.mayGrantReach) {
-    log.warn("credential issue refused: principal may not change agents", {
-      principalId: userId,
+  const principal = await principalForUser(userId);
+  if (!principal) {
+    log.warn("credential issue refused: no principal for this caller", {
+      userId,
       stationKey: station.stationKey,
     });
     throw new GrantReachDenied(userId, station.stationKey, "credentials");
   }
 
-  const [node] = await db
-    .select({ name: nodes.name })
-    .from(nodes)
-    .where(eq(nodes.id, station.nodeId))
+  const grant = await getGrant(principal.id);
+  if (!grant?.mayGrantReach) {
+    log.warn("credential issue refused: principal may not change agents", {
+      principalId: principal.id,
+      stationKey: station.stationKey,
+    });
+    throw new GrantReachDenied(principal.id, station.stationKey, "credentials");
+  }
+
+  const [row] = await db
+    .select({ principalId: stations.principalId })
+    .from(stations)
+    .where(and(eq(stations.nodeId, station.nodeId), eq(stations.stationKey, station.stationKey)))
     .limit(1);
 
-  const inScope =
-    node !== undefined &&
-    grantAllowsStation(grant, { nodeName: node.name, stationKey: station.stationKey });
+  const inScope = row !== undefined && grantAllowsPrincipal(grant, row.principalId);
 
   if (!inScope) {
     log.warn("credential issue refused: station out of scope", {
-      principalId: userId,
+      principalId: principal.id,
       stationKey: station.stationKey,
     });
-    throw new GrantReachDenied(userId, station.stationKey, "credentials");
+    throw new GrantReachDenied(principal.id, station.stationKey, "credentials");
   }
 }
 

--- a/apps/hub/src/services/grants.test.ts
+++ b/apps/hub/src/services/grants.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { grantAllowsPrincipal } from "./grants";
+
+const grant = (ids: string[]) => ({ mayDispatch: ids, mayGrantReach: false });
+
+describe("a grant names one principal", () => {
+  test("allows exactly the principal it names", () => {
+    expect(grantAllowsPrincipal(grant(["prn_0123456789abcdef0123"]), "prn_0123456789abcdef0123")).toBe(true);
+  });
+
+  test("no grant is not an unrestricted grant", () => {
+    expect(grantAllowsPrincipal(null, "prn_0123456789abcdef0123")).toBe(false);
+  });
+
+  test("an unassigned station is dispatchable by nobody", () => {
+    expect(grantAllowsPrincipal(grant(["prn_0123456789abcdef0123"]), null)).toBe(false);
+  });
+
+  test("ignores a value from another plane rather than denying on it", () => {
+    // A claim is read by more planes over time, not fewer. Refusing an
+    // unrecognised value breaks every time one is added.
+    expect(grantAllowsPrincipal(grant(["tm_editors", "prn_0123456789abcdef0123"]), "prn_0123456789abcdef0123")).toBe(true);
+  });
+
+  test("there is no wildcard", () => {
+    // agentpod:*/hermes matched a root station that should never have existed,
+    // and hermes:* silently spanned nodes. A pattern matches things nobody
+    // intended; an enumeration cannot.
+    expect(grantAllowsPrincipal(grant(["*"]), "prn_0123456789abcdef0123")).toBe(false);
+    expect(grantAllowsPrincipal(grant(["prn_*"]), "prn_0123456789abcdef0123")).toBe(false);
+  });
+});

--- a/apps/hub/src/services/grants.ts
+++ b/apps/hub/src/services/grants.ts
@@ -6,19 +6,20 @@
  * shape of the eventual claim — and its whole purpose was that this change would
  * be a data move rather than a redesign. It is.
  *
- * Values are namespaced (`agentpod:<stationKey>`, `kaambaan:<agentId>`) per
- * charter decisions/2026-08-15-a-grant-names-an-agent-per-plane.md.
+ * Values are bare principal ids (`prn_…`), matched by equality — per charter
+ * decisions/2026-08-30-an-agent-is-a-principal.md §3, which replaced the two
+ * namespaced, pattern-matched forms this file used to carry
+ * (`agentpod:<node>/<stationKey>`, `kaambaan:<agentId>`) with one enumeration.
+ * The phased path — a third value alongside the two retiring ones — was
+ * skipped: nothing is in production, so the destination is built directly.
  */
 
 import { eq } from "drizzle-orm";
 import { db } from "../db/drizzle";
 import { principalGrants } from "../db/schema/grants";
 
-/** The namespace this plane answers for. Others are ignored, never refused. */
-export const AGENTPOD_NS = "agentpod:";
-
 export interface Grant {
-  /** Namespaced patterns. Empty means "may dispatch nothing", which is a decision. */
+  /** Principal ids. Empty means "may dispatch nothing", which is a decision. */
   mayDispatch: string[];
   mayGrantReach: boolean;
 }
@@ -64,7 +65,7 @@ export async function getGrant(principalId: string): Promise<Grant | null> {
 
 export async function setGrant(principalId: string, grant: Grant): Promise<void> {
   if (!Array.isArray(grant.mayDispatch) || grant.mayDispatch.some((v) => typeof v !== "string")) {
-    throw new Error("mayDispatch must be an array of namespaced patterns");
+    throw new Error("mayDispatch must be an array of principal ids");
   }
   if (typeof grant.mayGrantReach !== "boolean") {
     // Both halves are required. Dispatch control alone is decorative: anyone who
@@ -108,78 +109,21 @@ export async function listGrants(): Promise<Array<{ principalId: string } & Gran
 }
 
 /**
- * What a grant value has to identify, and why a station key alone will not do.
+ * Does this grant permit dispatching to this principal?
  *
- * Station keys are **not unique across the fleet**: uniqueness is
- * `(node_id, station_key)`, and in production `opencode:c52ddf65` exists on two
- * different nodes today. Matching on the key alone would mean a grant for an
- * agent on a staging box silently authorising the identically-named agent in
- * production — different host, different workspace, different credentials.
+ * Equality, and deliberately nothing more. `charter →
+ * decisions/2026-08-30-an-agent-is-a-principal.md` §3 removed patterns because
+ * they matched things nobody intended: `hermes:*` silently spanned nodes, and
+ * `agentpod:*&#47;hermes` reached a root station that should never have existed.
  *
- * So a value names a node and a station:
+ * `null` — a station with no agent — is refused, not allowed. An unassigned
+ * station is a machine, not an agent.
  *
- *     agentpod:<nodePattern>/<stationKeyPattern>
- *
- *     agentpod:*&#47;hermes:*                 every Hermes station, anywhere
- *     agentpod:molt-bot/hermes:*          every Hermes station on molt-bot
- *     agentpod:molt-bot/hermes:analyst-echo   exactly one
- *
- * `/` separates them because station keys already contain `:`.
- *
- * Node NAMES rather than ids, because a grant has to be readable by the person
- * who writes it, and ids are opaque and change when a runtime is reprovisioned.
- *
- * That only works because names are now unique within a tenant, by construction:
- * enrollment suffixes a collision (`molt-bot`, `molt-bot-2`) and migration 0043
- * enforces it. Before that they were merely usually distinct — which is the same
- * assumed-uniqueness that made station keys unsafe to grant on in the first
- * place.
+ * An unrecognised value is ignored rather than denied: a claim is read by more
+ * planes over time, and a plane that refused what it did not understand would
+ * break each time one was added.
  */
-export interface StationRef {
-  /** The node's display name — unique within the tenant. */
-  nodeName: string;
-  stationKey: string;
-}
-
-/** `hermes:*` matches `hermes:x`, but never crosses the `:` it was written inside. */
-function segmentMatches(pattern: string, value: string): boolean {
-  if (pattern === "*") return true;
-  if (pattern === value) return true;
-  if (!pattern.endsWith("*")) return false;
-
-  const prefix = pattern.slice(0, -1);
-  if (!value.startsWith(prefix)) return false;
-  const rest = value.slice(prefix.length);
-  return !prefix.includes(":") || !rest.includes(":");
-}
-
-/**
- * Does one namespaced value permit dispatching this station?
- *
- * Only `agentpod:` values are considered; anything else belongs to another plane
- * and is ignored rather than denied.
- *
- * A value without a `/` is the earlier two-part form (`agentpod:hermes:*`). It
- * matches NOTHING — deliberately, because it cannot say which node it meant, and
- * silently reading it as "any node" is exactly the over-grant this shape exists
- * to remove.
- */
-export function patternMatchesStation(pattern: string, station: StationRef): boolean {
-  if (!pattern.startsWith(AGENTPOD_NS)) return false; // another plane's business
-
-  const target = pattern.slice(AGENTPOD_NS.length);
-  const slash = target.indexOf("/");
-  if (slash === -1) return false; // the retired two-part form names no node
-
-  const nodePattern = target.slice(0, slash);
-  const keyPattern = target.slice(slash + 1);
-  if (!nodePattern || !keyPattern) return false;
-
-  return segmentMatches(nodePattern, station.nodeName) && segmentMatches(keyPattern, station.stationKey);
-}
-
-/** May this principal dispatch this station, given their grant? */
-export function grantAllowsStation(grant: Grant | null, station: StationRef): boolean {
-  if (!grant) return false; // no grant is not an unrestricted grant
-  return grant.mayDispatch.some((p) => patternMatchesStation(p, station));
+export function grantAllowsPrincipal(grant: Grant | null, principalId: string | null): boolean {
+  if (!grant || !principalId) return false;
+  return grant.mayDispatch.includes(principalId);
 }

--- a/apps/hub/src/services/matrix-as/assign-provisions.test.ts
+++ b/apps/hub/src/services/matrix-as/assign-provisions.test.ts
@@ -1,0 +1,429 @@
+/**
+ * The slice's exit test: adopt → create an agent → assign → gate, with no
+ * SQL and **no hand-called `provisionStation` anywhere in it**.
+ *
+ * That last clause is the whole reason this file exists. The whole-branch
+ * review found that assigning an agent wrote `stations.principal_id`,
+ * conditionally bound an existing unbound room, and never provisioned —
+ * and that a fully green suite could not see it, because every test in this
+ * area called `provisionStation` by hand after assigning. The manual call
+ * supplied the exact step production omitted, so the tests proved the half
+ * of the chain that worked and silently stood in for the half that did not.
+ *
+ * The consequence in production was invisible and permanent:
+ * `stations.matrix_identity_mode` defaults to `bridge`, `provision.ts`
+ * returns early for a bridge-mode station with no occupant, and adoption
+ * fires before there IS an occupant. So adoption made no room, assignment
+ * made no room, `roomForStation` answered `room: null`, `projectGate`
+ * returned `no-room`, and `gate-sweep.ts` does not count that status.
+ * Nobody would have learned until somebody restarted the hub.
+ *
+ * Everything below drives the REAL surfaces: the real station registry for
+ * adoption, the real `POST /api/admin/agents` and
+ * `PUT /api/admin/stations/:id/agent` behind the real admin guard, and the
+ * real `projectGate`. Only the homeserver is faked — and `bridge_dispatches`
+ * is inserted directly, because that row is kaambaan's record of work this
+ * fleet already did, not the thing under test.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../../tests/helpers/database";
+import { db, rawSql } from "../../db/drizzle";
+import { stations } from "../../db/schema/stations";
+import { nodes } from "../../db/schema/nodes";
+import { matrixRooms } from "../../db/schema/matrix";
+import { bridgeDispatches } from "../../db/schema/bridge";
+import { BOOTSTRAP_TENANT_ID } from "../../db/schema/tenants";
+import { mintEnrollmentToken, enrollNode } from "../enrollment";
+import { adoptStations } from "../station-registry";
+import { adminMiddleware } from "../../auth/admin-middleware";
+import { agentsAdminRouter } from "../../routes/agents-admin";
+import { onProvisionStation, onStationsAdopted } from "./hooks";
+import { provisionStation } from "./provision";
+import { roomForStation } from "./station-room";
+import { projectGate } from "./gates";
+import { bridgeUserId } from "./names";
+import type { GatePendingDelivery } from "./gates";
+
+const DOMAIN = "id.agentpod.dev";
+const RUN = crypto.randomUUID().slice(0, 8);
+const ACTOR = `test-admin-assign-prov-${RUN}`;
+const HANDLE = `assign-prov-${RUN}`;
+
+let nodeId: string;
+
+/**
+ * The homeserver, faked at the only place this suite touches it. Every room
+ * id it mints is fresh and recorded, so "a room was created" is an
+ * observation rather than an assumption.
+ */
+function fakeHomeserver() {
+  const ensuredRooms: Array<{ alias: string; creator: string }> = [];
+  const ensuredUsers: string[] = [];
+  return {
+    ensuredRooms,
+    ensuredUsers,
+    deps: {
+      domain: DOMAIN,
+      client: {
+        ensureUser: async (localpart: string) => {
+          ensuredUsers.push(localpart);
+        },
+        ensureRoom: async (alias: string, opts: { creator: string }) => {
+          ensuredRooms.push({ alias, creator: opts.creator });
+          return `!provisioned-${crypto.randomUUID().slice(0, 8)}:${DOMAIN}`;
+        },
+        invite: async () => {},
+      },
+    },
+  };
+}
+
+/** The admin API, behind its real guard. */
+const app = (() => {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: ACTOR, authType: "api_key", tenantId: "default" });
+    await next();
+  });
+  a.use("*", adminMiddleware);
+  a.route("/", agentsAdminRouter);
+  return a;
+})();
+
+async function createAgent(handle: string): Promise<string> {
+  const res = await app.request("/agents", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ handle }),
+  });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function assign(stationId: string, principalId: string) {
+  const res = await app.request(`/stations/${stationId}/agent`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ principalId }),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+/** Adopt one station the way a node agent does — through the real registry. */
+async function adopt(key: string, extra: { matrixId?: string } = {}) {
+  const [row] = await adoptStations(ACTOR, nodeId, [key], [
+    {
+      key,
+      harness: "opencode",
+      kind: "leaf",
+      displayName: `Station ${key}`,
+      parentKey: null,
+      workspacePath: null,
+      capabilities: ["acp"],
+      adopted: false,
+      ...extra,
+    },
+  ]);
+  expect(row, "the registry adopted the station").toBeTruthy();
+  return row!.id;
+}
+
+function delivery(gateId: string, cardId: string): GatePendingDelivery {
+  return {
+    event: "gate.pending",
+    boardId: `brd_${RUN}`,
+    cardId,
+    gateId,
+    stageKey: "review",
+    returnStageKey: "code",
+    cardTitle: "Ship the fix",
+    producedBy: "agt_x",
+    options: [{ id: "approve", label: "Approve" }],
+    ts: "2026-08-31T00:00:00.000Z",
+  };
+}
+
+function gateDeps() {
+  const sent: Array<{ userId: string; roomId: string }> = [];
+  return {
+    sent,
+    deps: {
+      domain: DOMAIN,
+      sendText: async (userId: string, roomId: string) => {
+        sent.push({ userId, roomId });
+        return `$prose-${crypto.randomUUID()}`;
+      },
+      sendCustomEvent: async (userId: string, roomId: string) => {
+        sent.push({ userId, roomId });
+        return `$gate-${crypto.randomUUID()}`;
+      },
+    },
+  };
+}
+
+/** kaambaan's record that this fleet ran the card. Not the thing under test. */
+async function dispatched(stationId: string, cardId: string) {
+  await db.insert(bridgeDispatches).values({
+    externalSource: "kaambaan",
+    externalRunId: `run_${cardId}`,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    boardId: `brd_${RUN}`,
+    externalCardId: cardId,
+    agentKey: "test",
+    stationId,
+    leaseEpoch: 1,
+    outcome: "produced",
+    startedAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: ACTOR,
+    email: `assign-prov-${RUN}@example.com`,
+    name: "Actor",
+    role: "admin",
+  });
+  const { token } = await mintEnrollmentToken(ACTOR);
+  const enrolled = await enrollNode(token, {
+    hostname: `assign-prov-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 1,
+  });
+  nodeId = enrolled.nodeId;
+});
+
+afterAll(async () => {
+  onProvisionStation(null);
+  onStationsAdopted(null);
+  try {
+    await rawSql`DELETE FROM matrix_gate_events WHERE tenant_id = ${BOOTSTRAP_TENANT_ID} AND board_id = ${"brd_" + RUN}`;
+    await rawSql`DELETE FROM bridge_dispatches WHERE tenant_id = ${BOOTSTRAP_TENANT_ID} AND board_id = ${"brd_" + RUN}`;
+    await rawSql`DELETE FROM stations WHERE user_id = ${ACTOR}`;
+    await rawSql`DELETE FROM nodes WHERE user_id = ${ACTOR}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${ACTOR}`;
+    await rawSql`DELETE FROM principals WHERE handle LIKE ${HANDLE + "%"}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${ACTOR}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("assigning an agent provisions its station", () => {
+  test("adopt → create → assign → gate lands in a room nothing in this test provisioned by hand", async () => {
+    const hs = fakeHomeserver();
+    // Boot wiring, exactly as `index.ts` does it: BOTH triggers registered,
+    // so nothing here is reaching past a path production also has.
+    onStationsAdopted(async (ids) => {
+      for (const id of ids) await provisionStation(id, hs.deps);
+    });
+    onProvisionStation((id) => provisionStation(id, hs.deps));
+
+    const stationId = await adopt(`opencode:${RUN}-exit`);
+
+    // Adoption alone gives a bridge-mode station with no occupant nothing —
+    // `provision.ts` returns early. Asserted rather than assumed, because it
+    // is the first half of the gap: the room does not arrive here.
+    // `notifyStationsAdopted` is fire-and-forget, so give it a real
+    // round-trip to have happened in before looking.
+    await db.select({ id: stations.id }).from(stations).where(eq(stations.id, stationId));
+    expect(await roomForStation(stationId)).toEqual({ principalId: null, room: null });
+
+    const principalId = await createAgent(HANDLE);
+
+    // The act under test. After this line NOTHING in this test provisions.
+    const assigned = await assign(stationId, principalId);
+    expect(assigned.status).toBe(200);
+    expect(
+      assigned.body.room,
+      "the response says plainly whether the agent got a room"
+    ).toEqual({ status: "provisioned" });
+
+    // THE GATE, asserted first and deliberately: it is the end of the chain
+    // the slice exists to make work, and it is the assertion that fails when
+    // assignment stops provisioning. Everything after it is corroboration.
+    const cardId = `crd_${RUN}_exit`;
+    await dispatched(stationId, cardId);
+    const { deps, sent } = gateDeps();
+    const outcome = await projectGate(BOOTSTRAP_TENANT_ID, delivery(`gate_${RUN}_exit`, cardId), deps);
+
+    expect(
+      outcome.status,
+      "the gate is sent — 'no-room' here is the Critical, and gate-sweep does not count it"
+    ).toBe("sent");
+
+    // The room it landed in was really created by the fake homeserver during
+    // the assign call, rather than found lying around, and belongs to THIS
+    // agent.
+    expect(hs.ensuredRooms, "assignment created exactly one room").toHaveLength(1);
+    expect(hs.ensuredUsers, "and registered the agent's bridge identity").toEqual([
+      `agent_${HANDLE}`,
+    ]);
+    const occupancy = await roomForStation(stationId);
+    expect(occupancy.principalId).toBe(principalId);
+    expect(occupancy.room, "the station's occupant has a room of its own").not.toBeNull();
+    const [bound] = await db
+      .select({ principalId: matrixRooms.principalId, stationId: matrixRooms.stationId })
+      .from(matrixRooms)
+      .where(eq(matrixRooms.roomId, occupancy.room!.roomId));
+    expect(bound!.principalId).toBe(principalId);
+    expect(bound!.stationId, "station_id is still populated — the deployed sweep joins on it").toBe(
+      stationId
+    );
+
+    expect((outcome as { roomId: string }).roomId).toBe(occupancy.room!.roomId);
+    expect(sent.every((s) => s.roomId === occupancy.room!.roomId)).toBe(true);
+    expect(sent.every((s) => s.userId === bridgeUserId(HANDLE, DOMAIN))).toBe(true);
+  });
+
+  test("a homeserver that refuses leaves the assignment standing, and says so rather than reporting success", async () => {
+    // The deliberate half of the decision, asserted as behaviour. Occupancy
+    // is a fact in the organization plane; a room is its shadow on a system
+    // this hub does not own, and assignment is a MOVE that has already
+    // vacated wherever the principal was — so a rollback could not be
+    // partial. What it must not do is read as success.
+    onProvisionStation(async () => {
+      throw new Error("homeserver unreachable");
+    });
+
+    const stationId = await adopt(`opencode:${RUN}-refused`);
+    const principalId = await createAgent(`${HANDLE}-refused`);
+
+    const assigned = await assign(stationId, principalId);
+    expect(assigned.status).toBe(200);
+    expect(assigned.body.room, "the failure is in the answer, not swallowed").toEqual({
+      status: "failed",
+      error: "homeserver unreachable",
+    });
+
+    const [row] = await db
+      .select({ principalId: stations.principalId })
+      .from(stations)
+      .where(eq(stations.id, stationId));
+    expect(row!.principalId, "the assignment stands — it is not undone by a homeserver").toBe(
+      principalId
+    );
+    expect(
+      (await roomForStation(stationId)).room,
+      "and it is honest that there is no room yet"
+    ).toBeNull();
+  });
+
+  test("a hub with no Matrix bridge reports that, rather than a fault", async () => {
+    onProvisionStation(null);
+
+    const stationId = await adopt(`opencode:${RUN}-nobridge`);
+    const principalId = await createAgent(`${HANDLE}-nobridge`);
+
+    const assigned = await assign(stationId, principalId);
+    expect(assigned.status).toBe(200);
+    expect(assigned.body.room).toEqual({ status: "no-bridge" });
+    const [row] = await db
+      .select({ principalId: stations.principalId })
+      .from(stations)
+      .where(eq(stations.id, stationId));
+    expect(row!.principalId).toBe(principalId);
+  });
+});
+
+describe("a harness-mode station is spoken for as the account it actually owns", () => {
+  test("its gate is sent as the harness's own mxid, never as an @agent_ the bridge never registered", async () => {
+    const hs = fakeHomeserver();
+    onProvisionStation((id) => provisionStation(id, hs.deps));
+
+    // A station that answers for itself: the node agent reports the mxid it
+    // holds, and `station-registry` records it.
+    const harnessMxid = `@molt-${RUN}:${DOMAIN}`;
+    const stationId = await adopt(`opencode:${RUN}-harness`, { matrixId: harnessMxid });
+    await db
+      .update(stations)
+      .set({ matrixIdentityMode: "harness" })
+      .where(eq(stations.id, stationId));
+
+    const principalId = await createAgent(`${HANDLE}-harness`);
+    const assigned = await assign(stationId, principalId);
+    expect(assigned.status).toBe(200);
+    expect(assigned.body.room).toEqual({ status: "provisioned" });
+
+    // `provision.ts` creates the room AS the harness account and never
+    // registers a bridge user for it — that is the mode's whole point.
+    expect(hs.ensuredRooms).toHaveLength(1);
+    expect(hs.ensuredRooms[0]!.creator).toBe(harnessMxid);
+    expect(hs.ensuredUsers, "no bridge identity is minted over an account somebody else holds").toEqual(
+      []
+    );
+
+    const room = (await roomForStation(stationId)).room!;
+    const cardId = `crd_${RUN}_harness`;
+    await dispatched(stationId, cardId);
+    const { deps, sent } = gateDeps();
+    const outcome = await projectGate(
+      BOOTSTRAP_TENANT_ID,
+      delivery(`gate_${RUN}_harness`, cardId),
+      deps
+    );
+
+    expect(outcome.status).toBe("sent");
+    expect(sent.length).toBeGreaterThan(0);
+    expect(
+      sent.every((s) => s.userId === harnessMxid),
+      "sent as the account that created the room and is joined to it"
+    ).toBe(true);
+    expect(
+      sent.some((s) => s.userId === bridgeUserId(`${HANDLE}-harness`, DOMAIN)),
+      "never as the @agent_ nothing registered — the homeserver would refuse it"
+    ).toBe(false);
+    expect(room.roomId).toBe((outcome as { roomId: string }).roomId);
+  });
+
+  test("a harness-mode station that has reported no mxid gets its claim back rather than an undeliverable send", async () => {
+    onProvisionStation(null);
+    const stationId = await adopt(`opencode:${RUN}-mute`);
+    await db
+      .update(stations)
+      .set({ matrixIdentityMode: "harness" })
+      .where(eq(stations.id, stationId));
+
+    // A room from before the station flipped modes, bound to its occupant —
+    // the only way to reach "there is a room and an occupant, and still
+    // nobody to speak as".
+    const principalId = await createAgent(`${HANDLE}-mute`);
+    await assign(stationId, principalId);
+    await db.insert(matrixRooms).values({
+      roomId: `!mute-${RUN}:${DOMAIN}`,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      stationId,
+      alias: `#mute-${RUN}:${DOMAIN}`,
+      principalId,
+    });
+
+    const cardId = `crd_${RUN}_mute`;
+    await dispatched(stationId, cardId);
+    const { deps, sent } = gateDeps();
+    const gateId = `gate_${RUN}_mute`;
+    const outcome = await projectGate(BOOTSTRAP_TENANT_ID, delivery(gateId, cardId), deps);
+
+    expect(outcome.status).toBe("no-speaker");
+    expect(sent, "nothing was posted as an identity that could not deliver it").toEqual([]);
+    const claims =
+      await rawSql`SELECT gate_id FROM matrix_gate_events WHERE gate_id = ${gateId}`;
+    expect(
+      claims.length,
+      "the claim is released, so the sweep can retry once the harness reports its mxid"
+    ).toBe(0);
+  });
+});

--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -351,6 +351,33 @@ describe("join, leave, isJoined — what the mxid migration needs", () => {
 
     expect(await client().isJoined(USER, ROOM)).toBe(false);
   });
+
+  test("a homeserver that could not answer is not the same as 'already left'", async () => {
+    // This is the idempotency check on the only irreversible step in the slice.
+    // Read as `false`, a transient 502 says "the new user never joined" and
+    // "the old user has already left" in the same breath — so the migration
+    // re-joins a user that is already in, then reports the room as done while
+    // the old identity is still sitting in it. Thirty-two rooms with two agents
+    // in them, and a report saying there is nothing left to do.
+    replies = [{ status: 502, body: {} }];
+
+    await expect(client().isJoined(USER, ROOM)).rejects.toThrow(/502/);
+  });
+
+  test("a refusal is not 'already left' either", async () => {
+    replies = [{ status: 403, body: { errcode: "M_FORBIDDEN", error: "not in namespace" } }];
+
+    await expect(client().isJoined(USER, ROOM)).rejects.toThrow(/M_FORBIDDEN/);
+  });
+
+  test("a 404 is still a clean 'not joined' — the user has no rooms to be in", async () => {
+    // The one non-200 that is an answer rather than a failure to answer: the
+    // homeserver knows nothing of this user, which for the migration's purposes
+    // is exactly "not in that room".
+    replies = [{ status: 404, body: { errcode: "M_NOT_FOUND" } }];
+
+    expect(await client().isJoined(USER, ROOM)).toBe(false);
+  });
 });
 
 describe("account data — the read-modify-write m.direct needs", () => {

--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -306,3 +306,78 @@ describe("registerWithCredentials", () => {
     expect(String(err)).toContain("M_FORBIDDEN");
   });
 });
+
+describe("join, leave, isJoined — what the mxid migration needs", () => {
+  test("join impersonates the new user against the join endpoint", async () => {
+    await client().join(USER, ROOM);
+
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.url).toContain(`/join/${encodeURIComponent(ROOM)}`);
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+  });
+
+  test("joining a room the user is already in is not an error", async () => {
+    // What makes it safe to call unconditionally on a re-run: the endpoint's
+    // own idempotence, not a flag this script keeps.
+    replies = [{ status: 200, body: { room_id: ROOM } }];
+
+    await client().join(USER, ROOM);
+  });
+
+  test("a real failure to join surfaces", async () => {
+    replies = [{ status: 403, body: { errcode: "M_FORBIDDEN", error: "not in namespace" } }];
+
+    await expect(client().join(USER, ROOM)).rejects.toThrow(/M_FORBIDDEN/);
+  });
+
+  test("leave impersonates the old user against the room's leave endpoint", async () => {
+    await client().leave(USER, ROOM);
+
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.url).toContain(`/rooms/${encodeURIComponent(ROOM)}/leave`);
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+  });
+
+  test("isJoined reads the user's own joined_rooms, not a room membership list", async () => {
+    replies = [{ status: 200, body: { joined_rooms: [ROOM, "!other:id.agentpod.dev"] } }];
+
+    expect(await client().isJoined(USER, ROOM)).toBe(true);
+    expect(calls[0]!.url).toContain("/joined_rooms");
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+  });
+
+  test("isJoined is false once the room drops out of joined_rooms", async () => {
+    replies = [{ status: 200, body: { joined_rooms: ["!other:id.agentpod.dev"] } }];
+
+    expect(await client().isJoined(USER, ROOM)).toBe(false);
+  });
+});
+
+describe("account data — the read-modify-write m.direct needs", () => {
+  test("a type never set answers null, not an error", async () => {
+    replies = [{ status: 404, body: { errcode: "M_NOT_FOUND" } }];
+
+    expect(await client().getAccountData(USER, "m.direct")).toBeNull();
+  });
+
+  test("existing content comes back as-is, for the caller to merge", async () => {
+    replies = [{ status: 200, body: { "@old:h": ["!r:h"] } }];
+
+    expect(await client().getAccountData(USER, "m.direct")).toEqual({ "@old:h": ["!r:h"] });
+  });
+
+  test("a real failure reading account data surfaces", async () => {
+    replies = [{ status: 403, body: { errcode: "M_FORBIDDEN" } }];
+
+    await expect(client().getAccountData(USER, "m.direct")).rejects.toThrow(/M_FORBIDDEN/);
+  });
+
+  test("setAccountData writes the whole object as the given user", async () => {
+    await client().setAccountData(USER, "m.direct", { "@new:h": ["!r:h"] });
+
+    expect(calls[0]!.method).toBe("PUT");
+    expect(calls[0]!.url).toContain("/account_data/m.direct");
+    expect(calls[0]!.url).toContain(`user_id=${encodeURIComponent(USER)}`);
+    expect(calls[0]!.body).toEqual({ "@new:h": ["!r:h"] });
+  });
+});

--- a/apps/hub/src/services/matrix-as/client.test.ts
+++ b/apps/hub/src/services/matrix-as/client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { createMatrixClient, isMatrixUserInUse } from "./client";
+import { createMatrixClient, isMatrixExclusiveNamespace, isMatrixUserInUse } from "./client";
 
 /**
  * Speaking to a homeserver *as* a station.
@@ -397,6 +397,21 @@ describe("account data — the read-modify-write m.direct needs", () => {
     replies = [{ status: 403, body: { errcode: "M_FORBIDDEN" } }];
 
     await expect(client().getAccountData(USER, "m.direct")).rejects.toThrow(/M_FORBIDDEN/);
+  });
+
+  test("reading account data as a user outside the AS's namespace throws a typed error", async () => {
+    // Confirmed live against tuwunel: GET account_data as the human operator
+    // (who is outside the AS's exclusive @agent_.* namespace) answers 400
+    // M_EXCLUSIVE. Typed, like MatrixUserInUse, so a caller can branch on it
+    // without matching a message — the migration report needs to tell this
+    // permanent case apart from a transient failure.
+    replies = [{ status: 400, body: { errcode: "M_EXCLUSIVE", error: "User is not in namespace." } }];
+
+    const err = await client()
+      .getAccountData("@rakesh:id.agentpod.dev", "m.direct")
+      .catch((e: unknown) => e);
+
+    expect(isMatrixExclusiveNamespace(err)).toBe(true);
   });
 
   test("setAccountData writes the whole object as the given user", async () => {

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -126,7 +126,12 @@ export interface MatrixClient {
    * Whether `userId` is currently a member of `roomId`.
    *
    * The migration's way of asking "which of this room's steps are already
-   * done" — live membership, not a database flag nothing writes yet.
+   * done" — live membership, not a database flag nothing writes yet
+   * (`matrix_rooms.principal_id` is reserved ahead of its first writer).
+   *
+   * **Throws when the homeserver did not answer.** Only a 200 and a clean 404
+   * produce a boolean; see the implementation for why "could not ask" must not
+   * collapse into "already left".
    */
   isJoined(userId: string, roomId: string): Promise<boolean>;
   /** A user's account data of the given type, or null when it was never set. */
@@ -258,10 +263,33 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
     return String(res.body.room_id ?? "") || null;
   }
 
-  /** Whether `userId` is still in `roomId`. */
+  /**
+   * Whether `userId` is still in `roomId`.
+   *
+   * **Anything that is not a 200 or a clean 404 throws.** This used to answer
+   * `false` for every non-200, which quietly conflated "the homeserver says
+   * no" with "the homeserver did not say" — and this is the idempotency check
+   * on the only irreversible step in the mxid migration. A transient 502 read
+   * as `false` tells the migration both that the new user never joined and
+   * that the old one has already left: it re-joins an identity that is already
+   * in the room, skips the leave it still owes, and reports the room finished
+   * with two agents sitting in it. A failure to answer must stop the run and
+   * be retried, which is what a re-run is for; the same failure swallowed
+   * strands the room with nothing left looking at it.
+   *
+   * A 404 is the one non-200 that IS an answer: the homeserver knows nothing
+   * of this user, so it is in no rooms, so it is not in this one.
+   */
   async function isJoined(userId: string, roomId: string): Promise<boolean> {
     const res = await call("/_matrix/client/v3/joined_rooms", { method: "GET", userId });
-    if (res.status !== 200) return false;
+    if (res.status === 404) return false;
+    if (res.status !== 200) {
+      throw new Error(
+        `matrix joined_rooms ${userId} failed: ${res.status} ${String(
+          res.body.errcode ?? ""
+        )} ${String(res.body.error ?? "")}`.trim()
+      );
+    }
     const rooms = Array.isArray(res.body.joined_rooms) ? res.body.joined_rooms : [];
     return rooms.some((r) => r === roomId);
   }
@@ -404,6 +432,12 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
       const existing = await resolveAlias(alias);
       if (!existing) return null;
 
+      // Left to throw on a homeserver that could not answer, and deliberately.
+      // The branch below this line DELETES the alias directory entry, so a
+      // swallowed 502 answering "not joined" would release the alias of a room
+      // this agent is still living in. `provisionAll` counts a thrown station
+      // as a failure and the next boot retries it; a released alias is not
+      // retried, it is gone.
       if (await isJoined(opts.creator, existing)) return existing;
 
       log.info("reclaiming an alias from a room this agent has left", {

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -105,6 +105,42 @@ export interface MatrixClient {
   ): Promise<void>;
   setDisplayName(userId: string, displayName: string): Promise<void>;
   invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  /**
+   * Join a room as a virtual user. The AS owns the whole `@agent_.*`
+   * namespace, so this needs no invite.
+   *
+   * Idempotent by the ordinary meaning of the Matrix endpoint: joining a room
+   * you are already in succeeds rather than erroring, which is what makes it
+   * safe for the migration to call unconditionally on a re-run.
+   */
+  join(userId: string, roomId: string): Promise<void>;
+  /**
+   * Leave a room as a virtual user.
+   *
+   * Must be safe to call on a user who is not currently a member — a run that
+   * crashed after a previous leave, and is simply run again, must not throw
+   * over a departure that already happened.
+   */
+  leave(userId: string, roomId: string): Promise<void>;
+  /**
+   * Whether `userId` is currently a member of `roomId`.
+   *
+   * The migration's way of asking "which of this room's steps are already
+   * done" — live membership, not a database flag nothing writes yet.
+   */
+  isJoined(userId: string, roomId: string): Promise<boolean>;
+  /** A user's account data of the given type, or null when it was never set. */
+  getAccountData(userId: string, type: string): Promise<Record<string, unknown> | null>;
+  /**
+   * Replace a user's account data of the given type outright.
+   *
+   * Not a merge: `m.direct` is a map covering every DM the owner has, and a
+   * caller that must preserve the entries it did not come to change — which is
+   * every caller of this for `m.direct` — reads first with `getAccountData`
+   * and writes back the whole object. Blindly writing one entry here is the
+   * single most destructive thing available to a caller of this client.
+   */
+  setAccountData(userId: string, type: string, content: Record<string, unknown>): Promise<void>;
   /** Mark another event — 👀 while working, ✅ done, ❌ failed. */
   sendReaction(
     userId: string,
@@ -576,6 +612,50 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
         body: { user_id: invitee },
       });
       assertOkOrAlready("invite", res);
+    },
+
+    async join(userId, roomId) {
+      const res = await call(`/_matrix/client/v3/join/${encodeURIComponent(roomId)}`, {
+        method: "POST",
+        userId,
+        body: {},
+      });
+      assertOkOrAlready("join", res);
+    },
+
+    async leave(userId, roomId) {
+      const res = await call(`/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/leave`, {
+        method: "POST",
+        userId,
+        body: {},
+      });
+      assertOkOrAlready("leave", res);
+    },
+
+    isJoined,
+
+    async getAccountData(userId, type) {
+      const res = await call(
+        `/_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${encodeURIComponent(type)}`,
+        { method: "GET", userId }
+      );
+      // No account data of this type yet — the map this migration reads and
+      // rewrites simply starts empty, same as a profile with no avatar.
+      if (res.status === 404) return null;
+      if (res.status < 200 || res.status >= 300) {
+        throw new Error(
+          `matrix account_data GET ${type} failed: ${res.status} ${String(res.body.errcode ?? "")}`.trim()
+        );
+      }
+      return res.body;
+    },
+
+    async setAccountData(userId, type, content) {
+      const res = await call(
+        `/_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${encodeURIComponent(type)}`,
+        { method: "PUT", userId, body: content }
+      );
+      assertOkOrAlready("account_data", res);
     },
   };
 }

--- a/apps/hub/src/services/matrix-as/client.ts
+++ b/apps/hub/src/services/matrix-as/client.ts
@@ -203,6 +203,28 @@ export class MatrixUserInUse extends Error {
 export const isMatrixUserInUse = (e: unknown): e is MatrixUserInUse =>
   e instanceof MatrixUserInUse;
 
+/**
+ * The appservice tried to act as a user outside its own exclusive namespace.
+ *
+ * Confirmed live against tuwunel on 2026-08-30: `GET account_data` as the
+ * human operator answers `400 M_EXCLUSIVE — User is not in namespace.` This
+ * is permanent, not transient — the AS's exclusive namespace is `@agent_.*`,
+ * the operator's own mxid is outside it, and no retry changes that. Typed,
+ * like `MatrixUserInUse`, so a caller (the mxid migration's report, in
+ * particular) can tell this apart from a real, retriable failure without
+ * matching an error message.
+ */
+export class MatrixExclusiveNamespace extends Error {
+  readonly errcode = "M_EXCLUSIVE";
+  constructor(what: string, userId: string) {
+    super(`matrix ${what} refused: ${userId} is outside the appservice's exclusive namespace`);
+    this.name = "MatrixExclusiveNamespace";
+  }
+}
+
+export const isMatrixExclusiveNamespace = (e: unknown): e is MatrixExclusiveNamespace =>
+  e instanceof MatrixExclusiveNamespace;
+
 export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
   const doFetch = deps.fetch ?? fetch;
 
@@ -677,8 +699,12 @@ export function createMatrixClient(deps: MatrixClientDeps): MatrixClient {
       // rewrites simply starts empty, same as a profile with no avatar.
       if (res.status === 404) return null;
       if (res.status < 200 || res.status >= 300) {
+        const errcode = String(res.body.errcode ?? "");
+        if (errcode === "M_EXCLUSIVE") {
+          throw new MatrixExclusiveNamespace(`account_data GET ${type}`, userId);
+        }
         throw new Error(
-          `matrix account_data GET ${type} failed: ${res.status} ${String(res.body.errcode ?? "")}`.trim()
+          `matrix account_data GET ${type} failed: ${res.status} ${errcode}`.trim()
         );
       }
       return res.body;

--- a/apps/hub/src/services/matrix-as/gate-sweep.test.ts
+++ b/apps/hub/src/services/matrix-as/gate-sweep.test.ts
@@ -96,6 +96,36 @@ describe("the gate sweep", () => {
     expect((await sweepGates(f.deps)).projected).toBe(0);
   });
 
+  test("does not count a gate whose room has a station but no agent in it", async () => {
+    // The outcome this slice added, and the one that is now fleet-wide rather
+    // than exceptional: `stations.principal_id` is nullable and nothing assigns
+    // it, so a room can exist with nobody to post the gate AS. Distinct from
+    // `no-room` — there is somewhere to put the question and no one to ask it —
+    // and, like `no-room`, it is not a delivery. Counting it would make the
+    // sweep's own logs say a person had been asked for an approval that is
+    // still sitting on the board.
+    const f = fake({}, { gate_1: { status: "no-agent" } });
+
+    const result = await sweepGates(f.deps);
+
+    expect(result.checked).toBe(1);
+    expect(result.projected).toBe(0);
+  });
+
+  test("a station with no agent does not stop the gates behind it", async () => {
+    // Every failure here is per-gate. One station left unoccupied must not take
+    // the rest of the board's pending gates with it — that is how a sweep stops
+    // being a floor and does it invisibly.
+    const f = fake({ pendingGates: async (b) => [gate("gate_1", b), gate("gate_2", b)] }, {
+      gate_1: { status: "no-agent" },
+    });
+
+    const result = await sweepGates(f.deps);
+
+    expect(f.offered).toEqual(["gate_1", "gate_2"]);
+    expect(result.projected).toBe(1);
+  });
+
   test("never asks a board whose gates it could not place anyway", async () => {
     // `tenantIdFor` is null for a board this hub has never dispatched work to,
     // which means no card→station binding and therefore no room for any gate on

--- a/apps/hub/src/services/matrix-as/gate-sweep.test.ts
+++ b/apps/hub/src/services/matrix-as/gate-sweep.test.ts
@@ -14,7 +14,7 @@
  * that already has one, and the two would eventually disagree.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import { bridgeGateSweepDeps, startGateSweeper, sweepGates, type GateSweepDeps } from "./gate-sweep";
 import type { GatePendingDelivery, ProjectionOutcome } from "./gates";
@@ -124,6 +124,93 @@ describe("the gate sweep", () => {
 
     expect(f.offered).toEqual(["gate_1", "gate_2"]);
     expect(result.projected).toBe(1);
+  });
+
+  test("tallies every outcome by status, so a pass that delivered nothing cannot read as a pass that delivered", async () => {
+    // The whole-branch review's last finding, and this branch's own doing:
+    // `projected` counted `sent` alone, so a sweep in which every single gate
+    // came back `no-room` reported the identical number as one in which every
+    // gate was already safely in a room. That is exactly the shape that hid
+    // this branch's Critical — assignment never provisioned, so every gate
+    // resolved `no-room`, and the floor beneath push had no way to say so.
+    const f = fake(
+      {
+        pendingGates: async (b) => [
+          gate("gate_sent", b),
+          gate("gate_already", b),
+          gate("gate_noroom", b),
+          gate("gate_noagent", b),
+          gate("gate_nospeaker", b),
+        ],
+      },
+      {
+        gate_already: { status: "already" },
+        gate_noroom: { status: "no-room" },
+        gate_noagent: { status: "no-agent" },
+        gate_nospeaker: { status: "no-speaker" },
+      },
+    );
+
+    const result = await sweepGates(f.deps);
+
+    expect(result.byStatus).toEqual({
+      sent: 1,
+      already: 1,
+      "no-room": 1,
+      "no-agent": 1,
+      "no-speaker": 1,
+    });
+    // Every gate it looked at is accounted for somewhere — nothing falls
+    // through the tally unseen, which is the property that failed before.
+    const tallied = Object.values(result.byStatus).reduce((a, b) => a + b, 0);
+    expect(tallied).toBe(result.checked);
+    expect(result.projected, "and `projected` still means delivered, not seen").toBe(1);
+  });
+
+  test("a gate it could not place reaches the log of a running hub — no-room, no-agent and no-speaker alike", async () => {
+    // Behaviour, not the wording: the assertion is that each stuck outcome is
+    // surfaced at warn level and identifies the gate, because the whole point
+    // is that an operator sees this while it is happening rather than a
+    // reviewer finding it months later.
+    for (const status of ["no-room", "no-agent", "no-speaker"] as const) {
+      const f = fake({}, { gate_1: { status } });
+      const warnSpy = spyOn(console, "warn");
+      try {
+        const result = await sweepGates(f.deps);
+
+        expect(result.byStatus[status], `${status} is counted`).toBe(1);
+        const surfaced = warnSpy.mock.calls.some(([line]) =>
+          typeof line === "string" && line.includes("gate_1") && line.includes(status),
+        );
+        expect(surfaced, `${status} is surfaced at warn, naming the gate`).toBe(true);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    }
+  });
+
+  test("a pass where everything landed says nothing alarming — `already` is a delivery, not a fault", async () => {
+    // The other half, and why `already` is deliberately not warned on: it is
+    // the ordinary healthy answer on a sweep pass (push got there first). A
+    // warn per delivered gate every five minutes would bury the three that
+    // actually mean a person is waiting.
+    const f = fake({ pendingGates: async (b) => [gate("gate_1", b), gate("gate_2", b)] }, {
+      gate_1: { status: "already" },
+      gate_2: { status: "already" },
+    });
+
+    const warnSpy = spyOn(console, "warn");
+    try {
+      const result = await sweepGates(f.deps);
+
+      expect(result.byStatus.already).toBe(2);
+      const alarmed = warnSpy.mock.calls.some(([line]) =>
+        typeof line === "string" && line.includes("could not"),
+      );
+      expect(alarmed, "nothing is reported as stuck").toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test("never asks a board whose gates it could not place anyway", async () => {

--- a/apps/hub/src/services/matrix-as/gate-sweep.ts
+++ b/apps/hub/src/services/matrix-as/gate-sweep.ts
@@ -12,6 +12,18 @@
  * failing 116,666 times over eight days with nothing configured to notice. The
  * sweep is what makes "a gate cannot be lost" a property rather than a hope.
  *
+ * ## It has to report what it could NOT place
+ *
+ * This file counted `sent` and nothing else for most of its life, which made it
+ * the same failure one level up: a gate that came back `no-room`, `no-agent` or
+ * `no-speaker` was seen, stepped over, and reported as nothing — the number an
+ * operator reads is identical whether every gate landed or none did. The
+ * whole-branch review found precisely that hiding this branch's own Critical
+ * (assignment never provisioned, so every gate resolved `no-room`). The
+ * detector and the defect were built on the same branch. Outcomes are tallied
+ * by status now, and the three that mean a gate is stuck are warned per gate
+ * and again as a pass summary.
+ *
  * ## It holds no idempotency of its own
  *
  * `projectGate` claims the gate in `matrix_gate_events` before it sends, so
@@ -51,12 +63,41 @@ export interface GateSweepDeps {
   project(tenantId: string, d: GatePendingDelivery): Promise<ProjectionOutcome>;
 }
 
+/** Every way `projectGate` can end. Derived, so a new outcome cannot be forgotten here. */
+export type GateOutcomeStatus = ProjectionOutcome["status"];
+
+/**
+ * The outcomes a gate can land in that mean it is STUCK — a person is waiting
+ * on an approval that is not in any room, and nothing else is looking.
+ *
+ * `sent` is a delivery. `already` is a delivery somebody else made, which is
+ * the ordinary healthy answer on a sweep pass and would be pure noise if it
+ * warned. These three are the ones that were invisible.
+ */
+const STUCK: readonly GateOutcomeStatus[] = ["no-room", "no-agent", "no-speaker"];
+
 export interface GateSweepResult {
   /** Pending gates seen across every board that answered. */
   checked: number;
   /** Gates this pass actually put in a room. Anything else was already there,
    *  had nowhere to go, or failed — and none of those is a delivery. */
   projected: number;
+  /**
+   * Every outcome this pass produced, by status.
+   *
+   * **The whole-branch review's last finding, and it is this branch's own
+   * doing.** `projected` counted `sent` alone, so `no-room`, `no-agent` and
+   * `no-speaker` were seen, stepped over, and reported as nothing at all — a
+   * sweep whose number reads the same whether every gate landed or none did.
+   * That is exactly how the Critical this wave closed stayed invisible:
+   * assignment never provisioned, `roomForStation` answered null, every gate
+   * came back `no-room`, and the detector built to be the floor beneath push
+   * had no way to say so. The detector and the defect shipped on the same
+   * branch. Counting by status is what makes "a gate cannot be lost" a
+   * property the sweep can actually report on rather than one it merely
+   * intends.
+   */
+  byStatus: Record<GateOutcomeStatus, number>;
   /** Boards that could not be asked. Named, because an empty sweep and an
    *  unreachable board look identical from the outside. */
   failedBoards: string[];
@@ -66,6 +107,13 @@ export interface GateSweepResult {
 export async function sweepGates(deps: GateSweepDeps): Promise<GateSweepResult> {
   let checked = 0;
   let projected = 0;
+  const byStatus: Record<GateOutcomeStatus, number> = {
+    sent: 0,
+    already: 0,
+    "no-room": 0,
+    "no-agent": 0,
+    "no-speaker": 0,
+  };
   const failedBoards: string[] = [];
 
   for (const boardId of await deps.boards()) {
@@ -95,6 +143,7 @@ export async function sweepGates(deps: GateSweepDeps): Promise<GateSweepResult> 
       checked++;
       try {
         const outcome = await deps.project(tenantId, gate);
+        byStatus[outcome.status]++;
         if (outcome.status === "sent") {
           projected++;
           // Deliberately loud. Every line here is a gate that push failed to
@@ -104,6 +153,18 @@ export async function sweepGates(deps: GateSweepDeps): Promise<GateSweepResult> 
             gateId: gate.gateId,
             boardId,
             roomId: outcome.roomId,
+          });
+        } else if (STUCK.includes(outcome.status)) {
+          // Louder still, and this is the line that was missing. A gate the
+          // sweep could not place is the failure the sweep exists to be the
+          // floor beneath — it must reach the log of a RUNNING hub, not wait
+          // to be noticed in a review months later. `already` is skipped
+          // deliberately: it is a gate that was delivered, and warning on it
+          // every five minutes would bury these three.
+          log.warn("a pending gate could not be put in a room", {
+            gateId: gate.gateId,
+            boardId,
+            status: outcome.status,
           });
         }
       } catch (err) {
@@ -115,7 +176,14 @@ export async function sweepGates(deps: GateSweepDeps): Promise<GateSweepResult> 
     }
   }
 
-  return { checked, projected, failedBoards };
+  const stuck = STUCK.reduce((n, status) => n + byStatus[status], 0);
+  if (stuck > 0) {
+    // One line an operator can alert on, with the tally beside it — the
+    // per-gate warns above say which, this says how bad.
+    log.warn("pending gates the sweep could not deliver", { stuck, ...byStatus });
+  }
+
+  return { checked, projected, byStatus, failedBoards };
 }
 
 /**

--- a/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
+++ b/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
@@ -1,0 +1,250 @@
+/**
+ * The room follows the agent — Task 5, closing slice A's finding I2.
+ *
+ * `matrix_rooms.principal_id` gains its first writer in `routes/agents-
+ * admin.ts`'s assign endpoint, and `gates.ts` reads it in preference to the
+ * plain `stationId` join. This proves the thing that actually matters: a
+ * reassigned agent's gate lands in the SAME room it always had — not merely
+ * that some column got written. Runs against the real Postgres test
+ * database, exercising the real admin routes rather than writing to
+ * `matrix_rooms` by hand, so this is the same write path an operator's click
+ * goes through.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../../tests/helpers/database";
+import { db, rawSql } from "../../db/drizzle";
+import { stations } from "../../db/schema/stations";
+import { matrixRooms } from "../../db/schema/matrix";
+import { bridgeDispatches } from "../../db/schema/bridge";
+import { BOOTSTRAP_TENANT_ID } from "../../db/schema/tenants";
+import { mintEnrollmentToken, enrollNode } from "../enrollment";
+import { createPrincipal } from "../principals";
+import { adminMiddleware } from "../../auth/admin-middleware";
+import { agentsAdminRouter } from "../../routes/agents-admin";
+import { projectGate, roomAgentUser } from "./gates";
+import type { GatePendingDelivery } from "./gates";
+
+const RUN = crypto.randomUUID().slice(0, 8);
+const HANDLE_PREFIX = `gates-reassign-${RUN}`;
+const ADMIN_ACTOR = `test-admin-actor-gates-reassign-${RUN}`;
+
+let stationAId: string;
+let stationBId: string;
+let principalId: string;
+
+function adminApp() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: ADMIN_ACTOR, authType: "api_key", tenantId: "default" });
+    await next();
+  });
+  a.use("*", adminMiddleware);
+  a.route("/", agentsAdminRouter);
+  return a;
+}
+
+const app = adminApp();
+
+async function assign(stationId: string, principal: string) {
+  const res = await app.request(`/stations/${stationId}/agent`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ principalId: principal }),
+  });
+  expect(res.status).toBe(200);
+}
+
+async function unassign(stationId: string) {
+  const res = await app.request(`/stations/${stationId}/agent`, { method: "DELETE" });
+  expect(res.status).toBe(200);
+}
+
+async function roomRow(roomId: string) {
+  const [row] = await db
+    .select({ stationId: matrixRooms.stationId, principalId: matrixRooms.principalId })
+    .from(matrixRooms)
+    .where(eq(matrixRooms.roomId, roomId));
+  return row;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+
+  await createTestUser({
+    id: ADMIN_ACTOR,
+    email: `gates-reassign-actor-${RUN}@example.com`,
+    name: "Actor",
+    role: "admin",
+  });
+
+  const { token } = await mintEnrollmentToken(ADMIN_ACTOR);
+  const { nodeId } = await enrollNode(token, {
+    hostname: `gates-reassign-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 1,
+  });
+
+  stationAId = `st_gra_a_${RUN}`;
+  stationBId = `st_gra_b_${RUN}`;
+  await db.insert(stations).values([
+    {
+      id: stationAId,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      userId: ADMIN_ACTOR,
+      nodeId,
+      harness: "opencode",
+      stationKey: `opencode:${RUN}-a`,
+      kind: "workspace",
+      displayName: "Station A",
+    },
+    {
+      id: stationBId,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      userId: ADMIN_ACTOR,
+      nodeId,
+      harness: "opencode",
+      stationKey: `opencode:${RUN}-b`,
+      kind: "workspace",
+      displayName: "Station B",
+    },
+  ]);
+
+  // Both stations are already provisioned with their own room — the ordinary
+  // case, and the one that actually exercises the fix: station B having a
+  // room of its own is exactly what would swallow the agent's history if
+  // `roomForCard` still preferred the dispatch's own station-tied room.
+  await db.insert(matrixRooms).values([
+    {
+      roomId: `!room-a-${RUN}:id.agentpod.dev`,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      stationId: stationAId,
+      alias: `#a-${RUN}:id.agentpod.dev`,
+    },
+    {
+      roomId: `!room-b-${RUN}:id.agentpod.dev`,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      stationId: stationBId,
+      alias: `#b-${RUN}:id.agentpod.dev`,
+    },
+  ]);
+
+  principalId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-agent` });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM matrix_gate_events WHERE tenant_id = ${BOOTSTRAP_TENANT_ID} AND board_id LIKE ${"brd_" + RUN + "%"}`;
+    await rawSql`DELETE FROM bridge_dispatches WHERE tenant_id = ${BOOTSTRAP_TENANT_ID} AND external_source = 'kaambaan' AND board_id LIKE ${"brd_" + RUN + "%"}`;
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${stationAId}, ${stationBId})`;
+    await rawSql`DELETE FROM stations WHERE user_id = ${ADMIN_ACTOR}`;
+    await rawSql`DELETE FROM nodes WHERE user_id = ${ADMIN_ACTOR}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${ADMIN_ACTOR}`;
+    await rawSql`DELETE FROM principals WHERE handle LIKE ${HANDLE_PREFIX + "%"}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${ADMIN_ACTOR}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+function delivery(gateId: string, cardId: string): GatePendingDelivery {
+  return {
+    event: "gate.pending",
+    boardId: `brd_${RUN}`,
+    cardId,
+    gateId,
+    stageKey: "review",
+    returnStageKey: "code",
+    cardTitle: "Ship the fix",
+    producedBy: "agt_x",
+    options: [{ id: "approve", label: "Approve" }],
+    ts: "2026-08-31T00:00:00.000Z",
+  };
+}
+
+function fakeDeps() {
+  const sent: Array<{ userId: string; roomId: string }> = [];
+  return {
+    sent,
+    deps: {
+      domain: "id.agentpod.dev",
+      sendText: async (userId: string, roomId: string) => {
+        sent.push({ userId, roomId });
+        return `$prose-${sent.length}`;
+      },
+      sendCustomEvent: async (userId: string, roomId: string) => {
+        sent.push({ userId, roomId });
+        return `$gate-${sent.length}`;
+      },
+    },
+  };
+}
+
+describe("reassignment: the room follows the agent, not the station", () => {
+  test("a reassigned agent keeps its room, its id, and its history", async () => {
+    // The principal is bound to station A's room on its first assignment —
+    // the whole reason the mxid comes from a handle rather than a station.
+    await assign(stationAId, principalId);
+    const roomBefore = (await roomRow(`!room-a-${RUN}:id.agentpod.dev`))!;
+    expect(roomBefore.principalId).toBe(principalId);
+
+    // Reassigned to a DIFFERENT station that already has its OWN room.
+    await unassign(stationAId);
+    await assign(stationBId, principalId);
+
+    // New work dispatched to the agent's new station.
+    const cardId = `crd_${RUN}_1`;
+    await db.insert(bridgeDispatches).values({
+      externalSource: "kaambaan",
+      externalRunId: `run_${RUN}_1`,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      boardId: `brd_${RUN}`,
+      externalCardId: cardId,
+      agentKey: "test",
+      stationId: stationBId,
+      leaseEpoch: 1,
+      outcome: "produced",
+      startedAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const { deps, sent } = fakeDeps();
+    const outcome = await projectGate(BOOTSTRAP_TENANT_ID, delivery(`gate_${RUN}_1`, cardId), deps);
+
+    expect(outcome.status).toBe("sent");
+    // Same room id as before reassignment — not station B's own room.
+    expect((outcome as { roomId: string }).roomId).toBe(`!room-a-${RUN}:id.agentpod.dev`);
+    expect(sent.every((s) => s.roomId === `!room-a-${RUN}:id.agentpod.dev`)).toBe(true);
+  });
+
+  test("station_id is not dropped — the sweep deployed on infra joins on it", async () => {
+    const roomBefore = await roomRow(`!room-a-${RUN}:id.agentpod.dev`);
+    expect(roomBefore!.stationId).not.toBeNull();
+    expect(roomBefore!.stationId).toBe(stationAId);
+
+    // Station B's own room was never touched by the reassignment — its
+    // binding stays free for whoever occupies it next.
+    const roomB = await roomRow(`!room-b-${RUN}:id.agentpod.dev`);
+    expect(roomB!.stationId).toBe(stationBId);
+    expect(roomB!.principalId).toBeNull();
+  });
+
+  test("roomAgentUser still answers for the agent's original room after it has moved on", async () => {
+    // Station A is unassigned at this point in the suite (from the test
+    // above) — the room's OWN binding, not the station's current occupant,
+    // is what must answer here.
+    const user = await roomAgentUser(`!room-a-${RUN}:id.agentpod.dev`, "id.agentpod.dev");
+    expect(user).toBe(`@agent_${HANDLE_PREFIX}-agent:id.agentpod.dev`);
+  });
+});

--- a/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
+++ b/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
@@ -26,7 +26,7 @@ process.env.DATABASE_URL =
   "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
 process.env.NODE_ENV = "test";
 
-import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll, spyOn } from "bun:test";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 
@@ -43,6 +43,7 @@ import { adminMiddleware } from "../../auth/admin-middleware";
 import { agentsAdminRouter } from "../../routes/agents-admin";
 import { projectGate, roomAgentUser } from "./gates";
 import { bridgeUserId } from "./names";
+import { provisionStation } from "./provision";
 import type { GatePendingDelivery } from "./gates";
 
 const RUN = crypto.randomUUID().slice(0, 8);
@@ -367,21 +368,37 @@ describe("occupancy is exclusive — a principal runs in one station at a time",
     const xAfterPLeaves = await db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationXId));
     expect(xAfterPLeaves[0]!.principalId).toBeNull();
 
-    // X gets a second, fresh room — what provisioning gives whoever occupies
-    // X next, since roomX1 is P's and stays P's. Inserted directly here
-    // rather than through a Matrix client this suite has no fake for.
-    await db.insert(matrixRooms).values({
-      roomId: roomX2,
-      tenantId: BOOTSTRAP_TENANT_ID,
-      stationId: stationXId,
-      alias: `#x2-${RUN}:id.agentpod.dev`,
-    });
-
-    // Q takes X. The admin route binds the ONE unbound room at X (roomX2) —
-    // roomX1, still P's, is never touched.
+    // Q takes X. X is already empty at this point (P vacated it the moment
+    // it was assigned to Y, above) — nothing to evict here. Nothing at X is
+    // bound to Q yet either — the admin route's bind-on-assign found no
+    // unbound room to give it (roomX1, still P's, is not null), same as it
+    // would in production the moment a station's room already belongs to a
+    // departed occupant.
     await assign(stationXId, qId);
     expect((await roomRow(roomX1))!.principalId, "P's room is untouched by Q's assignment").toBe(pId);
-    expect((await roomRow(roomX2))!.principalId).toBe(qId);
+
+    // THE REAL PROVISIONING PATH gives Q its own room — nothing here is
+    // hand-inserted into `matrix_rooms`. A fix-round review named this
+    // exactly: a test whose room is hand-seeded with a "simulating
+    // provisioning" comment proves nothing about whether provisioning
+    // actually works, and it did not — `provision.ts`'s own station->room
+    // join had the identical unordered-[row] bug `roomForCard` was fixed
+    // for, so a new occupant with no room of its own never got one. This
+    // fails if that regresses.
+    const ensuredRooms: string[] = [];
+    await provisionStation(stationXId, {
+      domain: "id.agentpod.dev",
+      client: {
+        ensureUser: async () => {},
+        ensureRoom: async () => {
+          ensuredRooms.push(roomX2);
+          return roomX2;
+        },
+        invite: async () => {},
+      },
+    });
+    expect(ensuredRooms, "a room was actually created for Q, not skipped").toHaveLength(1);
+    expect((await roomRow(roomX2))!.principalId, "and bound to Q at creation").toBe(qId);
 
     // New work dispatched to X, now that Q occupies it.
     const cardId = `crd_${RUN}_q`;
@@ -422,5 +439,51 @@ describe("occupancy is exclusive — a principal runs in one station at a time",
     // station's current one.
     expect(await roomAgentUser(roomX1, "id.agentpod.dev")).toBe(pHandleMxid);
     expect(await roomAgentUser(roomX2, "id.agentpod.dev")).toBe(qHandleMxid);
+  });
+
+  test("assigning a station already held by a DIFFERENT principal evicts it — and that eviction is logged", async () => {
+    // A genuine eviction, not a move: R already occupies Y (assigned above,
+    // and never vacated by anything since), and S is assigned to Y directly
+    // — nobody unassigned R first. R silently loses its station as a
+    // consequence, which is legitimate (Ruling 6's "assign a different
+    // agent" reassigns exactly this way) but must not be SILENT.
+    const rId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-r` });
+    const sId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-s` });
+    const stationEvictId = `st_gra_evict_${RUN}`;
+    await db.insert(stations).values({
+      id: stationEvictId,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      userId: ADMIN_ACTOR,
+      nodeId: sharedNodeId,
+      harness: "opencode",
+      stationKey: `opencode:${RUN}-evict`,
+      kind: "workspace",
+      displayName: "Station Evict",
+    });
+
+    await assign(stationEvictId, rId);
+    const before = await db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationEvictId));
+    expect(before[0]!.principalId).toBe(rId);
+
+    const warnSpy = spyOn(console, "warn");
+    try {
+      await assign(stationEvictId, sId);
+
+      const after = await db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationEvictId));
+      expect(after[0]!.principalId, "S actually occupies the station now").toBe(sId);
+
+      const evictionLogged = warnSpy.mock.calls.some(([line]) => {
+        if (typeof line !== "string") return false;
+        return (
+          line.includes("evicted") &&
+          line.includes(stationEvictId) &&
+          line.includes(rId) &&
+          line.includes(sId)
+        );
+      });
+      expect(evictionLogged, "R's eviction from the station is logged, not silent").toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
+++ b/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
@@ -9,6 +9,15 @@
  * database, exercising the real admin routes rather than writing to
  * `matrix_rooms` by hand, so this is the same write path an operator's click
  * goes through.
+ *
+ * **Fix round: occupancy is exclusive.** A principal runs in one station at
+ * a time (`stations_principal_id_idx`), assigning an already-placed
+ * principal elsewhere is a MOVE (no manual unassign required), and the
+ * `stationId` fallback that used to hand a new occupant another principal's
+ * room is scoped to stations with no current occupant at all. The most
+ * important test below is the one the review's finding named directly: when
+ * P leaves a station and Q takes it, Q's gate must reach Q's own room,
+ * answered as `@agent_Q` — never P's room, never `@agent_P`.
  */
 
 // ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
@@ -33,6 +42,7 @@ import { createPrincipal } from "../principals";
 import { adminMiddleware } from "../../auth/admin-middleware";
 import { agentsAdminRouter } from "../../routes/agents-admin";
 import { projectGate, roomAgentUser } from "./gates";
+import { bridgeUserId } from "./names";
 import type { GatePendingDelivery } from "./gates";
 
 const RUN = crypto.randomUUID().slice(0, 8);
@@ -42,6 +52,7 @@ const ADMIN_ACTOR = `test-admin-actor-gates-reassign-${RUN}`;
 let stationAId: string;
 let stationBId: string;
 let principalId: string;
+let sharedNodeId: string;
 
 function adminApp() {
   const a = new Hono();
@@ -95,6 +106,7 @@ beforeAll(async () => {
     arch: "amd64",
     cpuCount: 1,
   });
+  sharedNodeId = nodeId;
 
   stationAId = `st_gra_a_${RUN}`;
   stationBId = `st_gra_b_${RUN}`;
@@ -147,7 +159,9 @@ afterAll(async () => {
   try {
     await rawSql`DELETE FROM matrix_gate_events WHERE tenant_id = ${BOOTSTRAP_TENANT_ID} AND board_id LIKE ${"brd_" + RUN + "%"}`;
     await rawSql`DELETE FROM bridge_dispatches WHERE tenant_id = ${BOOTSTRAP_TENANT_ID} AND external_source = 'kaambaan' AND board_id LIKE ${"brd_" + RUN + "%"}`;
-    await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${stationAId}, ${stationBId})`;
+    // `matrix_rooms` cascades from `stations` (ON DELETE CASCADE), so every
+    // room this file created — however many stations it added below — goes
+    // with it, without listing station ids by hand.
     await rawSql`DELETE FROM stations WHERE user_id = ${ADMIN_ACTOR}`;
     await rawSql`DELETE FROM nodes WHERE user_id = ${ADMIN_ACTOR}`;
     await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${ADMIN_ACTOR}`;
@@ -181,11 +195,15 @@ function fakeDeps() {
       domain: "id.agentpod.dev",
       sendText: async (userId: string, roomId: string) => {
         sent.push({ userId, roomId });
-        return `$prose-${sent.length}`;
+        // `matrix_gate_events.event_id` is globally unique, and this file
+        // runs several gates through several `fakeDeps()` calls — a plain
+        // per-call counter (`$prose-1`, `$prose-2`, …) collides across
+        // tests, not just within one.
+        return `$prose-${crypto.randomUUID()}`;
       },
       sendCustomEvent: async (userId: string, roomId: string) => {
         sent.push({ userId, roomId });
-        return `$gate-${sent.length}`;
+        return `$gate-${crypto.randomUUID()}`;
       },
     },
   };
@@ -246,5 +264,163 @@ describe("reassignment: the room follows the agent, not the station", () => {
     // is what must answer here.
     const user = await roomAgentUser(`!room-a-${RUN}:id.agentpod.dev`, "id.agentpod.dev");
     expect(user).toBe(`@agent_${HANDLE_PREFIX}-agent:id.agentpod.dev`);
+  });
+});
+
+describe("occupancy is exclusive — a principal runs in one station at a time", () => {
+  let stationMoveAId: string;
+  let stationMoveBId: string;
+  let movePrincipalId: string;
+
+  let stationXId: string;
+  let stationYId: string;
+  let pId: string;
+  let qId: string;
+  const roomX1 = `!room-x1-${RUN}:id.agentpod.dev`;
+  const roomX2 = `!room-x2-${RUN}:id.agentpod.dev`;
+  const roomY = `!room-y-${RUN}:id.agentpod.dev`;
+
+  beforeAll(async () => {
+    stationMoveAId = `st_gra_ma_${RUN}`;
+    stationMoveBId = `st_gra_mb_${RUN}`;
+    stationXId = `st_gra_x_${RUN}`;
+    stationYId = `st_gra_y_${RUN}`;
+
+    await db.insert(stations).values([
+      {
+        id: stationMoveAId,
+        tenantId: BOOTSTRAP_TENANT_ID,
+        userId: ADMIN_ACTOR,
+        nodeId: sharedNodeId,
+        harness: "opencode",
+        stationKey: `opencode:${RUN}-ma`,
+        kind: "workspace",
+        displayName: "Station Move A",
+      },
+      {
+        id: stationMoveBId,
+        tenantId: BOOTSTRAP_TENANT_ID,
+        userId: ADMIN_ACTOR,
+        nodeId: sharedNodeId,
+        harness: "opencode",
+        stationKey: `opencode:${RUN}-mb`,
+        kind: "workspace",
+        displayName: "Station Move B",
+      },
+      {
+        id: stationXId,
+        tenantId: BOOTSTRAP_TENANT_ID,
+        userId: ADMIN_ACTOR,
+        nodeId: sharedNodeId,
+        harness: "opencode",
+        stationKey: `opencode:${RUN}-x`,
+        kind: "workspace",
+        displayName: "Station X",
+      },
+      {
+        id: stationYId,
+        tenantId: BOOTSTRAP_TENANT_ID,
+        userId: ADMIN_ACTOR,
+        nodeId: sharedNodeId,
+        harness: "opencode",
+        stationKey: `opencode:${RUN}-y`,
+        kind: "workspace",
+        displayName: "Station Y",
+      },
+    ]);
+
+    await db.insert(matrixRooms).values([
+      { roomId: roomX1, tenantId: BOOTSTRAP_TENANT_ID, stationId: stationXId, alias: `#x1-${RUN}:id.agentpod.dev` },
+      { roomId: roomY, tenantId: BOOTSTRAP_TENANT_ID, stationId: stationYId, alias: `#y-${RUN}:id.agentpod.dev` },
+    ]);
+
+    movePrincipalId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-mover` });
+    pId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-p` });
+    qId = await createPrincipal({ kind: "agent", handle: `${HANDLE_PREFIX}-q` });
+  });
+
+  test("assigning an already-placed principal elsewhere moves it — no manual unassign, and the old station ends up empty", async () => {
+    await assign(stationMoveAId, movePrincipalId);
+    const before = await db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationMoveAId));
+    expect(before[0]!.principalId).toBe(movePrincipalId);
+
+    // No unassign call in between — the assign endpoint itself vacates
+    // wherever the principal already was.
+    await assign(stationMoveBId, movePrincipalId);
+
+    const [a, b] = await Promise.all([
+      db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationMoveAId)),
+      db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationMoveBId)),
+    ]);
+    expect(a[0]!.principalId, "the old station is empty").toBeNull();
+    expect(b[0]!.principalId, "the principal is in exactly the new station").toBe(movePrincipalId);
+  });
+
+  test("P leaves X, Q takes X: Q's gate goes to Q's own room and is answered by @agent_Q — never P's room, never @agent_P", async () => {
+    // P occupies X first, binding X's only room at the time (roomX1) to P.
+    await assign(stationXId, pId);
+    const roomX1Bound = await roomRow(roomX1);
+    expect(roomX1Bound!.principalId, "P's assignment bound X's room to P").toBe(pId);
+
+    // P moves on to Y — the move this whole slice is about. X is now empty.
+    await assign(stationYId, pId);
+    const xAfterPLeaves = await db.select({ principalId: stations.principalId }).from(stations).where(eq(stations.id, stationXId));
+    expect(xAfterPLeaves[0]!.principalId).toBeNull();
+
+    // X gets a second, fresh room — what provisioning gives whoever occupies
+    // X next, since roomX1 is P's and stays P's. Inserted directly here
+    // rather than through a Matrix client this suite has no fake for.
+    await db.insert(matrixRooms).values({
+      roomId: roomX2,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      stationId: stationXId,
+      alias: `#x2-${RUN}:id.agentpod.dev`,
+    });
+
+    // Q takes X. The admin route binds the ONE unbound room at X (roomX2) —
+    // roomX1, still P's, is never touched.
+    await assign(stationXId, qId);
+    expect((await roomRow(roomX1))!.principalId, "P's room is untouched by Q's assignment").toBe(pId);
+    expect((await roomRow(roomX2))!.principalId).toBe(qId);
+
+    // New work dispatched to X, now that Q occupies it.
+    const cardId = `crd_${RUN}_q`;
+    await db.insert(bridgeDispatches).values({
+      externalSource: "kaambaan",
+      externalRunId: `run_${RUN}_q`,
+      tenantId: BOOTSTRAP_TENANT_ID,
+      boardId: `brd_${RUN}`,
+      externalCardId: cardId,
+      agentKey: "test",
+      stationId: stationXId,
+      leaseEpoch: 1,
+      outcome: "produced",
+      startedAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const { deps, sent } = fakeDeps();
+    const outcome = await projectGate(BOOTSTRAP_TENANT_ID, delivery(`gate_${RUN}_q`, cardId), deps);
+
+    expect(outcome.status).toBe("sent");
+    // Q's OWN room — never roomX1, which is P's.
+    expect((outcome as { roomId: string }).roomId).toBe(roomX2);
+    expect((outcome as { roomId: string }).roomId).not.toBe(roomX1);
+    expect(sent.every((s) => s.roomId === roomX2)).toBe(true);
+    // Posted as Q — never as P.
+    const qHandleMxid = bridgeUserId(`${HANDLE_PREFIX}-q`, "id.agentpod.dev");
+    const pHandleMxid = bridgeUserId(`${HANDLE_PREFIX}-p`, "id.agentpod.dev");
+    expect(sent.every((s) => s.userId === qHandleMxid)).toBe(true);
+    expect(sent.some((s) => s.userId === pHandleMxid)).toBe(false);
+
+    // `station_id` is still populated on both rooms at X — the brief's
+    // explicit negative, since the deployed sweep joins on it.
+    expect((await roomRow(roomX1))!.stationId).toBe(stationXId);
+    expect((await roomRow(roomX2))!.stationId).toBe(stationXId);
+
+    // And each room still answers as its OWN bound resident, not the
+    // station's current one.
+    expect(await roomAgentUser(roomX1, "id.agentpod.dev")).toBe(pHandleMxid);
+    expect(await roomAgentUser(roomX2, "id.agentpod.dev")).toBe(qHandleMxid);
   });
 });

--- a/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
+++ b/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
@@ -34,6 +34,7 @@ import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
 import { createTestUser } from "../../../tests/helpers/database";
 import { db, rawSql } from "../../db/drizzle";
 import { stations } from "../../db/schema/stations";
+import { nodes } from "../../db/schema/nodes";
 import { matrixRooms } from "../../db/schema/matrix";
 import { bridgeDispatches } from "../../db/schema/bridge";
 import { BOOTSTRAP_TENANT_ID } from "../../db/schema/tenants";
@@ -42,7 +43,7 @@ import { createPrincipal } from "../principals";
 import { adminMiddleware } from "../../auth/admin-middleware";
 import { agentsAdminRouter } from "../../routes/agents-admin";
 import { projectGate, roomAgentUser } from "./gates";
-import { bridgeUserId } from "./names";
+import { bridgeUserId, bridgeAlias } from "./names";
 import { provisionStation } from "./provision";
 import type { GatePendingDelivery } from "./gates";
 
@@ -54,6 +55,7 @@ let stationAId: string;
 let stationBId: string;
 let principalId: string;
 let sharedNodeId: string;
+let sharedNodeName: string;
 
 function adminApp() {
   const a = new Hono();
@@ -108,6 +110,8 @@ beforeAll(async () => {
     cpuCount: 1,
   });
   sharedNodeId = nodeId;
+  const [node] = await db.select({ name: nodes.name }).from(nodes).where(eq(nodes.id, nodeId));
+  sharedNodeName = node!.name;
 
   stationAId = `st_gra_a_${RUN}`;
   stationBId = `st_gra_b_${RUN}`;
@@ -385,19 +389,39 @@ describe("occupancy is exclusive — a principal runs in one station at a time",
     // join had the identical unordered-[row] bug `roomForCard` was fixed
     // for, so a new occupant with no room of its own never got one. This
     // fails if that regresses.
+    //
+    // The fake below models alias collision, not just room-id minting — a
+    // second fix-round review's finding: the room's ALIAS was still
+    // `bridgeAlias(nodeName, stationKey)`, station-derived, so a room
+    // created for Q reused P's exact alias, and a fake that ignores the
+    // alias argument entirely (what shipped in round 2) can never fail the
+    // way the real homeserver's M_ROOM_IN_USE would. `stationDerivedAlias`
+    // is what P's room WOULD collide on if `provision.ts` regressed to it;
+    // asking for it here returns P's own room id — exactly what a
+    // same-alias `ensureRoom` call answers with in production — so this
+    // test fails if the alias fix regresses, not only if the room-binding
+    // fix does.
+    const stationDerivedAlias = bridgeAlias(sharedNodeName, `opencode:${RUN}-x`, "id.agentpod.dev");
     const ensuredRooms: string[] = [];
     await provisionStation(stationXId, {
       domain: "id.agentpod.dev",
       client: {
         ensureUser: async () => {},
-        ensureRoom: async () => {
+        ensureRoom: async (alias: string) => {
+          if (alias === stationDerivedAlias) {
+            // The collision a station-derived alias would still produce —
+            // modelled as the real homeserver's M_ROOM_IN_USE, answered
+            // here as P's own room id (the "already joined" branch a
+            // harness-mode station would take in production).
+            return roomX1;
+          }
           ensuredRooms.push(roomX2);
           return roomX2;
         },
         invite: async () => {},
       },
     });
-    expect(ensuredRooms, "a room was actually created for Q, not skipped").toHaveLength(1);
+    expect(ensuredRooms, "a room was actually created for Q, not skipped, and not P's").toHaveLength(1);
     expect((await roomRow(roomX2))!.principalId, "and bound to Q at creation").toBe(qId);
 
     // New work dispatched to X, now that Q occupies it.

--- a/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
+++ b/apps/hub/src/services/matrix-as/gates-reassignment.test.ts
@@ -411,8 +411,20 @@ describe("occupancy is exclusive — a principal runs in one station at a time",
           if (alias === stationDerivedAlias) {
             // The collision a station-derived alias would still produce —
             // modelled as the real homeserver's M_ROOM_IN_USE, answered
-            // here as P's own room id (the "already joined" branch a
-            // harness-mode station would take in production).
+            // here as P's own room id.
+            //
+            // That is `client.ts`'s "already joined" branch, and station X
+            // is bridge-mode (the column's default), so in production this
+            // collision would take the RECLAIM branch instead: Q's speaker
+            // is `@agent_Q`, never a member of P's room, so the alias would
+            // be pulled off P's still-live room and Q would get a fresh one.
+            // Handing back P's room here is therefore strictly harsher than
+            // reality — the test asserts a room was created FOR Q, and this
+            // branch makes that assertion fail if the alias ever regresses
+            // to the station-derived form, where the real reclaim branch
+            // would have hidden the regression behind a new room id while
+            // silently stealing P's address. Harsher on purpose; do not
+            // soften it to match production.
             return roomX1;
           }
           ensuredRooms.push(roomX2);
@@ -509,5 +521,121 @@ describe("occupancy is exclusive — a principal runs in one station at a time",
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+/**
+ * Fix round 4: an unattributable room gets NO answer, not the wrong one.
+ *
+ * `roomAgentUser` used to read `matrix_rooms.principal_id ?? stations.
+ * principal_id` — so a room with no binding of its own was answered as
+ * whoever occupies its station *right now*. Migration 0060 backfilled every
+ * legacy room whose station had an occupant, which leaves the fallback
+ * covering only rooms their station's occupant never lived in, and putting
+ * that agent's name on a reply in somebody else's old room.
+ *
+ * The schema cannot tell "never bound" from "a departed occupant's, never
+ * bound". That argues for silence, not for a guess: the one caller
+ * (`index.ts`'s gate `reply`) already says nothing when there is nobody to
+ * say it as, and a missing reply is visible and recoverable where a
+ * misattributed one is neither.
+ */
+describe("a room nobody is bound to is not answered as its station's current occupant", () => {
+  test("an unbound room left behind by an arriving occupant gets null, while that occupant's own room still answers as it", async () => {
+    const tHandle = `${HANDLE_PREFIX}-t`;
+    const tId = await createPrincipal({ kind: "agent", handle: tHandle });
+    const homeStationId = `st_gra_home_${RUN}`;
+    const orphanStationId = `st_gra_orphan_${RUN}`;
+
+    await db.insert(stations).values([
+      {
+        id: homeStationId,
+        tenantId: BOOTSTRAP_TENANT_ID,
+        userId: ADMIN_ACTOR,
+        nodeId: sharedNodeId,
+        harness: "opencode",
+        stationKey: `opencode:${RUN}-home`,
+        kind: "workspace",
+        displayName: "Station Home",
+      },
+      {
+        // Harness mode, and this matters: it is the one control still live
+        // in this slice that writes a room with NO occupant bound to it.
+        // `provision.ts` reaches `ensureRoom` with `principal_id: null` only
+        // when the station answers for itself and nobody is in it — a
+        // bridge-mode station with no occupant has no handle, so it
+        // provisions nothing at all.
+        id: orphanStationId,
+        tenantId: BOOTSTRAP_TENANT_ID,
+        userId: ADMIN_ACTOR,
+        nodeId: sharedNodeId,
+        harness: "opencode",
+        stationKey: `opencode:${RUN}-orphan`,
+        kind: "workspace",
+        displayName: "Station Orphan",
+        matrixIdentityMode: "harness",
+        matrixId: `@harness-${RUN}:id.agentpod.dev`,
+      },
+    ]);
+
+    // The homeserver's alias directory, so one alias means one room.
+    const roomsByAlias = new Map<string, string>();
+    const client = {
+      ensureUser: async () => {},
+      ensureRoom: async (alias: string) => {
+        const existing = roomsByAlias.get(alias);
+        if (existing) return existing;
+        const roomId = `!room-orphan-${roomsByAlias.size + 1}-${RUN}:id.agentpod.dev`;
+        roomsByAlias.set(alias, roomId);
+        return roomId;
+      },
+      invite: async () => {},
+    };
+
+    // T takes its home station and is provisioned there, which binds its
+    // room to it at creation.
+    await assign(homeStationId, tId);
+    await provisionStation(homeStationId, { domain: "id.agentpod.dev", client });
+
+    // The harness station is provisioned while EMPTY: its room is written
+    // with no binding, through the real provisioning path.
+    await provisionStation(orphanStationId, { domain: "id.agentpod.dev", client });
+
+    const roomIdFor = async (stationId: string) => {
+      const [row] = await db
+        .select({ roomId: matrixRooms.roomId })
+        .from(matrixRooms)
+        .where(eq(matrixRooms.stationId, stationId));
+      return row!.roomId;
+    };
+    const homeRoom = await roomIdFor(homeStationId);
+    const orphanRoom = await roomIdFor(orphanStationId);
+    expect((await roomRow(homeRoom))!.principalId, "T's own room is bound to T").toBe(tId);
+    expect((await roomRow(orphanRoom))!.principalId, "the empty station's room is unbound").toBeNull();
+
+    // T MOVES to the harness station. `agents-admin`'s bind-on-assign binds
+    // an unbound room only to a principal that holds no room anywhere, and T
+    // already holds its own — so the room stays unbound, and the station now
+    // has an occupant who has never spoken in it.
+    await assign(orphanStationId, tId);
+    expect((await roomRow(orphanRoom))!.principalId, "still unbound after the move").toBeNull();
+    const [occupied] = await db
+      .select({ principalId: stations.principalId })
+      .from(stations)
+      .where(eq(stations.id, orphanStationId));
+    expect(occupied!.principalId, "and T is the station's current occupant").toBe(tId);
+
+    // The fix. Before it, this answered `@agent_…-t` — T's name on a reply
+    // in a room T has no history in.
+    expect(
+      await roomAgentUser(orphanRoom, "id.agentpod.dev"),
+      "an unattributable room gets no answer at all"
+    ).toBeNull();
+
+    // And failing closed costs nothing that was working: T's own room still
+    // answers as T, from its own binding.
+    expect(await roomAgentUser(homeRoom, "id.agentpod.dev")).toBe(
+      bridgeUserId(tHandle, "id.agentpod.dev")
+    );
   });
 });

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -136,6 +136,24 @@ export type ProjectionOutcome =
  * exactly this tuple, so the binding is free — the hub's own bridge wrote it
  * when it dispatched the work.
  *
+ * card → dispatch → station → principal → room: the dispatch names a
+ * station, and the station's CURRENT occupant (not necessarily who did the
+ * work — occupancy can move on) is who this posts as. That occupant's OWN
+ * room — the one `routes/agents-admin.ts` bound it to, wherever it was bound
+ * — is preferred over the dispatch's own station-tied room, so an agent
+ * reassigned to a brand-new station still speaks in the room it has always
+ * had rather than a fresh one its new station happens to own. This is the
+ * entire reason an agent's mxid comes from its handle rather than
+ * `(nodeName, stationKey)`.
+ *
+ * Falls back to the plain `stationId` join — this table's ORIGINAL and still
+ * primary index — whenever there is no such binding: a room the backfill
+ * migration has not reached, a station whose occupant has never moved, or a
+ * station with no occupant at all (handled below as `no-agent`). This is the
+ * fallback `gate-sweep.ts` depends on without knowing it — it calls into this
+ * function rather than querying `matrix_rooms` itself, and it is deployed in
+ * production today.
+ *
  * `null` when no AgentPod station ran the card. That is a real and named
  * limitation rather than a fault: a gate on work this fleet never touched has
  * no room to appear in, and inventing one would put an approval somewhere
@@ -165,25 +183,46 @@ async function roomForCard(
     .limit(1);
   if (!dispatch) return null;
 
-  const [room] = await db
+  const [station] = await db
     .select({
-      roomId: matrixRooms.roomId,
       stationKey: stations.stationKey,
       nodeName: nodes.name,
       principalId: stations.principalId,
     })
-    .from(matrixRooms)
-    .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
+    .from(stations)
     .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .where(eq(stations.id, dispatch.stationId))
+    .limit(1);
+  if (!station) return null;
+
+  if (station.principalId) {
+    const [own] = await db
+      .select({ roomId: matrixRooms.roomId })
+      .from(matrixRooms)
+      .where(eq(matrixRooms.principalId, station.principalId))
+      .limit(1);
+    if (own) {
+      return {
+        roomId: own.roomId,
+        nodeName: station.nodeName,
+        stationKey: station.stationKey,
+        principalId: station.principalId,
+      };
+    }
+  }
+
+  const [room] = await db
+    .select({ roomId: matrixRooms.roomId })
+    .from(matrixRooms)
     .where(eq(matrixRooms.stationId, dispatch.stationId))
     .limit(1);
   if (!room) return null;
 
   return {
     roomId: room.roomId,
-    nodeName: room.nodeName,
-    stationKey: room.stationKey,
-    principalId: room.principalId,
+    nodeName: station.nodeName,
+    stationKey: station.stationKey,
+    principalId: station.principalId,
   };
 }
 
@@ -611,15 +650,27 @@ export async function projectionForGate(gateId: string): Promise<{
  * Used when a gate needs an answer *about* itself — "that was already decided"
  * — which must come from the agent whose room it is rather than from a bot
  * nobody invited.
+ *
+ * Prefers the room's OWN bound occupant (`matrixRooms.principalId`) over its
+ * station's current one: a room keeps its resident even after that agent
+ * moves to a different station, and a reply about an old gate must still come
+ * from the agent whose history is actually in this room. Falls back to the
+ * station's current occupant — the only fact there was before this room had
+ * its own binding — for a room the backfill has not reached.
  */
 export async function roomAgentUser(roomId: string, domain: string): Promise<string | null> {
   const [row] = await db
-    .select({ principalId: stations.principalId })
+    .select({
+      ownPrincipalId: matrixRooms.principalId,
+      stationPrincipalId: stations.principalId,
+    })
     .from(matrixRooms)
     .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
     .where(eq(matrixRooms.roomId, roomId))
     .limit(1);
-  if (!row?.principalId) return null;
-  const handle = await principalHandle(row.principalId);
+  if (!row) return null;
+  const principalId = row.ownPrincipalId ?? row.stationPrincipalId;
+  if (!principalId) return null;
+  const handle = await principalHandle(principalId);
   return handle ? bridgeUserId(handle, domain) : null;
 }

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -35,6 +35,7 @@ import { nodes } from "../../db/schema/nodes";
 import { stations } from "../../db/schema/stations";
 import { createLogger } from "../../utils/logger";
 import { bridgeUserId } from "./names";
+import { principalHandle } from "../principals";
 
 const log = createLogger("matrix-gates");
 
@@ -118,7 +119,15 @@ export interface GateProjectionDeps {
 export type ProjectionOutcome =
   | { status: "sent"; eventId: string; roomId: string }
   | { status: "already" }
-  | { status: "no-room" };
+  | { status: "no-room" }
+  /**
+   * The room exists, but its station currently has no occupying agent — no
+   * handle, and therefore no mxid to post the gate as. Distinct from
+   * `no-room`, which means there is nowhere to post at all; this means there
+   * is a room but nobody to speak in it as, which must refuse rather than
+   * invent an address from `(nodeName, stationKey)`.
+   */
+  | { status: "no-agent" };
 
 /**
  * The room a card's work happened in.
@@ -136,7 +145,12 @@ async function roomForCard(
   tenantId: string,
   boardId: string,
   cardId: string
-): Promise<{ roomId: string; nodeName: string; stationKey: string } | null> {
+): Promise<{
+  roomId: string;
+  nodeName: string;
+  stationKey: string;
+  principalId: string | null;
+} | null> {
   const [dispatch] = await db
     .select({ stationId: bridgeDispatches.stationId })
     .from(bridgeDispatches)
@@ -156,6 +170,7 @@ async function roomForCard(
       roomId: matrixRooms.roomId,
       stationKey: stations.stationKey,
       nodeName: nodes.name,
+      principalId: stations.principalId,
     })
     .from(matrixRooms)
     .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
@@ -164,7 +179,12 @@ async function roomForCard(
     .limit(1);
   if (!room) return null;
 
-  return { roomId: room.roomId, nodeName: room.nodeName, stationKey: room.stationKey };
+  return {
+    roomId: room.roomId,
+    nodeName: room.nodeName,
+    stationKey: room.stationKey,
+    principalId: room.principalId,
+  };
 }
 
 /**
@@ -269,10 +289,23 @@ export async function projectGate(
   }
 
   // The station's own virtual user, built the one way this codebase builds
-  // them. Registering or sending as anything else lands outside the exclusive
-  // `@agent_.*` namespace, where the appservice may not act — a 403 that
-  // arrives later and elsewhere. See `names.ts`.
-  const stationUser = bridgeUserId(found.nodeName, found.stationKey, deps.domain);
+  // them: from its occupying agent's handle, never from `(nodeName,
+  // stationKey)`. Registering or sending as anything else lands outside the
+  // exclusive `@agent_.*` namespace, where the appservice may not act — a 403
+  // that arrives later and elsewhere. See `names.ts`.
+  const handle = found.principalId ? await principalHandle(found.principalId) : null;
+  if (!handle) {
+    // The claim must go, or a gate for a station that later gains an
+    // occupying agent could never be re-attempted — the sweep would see the
+    // claimed row and conclude it had already been handled.
+    await db.delete(matrixGateEvents).where(eq(matrixGateEvents.gateId, d.gateId));
+    log.warn("gate's station has no occupying agent; claim released", {
+      gateId: d.gateId,
+      stationKey: found.stationKey,
+    });
+    return { status: "no-agent" };
+  }
+  const stationUser = bridgeUserId(handle, deps.domain);
   const deepLink = boardLink(deps.boardBaseUrl, d.boardId, d.cardId);
 
   // Prose first, deliberately: if only one lands, leave the room with a
@@ -581,11 +614,12 @@ export async function projectionForGate(gateId: string): Promise<{
  */
 export async function roomAgentUser(roomId: string, domain: string): Promise<string | null> {
   const [row] = await db
-    .select({ stationKey: stations.stationKey, nodeName: nodes.name })
+    .select({ principalId: stations.principalId })
     .from(matrixRooms)
     .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
-    .innerJoin(nodes, eq(nodes.id, stations.nodeId))
     .where(eq(matrixRooms.roomId, roomId))
     .limit(1);
-  return row ? bridgeUserId(row.nodeName, row.stationKey, domain) : null;
+  if (!row?.principalId) return null;
+  const handle = await principalHandle(row.principalId);
+  return handle ? bridgeUserId(handle, domain) : null;
 }

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -26,7 +26,7 @@
  * `gate_id` is what turns that overlap into one question instead of three.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { db } from "../../db/drizzle";
 import { bridgeDispatches } from "../../db/schema/bridge";
@@ -137,22 +137,34 @@ export type ProjectionOutcome =
  * when it dispatched the work.
  *
  * card → dispatch → station → principal → room: the dispatch names a
- * station, and the station's CURRENT occupant (not necessarily who did the
- * work — occupancy can move on) is who this posts as. That occupant's OWN
- * room — the one `routes/agents-admin.ts` bound it to, wherever it was bound
- * — is preferred over the dispatch's own station-tied room, so an agent
- * reassigned to a brand-new station still speaks in the room it has always
- * had rather than a fresh one its new station happens to own. This is the
- * entire reason an agent's mxid comes from its handle rather than
- * `(nodeName, stationKey)`.
+ * station, and the station's CURRENT occupant is who this posts as. That
+ * occupant's OWN room — the one `routes/agents-admin.ts` bound it to,
+ * wherever it was bound — is what a gate lands in, not the dispatch's own
+ * station-tied room, so an agent reassigned to a brand-new station still
+ * speaks in the room it has always had. This is the entire reason an
+ * agent's mxid comes from its handle rather than `(nodeName, stationKey)`.
  *
- * Falls back to the plain `stationId` join — this table's ORIGINAL and still
- * primary index — whenever there is no such binding: a room the backfill
- * migration has not reached, a station whose occupant has never moved, or a
- * station with no occupant at all (handled below as `no-agent`). This is the
- * fallback `gate-sweep.ts` depends on without knowing it — it calls into this
- * function rather than querying `matrix_rooms` itself, and it is deployed in
- * production today.
+ * **When the station has a current occupant, this NEVER falls back to the
+ * `stationId` join — fix round on Task 5.** A room still sitting at this
+ * `stationId` from a departed occupant is not the current one's room, and
+ * that fallback used to hand it out anyway: P leaves a station, Q takes it,
+ * Q's own binding is a no-op (the room is still P's — occupancy binds a
+ * room once and never rebinds it), and the old fallback then posted Q's
+ * gates into P's room, addressed as `@agent_P`, in a room whose Matrix
+ * membership belongs to P — reachable through the very controls this slice
+ * shipped. An occupied station whose occupant has no room of its own yet
+ * answers `null` (no room yet) instead of guessing; provisioning is what
+ * gives that occupant a room.
+ *
+ * The `stationId` join is used ONLY when the station has NO occupant at
+ * all, constrained to the row whose `principal_id IS NULL` — a station can
+ * now carry more than one room (occupancy binds a room to the agent, not
+ * the other way around, so a departed occupant's room stays here too), and
+ * without that constraint an arbitrary one of them would answer. This is
+ * the fallback `gate-sweep.ts` depends on without knowing it — it calls
+ * into this function rather than querying `matrix_rooms` itself, and it is
+ * deployed in production today; it is unaffected, since an unoccupied
+ * station's own `no-agent` outcome is unchanged by this scoping.
  *
  * `null` when no AgentPod station ran the card. That is a real and named
  * limitation rather than a fault: a gate on work this fleet never touched has
@@ -196,25 +208,31 @@ async function roomForCard(
   if (!station) return null;
 
   if (station.principalId) {
+    // The station has an occupant. Only THAT principal's own room counts —
+    // no fallback to whatever room happens to sit at this `stationId`, which
+    // could belong to whoever occupied it before.
     const [own] = await db
       .select({ roomId: matrixRooms.roomId })
       .from(matrixRooms)
       .where(eq(matrixRooms.principalId, station.principalId))
       .limit(1);
-    if (own) {
-      return {
-        roomId: own.roomId,
-        nodeName: station.nodeName,
-        stationKey: station.stationKey,
-        principalId: station.principalId,
-      };
-    }
+    if (!own) return null;
+    return {
+      roomId: own.roomId,
+      nodeName: station.nodeName,
+      stationKey: station.stationKey,
+      principalId: station.principalId,
+    };
   }
 
+  // No current occupant at all — the room this station's own row names, if
+  // it has one with no binding of its own. `principal_id IS NULL` matters
+  // once a station can carry more than one room: a departed occupant's room
+  // stays here too, and is never this answer.
   const [room] = await db
     .select({ roomId: matrixRooms.roomId })
     .from(matrixRooms)
-    .where(eq(matrixRooms.stationId, dispatch.stationId))
+    .where(and(eq(matrixRooms.stationId, dispatch.stationId), isNull(matrixRooms.principalId)))
     .limit(1);
   if (!room) return null;
 
@@ -222,7 +240,7 @@ async function roomForCard(
     roomId: room.roomId,
     nodeName: station.nodeName,
     stationKey: station.stationKey,
-    principalId: station.principalId,
+    principalId: null,
   };
 }
 

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -34,7 +34,7 @@ import { matrixGateEvents, matrixRooms } from "../../db/schema/matrix";
 import { nodes } from "../../db/schema/nodes";
 import { stations } from "../../db/schema/stations";
 import { createLogger } from "../../utils/logger";
-import { bridgeUserId } from "./names";
+import { stationSpeaker } from "./names";
 import { principalHandle } from "../principals";
 import { roomForStation } from "./station-room";
 
@@ -128,7 +128,16 @@ export type ProjectionOutcome =
    * is a room but nobody to speak in it as, which must refuse rather than
    * invent an address from `(nodeName, stationKey)`.
    */
-  | { status: "no-agent" };
+  | { status: "no-agent" }
+  /**
+   * The room exists and its station HAS an occupying agent, but the station
+   * answers for itself on Matrix and has never reported the account it
+   * answers as (`stations.matrix_id`). Distinct from `no-agent`: there is
+   * an agent, and the missing thing is the harness's own identity. Posting
+   * as `@agent_<handle>` anyway is what this status replaced — an mxid the
+   * bridge never registered, in a room it never joined.
+   */
+  | { status: "no-speaker" };
 
 /**
  * The room a card's work happened in.
@@ -167,6 +176,8 @@ async function roomForCard(
   nodeName: string;
   stationKey: string;
   principalId: string | null;
+  identityMode: string;
+  harnessMxid: string | null;
 } | null> {
   const [dispatch] = await db
     .select({ stationId: bridgeDispatches.stationId })
@@ -186,6 +197,13 @@ async function roomForCard(
     .select({
       stationKey: stations.stationKey,
       nodeName: nodes.name,
+      // Who this hub may speak as here. Carried out of the same row rather
+      // than re-derived downstream — the whole-branch review's Minor was
+      // that `projectGate` assumed the bridge answered for every station
+      // and posted as `@agent_<handle>` into harness-mode rooms, where that
+      // account was never registered and never a member.
+      identityMode: stations.matrixIdentityMode,
+      harnessMxid: stations.matrixId,
     })
     .from(stations)
     .innerJoin(nodes, eq(nodes.id, stations.nodeId))
@@ -205,6 +223,8 @@ async function roomForCard(
     nodeName: station.nodeName,
     stationKey: station.stationKey,
     principalId: occupancy.principalId,
+    identityMode: station.identityMode,
+    harnessMxid: station.harnessMxid,
   };
 }
 
@@ -271,6 +291,18 @@ export function gateEventContent(
 }
 
 /**
+ * Give back a claim this delivery took and could not use.
+ *
+ * Without it the row sits at `pending:<gateId>` forever and `gate-sweep.ts`
+ * reads it as handled, so a gate that becomes sendable later — the station
+ * gains an occupant, or the harness finally reports its mxid — is never
+ * re-attempted.
+ */
+async function releaseClaim(gateId: string): Promise<void> {
+  await db.delete(matrixGateEvents).where(eq(matrixGateEvents.gateId, gateId));
+}
+
+/**
  * Post a gate into its station's room, exactly once.
  *
  * The insert is the gate on the send, not a record of it: `onConflictDoNothing`
@@ -319,14 +351,38 @@ export async function projectGate(
     // The claim must go, or a gate for a station that later gains an
     // occupying agent could never be re-attempted — the sweep would see the
     // claimed row and conclude it had already been handled.
-    await db.delete(matrixGateEvents).where(eq(matrixGateEvents.gateId, d.gateId));
+    await releaseClaim(d.gateId);
     log.warn("gate's station has no occupying agent; claim released", {
       gateId: d.gateId,
       stationKey: found.stationKey,
     });
     return { status: "no-agent" };
   }
-  const stationUser = bridgeUserId(handle, deps.domain);
+
+  // …and WHICH virtual user is `names.ts`'s `stationSpeaker`, not
+  // `bridgeUserId` applied unconditionally, which is what this line was.
+  // A harness-mode station's room was created by the account the harness
+  // holds (`stations.matrix_id`), and `provision.ts` deliberately never
+  // calls `ensureUser` for such a station — so `@agent_<handle>` there is an
+  // mxid nothing registered, in a room it never joined. The homeserver
+  // refuses, and the gate is lost with its claim already taken. Speaking as
+  // the identity that actually owns the room is the only send that can land.
+  const stationUser = stationSpeaker(
+    { identityMode: found.identityMode, harnessMxid: found.harnessMxid, handle },
+    deps.domain
+  );
+  if (!stationUser) {
+    // Harness mode with no reported mxid: there is a room and an occupant,
+    // and still nobody this hub may speak as. Released for the same reason
+    // as above — the node agent reports `matrix_id`, so this can become
+    // sendable later without anything else changing.
+    await releaseClaim(d.gateId);
+    log.warn("gate's station answers for itself but has reported no Matrix identity; claim released", {
+      gateId: d.gateId,
+      stationKey: found.stationKey,
+    });
+    return { status: "no-speaker" };
+  }
   const deepLink = boardLink(deps.boardBaseUrl, d.boardId, d.cardId);
 
   // Prose first, deliberately: if only one lands, leave the room with a
@@ -657,11 +713,32 @@ export async function projectionForGate(gateId: string): Promise<{
  */
 export async function roomAgentUser(roomId: string, domain: string): Promise<string | null> {
   const [row] = await db
-    .select({ ownPrincipalId: matrixRooms.principalId })
+    .select({
+      ownPrincipalId: matrixRooms.principalId,
+      // The station is joined for its MODE, not for its occupant. Fix round
+      // 4 removed a `stations.principal_id` fallback from here on purpose
+      // and nothing below reinstates it: a room with no binding of its own
+      // still answers null.
+      identityMode: stations.matrixIdentityMode,
+      harnessMxid: stations.matrixId,
+    })
     .from(matrixRooms)
+    .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
     .where(eq(matrixRooms.roomId, roomId))
     .limit(1);
   if (!row?.ownPrincipalId) return null;
   const handle = await principalHandle(row.ownPrincipalId);
-  return handle ? bridgeUserId(handle, domain) : null;
+  if (!handle) return null;
+  // Same rule as the send path, from the same function — a reply that goes
+  // out as an identity the room's send path could not use would be the two
+  // halves of one question answered two ways again.
+  //
+  // Known limit, stated rather than hidden: a station that changed modes
+  // after this room was created is unknowable from the schema, which records
+  // no creator. The mode is read live because it is the only answer there
+  // is, and it is right for every room whose station has not changed modes.
+  return stationSpeaker(
+    { identityMode: row.identityMode, harnessMxid: row.harnessMxid, handle },
+    domain
+  );
 }

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -26,7 +26,7 @@
  * `gate_id` is what turns that overlap into one question instead of three.
  */
 
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { db } from "../../db/drizzle";
 import { bridgeDispatches } from "../../db/schema/bridge";
@@ -36,6 +36,7 @@ import { stations } from "../../db/schema/stations";
 import { createLogger } from "../../utils/logger";
 import { bridgeUserId } from "./names";
 import { principalHandle } from "../principals";
+import { roomForStation } from "./station-room";
 
 const log = createLogger("matrix-gates");
 
@@ -136,35 +137,21 @@ export type ProjectionOutcome =
  * exactly this tuple, so the binding is free — the hub's own bridge wrote it
  * when it dispatched the work.
  *
- * card → dispatch → station → principal → room: the dispatch names a
- * station, and the station's CURRENT occupant is who this posts as. That
- * occupant's OWN room — the one `routes/agents-admin.ts` bound it to,
- * wherever it was bound — is what a gate lands in, not the dispatch's own
- * station-tied room, so an agent reassigned to a brand-new station still
- * speaks in the room it has always had. This is the entire reason an
- * agent's mxid comes from its handle rather than `(nodeName, stationKey)`.
+ * card → dispatch → station → `roomForStation` (`station-room.ts`): the
+ * dispatch names a station, and its CURRENT occupant's own room — never a
+ * departed occupant's, however that occupant's assignment ended — is what a
+ * gate lands in. So an agent reassigned to a brand-new station still speaks
+ * in the room it has always had. This is the entire reason an agent's mxid
+ * comes from its handle rather than `(nodeName, stationKey)`.
  *
- * **When the station has a current occupant, this NEVER falls back to the
- * `stationId` join — fix round on Task 5.** A room still sitting at this
- * `stationId` from a departed occupant is not the current one's room, and
- * that fallback used to hand it out anyway: P leaves a station, Q takes it,
- * Q's own binding is a no-op (the room is still P's — occupancy binds a
- * room once and never rebinds it), and the old fallback then posted Q's
- * gates into P's room, addressed as `@agent_P`, in a room whose Matrix
- * membership belongs to P — reachable through the very controls this slice
- * shipped. An occupied station whose occupant has no room of its own yet
- * answers `null` (no room yet) instead of guessing; provisioning is what
- * gives that occupant a room.
- *
- * The `stationId` join is used ONLY when the station has NO occupant at
- * all, constrained to the row whose `principal_id IS NULL` — a station can
- * now carry more than one room (occupancy binds a room to the agent, not
- * the other way around, so a departed occupant's room stays here too), and
- * without that constraint an arbitrary one of them would answer. This is
- * the fallback `gate-sweep.ts` depends on without knowing it — it calls
- * into this function rather than querying `matrix_rooms` itself, and it is
- * deployed in production today; it is unaffected, since an unoccupied
- * station's own `no-agent` outcome is unchanged by this scoping.
+ * Fix round 2 moved the actual resolution into `station-room.ts`, shared
+ * with `routes/station-say.ts` and `provision.ts` — the round-1 version
+ * inlined the same logic here alone, and a review found two more call
+ * sites making the bug this function was written to close (P leaves a
+ * station, Q takes it, and something still answers as if P were still
+ * there). `gate-sweep.ts` is unaffected: it calls into this function
+ * rather than querying `matrix_rooms` itself, and it is deployed in
+ * production today.
  *
  * `null` when no AgentPod station ran the card. That is a real and named
  * limitation rather than a fault: a gate on work this fleet never touched has
@@ -199,7 +186,6 @@ async function roomForCard(
     .select({
       stationKey: stations.stationKey,
       nodeName: nodes.name,
-      principalId: stations.principalId,
     })
     .from(stations)
     .innerJoin(nodes, eq(nodes.id, stations.nodeId))
@@ -207,40 +193,18 @@ async function roomForCard(
     .limit(1);
   if (!station) return null;
 
-  if (station.principalId) {
-    // The station has an occupant. Only THAT principal's own room counts —
-    // no fallback to whatever room happens to sit at this `stationId`, which
-    // could belong to whoever occupied it before.
-    const [own] = await db
-      .select({ roomId: matrixRooms.roomId })
-      .from(matrixRooms)
-      .where(eq(matrixRooms.principalId, station.principalId))
-      .limit(1);
-    if (!own) return null;
-    return {
-      roomId: own.roomId,
-      nodeName: station.nodeName,
-      stationKey: station.stationKey,
-      principalId: station.principalId,
-    };
-  }
-
-  // No current occupant at all — the room this station's own row names, if
-  // it has one with no binding of its own. `principal_id IS NULL` matters
-  // once a station can carry more than one room: a departed occupant's room
-  // stays here too, and is never this answer.
-  const [room] = await db
-    .select({ roomId: matrixRooms.roomId })
-    .from(matrixRooms)
-    .where(and(eq(matrixRooms.stationId, dispatch.stationId), isNull(matrixRooms.principalId)))
-    .limit(1);
-  if (!room) return null;
+  // The one resolver every station→room lookup in this codebase routes
+  // through — see `station-room.ts`. It, not this function, decides
+  // whether an occupied station's room is real yet, or falls back to the
+  // plain `stationId` join for a station with no occupant at all.
+  const occupancy = await roomForStation(dispatch.stationId);
+  if (!occupancy.room) return null;
 
   return {
-    roomId: room.roomId,
+    roomId: occupancy.room.roomId,
     nodeName: station.nodeName,
     stationKey: station.stationKey,
-    principalId: null,
+    principalId: occupancy.principalId,
   };
 }
 

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -633,26 +633,35 @@ export async function projectionForGate(gateId: string): Promise<{
  * — which must come from the agent whose room it is rather than from a bot
  * nobody invited.
  *
- * Prefers the room's OWN bound occupant (`matrixRooms.principalId`) over its
- * station's current one: a room keeps its resident even after that agent
- * moves to a different station, and a reply about an old gate must still come
- * from the agent whose history is actually in this room. Falls back to the
- * station's current occupant — the only fact there was before this room had
- * its own binding — for a room the backfill has not reached.
+ * Answered from the room's OWN bound occupant (`matrixRooms.principalId`)
+ * and from nothing else: a room keeps its resident even after that agent
+ * moves to a different station, and a reply about an old gate must come from
+ * the agent whose history is actually in this room.
+ *
+ * An UNBOUND room gets null — fix round 4, and a deliberate reversal. This
+ * used to fall back to `stations.principalId`, the station's *current*
+ * occupant, on the reasoning that a room from before the binding existed had
+ * been speaking as that agent all along. Migration 0060 already backfilled
+ * every such room, and what the fallback actually covers now is a room its
+ * station's occupant never lived in — a harness-mode station's room,
+ * provisioned while nobody occupied it (`provision.ts` writes
+ * `principal_id: null` there), left behind when an occupant arrives who
+ * already holds a room elsewhere. Answering that as the station's current
+ * occupant puts the WRONG agent's name on a reply in somebody else's old
+ * room. The schema genuinely cannot tell "never bound" from "a departed
+ * occupant's, never bound" — but "cannot distinguish" argues for no answer,
+ * not for a guess. The one caller (`index.ts`'s gate `reply`) already treats
+ * null as "there is nobody to say this as" and stays silent, which is the
+ * failure worth having: a missing reply is visible and recoverable, a
+ * misattributed one is neither.
  */
 export async function roomAgentUser(roomId: string, domain: string): Promise<string | null> {
   const [row] = await db
-    .select({
-      ownPrincipalId: matrixRooms.principalId,
-      stationPrincipalId: stations.principalId,
-    })
+    .select({ ownPrincipalId: matrixRooms.principalId })
     .from(matrixRooms)
-    .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
     .where(eq(matrixRooms.roomId, roomId))
     .limit(1);
-  if (!row) return null;
-  const principalId = row.ownPrincipalId ?? row.stationPrincipalId;
-  if (!principalId) return null;
-  const handle = await principalHandle(principalId);
+  if (!row?.ownPrincipalId) return null;
+  const handle = await principalHandle(row.ownPrincipalId);
   return handle ? bridgeUserId(handle, domain) : null;
 }

--- a/apps/hub/src/services/matrix-as/hooks.ts
+++ b/apps/hub/src/services/matrix-as/hooks.ts
@@ -41,3 +41,57 @@ export function notifyStationsAdopted(stationIds: string[]): void {
     });
   });
 }
+
+/**
+ * Provisioning ONE station, on demand, and waiting for the answer.
+ *
+ * The adoption hook above is fire-and-forget because adoption has already
+ * succeeded by the time it runs and must not be undone by a homeserver.
+ * This one is awaited, because its caller — `routes/agents-admin.ts`'s
+ * assign endpoint — is the act that makes a station dispatchable, and
+ * whether the agent actually got a room is part of the answer an operator
+ * needs, not a detail to discover weeks later from a silent gate.
+ *
+ * The whole-branch review's Critical: assigning an agent wrote
+ * `stations.principal_id`, conditionally bound an EXISTING unbound room,
+ * and never provisioned. The console reaches no other provisioning trigger
+ * — `onStationsAdopted` fires before there is an occupant, and
+ * `provision.ts` returns early for a bridge-mode station with none — so a
+ * console-created agent had no room, its gates resolved to `no-room`, and
+ * `gate-sweep.ts` does not count that status. Silent, and permanent until
+ * somebody restarted the hub.
+ */
+type Provisioner = (stationId: string) => Promise<void>;
+
+let provisioner: Provisioner | null = null;
+
+/** Register the one provisioner. Boot wiring, same as `onStationsAdopted`. */
+export function onProvisionStation(fn: Provisioner | null): void {
+  provisioner = fn;
+}
+
+/**
+ * Whether a station ended up with a Matrix room, and if not, why not.
+ *
+ * `"no-bridge"` is a real answer rather than a failure: a hub with
+ * `MATRIX_AS_*` unset has no homeserver, no rooms for anything, and an
+ * assignment there is complete when the row is written. Distinguished from
+ * `"failed"` so a caller never reports a configuration choice as a fault,
+ * or a fault as a configuration choice.
+ */
+export type ProvisionOutcome =
+  | { status: "provisioned" }
+  | { status: "no-bridge" }
+  | { status: "failed"; error: string };
+
+export async function provisionStationNow(stationId: string): Promise<ProvisionOutcome> {
+  if (!provisioner) return { status: "no-bridge" };
+  try {
+    await provisioner(stationId);
+    return { status: "provisioned" };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log.error("could not provision a Matrix room for a station", { stationId, error });
+    return { status: "failed", error };
+  }
+}

--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -26,6 +26,7 @@ import { resolveMatrixId } from "../matrix-identity";
 import { getGrant, grantAllowsPrincipal } from "../grants";
 import { isControlPairEnforced } from "../control-pair";
 import { bridgeUserId } from "./names";
+import { principalHandle } from "../principals";
 import {
   clearPendingPermission,
   matchPermissionAnswer,
@@ -150,7 +151,21 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
   // the failure the mode exists to prevent.
   if (room.identityMode !== "bridge") return;
 
-  const agentUser = bridgeUserId(room.nodeName, room.stationKey, deps.domain);
+  // A station with no occupying agent has no handle and therefore no mxid to
+  // speak as. This should not happen — provisioning refuses to create a room
+  // for an unoccupied bridge-mode station in the first place — but a defensive
+  // check beats inventing an address from `(nodeName, stationKey)` if it ever
+  // does.
+  const handle = room.principalId ? await principalHandle(room.principalId) : null;
+  if (!handle) {
+    log.warn("matrix room's station has no occupying agent; cannot speak as it", {
+      room: room.roomId,
+      stationKey: room.stationKey,
+    });
+    return;
+  }
+
+  const agentUser = bridgeUserId(handle, deps.domain);
   const say = (body: string) => deps.client.sendText(agentUser, room.roomId, body);
 
   // ── Who is this? ──────────────────────────────────────────────────────────

--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -23,7 +23,7 @@ import { acpSessions } from "../../db/schema/acp";
 import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
 import { resolveMatrixId } from "../matrix-identity";
-import { getGrant, grantAllowsStation } from "../grants";
+import { getGrant, grantAllowsPrincipal } from "../grants";
 import { isControlPairEnforced } from "../control-pair";
 import { bridgeUserId } from "./names";
 import {
@@ -106,6 +106,7 @@ async function roomContext(roomId: string) {
       stationKey: stations.stationKey,
       identityMode: stations.matrixIdentityMode,
       nodeName: nodes.name,
+      principalId: stations.principalId,
       sessionStatus: acpSessions.status,
     })
     .from(matrixRooms)
@@ -174,10 +175,7 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
   // ── May they dispatch THIS agent? ─────────────────────────────────────────
   if (isControlPairEnforced()) {
     const grant = await getGrant(principalId);
-    const allowed = grantAllowsStation(grant, {
-      nodeName: room.nodeName,
-      stationKey: room.stationKey,
-    });
+    const allowed = grantAllowsPrincipal(grant, room.principalId);
 
     if (!allowed) {
       log.warn("matrix message refused by the control pair", {

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -19,7 +19,7 @@ import { matrixRooms } from "../../db/schema/matrix";
 import { principalIdentities } from "../../db/schema/identities";
 import * as broker from "../broker";
 import { createMatrixClient, type MatrixClient } from "./client";
-import { provisionStation, provisionAll } from "./provision";
+import { provisionStation, provisionAll, provisionStationForAlias } from "./provision";
 import { handleRoomMessage } from "./inbound";
 import {
   handleGateDecision,
@@ -269,25 +269,12 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
     },
 
     async onProvisionAlias(alias: string) {
-      // The homeserver asks about an alias when somebody tried to resolve it.
-      // Answering yes without creating the room would send them somewhere that
-      // is not there.
-      //
-      // Two shapes to try — fix round 3 on Task 5: an occupied station's
-      // room alias is occupant-derived now (`bridgeAliasForHandle`), and a
-      // station with no occupant still uses the station-derived form
-      // (`bridgeAlias`). Occupant-derived is tried first since it is the
-      // ordinary case for any station with someone in it; station-derived
-      // is what a room with no occupant, or one this migration hasn't
-      // reached, still resolves through.
-      const { stationForLocalpart, stationForOccupantLocalpart, localpartFromAlias } = await import(
-        "./stations"
-      );
-      const localpart = localpartFromAlias(alias, cfg.domain);
-      const station = localpart
-        ? (await stationForOccupantLocalpart(localpart)) ?? (await stationForLocalpart(localpart))
-        : null;
-      if (station) await provisionStation(station.stationId, provisionDeps);
+      // Both alias shapes, resolved by the same `stationForAlias` the route
+      // in front of this one gates on — fix round 4. Round 3 wrote the
+      // two-shape lookup out longhand here, and the route kept its own
+      // narrower one, which is how an occupant-derived alias came to be
+      // 404'd before this ever ran.
+      await provisionStationForAlias(alias, provisionDeps);
     },
   };
 }

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -272,9 +272,21 @@ export function createMatrixBridge(cfg = matrixBridgeConfig()): MatrixBridge | n
       // The homeserver asks about an alias when somebody tried to resolve it.
       // Answering yes without creating the room would send them somewhere that
       // is not there.
-      const { stationForLocalpart, localpartFromAlias } = await import("./stations");
+      //
+      // Two shapes to try — fix round 3 on Task 5: an occupied station's
+      // room alias is occupant-derived now (`bridgeAliasForHandle`), and a
+      // station with no occupant still uses the station-derived form
+      // (`bridgeAlias`). Occupant-derived is tried first since it is the
+      // ordinary case for any station with someone in it; station-derived
+      // is what a room with no occupant, or one this migration hasn't
+      // reached, still resolves through.
+      const { stationForLocalpart, stationForOccupantLocalpart, localpartFromAlias } = await import(
+        "./stations"
+      );
       const localpart = localpartFromAlias(alias, cfg.domain);
-      const station = localpart ? await stationForLocalpart(localpart) : null;
+      const station = localpart
+        ? (await stationForOccupantLocalpart(localpart)) ?? (await stationForLocalpart(localpart))
+        : null;
       if (station) await provisionStation(station.stationId, provisionDeps);
     },
   };

--- a/apps/hub/src/services/matrix-as/index.ts
+++ b/apps/hub/src/services/matrix-as/index.ts
@@ -29,6 +29,7 @@ import {
 } from "./gates";
 import { mintPrincipalAssertion } from "../../auth/service-signing";
 import { resolveMatrixId } from "../matrix-identity";
+import { principalForUser } from "../principals";
 import { attachRoomToSession, noteTurnTrigger } from "./outbound";
 import { createSession, promptSession,
   answerPermission } from "../acp-sessions";
@@ -60,26 +61,36 @@ export interface MatrixBridgeConfig {
  *
  * A turn's text is pushed to that person's own devices while it is being
  * written (see `live.ts`), so this answers "whose devices". `null` — a room
- * whose owner has no Matrix identity mapped — simply means no live view; the
- * room still gets its message.
+ * whose owner has no principal, or a principal with no Matrix identity mapped —
+ * simply means no live view; the room still gets its message.
  *
- * Looked up once per attachment rather than per chunk: this is three joins and
- * an agent can emit hundreds of chunks in a turn.
+ * Two lookups rather than one join, because `stations.userId` is a Better Auth
+ * id and `principal_identities.principal_id` is a `prn_…` value now — joining
+ * them directly would silently match nothing for every station. Still looked
+ * up once per attachment rather than per chunk: an agent can emit hundreds of
+ * chunks in a turn.
  */
 async function readerForRoom(roomId: string): Promise<string | null> {
   const [row] = await db
-    .select({ externalId: principalIdentities.externalId })
+    .select({ userId: stations.userId })
     .from(matrixRooms)
     .innerJoin(stations, eq(stations.id, matrixRooms.stationId))
-    .innerJoin(
-      principalIdentities,
+    .where(eq(matrixRooms.roomId, roomId));
+  if (!row) return null;
+
+  const principal = await principalForUser(row.userId);
+  if (!principal) return null;
+
+  const [identity] = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(principalIdentities)
+    .where(
       and(
-        eq(principalIdentities.principalId, stations.userId),
+        eq(principalIdentities.principalId, principal.id),
         eq(principalIdentities.system, "matrix")
       )
-    )
-    .where(eq(matrixRooms.roomId, roomId));
-  return row?.externalId ?? null;
+    );
+  return identity?.externalId ?? null;
 }
 
 export function matrixBridgeConfig(env = process.env): MatrixBridgeConfig {

--- a/apps/hub/src/services/matrix-as/names.test.ts
+++ b/apps/hub/src/services/matrix-as/names.test.ts
@@ -2,49 +2,86 @@ import { describe, expect, test } from "bun:test";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart, localpartFor, isBridgeUser } from "./names";
 
 /**
- * A Matrix name for a station.
+ * An agent's Matrix name, and a room's.
  *
- * Derived, never stored: from the same `(node, stationKey)` pair that already
- * identifies a station in a grant
- * (`charter` → decisions/2026-08-15-a-grant-names-an-agent-per-plane.md). A
- * mapping table would be a second source of truth for a fact the fleet knows.
+ * `bridgeUserId`/`bridgeLocalpart` are derived from a principal's `handle` —
+ * immutable, and the same wherever the agent runs
+ * (`charter` → decisions/2026-08-30-an-agent-is-a-principal.md). `bridgeAlias`
+ * still derives from the `(node, stationKey)` pair that names a *station*: a
+ * room is a place, not the identity that occupies it, and station keys repeat
+ * across the fleet — `opencode:c52ddf65` exists on two nodes today.
  */
 
 const D = "id.agentpod.dev";
 
 describe("bridge names", () => {
+  test("an agent's address survives moving between nodes", () => {
+    // The principle the strategy states twice: an agent is an identity, a
+    // station is a location. Derived from node+station, moving an agent made
+    // it a different person in chat.
+    expect(bridgeUserId("writer-quill", "id.agentpod.dev")).toBe(
+      "@agent_writer-quill:id.agentpod.dev"
+    );
+  });
+
+  test("still lands inside the exclusive @agent_.* namespace", () => {
+    // Outside it the appservice may not act — a 403 that arrives later and
+    // elsewhere.
+    expect(bridgeLocalpart("Writer Quill")).toMatch(/^agent_[a-z0-9._=/-]+$/);
+  });
+
+  test("lowercase, because Matrix localparts are", () => {
+    expect(bridgeUserId("BOX", D)).toBe("@agent_box:id.agentpod.dev");
+  });
+
+  test("replaces characters an mxid localpart may not contain", () => {
+    // `:` is the mxid separator, and a handle picked before this rule existed
+    // could still contain one.
+    expect(bridgeUserId("box:pi", D)).toBe("@agent_box-pi:id.agentpod.dev");
+  });
+
+  test("the registered username is exactly the user id's localpart", () => {
+    // Registering the bare handle creates a user OUTSIDE the exclusive
+    // namespace, where the appservice may not act — and the failure surfaces
+    // later and elsewhere, as a 403 at send time.
+    const userId = bridgeUserId("molt-bot", D);
+    expect(userId).toBe(`@${bridgeLocalpart("molt-bot")}:${D}`);
+    expect(bridgeLocalpart("molt-bot").startsWith("agent_")).toBe(true);
+  });
+
+  test("are stable — the same handle always gets the same name", () => {
+    // A name that drifted would strand rooms behind identities nobody answers
+    // for.
+    expect(bridgeUserId("molt-bot", D)).toBe(bridgeUserId("molt-bot", D));
+  });
+});
+
+describe("room names, still keyed to a station", () => {
   test("name a node as well as a station", () => {
     // `opencode:c52ddf65` exists on two nodes in production right now. A name
-    // that omitted the node would merge two different agents on two different
-    // machines — the collision this suite has already undone once, for grants.
-    const a = bridgeUserId("cloudchamber", "opencode:c52ddf65", D);
-    const b = bridgeUserId("9247e5a88cfa", "opencode:c52ddf65", D);
+    // that omitted the node would merge two different agents' rooms on two
+    // different machines — the collision this suite has already undone once,
+    // for grants. A room's address is not an agent's, so it stays derived from
+    // where the station runs.
+    const a = bridgeAlias("cloudchamber", "opencode:c52ddf65", D);
+    const b = bridgeAlias("9247e5a88cfa", "opencode:c52ddf65", D);
     expect(a).not.toBe(b);
   });
 
   test("land inside the namespace the homeserver reserved", () => {
-    // agents.yaml claims `@agent_.*` and `#agentpod_.*` exclusive. A name
-    // outside them cannot be acted as, and the failure arrives late — a 403
-    // from the homeserver at send time, long after provisioning "worked".
-    // One `_`, and it is unambiguous because `_` cannot survive cleaning:
-    // every underscore in a station key or node name becomes `-`.
-    expect(bridgeUserId("molt-bot", "hermes:analyst-echo", D)).toBe(
-      "@agent_molt-bot_hermes-analyst-echo:id.agentpod.dev"
-    );
+    // agents.yaml claims `#agentpod_.*` exclusive. A name outside it cannot be
+    // acted as, and the failure arrives late — a 403 from the homeserver at
+    // send time, long after provisioning "worked".
     expect(bridgeAlias("molt-bot", "hermes:analyst-echo", D)).toBe(
       "#agentpod_molt-bot_hermes-analyst-echo:id.agentpod.dev"
     );
   });
 
-  test("replace characters an mxid localpart may not contain", () => {
+  test("replace characters a room alias's localpart may not contain", () => {
     // `:` is the mxid separator, and a station key is full of them.
-    expect(bridgeUserId("box", "claude-code:48c62ea7", D)).toBe(
-      "@agent_box_claude-code-48c62ea7:id.agentpod.dev"
+    expect(bridgeAlias("box", "claude-code:48c62ea7", D)).toBe(
+      "#agentpod_box_claude-code-48c62ea7:id.agentpod.dev"
     );
-  });
-
-  test("lowercase, because Matrix localparts are", () => {
-    expect(bridgeUserId("BOX", "Pi:59099BF1", D)).toBe("@agent_box_pi-59099bf1:id.agentpod.dev");
   });
 
   test("keep the node and the station distinguishable", () => {
@@ -61,20 +98,9 @@ describe("bridge names", () => {
     expect(localpartFor("a_b", "c").split("_")).toHaveLength(2);
   });
 
-  test("the registered username is exactly the user id's localpart", () => {
-    // Registering the bare name creates a user OUTSIDE the exclusive namespace,
-    // where the appservice may not act — and the failure surfaces later and
-    // elsewhere, as a 403 at send time.
-    const userId = bridgeUserId("molt-bot", "hermes:coder-kai", D);
-    expect(userId).toBe(`@${bridgeLocalpart("molt-bot", "hermes:coder-kai")}:${D}`);
-    expect(bridgeLocalpart("molt-bot", "hermes:coder-kai").startsWith("agent_")).toBe(true);
-  });
-
   test("are stable — the same station always gets the same name", () => {
-    // Provisioning runs on every adoption and every boot. A name that drifted
-    // would strand rooms behind identities nobody answers for.
-    expect(bridgeUserId("molt-bot", "hermes:coder-kai", D)).toBe(
-      bridgeUserId("molt-bot", "hermes:coder-kai", D)
+    expect(bridgeAlias("molt-bot", "hermes:coder-kai", D)).toBe(
+      bridgeAlias("molt-bot", "hermes:coder-kai", D)
     );
   });
 });

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -68,6 +68,38 @@ export function bridgeAlias(nodeName: string, stationKey: string, domain: string
 }
 
 /**
+ * A room's alias, derived from the HANDLE of whoever occupies it — fix
+ * round 3 on Task 5, and the same move `bridgeUserId` already made for the
+ * mxid: an occupant is an identity, a station is an execution location.
+ * `bridgeAlias` above stayed station-derived, and that was the last place
+ * still keyed to the station — which meant a room CREATED for a new
+ * occupant reused its predecessor's exact alias, and the real homeserver's
+ * only answer to "create a room at an alias that already exists" is
+ * `M_ROOM_IN_USE`. `client.ts`'s `ensureRoom` handles that response two
+ * ways, neither of which is "the new occupant gets its own room": if the
+ * new creator happens to already be a member (harness mode, where the
+ * speaker never changes with occupancy) it hands back the OLD room; if not
+ * (bridge mode) it deletes the alias off the old, still-live room and
+ * mints a fresh one. Deriving the alias from the occupant closes the
+ * collision at the source rather than depending on either branch.
+ *
+ * Deliberately the SAME localpart `bridgeLocalpart` builds for the mxid
+ * (`agent_<handle>`), not a new scheme — a reader (or `stations.ts`'s
+ * `stationForOccupantLocalpart`) can tell a principal-derived alias apart
+ * from a station-derived one on sight, since `localpartFor(nodeName,
+ * stationKey)` can never itself produce a string starting `agent_` unless a
+ * node is literally named "agent".
+ *
+ * Used only when a station HAS an occupant — `bridgeAlias` above remains
+ * the address for a room with none, which is the one case a station-keyed
+ * alias cannot collide with a predecessor's, because there is no
+ * predecessor's room to reuse it from.
+ */
+export function bridgeAliasForHandle(handle: string, domain: string): string {
+  return `#agentpod_${bridgeLocalpart(handle)}:${domain}`;
+}
+
+/**
  * Is this mxid one of ours?
  *
  * The first question asked of every inbound event. An Application Service is

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -127,6 +127,43 @@ export function roomAliasFor(
 }
 
 /**
+ * Who this hub speaks as in a station's room — the one place THAT choice is
+ * made, for the same reason `roomAliasFor` above exists.
+ *
+ * It is the identity that CREATED the room, and it has to be, because that
+ * is the identity the homeserver knows is registered and joined:
+ *
+ *  - **bridge** — the Application Service answers for the station, as its
+ *    occupying agent. `provision.ts` calls `ensureUser` for exactly this
+ *    localpart, so it exists.
+ *  - **harness** — the station runs its own Matrix client and owns its own
+ *    account, which is what `stations.matrix_id` records. `provision.ts`
+ *    creates the room as that account and deliberately does NOT call
+ *    `ensureUser`, since registering over an account somebody else holds is
+ *    the failure the mode exists to prevent.
+ *
+ * The whole-branch review's Minor: `gates.ts` posted as
+ * `bridgeUserId(handle)` for harness-mode stations too — an mxid nothing had
+ * registered, in a room it was never a member of. The `roomAgentUser` half
+ * of the same mistake was already on the record; the SEND half is worse,
+ * because a read that answers the wrong name is recoverable and a send that
+ * the homeserver refuses loses the gate.
+ *
+ * `null` — a bridge-mode station with no occupant, or a harness-mode one
+ * that has never reported an mxid — is a real answer meaning "there is
+ * nobody here to say this as". Never patched over with the retired
+ * `(nodeName, stationKey)` form, which would put words in a station-derived
+ * mouth this suite spent a slice retiring.
+ */
+export function stationSpeaker(
+  station: { identityMode: string; harnessMxid: string | null; handle: string | null },
+  domain: string
+): string | null {
+  if (station.identityMode !== "bridge") return station.harnessMxid;
+  return station.handle ? bridgeUserId(station.handle, domain) : null;
+}
+
+/**
  * Is this mxid one of ours?
  *
  * The first question asked of every inbound event. An Application Service is

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -41,17 +41,26 @@ export function localpartFor(nodeName: string, stationKey: string): string {
  * The username to register, which is the mxid's localpart INCLUDING the
  * `agent_` prefix.
  *
- * Separate from `localpartFor` because registering the bare name creates
- * `@prov-box__openclaw_krishna` — outside the exclusive namespace the homeserver
- * reserved, where the appservice may not act. The failure arrives later and
- * elsewhere, as a 403 at send time.
+ * Built from a principal's `handle`, not from where it runs. `bridgeUserId`
+ * used to take `(nodeName, stationKey)`, which made an agent's chat identity a
+ * function of its station: move it to another node and it became a different
+ * person, with new DM rooms and its history left behind. The strategy states
+ * the opposite principle twice — an agent is an identity, a station is an
+ * execution location — and a principal's `handle` is immutable, so an
+ * address built from it survives the move `bridgeAlias`'s room address does
+ * not need to.
+ *
+ * Separate from a bare `clean(handle)` because registering that creates a name
+ * outside the exclusive namespace the homeserver reserved, where the
+ * appservice may not act. The failure arrives later and elsewhere, as a 403 at
+ * send time.
  */
-export function bridgeLocalpart(nodeName: string, stationKey: string): string {
-  return `agent_${localpartFor(nodeName, stationKey)}`;
+export function bridgeLocalpart(handle: string): string {
+  return `agent_${clean(handle)}`;
 }
 
-export function bridgeUserId(nodeName: string, stationKey: string, domain: string): string {
-  return `@${bridgeLocalpart(nodeName, stationKey)}:${domain}`;
+export function bridgeUserId(handle: string, domain: string): string {
+  return `@${bridgeLocalpart(handle)}:${domain}`;
 }
 
 export function bridgeAlias(nodeName: string, stationKey: string, domain: string): string {

--- a/apps/hub/src/services/matrix-as/names.ts
+++ b/apps/hub/src/services/matrix-as/names.ts
@@ -100,6 +100,33 @@ export function bridgeAliasForHandle(handle: string, domain: string): string {
 }
 
 /**
+ * The address a station's room GETS — the one place that choice is made.
+ *
+ * Fix round 5 on Task 5. The choice between the two forms above lived
+ * inline in `provision.ts`, and `routes/station-matrix.ts` made its own
+ * choice — the wrong one, `bridgeAlias` unconditionally, so
+ * `POST /api/stations/:id/matrix/identity` handed back an address no room
+ * held for exactly the stations it can answer for at all (it 409s unless
+ * there IS an occupant, and an occupant's room is addressed by
+ * `bridgeAliasForHandle`). That is the same shape of miss as rounds 1-4:
+ * a rule applied at one layer and re-derived, differently, at the entry
+ * point in front of it. There is one rule now and both callers read it
+ * through `station-room.ts`'s `roomAliasForStation`.
+ *
+ * `handle` null means the station has no occupant, and the station-derived
+ * form is the address for a room with none — the one case it cannot
+ * collide with a predecessor's, because there is no predecessor.
+ */
+export function roomAliasFor(
+  station: { handle: string | null; nodeName: string; stationKey: string },
+  domain: string
+): string {
+  return station.handle
+    ? bridgeAliasForHandle(station.handle, domain)
+    : bridgeAlias(station.nodeName, station.stationKey, domain);
+}
+
+/**
  * Is this mxid one of ours?
  *
  * The first question asked of every inbound event. An Application Service is

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -22,6 +22,7 @@ import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
 import { principalHandle, principalForUser } from "../principals";
 import { roomForStation } from "./station-room";
+import { stationForAlias } from "./stations";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-provision");
@@ -338,6 +339,29 @@ async function fileByNode(
   );
 
   await fileRoomUnderSpace(room.roomId, desired, room.spaceRoomId, spaceDeps);
+}
+
+/**
+ * Provision the station behind a room alias the homeserver asked about.
+ *
+ * The homeserver asks when somebody tried to resolve the alias. Answering
+ * yes without creating the room would send them somewhere that is not
+ * there — so the route's 200 and this call have to agree about which
+ * aliases are ours, which is why both go through `stationForAlias` and
+ * neither carries a shape list of its own. Fix round 4: they did not agree,
+ * and the route's narrower gate made this function's second shape
+ * unreachable.
+ *
+ * Silent on an alias with no station behind it: the route has already
+ * answered 404 for that case, and this is also called on aliases the
+ * homeserver merely wondered about.
+ */
+export async function provisionStationForAlias(
+  alias: string,
+  deps: ProvisionDeps
+): Promise<void> {
+  const station = await stationForAlias(alias, deps.domain);
+  if (station) await provisionStation(station.stationId, deps);
 }
 
 /**

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -17,7 +17,7 @@ import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
 import { matrixRooms } from "../../db/schema/matrix";
 import { principalIdentities } from "../../db/schema/identities";
-import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
+import { bridgeUserId, bridgeAlias, bridgeAliasForHandle, bridgeLocalpart } from "./names";
 import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
 import { principalHandle, principalForUser } from "../principals";
@@ -175,6 +175,13 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
       });
       return;
     }
+    // Harness mode's SPEAKER is the harness's own fixed identity, unchanged
+    // by who occupies the station — but the ROOM'S ALIAS still has to
+    // follow the occupant (below), or a harness station whose occupant
+    // changes collides on the exact alias its predecessor's room still
+    // holds. Resolved here for that alone; it never becomes the speaker in
+    // this branch.
+    handle = s.principalId ? await principalHandle(s.principalId) : null;
   }
 
   // A name a person can read. The mxid is derived and unlovely; this is what a
@@ -222,7 +229,15 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
   // The room is created once. A second one for the same station would split its
   // conversation in two, with each half unaware of the other.
   if (!s.roomId) {
-    const alias = bridgeAlias(s.nodeName, s.stationKey, deps.domain);
+    // Occupant-derived when there is one — fix round 3: the station-keyed
+    // form below is what let a new occupant's room silently collide with
+    // its predecessor's, since two different occupants of the same
+    // station used to produce the identical alias. `bridgeAlias` stays the
+    // address for a room with NO occupant, the one case nothing else could
+    // be holding it.
+    const alias = handle
+      ? bridgeAliasForHandle(handle, deps.domain)
+      : bridgeAlias(s.nodeName, s.stationKey, deps.domain);
 
     // The owner is invited AT creation rather than afterwards, because the flag
     // that makes this a DM rides on the invite's own member event and can only

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -20,7 +20,7 @@ import { principalIdentities } from "../../db/schema/identities";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
 import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
-import { principalHandle } from "../principals";
+import { principalHandle, principalForUser } from "../principals";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-provision");
@@ -94,14 +94,32 @@ async function context(stationId: string) {
   return row ?? null;
 }
 
-/** The owner's Matrix id, so the room is not a locked door. */
-async function ownerMxid(principalId: string): Promise<string | null> {
+/**
+ * The owner's Matrix id, so the room is not a locked door.
+ *
+ * Two lookups rather than one, and for the same reason `readerForRoom` in
+ * `index.ts` does it this way: `stations.userId` is a Better Auth id and
+ * `principal_identities.principal_id` holds `prn_…` values now, so handing
+ * this a user id and querying that column directly answers null for every
+ * station in the fleet. It did — the parameter was already named
+ * `principalId` while both call sites passed `s.userId`, and the only visible
+ * symptom was that `ensureRoom` quietly dropped `invite` and `isDirect`, so
+ * every room this created at boot was a room nobody was in but the agent.
+ *
+ * `null` — an owner with no principal, or a principal with no Matrix identity
+ * mapped — is an ordinary answer: the room is still made, so the agent has
+ * somewhere to be, and somebody can be invited later.
+ */
+async function ownerMxid(userId: string): Promise<string | null> {
+  const principal = await principalForUser(userId);
+  if (!principal) return null;
+
   const [row] = await db
     .select({ externalId: principalIdentities.externalId })
     .from(principalIdentities)
     .where(
       and(
-        eq(principalIdentities.principalId, principalId),
+        eq(principalIdentities.principalId, principal.id),
         eq(principalIdentities.system, "matrix")
       )
     );

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -17,7 +17,7 @@ import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
 import { matrixRooms } from "../../db/schema/matrix";
 import { principalIdentities } from "../../db/schema/identities";
-import { bridgeUserId, bridgeAlias, bridgeAliasForHandle, bridgeLocalpart } from "./names";
+import { bridgeUserId, bridgeLocalpart, roomAliasFor } from "./names";
 import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
 import { principalHandle, principalForUser } from "../principals";
@@ -231,14 +231,16 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
   // conversation in two, with each half unaware of the other.
   if (!s.roomId) {
     // Occupant-derived when there is one — fix round 3: the station-keyed
-    // form below is what let a new occupant's room silently collide with
-    // its predecessor's, since two different occupants of the same
-    // station used to produce the identical alias. `bridgeAlias` stays the
-    // address for a room with NO occupant, the one case nothing else could
-    // be holding it.
-    const alias = handle
-      ? bridgeAliasForHandle(handle, deps.domain)
-      : bridgeAlias(s.nodeName, s.stationKey, deps.domain);
+    // form is what let a new occupant's room silently collide with its
+    // predecessor's, since two different occupants of the same station
+    // used to produce the identical alias. That choice now lives in
+    // `names.ts`'s `roomAliasFor` rather than inline here, because fix
+    // round 5 found `routes/station-matrix.ts` making the same choice
+    // separately and getting it wrong.
+    const alias = roomAliasFor(
+      { handle, nodeName: s.nodeName, stationKey: s.stationKey },
+      deps.domain
+    );
 
     // The owner is invited AT creation rather than afterwards, because the flag
     // that makes this a DM rides on the invite's own member event and can only

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -21,6 +21,7 @@ import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
 import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
 import { principalHandle, principalForUser } from "../principals";
+import { roomForStation } from "./station-room";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-provision");
@@ -69,7 +70,18 @@ export interface ProvisionDeps {
   ): Promise<{ bytes: Uint8Array; contentType: string } | null>;
 }
 
-/** The station, its node's name, and whether a room already exists for it. */
+/**
+ * The station, its node's name, and whether its CURRENT occupant already
+ * has a room.
+ *
+ * `roomId`/`spaceRoomId` come from `station-room.ts`, not from a bare
+ * `leftJoin(matrixRooms, eq(matrixRooms.stationId, stations.id))` — that
+ * join, with no `ORDER BY` and `[row]` picked off whatever Postgres
+ * happened to return, was a fix-round review's finding: it could answer
+ * with a DEPARTED occupant's room, which made this function believe a new
+ * occupant already had one and skip creating it. A new occupant with no
+ * room of its own must see `roomId: null` here, or it never gets one.
+ */
 async function context(stationId: string) {
   const [row] = await db
     .select({
@@ -84,14 +96,18 @@ async function context(stationId: string) {
       purpose: stations.purpose,
       principalId: stations.principalId,
       nodeName: nodes.name,
-      roomId: matrixRooms.roomId,
-      spaceRoomId: matrixRooms.spaceRoomId,
     })
     .from(stations)
     .innerJoin(nodes, eq(nodes.id, stations.nodeId))
-    .leftJoin(matrixRooms, eq(matrixRooms.stationId, stations.id))
     .where(eq(stations.id, stationId));
-  return row ?? null;
+  if (!row) return null;
+
+  const occupancy = await roomForStation(stationId);
+  return {
+    ...row,
+    roomId: occupancy.room?.roomId ?? null,
+    spaceRoomId: occupancy.room?.spaceRoomId ?? null,
+  };
 }
 
 /**
@@ -237,7 +253,20 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
 
     await db
       .insert(matrixRooms)
-      .values({ roomId, tenantId: s.tenantId, stationId: s.stationId, alias })
+      .values({
+        roomId,
+        tenantId: s.tenantId,
+        stationId: s.stationId,
+        alias,
+        // Bound to this occupant at creation — the room this function just
+        // made exists FOR whoever `s.principalId` names (null for a
+        // harness-mode or not-yet-occupied station, same as ever). Without
+        // this, a freshly created room sat unbound until some later assign
+        // call happened to find it, and `agents-admin.ts`'s bind-on-assign
+        // already ran BEFORE this room existed for a station occupied via
+        // the admin route first — it would never bind on its own.
+        principalId: s.principalId,
+      })
       .onConflictDoNothing();
   }
 
@@ -268,12 +297,14 @@ async function fileByNode(
   const { createSpace, addSpaceChild, removeSpaceChild } = deps.client;
   if (!createSpace || !addSpaceChild || !removeSpaceChild) return;
 
-  // Re-read: the room may have been created moments ago, above.
-  const [room] = await db
-    .select({ roomId: matrixRooms.roomId, spaceRoomId: matrixRooms.spaceRoomId })
-    .from(matrixRooms)
-    .where(eq(matrixRooms.stationId, s.stationId));
-  if (!room) return;
+  // Re-resolve: the room may have been created moments ago, above, and
+  // `station-room.ts` is what makes this the CURRENT occupant's own room —
+  // a departed occupant's room, still sitting at this `station_id`, must
+  // never be re-filed under a space as if it belonged to whoever occupies
+  // the station now.
+  const occupancy = await roomForStation(s.stationId);
+  if (!occupancy.room) return;
+  const room = occupancy.room;
 
   const spaceDeps = {
     client: { createSpace, addSpaceChild, removeSpaceChild, invite: deps.client.invite },

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -17,7 +17,7 @@ import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
 import { matrixRooms } from "../../db/schema/matrix";
 import { principalIdentities } from "../../db/schema/identities";
-import { bridgeUserId, bridgeLocalpart, roomAliasFor } from "./names";
+import { bridgeLocalpart, roomAliasFor, stationSpeaker } from "./names";
 import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
 import { principalHandle, principalForUser } from "../principals";
@@ -155,34 +155,30 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
   // nobody to answer as, there is nobody to create the room as — inventing an
   // identity from `(nodeName, stationKey)` would be exactly the
   // station-derived address this suite moved away from.
-  let speaker: string | null;
-  let handle: string | null = null;
-  if (bridged) {
-    handle = s.principalId ? await principalHandle(s.principalId) : null;
-    if (!handle) {
-      log.warn(
-        "station has no occupying agent, so it has no handle to provision a Matrix identity for",
-        { stationId, stationKey: s.stationKey }
-      );
-      return;
-    }
-    speaker = bridgeUserId(handle, deps.domain);
-  } else {
-    speaker = s.harnessMxid;
-    if (!speaker) {
-      log.warn("station answers for itself but has no Matrix identity; nothing to provision", {
-        stationId,
-        stationKey: s.stationKey,
-      });
-      return;
-    }
-    // Harness mode's SPEAKER is the harness's own fixed identity, unchanged
-    // by who occupies the station — but the ROOM'S ALIAS still has to
-    // follow the occupant (below), or a harness station whose occupant
-    // changes collides on the exact alias its predecessor's room still
-    // holds. Resolved here for that alone; it never becomes the speaker in
-    // this branch.
-    handle = s.principalId ? await principalHandle(s.principalId) : null;
+  // Resolved unconditionally, in both modes. Harness mode's SPEAKER is the
+  // harness's own fixed identity, unchanged by who occupies the station —
+  // but the ROOM'S ALIAS still has to follow the occupant (below), or a
+  // harness station whose occupant changes collides on the exact alias its
+  // predecessor's room still holds.
+  const handle: string | null = s.principalId ? await principalHandle(s.principalId) : null;
+
+  // `names.ts`'s `stationSpeaker` is the one place this choice is made now —
+  // `gates.ts` was making it a second time and getting harness mode wrong,
+  // posting as an `@agent_…` nothing had registered. Two independently
+  // maintained answers to one question is how every other divergence in this
+  // task started.
+  const speaker = stationSpeaker(
+    { identityMode: s.identityMode, harnessMxid: s.harnessMxid, handle },
+    deps.domain
+  );
+  if (!speaker) {
+    log.warn(
+      bridged
+        ? "station has no occupying agent, so it has no handle to provision a Matrix identity for"
+        : "station answers for itself but has no Matrix identity; nothing to provision",
+      { stationId, stationKey: s.stationKey }
+    );
+    return;
   }
 
   // A name a person can read. The mxid is derived and unlovely; this is what a

--- a/apps/hub/src/services/matrix-as/provision.ts
+++ b/apps/hub/src/services/matrix-as/provision.ts
@@ -20,6 +20,7 @@ import { principalIdentities } from "../../db/schema/identities";
 import { bridgeUserId, bridgeAlias, bridgeLocalpart } from "./names";
 import { ensureNodeSpace, fileRoomUnderSpace } from "./spaces";
 import { pickAvatar } from "./avatar";
+import { principalHandle } from "../principals";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("matrix-provision");
@@ -81,6 +82,7 @@ async function context(stationId: string) {
       identityMode: stations.matrixIdentityMode,
       harnessMxid: stations.matrixId,
       purpose: stations.purpose,
+      principalId: stations.principalId,
       nodeName: nodes.name,
       roomId: matrixRooms.roomId,
       spaceRoomId: matrixRooms.spaceRoomId,
@@ -113,19 +115,32 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
   const bridged = s.identityMode === "bridge";
 
   // Whoever answers in this room is who creates it. For a bridge-mode station
-  // that is the identity we mint; for a harness-mode one it is the account the
-  // harness already holds, and if it has none there is nobody to create the
-  // room as — inventing one would be the bridge answering for a station that is
-  // supposed to answer for itself.
-  const speaker = bridged
-    ? bridgeUserId(s.nodeName, s.stationKey, deps.domain)
-    : s.harnessMxid;
-  if (!speaker) {
-    log.warn("station answers for itself but has no Matrix identity; nothing to provision", {
-      stationId,
-      stationKey: s.stationKey,
-    });
-    return;
+  // that is the identity minted for its occupying agent; for a harness-mode
+  // one it is the account the harness already holds. Either way, if there is
+  // nobody to answer as, there is nobody to create the room as — inventing an
+  // identity from `(nodeName, stationKey)` would be exactly the
+  // station-derived address this suite moved away from.
+  let speaker: string | null;
+  let handle: string | null = null;
+  if (bridged) {
+    handle = s.principalId ? await principalHandle(s.principalId) : null;
+    if (!handle) {
+      log.warn(
+        "station has no occupying agent, so it has no handle to provision a Matrix identity for",
+        { stationId, stationKey: s.stationKey }
+      );
+      return;
+    }
+    speaker = bridgeUserId(handle, deps.domain);
+  } else {
+    speaker = s.harnessMxid;
+    if (!speaker) {
+      log.warn("station answers for itself but has no Matrix identity; nothing to provision", {
+        stationId,
+        stationKey: s.stationKey,
+      });
+      return;
+    }
   }
 
   // A name a person can read. The mxid is derived and unlovely; this is what a
@@ -133,7 +148,7 @@ export async function provisionStation(stationId: string, deps: ProvisionDeps): 
   const displayName = `${s.displayName} (${s.harness} @ ${s.nodeName})`;
 
   if (bridged) {
-    await deps.client.ensureUser(bridgeLocalpart(s.nodeName, s.stationKey), displayName);
+    await deps.client.ensureUser(bridgeLocalpart(handle!), displayName);
   }
 
   // An agent's face, if it has one.

--- a/apps/hub/src/services/matrix-as/station-room.ts
+++ b/apps/hub/src/services/matrix-as/station-room.ts
@@ -20,15 +20,25 @@
  * provisioned, silently, forever). Patching call sites one at a time
  * leaves the next one for the next agent to find. Every reader that needs
  * "the room for this station's occupant" goes through this function now.
+ *
+ * The whole-branch review found the second half of the same problem: once
+ * a station can carry several rooms, *choosing between the unbound ones*
+ * was being done four different ways, three of them by an unordered
+ * `LIMIT 1`. `unboundRoomsForStation` below is that choice, made once —
+ * see its comment for the rule and why the earlier alias-matching rule was
+ * withdrawn.
  */
 
-import { and, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { db } from "../../db/drizzle";
 import { matrixRooms } from "../../db/schema/matrix";
 import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
 import { roomAliasFor } from "./names";
 import { principalHandle } from "../principals";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("station-room");
 
 export interface StationRoom {
   roomId: string;
@@ -52,6 +62,71 @@ export interface StationOccupancy {
    * merely happens to share this station's `station_id`.
    */
   room: StationRoom | null;
+}
+
+/**
+ * **The rule for choosing among a station's UNBOUND rooms: oldest
+ * `created_at` wins, tie-broken by `room_id`.**
+ *
+ * One rule, applied at every site that has to make this choice — here, at
+ * `roomAliasForStation` below, at `routes/agents-admin.ts`'s bind-on-assign
+ * `UPDATE` (as an inline `ORDER BY`, because that write must stay a single
+ * atomic statement), and in migration `0062`. Four sites making the same
+ * choice by four different accidents is how this codebase acquired the bug
+ * class this whole task has been closing.
+ *
+ * Oldest, because the station's ORIGINAL room is the one carrying the
+ * history — the room adoption provisioned, the one an operator has been
+ * reading for months. `room_id` breaks a tie because `created_at` has no
+ * uniqueness of its own and two rooms provisioned in the same batch can
+ * share a timestamp to the microsecond; without it the "rule" would still
+ * be an arbitrary pick, just a better-dressed one.
+ *
+ * A previously-proposed rule — match the sibling whose stored alias equals
+ * `bridgeAliasForHandle(handle)` — was withdrawn as unsound: `provision.ts`
+ * binds `principal_id` at CREATION, so every room that is still unbound
+ * carries the STATION-derived alias. That rule matches all of a station's
+ * siblings or none of them, and at the assign site it would refuse the
+ * ordinary adoption-time room and hand the agent a fresh one, abandoning
+ * exactly the history this slice exists to preserve.
+ *
+ * **Logged whenever it actually had to choose.** A deterministic pick out of
+ * two candidates is still a guess about which room an operator meant; the
+ * point of the log line is that the ambiguity is visible in the record
+ * rather than settled in silence. One candidate is the ordinary case and
+ * says nothing.
+ */
+export async function unboundRoomsForStation(stationId: string): Promise<StationRoom[]> {
+  return db
+    .select({
+      roomId: matrixRooms.roomId,
+      spaceRoomId: matrixRooms.spaceRoomId,
+      alias: matrixRooms.alias,
+    })
+    .from(matrixRooms)
+    .where(and(eq(matrixRooms.stationId, stationId), isNull(matrixRooms.principalId)))
+    .orderBy(asc(matrixRooms.createdAt), asc(matrixRooms.roomId));
+}
+
+/**
+ * The one unbound room a station's history lives in, under the rule above,
+ * or null. `where` names the caller so an ambiguity log line says which
+ * decision was made on incomplete information.
+ */
+export async function oldestUnboundRoom(
+  stationId: string,
+  where: string
+): Promise<StationRoom | null> {
+  const rooms = await unboundRoomsForStation(stationId);
+  if (rooms.length > 1) {
+    log.warn("station carries more than one unbound room; chose the oldest", {
+      stationId,
+      where,
+      chose: rooms[0]!.roomId,
+      among: rooms.map((r) => r.roomId),
+    });
+  }
+  return rooms[0] ?? null;
 }
 
 /**
@@ -94,16 +169,11 @@ export async function roomForStation(stationId: string): Promise<StationOccupanc
     return { principalId, room: own ?? null };
   }
 
-  const [unbound] = await db
-    .select({
-      roomId: matrixRooms.roomId,
-      spaceRoomId: matrixRooms.spaceRoomId,
-      alias: matrixRooms.alias,
-    })
-    .from(matrixRooms)
-    .where(and(eq(matrixRooms.stationId, stationId), isNull(matrixRooms.principalId)))
-    .limit(1);
-  return { principalId: null, room: unbound ?? null };
+  // Ordered by `unboundRoomsForStation`'s rule rather than picked off an
+  // unordered `LIMIT 1` — with no `ORDER BY`, `routes/station-say.ts` and
+  // `gates.ts` could resolve the SAME unoccupied station to two different
+  // rooms across two calls and split one conversation in half.
+  return { principalId: null, room: await oldestUnboundRoom(stationId, "roomForStation") };
 }
 
 /**
@@ -137,6 +207,22 @@ export async function roomAliasForStation(
 ): Promise<string | null> {
   const occupancy = await roomForStation(stationId);
   if (occupancy.room) return occupancy.room.alias;
+
+  // An OCCUPIED station whose occupant holds no bound room yet is the case
+  // this branch used to misreport. `roomForStation` answers `null` there, on
+  // purpose — an honest "not yet" rather than a departed occupant's room —
+  // and deriving from here would then claim an address that is wrong twice
+  // over: the station carries a real room already, at a real stored alias,
+  // and bind-on-assign's `UPDATE` is going to hand the occupant THAT room
+  // under the same oldest-wins rule. Reporting where it will be, when the
+  // answer to where it IS is sitting in the table, is the same class of
+  // mistake as `routes/station-matrix.ts` re-deriving a station-keyed alias.
+  //
+  // Derivation is kept for what it is actually honest about: a station with
+  // no room at all, where "here is where it will be" is the only answer
+  // there is.
+  const unbound = await oldestUnboundRoom(stationId, "roomAliasForStation");
+  if (unbound) return unbound.alias;
 
   const [station] = await db
     .select({

--- a/apps/hub/src/services/matrix-as/station-room.ts
+++ b/apps/hub/src/services/matrix-as/station-room.ts
@@ -1,0 +1,88 @@
+/**
+ * The one place a station is resolved to its room.
+ *
+ * Fix round 2 on Task 5. `matrix_rooms.station_id` stopped being unique in
+ * fix round 1, so a station can now carry more than one row: a departed
+ * occupant's room, kept for its history and address, alongside its new
+ * occupant's own. A bare `leftJoin(matrixRooms, eq(matrixRooms.stationId,
+ * stations.id))` — no `ORDER BY`, `[row]` picked off whatever Postgres
+ * happens to return first — is not safe anywhere in this codebase after
+ * that: it names an ARBITRARY room, which can belong to whoever occupied
+ * the station before.
+ *
+ * Round 1 patched the two call sites it knew about (`gates.ts`'s
+ * `roomForCard`, `routes/agents-admin.ts`'s bind-on-assign write). A
+ * second review swept the rest of the codebase and found two more still
+ * making the identical mistake — `routes/station-say.ts` (speaking as the
+ * CURRENT occupant into whatever room the arbitrary join returned) and
+ * `provision.ts` (deciding "this station already has a room" from the same
+ * arbitrary join, so a new occupant with no room of its own never got one
+ * provisioned, silently, forever). Patching call sites one at a time
+ * leaves the next one for the next agent to find. Every reader that needs
+ * "the room for this station's occupant" goes through this function now.
+ */
+
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../../db/drizzle";
+import { matrixRooms } from "../../db/schema/matrix";
+import { stations } from "../../db/schema/stations";
+
+export interface StationRoom {
+  roomId: string;
+  spaceRoomId: string | null;
+}
+
+export interface StationOccupancy {
+  /** The station's current occupant, or null. */
+  principalId: string | null;
+  /**
+   * The room that occupant owns — or, when there is no current occupant,
+   * the station's own unbound room. Never a departed occupant's room that
+   * merely happens to share this station's `station_id`.
+   */
+  room: StationRoom | null;
+}
+
+/**
+ * The room a station's CURRENT occupant answers in.
+ *
+ * Two different "no room" answers, because two different situations need
+ * telling apart:
+ *
+ *  - The station has an occupant, and that occupant already has a room of
+ *    its own (`matrix_rooms.principal_id` bound to it): returned.
+ *  - The station has an occupant with NO room of its own yet: `room` is
+ *    `null` — an honest "not yet", never a departed occupant's room. This
+ *    is what tells `provision.ts` a room genuinely needs creating, and
+ *    what tells `gates.ts` there is nowhere to post yet.
+ *  - The station has NO occupant at all: the station's own UNBOUND room
+ *    (`station_id = stationId AND principal_id IS NULL`), if one exists.
+ *    This is the one case a plain `station_id` lookup is still correct,
+ *    because there is no current occupant whose room it could be mistaken
+ *    for — it is also what keeps a harness-mode or pre-this-slice room
+ *    (never bound to any principal) resolvable exactly as it always was.
+ */
+export async function roomForStation(stationId: string): Promise<StationOccupancy> {
+  const [station] = await db
+    .select({ principalId: stations.principalId })
+    .from(stations)
+    .where(eq(stations.id, stationId))
+    .limit(1);
+  const principalId = station?.principalId ?? null;
+
+  if (principalId) {
+    const [own] = await db
+      .select({ roomId: matrixRooms.roomId, spaceRoomId: matrixRooms.spaceRoomId })
+      .from(matrixRooms)
+      .where(eq(matrixRooms.principalId, principalId))
+      .limit(1);
+    return { principalId, room: own ?? null };
+  }
+
+  const [unbound] = await db
+    .select({ roomId: matrixRooms.roomId, spaceRoomId: matrixRooms.spaceRoomId })
+    .from(matrixRooms)
+    .where(and(eq(matrixRooms.stationId, stationId), isNull(matrixRooms.principalId)))
+    .limit(1);
+  return { principalId: null, room: unbound ?? null };
+}

--- a/apps/hub/src/services/matrix-as/station-room.ts
+++ b/apps/hub/src/services/matrix-as/station-room.ts
@@ -26,10 +26,21 @@ import { and, eq, isNull } from "drizzle-orm";
 import { db } from "../../db/drizzle";
 import { matrixRooms } from "../../db/schema/matrix";
 import { stations } from "../../db/schema/stations";
+import { nodes } from "../../db/schema/nodes";
+import { roomAliasFor } from "./names";
+import { principalHandle } from "../principals";
 
 export interface StationRoom {
   roomId: string;
   spaceRoomId: string | null;
+  /**
+   * The address this room is actually reachable at, as recorded when it was
+   * created. Read rather than re-derived — a room created before the alias
+   * followed its occupant still answers at the address it was created with,
+   * and deriving one afresh is how `routes/station-matrix.ts` came to hand
+   * out an alias no room held.
+   */
+  alias: string;
 }
 
 export interface StationOccupancy {
@@ -72,7 +83,11 @@ export async function roomForStation(stationId: string): Promise<StationOccupanc
 
   if (principalId) {
     const [own] = await db
-      .select({ roomId: matrixRooms.roomId, spaceRoomId: matrixRooms.spaceRoomId })
+      .select({
+        roomId: matrixRooms.roomId,
+        spaceRoomId: matrixRooms.spaceRoomId,
+        alias: matrixRooms.alias,
+      })
       .from(matrixRooms)
       .where(eq(matrixRooms.principalId, principalId))
       .limit(1);
@@ -80,9 +95,64 @@ export async function roomForStation(stationId: string): Promise<StationOccupanc
   }
 
   const [unbound] = await db
-    .select({ roomId: matrixRooms.roomId, spaceRoomId: matrixRooms.spaceRoomId })
+    .select({
+      roomId: matrixRooms.roomId,
+      spaceRoomId: matrixRooms.spaceRoomId,
+      alias: matrixRooms.alias,
+    })
     .from(matrixRooms)
     .where(and(eq(matrixRooms.stationId, stationId), isNull(matrixRooms.principalId)))
     .limit(1);
   return { principalId: null, room: unbound ?? null };
+}
+
+/**
+ * The address this station's room is reachable at — the one answer to that
+ * question, for anything that reports or logs an alias.
+ *
+ * Fix round 5 on Task 5, and the fourth time in this task that a rule was
+ * fixed one layer inside the entry point that serves it. Round 3 made a
+ * room's alias follow its occupant (`bridgeAliasForHandle`) inside
+ * `provision.ts`, and `routes/station-matrix.ts` went on deriving
+ * `bridgeAlias(nodeName, stationKey)` for its response — an address no room
+ * holds, for precisely the stations that endpoint answers for, since it
+ * 409s unless the station has an occupant. The AS route would even 200 on
+ * it through `stationForAlias`'s legacy fallback, and then create nothing,
+ * because provisioning sees the station already has a room; the directory
+ * lookup fails and the caller is left with a name that goes nowhere.
+ *
+ * A STORED alias beats a derived one whenever there is a room: a room
+ * created before the derivation changed still answers at the address it was
+ * actually created with, and re-deriving would misreport it. The derivation
+ * (`names.ts`'s `roomAliasFor`, which `provision.ts` also uses, so there is
+ * one rule rather than two) is only for a station whose room does not exist
+ * yet — the honest answer to "where it will be", not a claim about where it
+ * is.
+ *
+ * Null only for a station that does not exist.
+ */
+export async function roomAliasForStation(
+  stationId: string,
+  domain: string
+): Promise<string | null> {
+  const occupancy = await roomForStation(stationId);
+  if (occupancy.room) return occupancy.room.alias;
+
+  const [station] = await db
+    .select({
+      nodeName: nodes.name,
+      stationKey: stations.stationKey,
+      principalId: stations.principalId,
+    })
+    .from(stations)
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .where(eq(stations.id, stationId))
+    .limit(1);
+  if (!station) return null;
+
+  const handle = station.principalId ? await principalHandle(station.principalId) : null;
+  return roomAliasFor(
+    { handle, nodeName: station.nodeName, stationKey: station.stationKey },
+    domain
+  );
 }

--- a/apps/hub/src/services/matrix-as/stations.ts
+++ b/apps/hub/src/services/matrix-as/stations.ts
@@ -16,7 +16,8 @@ import { eq } from "drizzle-orm";
 import { db } from "../../db/drizzle";
 import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
-import { localpartFor } from "./names";
+import { localpartFor, bridgeUserId } from "./names";
+import { principalHandle } from "../principals";
 
 export interface BridgedStation {
   stationId: string;
@@ -26,6 +27,7 @@ export interface BridgedStation {
   harness: string;
   displayName: string;
   identityMode: string;
+  principalId: string | null;
 }
 
 /** Every adopted station, with the node name its Matrix identity is built from. */
@@ -39,6 +41,7 @@ async function allBridgeable(): Promise<BridgedStation[]> {
       harness: stations.harness,
       displayName: stations.displayName,
       identityMode: stations.matrixIdentityMode,
+      principalId: stations.principalId,
     })
     .from(stations)
     .innerJoin(nodes, eq(nodes.id, stations.nodeId));
@@ -47,6 +50,12 @@ async function allBridgeable(): Promise<BridgedStation[]> {
 
 /**
  * The station whose derived localpart is exactly this one, or null.
+ *
+ * For ROOM ALIASES only: `bridgeAlias`/`localpartFor` are still derived from
+ * `(nodeName, stationKey)` — a room's address is not the identity occupying
+ * it, and rooms are migrated separately (`charter` →
+ * decisions/2026-08-30-an-agent-is-a-principal.md). Do not use this for a
+ * user id; see `stationForAgentUserId` below.
  *
  * Null is the answer the homeserver needs for "there is nobody here" — claiming
  * every name in our namespace would let anyone conjure an agent by typing one.
@@ -58,12 +67,27 @@ export async function stationForLocalpart(localpart: string): Promise<BridgedSta
   return null;
 }
 
-/** `@agent_<localpart>:<domain>` → the localpart, or null if it is not one of ours. */
-export function localpartFromUserId(mxid: string, domain: string): string | null {
-  const prefix = "@agent_";
-  const suffix = `:${domain}`;
-  if (!mxid.startsWith(prefix) || !mxid.endsWith(suffix)) return null;
-  return mxid.slice(prefix.length, mxid.length - suffix.length) || null;
+/**
+ * The station whose OCCUPYING AGENT's mxid is exactly this one, or null.
+ *
+ * An agent's user id is built from its principal's immutable `handle` now
+ * (`names.ts`'s `bridgeUserId`), not from `(nodeName, stationKey)` —
+ * `stationForLocalpart` above answers a different question (a ROOM alias) and
+ * would 404 forever for a real agent mxid, since a handle and a
+ * `node_stationKey` pair are unrelated strings. A station with no occupying
+ * principal has no handle and therefore claims no user id here, the same
+ * fail-closed rule `missions.ts` and `station-matrix.ts` already apply.
+ */
+export async function stationForAgentUserId(
+  mxid: string,
+  domain: string
+): Promise<BridgedStation | null> {
+  for (const s of await allBridgeable()) {
+    if (!s.principalId) continue;
+    const handle = await principalHandle(s.principalId);
+    if (handle && bridgeUserId(handle, domain) === mxid) return s;
+  }
+  return null;
 }
 
 /** `#agentpod_<localpart>:<domain>` → the localpart, or null. */

--- a/apps/hub/src/services/matrix-as/stations.ts
+++ b/apps/hub/src/services/matrix-as/stations.ts
@@ -16,7 +16,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../../db/drizzle";
 import { stations } from "../../db/schema/stations";
 import { nodes } from "../../db/schema/nodes";
-import { localpartFor, bridgeUserId } from "./names";
+import { localpartFor, bridgeUserId, bridgeLocalpart } from "./names";
 import { principalHandle } from "../principals";
 
 export interface BridgedStation {
@@ -49,13 +49,16 @@ async function allBridgeable(): Promise<BridgedStation[]> {
 }
 
 /**
- * The station whose derived localpart is exactly this one, or null.
+ * The station whose STATION-DERIVED localpart is exactly this one, or null.
  *
- * For ROOM ALIASES only: `bridgeAlias`/`localpartFor` are still derived from
- * `(nodeName, stationKey)` — a room's address is not the identity occupying
- * it, and rooms are migrated separately (`charter` →
- * decisions/2026-08-30-an-agent-is-a-principal.md). Do not use this for a
- * user id; see `stationForAgentUserId` below.
+ * For a room alias with NO occupant — `bridgeAlias`/`localpartFor` are still
+ * derived from `(nodeName, stationKey)` for exactly that case (`names.ts`).
+ * An occupied station's room alias is occupant-derived instead (fix round
+ * 3, `bridgeAliasForHandle`) and resolves through
+ * `stationForOccupantLocalpart` below, not this function — a station-keyed
+ * lookup would never find it, since the two schemes produce different
+ * strings by design. Do not use this for a user id either; see
+ * `stationForAgentUserId` below.
  *
  * Null is the answer the homeserver needs for "there is nobody here" — claiming
  * every name in our namespace would let anyone conjure an agent by typing one.
@@ -63,6 +66,31 @@ async function allBridgeable(): Promise<BridgedStation[]> {
 export async function stationForLocalpart(localpart: string): Promise<BridgedStation | null> {
   for (const s of await allBridgeable()) {
     if (localpartFor(s.nodeName, s.stationKey) === localpart) return s;
+  }
+  return null;
+}
+
+/**
+ * The station whose CURRENT OCCUPANT's room-alias localpart is exactly this
+ * one, or null — the alias counterpart to `stationForAgentUserId` below,
+ * which answers the identical question for a full mxid instead.
+ *
+ * Fix round 3 on Task 5: once an occupied station's room alias is derived
+ * from its occupant's handle (`bridgeAliasForHandle`) rather than from
+ * `(nodeName, stationKey)`, resolving an inbound alias query has to try
+ * this shape too, or a homeserver asking about an occupant-derived alias
+ * for a station whose room does not exist yet would get no answer and
+ * provisioning would never run for it.
+ *
+ * A station with no occupying principal has no handle and therefore no
+ * occupant-derived alias to claim here — the same fail-closed rule
+ * `stationForAgentUserId` already applies.
+ */
+export async function stationForOccupantLocalpart(localpart: string): Promise<BridgedStation | null> {
+  for (const s of await allBridgeable()) {
+    if (!s.principalId) continue;
+    const handle = await principalHandle(s.principalId);
+    if (handle && bridgeLocalpart(handle) === localpart) return s;
   }
   return null;
 }

--- a/apps/hub/src/services/matrix-as/stations.ts
+++ b/apps/hub/src/services/matrix-as/stations.ts
@@ -118,6 +118,34 @@ export async function stationForAgentUserId(
   return null;
 }
 
+/**
+ * The station an inbound ROOM ALIAS names, in whichever shape it arrives —
+ * the one resolver for that question, and the only one anything should use.
+ *
+ * Fix round 4 on Task 5. Round 3 taught `index.ts`'s `onProvisionAlias` to
+ * try both shapes and left the HTTP entry point in front of it
+ * (`routes/matrix-as.ts`) gating on `stationForLocalpart` alone — so an
+ * occupant-derived alias for a room that does not exist yet was answered
+ * `M_NOT_FOUND` at the route and the new branch was never reached for
+ * exactly the shape it was added for. That is the third round running in
+ * which the layer under inspection was fixed and the adjacent entry point
+ * was not; a resolver both callers share is what stops there being a
+ * fourth, the same way `station-room.ts` closed the station→room reads.
+ *
+ * Order matters: occupant-derived first, because that is the ordinary case
+ * for any station with somebody in it, and station-derived second as the
+ * fallback that keeps the fleet's existing rooms — created before the alias
+ * followed the occupant — resolving exactly as they always have.
+ */
+export async function stationForAlias(
+  alias: string,
+  domain: string
+): Promise<BridgedStation | null> {
+  const localpart = localpartFromAlias(alias, domain);
+  if (!localpart) return null;
+  return (await stationForOccupantLocalpart(localpart)) ?? (await stationForLocalpart(localpart));
+}
+
 /** `#agentpod_<localpart>:<domain>` → the localpart, or null. */
 export function localpartFromAlias(alias: string, domain: string): string | null {
   const prefix = "#agentpod_";

--- a/apps/hub/src/services/matrix-as/unbound-room-rule.test.ts
+++ b/apps/hub/src/services/matrix-as/unbound-room-rule.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Which of a station's unbound rooms belongs to its occupant — one rule,
+ * four sites.
+ *
+ * `matrix_rooms_station_idx` stopped being unique in an earlier fix round so
+ * a departed occupant's room could sit beside its successor's. That made
+ * "which unbound room?" a real question, and the whole-branch review found
+ * it being answered four different ways, three of them by an unordered
+ * `LIMIT 1` — including in the LIVE writer, in exactly the state migration
+ * `0062` was politely declining to guess in.
+ *
+ * The rule is **oldest `created_at`, tie-broken by `room_id`**: the
+ * station's original room is the one carrying the history this slice exists
+ * to preserve. `station-room.ts`'s `unboundRoomsForStation` states it;
+ * `0062`'s own coverage lives in `db/drizzle-migrations/`.
+ *
+ * **On the fixtures.** A station carrying two unbound rooms is not a state
+ * production can reach any more — `provision.ts` binds at creation — so it
+ * is legacy data by construction: rows from before this column had a
+ * writer, or rows `0060` skipped. The older room here is created by the
+ * REAL `provisionStation` wherever it can be; the row that is hand-inserted
+ * is the DECOY, the one the rule must not pick. Nothing hand-writes the
+ * binding that is the thing under test.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import { ensurePgMigrations } from "../../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../../tests/helpers/database";
+import { db, rawSql } from "../../db/drizzle";
+import { stations } from "../../db/schema/stations";
+import { matrixRooms } from "../../db/schema/matrix";
+import { BOOTSTRAP_TENANT_ID } from "../../db/schema/tenants";
+import { mintEnrollmentToken, enrollNode } from "../enrollment";
+import { adoptStations } from "../station-registry";
+import { adminMiddleware } from "../../auth/admin-middleware";
+import { agentsAdminRouter } from "../../routes/agents-admin";
+import { createPrincipal } from "../principals";
+import { onProvisionStation } from "./hooks";
+import { provisionStation } from "./provision";
+import { roomForStation, roomAliasForStation } from "./station-room";
+
+const DOMAIN = "id.agentpod.dev";
+const RUN = crypto.randomUUID().slice(0, 8);
+const ACTOR = `test-admin-unbound-${RUN}`;
+const HANDLE = `unbound-rule-${RUN}`;
+
+let nodeId: string;
+
+const app = (() => {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: ACTOR, authType: "api_key", tenantId: "default" });
+    await next();
+  });
+  a.use("*", adminMiddleware);
+  a.route("/", agentsAdminRouter);
+  return a;
+})();
+
+async function assign(stationId: string, principalId: string) {
+  const res = await app.request(`/stations/${stationId}/agent`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ principalId }),
+  });
+  expect(res.status).toBe(200);
+}
+
+async function adopt(key: string, matrixId?: string) {
+  const [row] = await adoptStations(ACTOR, nodeId, [key], [
+    {
+      key,
+      ...(matrixId ? { matrixId } : {}),
+      harness: "opencode",
+      kind: "leaf",
+      displayName: `Station ${key}`,
+      parentKey: null,
+      workspacePath: null,
+      capabilities: ["acp"],
+      adopted: false,
+    },
+  ]);
+  return row!.id;
+}
+
+/**
+ * The REAL provisioning path, with only the homeserver faked.
+ *
+ * Driven against a HARNESS-mode station, because that is the one shape whose
+ * room provisioning genuinely creates while nobody occupies it —
+ * `provision.ts` returns early for bridge mode with no occupant, which is
+ * the very early-return the Critical turned on. So the unbound room these
+ * tests choose between is produced by production code rather than asserted
+ * into existence.
+ */
+async function provisionReal(stationId: string, roomId: string) {
+  await provisionStation(stationId, {
+    domain: DOMAIN,
+    client: {
+      ensureUser: async () => {},
+      ensureRoom: async () => roomId,
+      invite: async () => {},
+    },
+  });
+}
+
+/**
+ * A room from before `principal_id` had a writer. Hand-inserted because
+ * nothing can create one any more — and, in every test below, this is the
+ * room the rule must NOT choose.
+ */
+async function legacyRoom(stationId: string, roomId: string, createdAt: string) {
+  await db.insert(matrixRooms).values({
+    roomId,
+    tenantId: BOOTSTRAP_TENANT_ID,
+    stationId,
+    alias: `#legacy-${roomId.slice(1, 12)}:${DOMAIN}`,
+    createdAt: new Date(createdAt),
+  });
+}
+
+/** A station that answers for itself, so provisioning can make it a room. */
+async function adoptHarness(key: string) {
+  const stationId = await adopt(key, `@harness-${key.replace(/[^a-z0-9]/g, "-")}:${DOMAIN}`);
+  await db
+    .update(stations)
+    .set({ matrixIdentityMode: "harness" })
+    .where(eq(stations.id, stationId));
+  return stationId;
+}
+
+async function principalOf(roomId: string) {
+  const [row] = await db
+    .select({ principalId: matrixRooms.principalId })
+    .from(matrixRooms)
+    .where(eq(matrixRooms.roomId, roomId));
+  return row?.principalId ?? null;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({
+    id: ACTOR,
+    email: `unbound-rule-${RUN}@example.com`,
+    name: "Actor",
+    role: "admin",
+  });
+  const { token } = await mintEnrollmentToken(ACTOR);
+  const enrolled = await enrollNode(token, {
+    hostname: `unbound-rule-host-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    cpuCount: 1,
+  });
+  nodeId = enrolled.nodeId;
+  // No bridge for these tests unless a test asks for one: they are about
+  // which EXISTING room gets chosen, not about creating new ones.
+  onProvisionStation(null);
+});
+
+afterAll(async () => {
+  onProvisionStation(null);
+  try {
+    await rawSql`DELETE FROM stations WHERE user_id = ${ACTOR}`;
+    await rawSql`DELETE FROM nodes WHERE user_id = ${ACTOR}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${ACTOR}`;
+    await rawSql`DELETE FROM principals WHERE handle LIKE ${HANDLE + "%"}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${ACTOR}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("bind-on-assign chooses the oldest unbound room", () => {
+  test("the station's original room wins over a newer sibling, whatever order they were written in", async () => {
+    const stationId = await adoptHarness(`opencode:${RUN}-bind`);
+
+    // The ORIGINAL room, made by the real provisioning path while the
+    // station had no occupant — the room an operator has been reading.
+    // Provisioned FIRST because `provision.ts` creates a room only when the
+    // station has none, so a decoy inserted before it would suppress it.
+    const original = `!original-${RUN}:${DOMAIN}`;
+    await provisionReal(stationId, original);
+    expect(await principalOf(original), "provisioned unoccupied, so unbound").toBeNull();
+
+    const newer = `!newer-${RUN}:${DOMAIN}`;
+    await legacyRoom(stationId, newer, "2026-06-01T00:00:00Z");
+
+    // Backdating the original is what makes it the older of the two — AND,
+    // deliberately, what puts it LAST in Postgres's heap order, since an
+    // UPDATE writes a new tuple at the end. Heap order is what an unordered
+    // `LIMIT 1` reads, so after this line the two orders disagree and
+    // removing the rule becomes observable. Without that, this test would
+    // pass by luck whether the rule were applied or not.
+    await rawSql`UPDATE matrix_rooms SET created_at = ${"2026-01-01T00:00:00Z"} WHERE room_id = ${original}`;
+
+    const principalId = await createPrincipal({ kind: "agent", handle: `${HANDLE}-bind` });
+    await assign(stationId, principalId);
+
+    expect(
+      await principalOf(original),
+      "the agent inherits the station's ORIGINAL room and its history"
+    ).toBe(principalId);
+    expect(await principalOf(newer), "the newer sibling is left alone").toBeNull();
+  });
+
+  test("two rooms created in the same instant: room_id breaks the tie deterministically", async () => {
+    const stationId = await adopt(`opencode:${RUN}-tie`);
+    const sameInstant = "2026-04-01T00:00:00Z";
+    // `!tie-a…` sorts before `!tie-b…`, and is inserted SECOND.
+    await legacyRoom(stationId, `!tie-b-${RUN}:${DOMAIN}`, sameInstant);
+    await legacyRoom(stationId, `!tie-a-${RUN}:${DOMAIN}`, sameInstant);
+
+    const principalId = await createPrincipal({ kind: "agent", handle: `${HANDLE}-tie` });
+    await assign(stationId, principalId);
+
+    expect(await principalOf(`!tie-a-${RUN}:${DOMAIN}`)).toBe(principalId);
+    expect(await principalOf(`!tie-b-${RUN}:${DOMAIN}`)).toBeNull();
+  });
+});
+
+describe("roomForStation's unbound fallback is stable", () => {
+  test("an unoccupied station with two unbound rooms resolves to the same one every time — one conversation, not two", async () => {
+    const stationId = await adoptHarness(`opencode:${RUN}-stable`);
+    const original = `!stable-original-${RUN}:${DOMAIN}`;
+    await provisionReal(stationId, original);
+    await legacyRoom(stationId, `!stable-newer-${RUN}:${DOMAIN}`, "2026-07-01T00:00:00Z");
+    // Same construction as above: the backdating UPDATE also moves the
+    // original to the end of the heap, so heap order and the rule disagree.
+    await rawSql`UPDATE matrix_rooms SET created_at = ${"2026-02-01T00:00:00Z"} WHERE room_id = ${original}`;
+
+    // `station-say.ts` and `gates.ts` both ask this question, separately.
+    // Before the rule, an unordered LIMIT 1 could answer each of them with a
+    // different room and split one conversation across two.
+    const answers = new Set<string>();
+    for (let i = 0; i < 6; i++) {
+      const room = (await roomForStation(stationId)).room;
+      expect(room).not.toBeNull();
+      answers.add(room!.roomId);
+    }
+    expect(answers.size, "every reader gets the same room").toBe(1);
+    expect([...answers][0], "and it is the station's original").toBe(original);
+  });
+});
+
+describe("roomAliasForStation reports where a room IS, not where one would be", () => {
+  test("an occupied station whose occupant holds no bound room answers with the sibling's STORED alias", async () => {
+    // The state, reached through the real routes: the agent is assigned to a
+    // station whose only room is already someone else's, on a hub with no
+    // bridge — so nothing binds and nothing is provisioned. The unbound
+    // legacy sibling arrives afterwards, the way `0060`-skipped rows did.
+    const stationId = await adopt(`opencode:${RUN}-alias`);
+    const holder = `!alias-holder-${RUN}:${DOMAIN}`;
+    const departed = await createPrincipal({ kind: "agent", handle: `${HANDLE}-departed` });
+    await legacyRoom(stationId, holder, "2026-01-01T00:00:00Z");
+    await assign(stationId, departed); // binds `holder` to the departed agent
+
+    const occupant = await createPrincipal({ kind: "agent", handle: `${HANDLE}-occupant` });
+    await assign(stationId, occupant); // nothing left to bind, no bridge to provision
+    expect(
+      (await roomForStation(stationId)).room,
+      "the occupant honestly has no room of its own"
+    ).toBeNull();
+
+    const legacy = `!alias-legacy-${RUN}:${DOMAIN}`;
+    await legacyRoom(stationId, legacy, "2026-03-01T00:00:00Z");
+    const legacyAlias = `#legacy-${legacy.slice(1, 12)}:${DOMAIN}`;
+
+    expect(
+      await roomAliasForStation(stationId, DOMAIN),
+      "the address a room actually holds, not a derivation for a room that does not exist"
+    ).toBe(legacyAlias);
+
+    // The derivation is still what answers when there is genuinely no room.
+    const bare = await adopt(`opencode:${RUN}-bare`);
+    const alias = await roomAliasForStation(bare, DOMAIN);
+    expect(alias, "a station with no room at all still gets 'where it will be'").toMatch(
+      /^#agentpod_/
+    );
+  });
+});

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -83,6 +83,23 @@ describe("a principal can be suspended", () => {
     const payload = await buildTokenPayload({ principalId: id });
     expect(payload.sub).toBe(id);
   });
+
+  test("a suspended principal's own session cannot mint either, through the real user lookup", async () => {
+    // The two subject paths in buildTokenPayload merge before the suspension
+    // check, so proving the principalId path (above) does not prove the user
+    // path — a later refactor that special-cased either branch could pass
+    // every other test while a suspended human kept minting tokens. This goes
+    // through the real principalForUser, not an injected resolver, so it
+    // fails if that merge is ever undone.
+    const userId = `usr-${crypto.randomUUID()}`;
+    const id = await createPrincipal({
+      kind: "human",
+      handle: `t-${crypto.randomUUID().slice(0, 8)}`,
+      userId,
+    });
+    await suspendPrincipal(id);
+    expect(buildTokenPayload({ user: { id: userId } })).rejects.toThrow(/suspended/);
+  });
 });
 
 // ─── stations record which agent occupies them ────────────────────────────────

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -19,7 +19,8 @@ import { resolveTenantForUser } from "../auth/tenant";
 import { db, rawSql } from "../db/drizzle";
 import { stations } from "../db/schema/stations";
 import { seedAgentPrincipals } from "../../scripts/seed-agent-principals";
-import { createPrincipal, principalForUser } from "./principals";
+import { createPrincipal, principalForUser, suspendPrincipal, restorePrincipal } from "./principals";
+import { buildTokenPayload } from "../auth/jwt-claims";
 
 // Fixed handles, cleaned up below: running this suite twice against the same
 // database (no reset between runs, unlike CI) previously hit
@@ -63,6 +64,24 @@ describe("principals", () => {
   test("a user with no principal resolves to null, never to a default", async () => {
     // Falling back would hand one principal's authority to an unmapped caller.
     expect(await principalForUser("usr-nobody")).toBeNull();
+  });
+});
+
+describe("a principal can be suspended", () => {
+  test("a suspended principal cannot be minted for", async () => {
+    const id = await createPrincipal({ kind: "agent", handle: `t-${crypto.randomUUID().slice(0, 8)}` });
+    await suspendPrincipal(id);
+    // Fail closed, and for a reason a reader can act on — not the same message
+    // as "no principal", which means something different.
+    expect(buildTokenPayload({ principalId: id })).rejects.toThrow(/suspended/);
+  });
+
+  test("restoring lets it mint again", async () => {
+    const id = await createPrincipal({ kind: "agent", handle: `t-${crypto.randomUUID().slice(0, 8)}` });
+    await suspendPrincipal(id);
+    await restorePrincipal(id);
+    const payload = await buildTokenPayload({ principalId: id });
+    expect(payload.sub).toBe(id);
   });
 });
 

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -152,6 +152,9 @@ describe("stations record which agent occupies them", () => {
     const second = await seedAgentPrincipals();
     expect(first.created).toBeGreaterThan(0);
     expect(second.created).toBe(0); // re-running must not mint a second identity
+    // The second run's "nothing to do" must be a reported number, not silence
+    // — everything the first run touched now counts as skipped.
+    expect(second.skipped).toBeGreaterThanOrEqual(first.created);
 
     // The station this suite set up is one of the ones seeding must have
     // reached — otherwise `first.created > 0` could be satisfied by some

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, test } from "bun:test";
+/**
+ * Service Test: principals (mint + Better Auth lookup)
+ *
+ * Uses the local Docker test-postgres (localhost:5434).
+ * DATABASE_URL must be set before any src/ modules are imported.
+ */
+
+// ─── Set env vars BEFORE any src/ imports ─────────────────────────────────────
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+process.env.NODE_ENV = "test";
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
 import { createPrincipal, principalForUser } from "./principals";
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+});
 
 describe("principals", () => {
   test("mints an agent principal with a grammar-valid id", async () => {

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createPrincipal, principalForUser } from "./principals";
+
+describe("principals", () => {
+  test("mints an agent principal with a grammar-valid id", async () => {
+    const id = await createPrincipal({ kind: "agent", handle: "writer-quill" });
+    expect(id).toMatch(/^prn_[0-9a-f]{20}$/);
+  });
+
+  test("refuses a second principal on the same handle", async () => {
+    await createPrincipal({ kind: "agent", handle: "analyst-echo" });
+    // A handle is an address: two claimants make the mxid it produces ambiguous.
+    expect(createPrincipal({ kind: "agent", handle: "analyst-echo" })).rejects.toThrow();
+  });
+
+  test("finds the principal behind a Better Auth user", async () => {
+    const id = await createPrincipal({ kind: "human", handle: "rakesh", userId: "usr-uuid-here" });
+    const found = await principalForUser("usr-uuid-here");
+    expect(found?.id).toBe(id);
+    expect(found?.kind).toBe("human");
+  });
+
+  test("a user with no principal resolves to null, never to a default", async () => {
+    // Falling back would hand one principal's authority to an unmapped caller.
+    expect(await principalForUser("usr-nobody")).toBeNull();
+  });
+});

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -11,8 +11,14 @@ process.env.DATABASE_URL =
   "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
 process.env.NODE_ENV = "test";
 
-import { describe, expect, test, beforeAll } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { eq } from "drizzle-orm";
 import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+import { createTestUser } from "../../tests/helpers/database";
+import { resolveTenantForUser } from "../auth/tenant";
+import { db, rawSql } from "../db/drizzle";
+import { stations } from "../db/schema/stations";
+import { seedAgentPrincipals } from "../../scripts/seed-agent-principals";
 import { createPrincipal, principalForUser } from "./principals";
 
 beforeAll(async () => {
@@ -41,5 +47,65 @@ describe("principals", () => {
   test("a user with no principal resolves to null, never to a default", async () => {
     // Falling back would hand one principal's authority to an unmapped caller.
     expect(await principalForUser("usr-nobody")).toBeNull();
+  });
+});
+
+// ─── stations record which agent occupies them ────────────────────────────────
+
+const STATION_USER = "test-user-station-occupancy";
+const STATION_NODE = "node_station_occupancy";
+const UNOCCUPIED_STATION_ID = "station_unoccupied_test";
+
+const stationRow = async (id: string) => {
+  const [row] = await db.select().from(stations).where(eq(stations.id, id));
+  if (!row) throw new Error(`no station row for ${id}`);
+  return row;
+};
+
+beforeAll(async () => {
+  await createTestUser({
+    id: STATION_USER,
+    email: "station-occupancy@example.com",
+    name: "Station Occupancy",
+  });
+  const tenant = await resolveTenantForUser(STATION_USER);
+  await rawSql`DELETE FROM stations WHERE node_id = ${STATION_NODE}`;
+  await rawSql`DELETE FROM nodes WHERE id = ${STATION_NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${STATION_NODE}, ${tenant}, ${STATION_USER}, 'occupancy-box', 'occupancy-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, created_at)
+    VALUES (${UNOCCUPIED_STATION_ID}, ${tenant}, ${STATION_USER}, ${STATION_NODE}, 'openclaw', 'openclaw:unoccupied', 'leaf', 'unoccupied', now())`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM stations WHERE node_id = ${STATION_NODE}`;
+    await rawSql`DELETE FROM nodes WHERE id = ${STATION_NODE}`;
+    await rawSql`DELETE FROM "user" WHERE id = ${STATION_USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("stations record which agent occupies them", () => {
+  test("a station with no agent has no principal, and that is legal", async () => {
+    const s = await stationRow(UNOCCUPIED_STATION_ID);
+    expect(s.principalId).toBeNull();
+  });
+
+  test("seeding gives every adopted station an agent principal, and is idempotent", async () => {
+    const first = await seedAgentPrincipals();
+    const second = await seedAgentPrincipals();
+    expect(first.created).toBeGreaterThan(0);
+    expect(second.created).toBe(0); // re-running must not mint a second identity
+
+    // The station this suite set up is one of the ones seeding must have
+    // reached — otherwise `first.created > 0` could be satisfied by some
+    // other suite's leftover row and this test would prove nothing about
+    // the station above.
+    const s = await stationRow(UNOCCUPIED_STATION_ID);
+    expect(s.principalId).toMatch(/^prn_[0-9a-f]{20}$/);
   });
 });

--- a/apps/hub/src/services/principals.test.ts
+++ b/apps/hub/src/services/principals.test.ts
@@ -21,8 +21,24 @@ import { stations } from "../db/schema/stations";
 import { seedAgentPrincipals } from "../../scripts/seed-agent-principals";
 import { createPrincipal, principalForUser } from "./principals";
 
+// Fixed handles, cleaned up below: running this suite twice against the same
+// database (no reset between runs, unlike CI) previously hit
+// "principals_org_handle_idx" on the second pass because nothing deleted
+// these rows — the same reason every DB-bound fixture in this slice cleans up
+// its own fixed handles in `afterAll`.
+const HANDLES = ["writer-quill", "analyst-echo", "rakesh"];
+
 beforeAll(async () => {
   await ensurePgMigrations();
+  await rawSql`DELETE FROM principals WHERE handle = ANY(${HANDLES})`;
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM principals WHERE handle = ANY(${HANDLES})`;
+  } catch {
+    // cleanup only
+  }
 });
 
 describe("principals", () => {

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -79,3 +79,26 @@ export async function principalById(
     .limit(1);
   return row ? { id: row.id, kind: row.kind as PrincipalKind } : null;
 }
+
+/**
+ * A principal's immutable `handle`, or null.
+ *
+ * This is what an agent's Matrix identity is now built from
+ * (`charter` → decisions/2026-08-30-an-agent-is-a-principal.md): `names.ts`'s
+ * `bridgeUserId`/`bridgeLocalpart` take a handle, not a station, so every
+ * caller that used to derive an agent's mxid from `(nodeName, stationKey)`
+ * resolves the station's occupying principal to this instead. Kept here
+ * rather than let the matrix modules query `principals` themselves, so schema
+ * access to that table stays in the one service that owns it.
+ *
+ * Null both when the id names nobody and when a station has none — the two
+ * cases a caller must treat alike: fail closed, never invent an address.
+ */
+export async function principalHandle(id: string): Promise<string | null> {
+  const [row] = await db
+    .select({ handle: principals.handle })
+    .from(principals)
+    .where(eq(principals.id, id))
+    .limit(1);
+  return row?.handle ?? null;
+}

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -44,16 +44,16 @@ export async function createPrincipal(input: {
  */
 export async function principalForUser(
   userId: string
-): Promise<{ id: string; kind: PrincipalKind } | null> {
+): Promise<{ id: string; kind: PrincipalKind; suspendedAt: Date | null } | null> {
   const [row] = await db
-    .select({ id: principals.id, kind: principals.kind })
+    .select({ id: principals.id, kind: principals.kind, suspendedAt: principals.suspendedAt })
     .from(principalIdentities)
     .innerJoin(principals, eq(principals.id, principalIdentities.principalId))
     .where(
       and(eq(principalIdentities.system, "better-auth"), eq(principalIdentities.externalId, userId))
     )
     .limit(1);
-  return row ? { id: row.id, kind: row.kind as PrincipalKind } : null;
+  return row ? { id: row.id, kind: row.kind as PrincipalKind, suspendedAt: row.suspendedAt } : null;
 }
 
 /**
@@ -71,13 +71,31 @@ export async function principalForUser(
  */
 export async function principalById(
   id: string
-): Promise<{ id: string; kind: PrincipalKind } | null> {
+): Promise<{ id: string; kind: PrincipalKind; suspendedAt: Date | null } | null> {
   const [row] = await db
-    .select({ id: principals.id, kind: principals.kind })
+    .select({ id: principals.id, kind: principals.kind, suspendedAt: principals.suspendedAt })
     .from(principals)
     .where(eq(principals.id, id))
     .limit(1);
-  return row ? { id: row.id, kind: row.kind as PrincipalKind } : null;
+  return row ? { id: row.id, kind: row.kind as PrincipalKind, suspendedAt: row.suspendedAt } : null;
+}
+
+/**
+ * Stop a principal from being allowed to act, from now.
+ *
+ * Suspension rather than deletion: deleting a principal cascades its
+ * identities and grants away, destroying the audit trail exactly when someone
+ * wants to read it. `buildTokenPayload` refuses to mint for a suspended
+ * principal on both subject paths — a session caller whose principal is
+ * suspended is exactly as suspended as an agent.
+ */
+export async function suspendPrincipal(id: string): Promise<void> {
+  await db.update(principals).set({ suspendedAt: new Date() }).where(eq(principals.id, id));
+}
+
+/** Lift a suspension. The principal can be minted for again. */
+export async function restorePrincipal(id: string): Promise<void> {
+  await db.update(principals).set({ suspendedAt: null }).where(eq(principals.id, id));
 }
 
 /**

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -1,0 +1,57 @@
+import { and, eq } from "drizzle-orm";
+
+import { db } from "../db/drizzle";
+import { principalIdentities } from "../db/schema/identities";
+import { BOOTSTRAP_ORG_ID, principals, type PrincipalKind } from "../db/schema/organization";
+import { prefixedId } from "../utils/ids";
+
+export async function createPrincipal(input: {
+  kind: PrincipalKind;
+  handle: string;
+  displayName?: string;
+  /** When present, links the Better Auth user as this principal's login identity. */
+  userId?: string;
+}): Promise<string> {
+  const id = prefixedId("prn");
+  await db.insert(principals).values({
+    id,
+    kind: input.kind,
+    orgId: BOOTSTRAP_ORG_ID,
+    handle: input.handle,
+    displayName: input.displayName ?? null,
+  });
+  if (input.userId) {
+    await db.insert(principalIdentities).values({
+      id: crypto.randomUUID(),
+      principalId: id,
+      system: "better-auth",
+      externalId: input.userId,
+    });
+  }
+  return id;
+}
+
+/**
+ * The principal behind a Better Auth user, or null.
+ *
+ * Returns the id together with the kind, not the bare id: Task 4 uses this as
+ * its default principal resolver and needs both to answer "who is this and
+ * what is it" in one round trip — a second query for kind would be two round
+ * trips answering one question.
+ *
+ * Null rather than a fallback: an unmapped caller must fail closed, for the same
+ * reason `buildTokenPayload` refuses to mint a token when no tenant resolves.
+ */
+export async function principalForUser(
+  userId: string
+): Promise<{ id: string; kind: PrincipalKind } | null> {
+  const [row] = await db
+    .select({ id: principals.id, kind: principals.kind })
+    .from(principalIdentities)
+    .innerJoin(principals, eq(principals.id, principalIdentities.principalId))
+    .where(
+      and(eq(principalIdentities.system, "better-auth"), eq(principalIdentities.externalId, userId))
+    )
+    .limit(1);
+  return row ? { id: row.id, kind: row.kind as PrincipalKind } : null;
+}

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -55,3 +55,27 @@ export async function principalForUser(
     .limit(1);
   return row ? { id: row.id, kind: row.kind as PrincipalKind } : null;
 }
+
+/**
+ * A principal by its own id, or null.
+ *
+ * For a caller that already holds a `prn_…` id it obtained by an explicit
+ * lookup elsewhere — `mintPrincipalAssertion` reading `principal_identities`
+ * by mxid, for instance — and must never have that id re-resolved through
+ * Better Auth: `principalForUser` looks for a Better Auth external id, which
+ * a principal id is not, and would answer null for every one of these
+ * callers regardless of whether the principal exists.
+ *
+ * Null rather than a fallback, for the same reason `principalForUser` is:
+ * an id that names nobody must fail closed, not mint for a default.
+ */
+export async function principalById(
+  id: string
+): Promise<{ id: string; kind: PrincipalKind } | null> {
+  const [row] = await db
+    .select({ id: principals.id, kind: principals.kind })
+    .from(principals)
+    .where(eq(principals.id, id))
+    .limit(1);
+  return row ? { id: row.id, kind: row.kind as PrincipalKind } : null;
+}

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -142,7 +142,21 @@ export async function principalHandle(id: string): Promise<string | null> {
  * cannot be granted".
  */
 export async function listPrincipals(): Promise<
-  Array<{ id: string; kind: PrincipalKind; handle: string; displayName: string | null; userId: string | null }>
+  Array<{
+    id: string;
+    kind: PrincipalKind;
+    handle: string;
+    displayName: string | null;
+    userId: string | null;
+    /**
+     * Whether this principal is suspended right now, and since when. Carried
+     * here rather than left for a second call per row: an admin surface that
+     * had to ask separately for every principal's state would either be slow
+     * enough nobody used it, or would render the list before the state and
+     * flash a wrong answer first.
+     */
+    suspendedAt: Date | null;
+  }>
 > {
   const rows = await db
     .select({
@@ -150,6 +164,7 @@ export async function listPrincipals(): Promise<
       kind: principals.kind,
       handle: principals.handle,
       displayName: principals.displayName,
+      suspendedAt: principals.suspendedAt,
       externalId: principalIdentities.externalId,
     })
     .from(principals)
@@ -167,5 +182,6 @@ export async function listPrincipals(): Promise<
     handle: r.handle,
     displayName: r.displayName,
     userId: r.externalId ?? null,
+    suspendedAt: r.suspendedAt,
   }));
 }

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { db } from "../db/drizzle";
 import { principalIdentities } from "../db/schema/identities";
@@ -88,9 +88,19 @@ export async function principalById(
  * wants to read it. `buildTokenPayload` refuses to mint for a suspended
  * principal on both subject paths — a session caller whose principal is
  * suspended is exactly as suspended as an agent.
+ *
+ * Guarded by `suspendedAt IS NULL` rather than an unconditional write: the
+ * column exists to answer "since when" (see its comment in
+ * `db/schema/organization.ts`), and a stray second suspend — a stale tab, a
+ * retried request, a race between two admins — must not silently replace the
+ * real answer with the time of the click. Idempotent either way: a
+ * re-suspend still succeeds, it just leaves the original timestamp alone.
  */
 export async function suspendPrincipal(id: string): Promise<void> {
-  await db.update(principals).set({ suspendedAt: new Date() }).where(eq(principals.id, id));
+  await db
+    .update(principals)
+    .set({ suspendedAt: new Date() })
+    .where(and(eq(principals.id, id), isNull(principals.suspendedAt)));
 }
 
 /** Lift a suspension. The principal can be minted for again. */

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -102,3 +102,52 @@ export async function principalHandle(id: string): Promise<string | null> {
     .limit(1);
   return row?.handle ?? null;
 }
+
+/**
+ * Every principal, with the Better Auth login each one has if any.
+ *
+ * For the admin surface, and for one reason: a grant now names a principal id
+ * on both sides — the row is keyed by one and every value in `mayDispatch` is
+ * one — and a `prn_` id is not something a person can type from memory or
+ * recognise on sight. Without this the console can only offer a text box and
+ * hope, which is how an authorization surface stops being one people use.
+ *
+ * `userId` travels with the row so the console can put a name and an email
+ * against a human principal without a second call and a second guess about
+ * how to join the two id spaces. It is null for an agent or a service, which
+ * is the ordinary case and not a gap.
+ *
+ * Unpaginated, deliberately: this is one row per person and per agent in one
+ * organisation, which is the same order of magnitude as the fleet — and a
+ * paginated picker that silently stopped at page one would offer a narrower
+ * choice than exists, which on an authorization surface reads as "that agent
+ * cannot be granted".
+ */
+export async function listPrincipals(): Promise<
+  Array<{ id: string; kind: PrincipalKind; handle: string; displayName: string | null; userId: string | null }>
+> {
+  const rows = await db
+    .select({
+      id: principals.id,
+      kind: principals.kind,
+      handle: principals.handle,
+      displayName: principals.displayName,
+      externalId: principalIdentities.externalId,
+    })
+    .from(principals)
+    .leftJoin(
+      principalIdentities,
+      and(
+        eq(principalIdentities.principalId, principals.id),
+        eq(principalIdentities.system, "better-auth")
+      )
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    kind: r.kind as PrincipalKind,
+    handle: r.handle,
+    displayName: r.displayName,
+    userId: r.externalId ?? null,
+  }));
+}

--- a/apps/hub/src/utils/ids.ts
+++ b/apps/hub/src/utils/ids.ts
@@ -1,0 +1,10 @@
+/**
+ * Prefixed ids, one minter.
+ *
+ * Was a private const in `services/enrollment.ts`, which is why `station-registry`
+ * grew a second, incompatible shape (a hyphenated UUID that kaambaan's own id
+ * schema rejects — see `fixtures/ecosystem-identity/id_grammar.json`,
+ * `agentpod.station`). One exported minter is how that stops happening again.
+ */
+export const prefixedId = (prefix: string): string =>
+  `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;

--- a/apps/hub/tests/integration/admin-grants-route.test.ts
+++ b/apps/hub/tests/integration/admin-grants-route.test.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
-import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { adminGrantsRouter } from "../../src/routes/admin-grants";
 import { getGrant, setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 
 /**
  * The grants HTTP surface.
@@ -18,7 +18,15 @@ import { getGrant, setGrant } from "../../src/services/grants";
  * silently permit nothing.
  */
 
-const SUBJECT = "test-user-admin-grants";
+/**
+ * The principal being granted — a `prn_` id, not a Better Auth one.
+ *
+ * `principal_grants.principal_id` is a foreign key onto `principals.id`, so a
+ * grant keyed by a login id is not an older spelling of the same row, it is a
+ * write that cannot land. Both the path parameter and `setGrant` take this.
+ */
+const SUBJECT_HANDLE = "admin-grants-it-subject";
+let SUBJECT: string;
 
 /** The router, with a stub admin in context — the guard lives at the mount site. */
 function app() {
@@ -33,13 +41,13 @@ function app() {
 
 beforeAll(async () => {
   await ensurePgMigrations();
-  await createTestUser({ id: SUBJECT, email: "admin-grants@example.com", name: "Subject" });
+  await rawSql`DELETE FROM principals WHERE handle = ${SUBJECT_HANDLE}`;
+  SUBJECT = await createPrincipal({ kind: "human", handle: SUBJECT_HANDLE });
 });
 
 afterAll(async () => {
   try {
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${SUBJECT}`;
-    await rawSql`DELETE FROM "user" WHERE id = ${SUBJECT}`;
+    await rawSql`DELETE FROM principals WHERE handle = ${SUBJECT_HANDLE}`;
   } catch {
     // cleanup only
   }

--- a/apps/hub/tests/integration/admin-grants-route.test.ts
+++ b/apps/hub/tests/integration/admin-grants-route.test.ts
@@ -62,27 +62,26 @@ describe("/api/admin/grants", () => {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_x"],
+        mayDispatch: ["prn_0123456789abcdef0123", "prn_ffffffffffffffffffff"],
         mayGrantReach: true,
       }),
     });
     expect(res.status).toBe(200);
 
     expect(await getGrant(SUBJECT)).toEqual({
-      mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_x"],
+      mayDispatch: ["prn_0123456789abcdef0123", "prn_ffffffffffffffffffff"],
       mayGrantReach: true,
     });
   });
 
-  test("refuses an unnamespaced value instead of storing a grant that matches nothing", async () => {
-    // The retired `CONTROL_PAIR_GRANTS` format. A reader IGNORES a namespace it
-    // does not recognise; a WRITER must refuse a malformed one — otherwise this
-    // stores happily, matches nothing anywhere, and looks like a working grant,
-    // which is the worst of the three outcomes.
+  test("refuses a wildcard instead of storing a grant that matches nothing", async () => {
+    // A reader IGNORES a value it does not recognise; a WRITER must refuse a
+    // malformed one — otherwise this stores happily, matches nothing anywhere,
+    // and looks like a working grant, which is the worst of the three outcomes.
     const res = await app().request(`/grants/${SUBJECT}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["hermes:*"], mayGrantReach: false }),
+      body: JSON.stringify({ mayDispatch: ["*"], mayGrantReach: false }),
     });
 
     expect(res.status).toBe(400);
@@ -90,32 +89,45 @@ describe("/api/admin/grants", () => {
     expect((await getGrant(SUBJECT))!.mayGrantReach).toBe(true);
   });
 
+  test("refuses a value that is not a well-formed principal id", async () => {
+    // The retired `agentpod:`/`kaambaan:` namespaced form, and any other string
+    // shaped like something else — a grant now enumerates principal ids and
+    // nothing else, so this must match nothing rather than look like a working
+    // grant that silently permits nobody.
+    const res = await app().request(`/grants/${SUBJECT}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mayDispatch: ["kaambaan:agt_x"], mayGrantReach: false }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   test("refuses a grant missing half the pair", async () => {
     const res = await app().request(`/grants/${SUBJECT}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["agentpod:molt-bot/hermes:*"] }),
+      body: JSON.stringify({ mayDispatch: ["prn_0123456789abcdef0123"] }),
     });
     expect(res.status).toBe(400);
   });
 
   test("replaces rather than merges, so narrowing is as easy as widening", async () => {
     await setGrant(SUBJECT, {
-      mayDispatch: ["agentpod:molt-bot/hermes:*", "kaambaan:agt_x"],
+      mayDispatch: ["prn_0123456789abcdef0123", "prn_ffffffffffffffffffff"],
       mayGrantReach: true,
     });
 
     await app().request(`/grants/${SUBJECT}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["agentpod:molt-bot/hermes:analyst-echo"], mayGrantReach: false }),
+      body: JSON.stringify({ mayDispatch: ["prn_0123456789abcdef0123"], mayGrantReach: false }),
     });
 
     // A PATCH that merged arrays would make removing a permission harder than
     // adding one, and an authorization surface must never be easier to widen
     // than to narrow.
     expect(await getGrant(SUBJECT)).toEqual({
-      mayDispatch: ["agentpod:molt-bot/hermes:analyst-echo"],
+      mayDispatch: ["prn_0123456789abcdef0123"],
       mayGrantReach: false,
     });
   });
@@ -147,27 +159,16 @@ describe("/api/admin/grants", () => {
     }
   });
 
-  test("refuses an AgentPod value that names no node, because it matches nothing", async () => {
-    // `agentpod:hermes:*` is the shape everyone writes first, and since the
-    // amendment it matches no station on any node — uniqueness is (node, key).
-    // Stored, it reads as a working grant and permits nothing, which is the
-    // failure this writer exists to prevent. Fleet-wide has to be said out loud.
+  test("refuses a truncated principal id, because it matches nothing minted", async () => {
+    // One character short of `PrincipalId`'s grammar — the mint-site regex, not
+    // a hand-rolled one, is what decides this, so this pins that the two never
+    // drift apart rather than pinning a length nobody chose on purpose.
     const res = await app().request(`/grants/${SUBJECT}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["agentpod:hermes:*"], mayGrantReach: false }),
+      body: JSON.stringify({ mayDispatch: ["prn_0123456789abcdef012"], mayGrantReach: false }),
     });
     expect(res.status).toBe(400);
-    expect(await res.text()).toMatch(/node/i);
-  });
-
-  test("accepts fleet-wide only when it is written out", async () => {
-    const res = await app().request(`/grants/${SUBJECT}`, {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false }),
-    });
-    expect(res.status).toBe(200);
   });
 
   test("removing a grant is not the same as emptying it", async () => {

--- a/apps/hub/tests/integration/admin-principals-route.test.ts
+++ b/apps/hub/tests/integration/admin-principals-route.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { ensurePgMigrations } from "../helpers/pg-migrations";
+import { createTestUser } from "../helpers/database";
+import { rawSql } from "../../src/db/drizzle";
+import { adminPrincipalsRouter } from "../../src/routes/admin-principals";
+import { createPrincipal } from "../../src/services/principals";
+
+/**
+ * The directory a grant is written against.
+ *
+ * A grant names a `prn_` id on both sides and nothing else in this API says
+ * what those ids are. Without this list the console's grants page can offer
+ * only a bare text box for a twenty-hex string — which is the same failure
+ * `/api/admin/grants` was built to end: a control nobody can operate is one
+ * people route around.
+ *
+ * Mounted under `/api/admin` in production, behind the same auth + admin
+ * middleware as every other admin route; the guard is asserted at its mount
+ * site, so this exercises the router itself.
+ */
+
+const USER = "test-user-admin-principals";
+const HUMAN_HANDLE = "admin-principals-it-human";
+const AGENT_HANDLE = "admin-principals-it-agent";
+
+let HUMAN: string;
+let AGENT: string;
+
+interface Row {
+  id: string;
+  kind: string;
+  handle: string;
+  displayName: string | null;
+  userId: string | null;
+}
+
+function app() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: "test-admin", role: "admin" });
+    await next();
+  });
+  a.route("/principals", adminPrincipalsRouter);
+  return a;
+}
+
+async function list(): Promise<Row[]> {
+  const res = await app().request("/principals");
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { principals: Row[] }).principals;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await rawSql`DELETE FROM principals WHERE handle IN (${HUMAN_HANDLE}, ${AGENT_HANDLE})`;
+  await createTestUser({ id: USER, email: "admin-principals@example.com", name: "Directory" });
+  HUMAN = await createPrincipal({
+    kind: "human",
+    handle: HUMAN_HANDLE,
+    displayName: "Directory Person",
+    userId: USER,
+  });
+  AGENT = await createPrincipal({ kind: "agent", handle: AGENT_HANDLE, displayName: "Quill" });
+});
+
+afterAll(async () => {
+  try {
+    await rawSql`DELETE FROM principals WHERE handle IN (${HUMAN_HANDLE}, ${AGENT_HANDLE})`;
+    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+  } catch {
+    // cleanup only
+  }
+});
+
+describe("/api/admin/principals", () => {
+  test("lists an agent, which is the thing a grant's values name", async () => {
+    // The half of the vocabulary that has no other source. A human principal
+    // can at least be found through `/api/admin/users`; an agent appears in no
+    // other admin list at all, so before this there was no way to discover the
+    // id you were meant to type into `mayDispatch`.
+    const found = (await list()).find((p) => p.id === AGENT);
+
+    expect(found).toBeDefined();
+    expect(found!.kind).toBe("agent");
+    expect(found!.handle).toBe(AGENT_HANDLE);
+  });
+
+  test("an agent has no Better Auth login, and that is not a gap", async () => {
+    // A console must be able to tell "this principal is a person you can look
+    // up" from "this principal is an agent". Reading a missing login as a
+    // missing row would drop every agent off the picker.
+    const found = (await list()).find((p) => p.id === AGENT);
+
+    expect(found!.userId).toBeNull();
+  });
+
+  test("carries a human principal's login, so a name can be put against it", async () => {
+    // Otherwise the console has to join two id spaces itself and guess how —
+    // which is the exact mistake that made every one of this slice's owner
+    // lookups resolve to nothing.
+    const found = (await list()).find((p) => p.id === HUMAN);
+
+    expect(found!.kind).toBe("human");
+    expect(found!.userId).toBe(USER);
+    expect(found!.displayName).toBe("Directory Person");
+  });
+});

--- a/apps/hub/tests/integration/admin-principals-route.test.ts
+++ b/apps/hub/tests/integration/admin-principals-route.test.ts
@@ -183,6 +183,29 @@ describe("POST /api/admin/principals/:id/suspend and /restore", () => {
     expect(res.status).toBe(200);
   });
 
+  test("a re-suspend does not overwrite the original suspension time", async () => {
+    // The column's own reason for existing (`db/schema/organization.ts`): "a
+    // timestamp rather than a boolean, because 'since when' is the first
+    // question asked of a suspension, and a boolean cannot answer it." An
+    // unconditional UPDATE would answer that question with the time of the
+    // *second* click — a stale tab, a retry, a race between two admins — and
+    // nothing about the wrong answer would look wrong. Asserting only that the
+    // second call doesn't error, as the test above does, is exactly what let
+    // that through.
+    const first = (await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/suspend`, {
+      method: "POST",
+    }).then((r) => r.json())) as { suspendedAt: string | null };
+    expect(first.suspendedAt).not.toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const second = (await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/suspend`, {
+      method: "POST",
+    }).then((r) => r.json())) as { suspendedAt: string | null };
+
+    expect(second.suspendedAt).toBe(first.suspendedAt);
+  });
+
   test("suspension is reversible from the same surface", async () => {
     const res = await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/restore`, {
       method: "POST",

--- a/apps/hub/tests/integration/admin-principals-route.test.ts
+++ b/apps/hub/tests/integration/admin-principals-route.test.ts
@@ -4,7 +4,8 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { adminPrincipalsRouter } from "../../src/routes/admin-principals";
-import { createPrincipal } from "../../src/services/principals";
+import { adminMiddleware } from "../../src/auth/admin-middleware";
+import { createPrincipal, principalById } from "../../src/services/principals";
 
 /**
  * The directory a grant is written against.
@@ -23,6 +24,8 @@ import { createPrincipal } from "../../src/services/principals";
 const USER = "test-user-admin-principals";
 const HUMAN_HANDLE = "admin-principals-it-human";
 const AGENT_HANDLE = "admin-principals-it-agent";
+const ADMIN_ACTOR = "test-admin-actor-principals";
+const NON_ADMIN_ACTOR = "test-non-admin-actor-principals";
 
 let HUMAN: string;
 let AGENT: string;
@@ -33,6 +36,7 @@ interface Row {
   handle: string;
   displayName: string | null;
   userId: string | null;
+  suspendedAt: string | null;
 }
 
 function app() {
@@ -41,6 +45,24 @@ function app() {
     c.set("user", { id: "test-admin", role: "admin" });
     await next();
   });
+  a.route("/principals", adminPrincipalsRouter);
+  return a;
+}
+
+/**
+ * The real guard, not the stub above. `app()` fakes an already-admin context
+ * so the other tests in this file can exercise the router in isolation; the
+ * suspend/restore tests below need the actual `adminMiddleware` in the chain,
+ * because "a non-admin cannot suspend" is a claim about that middleware, not
+ * about the router.
+ */
+function guardedApp(actorId: string) {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: actorId, authType: "api_key", tenantId: "default" });
+    await next();
+  });
+  a.use("*", adminMiddleware);
   a.route("/principals", adminPrincipalsRouter);
   return a;
 }
@@ -55,6 +77,17 @@ beforeAll(async () => {
   await ensurePgMigrations();
   await rawSql`DELETE FROM principals WHERE handle IN (${HUMAN_HANDLE}, ${AGENT_HANDLE})`;
   await createTestUser({ id: USER, email: "admin-principals@example.com", name: "Directory" });
+  await createTestUser({
+    id: ADMIN_ACTOR,
+    email: "admin-principals-actor@example.com",
+    name: "Actor",
+    role: "admin",
+  });
+  await createTestUser({
+    id: NON_ADMIN_ACTOR,
+    email: "admin-principals-non-actor@example.com",
+    name: "Non-actor",
+  });
   HUMAN = await createPrincipal({
     kind: "human",
     handle: HUMAN_HANDLE,
@@ -67,7 +100,7 @@ beforeAll(async () => {
 afterAll(async () => {
   try {
     await rawSql`DELETE FROM principals WHERE handle IN (${HUMAN_HANDLE}, ${AGENT_HANDLE})`;
-    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${USER}, ${ADMIN_ACTOR}, ${NON_ADMIN_ACTOR})`;
   } catch {
     // cleanup only
   }
@@ -104,5 +137,76 @@ describe("/api/admin/principals", () => {
     expect(found!.kind).toBe("human");
     expect(found!.userId).toBe(USER);
     expect(found!.displayName).toBe("Directory Person");
+  });
+
+  test("reports suspendedAt: null for a principal never suspended, in the same call", async () => {
+    // The page must be able to show state without a second round trip.
+    const found = (await list()).find((p) => p.id === HUMAN);
+    expect(found!.suspendedAt).toBeNull();
+  });
+});
+
+describe("POST /api/admin/principals/:id/suspend and /restore", () => {
+  test("a non-admin cannot suspend a principal", async () => {
+    const res = await guardedApp(NON_ADMIN_ACTOR).request(`/principals/${AGENT}/suspend`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(403);
+    expect((await principalById(AGENT))!.suspendedAt).toBeNull();
+  });
+
+  test("a non-admin cannot restore a principal", async () => {
+    const res = await guardedApp(NON_ADMIN_ACTOR).request(`/principals/${AGENT}/restore`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("an admin can suspend, and the directory reflects it in the same call", async () => {
+    const res = await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/suspend`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; suspendedAt: string | null };
+    expect(body.id).toBe(AGENT);
+    expect(body.suspendedAt).not.toBeNull();
+
+    const found = (await list()).find((p) => p.id === AGENT);
+    expect(found!.suspendedAt).not.toBeNull();
+  });
+
+  test("suspending an already-suspended principal does not error", async () => {
+    // An operator double-clicking is ordinary, not a fault.
+    const res = await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/suspend`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("suspension is reversible from the same surface", async () => {
+    const res = await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/restore`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; suspendedAt: string | null };
+    expect(body.suspendedAt).toBeNull();
+
+    const found = (await list()).find((p) => p.id === AGENT);
+    expect(found!.suspendedAt).toBeNull();
+  });
+
+  test("restoring a principal that is not suspended does not error", async () => {
+    const res = await guardedApp(ADMIN_ACTOR).request(`/principals/${AGENT}/restore`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("suspending an unknown principal id answers 404, not a silent no-op", async () => {
+    const res = await guardedApp(ADMIN_ACTOR).request(
+      "/principals/prn_ffffffffffffffffff00/suspend",
+      { method: "POST" }
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/hub/tests/integration/control-pair-dispatch.test.ts
+++ b/apps/hub/tests/integration/control-pair-dispatch.test.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { createSession } from "../../src/services/acp-sessions";
 import { stationAcpRoutes } from "../../src/routes/station-acp";
 import { setGrant, deleteGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 
 /**
  * The control pair, enforced where dispatch actually happens.
@@ -27,9 +28,21 @@ import { setGrant, deleteGrant } from "../../src/services/grants";
 
 const USER = "test-user-controlpair";
 let nodeId = "";
-let nodeName = "";
 let stationKey = "";
 let stationId = "";
+
+let USER_PRINCIPAL: string;
+/** The agent occupying `stationId` — the matcher compares a grant against this now. */
+let AGENT_PRINCIPAL: string;
+
+// A second node, adopting a station with the SAME key, occupied by a
+// DIFFERENT agent — the shape that made a bare station key unsafe to grant on
+// (`opencode:c52ddf65` exists on two nodes in production). Proves the new,
+// principal-keyed matcher still tells the two apart, the same way the old
+// node-qualified pattern did.
+const OTHER_NODE = "node_controlpair_other";
+let otherStationId = "";
+let OTHER_AGENT_PRINCIPAL: string;
 
 beforeAll(async () => {
   await ensurePgMigrations();
@@ -43,9 +56,6 @@ beforeAll(async () => {
     cpuCount: 2,
   });
   nodeId = enrolled.nodeId;
-  // The grant names the node, so the test has to know what this fleet ended up
-  // calling it — enrolment suffixes a hostname collision.
-  nodeName = (await rawSql`SELECT name FROM nodes WHERE id = ${nodeId}`)[0]!.name as string;
 
   stationKey = "hermes:cp-agent";
   await adoptStations(USER, nodeId, [stationKey], [
@@ -61,19 +71,46 @@ beforeAll(async () => {
     },
   ]);
   stationId = (await listAdopted(USER, nodeId)).find((s) => s.stationKey === stationKey)!.id;
+
+  USER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "controlpair-it-user", userId: USER });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "controlpair-it-agent" });
+  await rawSql`UPDATE stations SET principal_id = ${AGENT_PRINCIPAL} WHERE id = ${stationId}`;
+
+  OTHER_AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "controlpair-it-other-agent" });
+  const tenant = (await rawSql`SELECT tenant_id FROM nodes WHERE id = ${nodeId}`)[0]!.tenant_id as string;
+  await rawSql`DELETE FROM nodes WHERE id = ${OTHER_NODE}`;
+  await rawSql`
+    INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
+    VALUES (${OTHER_NODE}, ${tenant}, ${USER}, 'controlpair-other-box', 'controlpair-other-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  await adoptStations(USER, OTHER_NODE, [stationKey], [
+    {
+      key: stationKey,
+      harness: "hermes",
+      kind: "leaf",
+      displayName: "CP Agent (other node)",
+      parentKey: null,
+      workspacePath: "/root/.hermes",
+      capabilities: ["health", "acp"],
+      adopted: false,
+    },
+  ]);
+  otherStationId = (await listAdopted(USER, OTHER_NODE)).find((s) => s.stationKey === stationKey)!.id;
+  await rawSql`UPDATE stations SET principal_id = ${OTHER_AGENT_PRINCIPAL} WHERE id = ${otherStationId}`;
 });
 
 afterEach(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
-  await deleteGrant(USER).catch(() => {});
+  await deleteGrant(USER_PRINCIPAL).catch(() => {});
 });
 
 afterAll(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
   try {
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
-    await rawSql`DELETE FROM stations WHERE node_id = ${nodeId}`;
-    await rawSql`DELETE FROM nodes WHERE id = ${nodeId}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id = ${USER}`;
+    await rawSql`DELETE FROM stations WHERE node_id IN (${nodeId}, ${OTHER_NODE})`;
+    await rawSql`DELETE FROM nodes WHERE id IN (${nodeId}, ${OTHER_NODE})`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('controlpair-it-user', 'controlpair-it-agent', 'controlpair-it-other-agent')`;
     await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
     await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
   } catch {
@@ -94,8 +131,8 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
 
   test("refuses a grant that does not cover this station", async () => {
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await setGrant(USER, {
-      mayDispatch: [`agentpod:${nodeName}/hermes:some-other-agent`],
+    await setGrant(USER_PRINCIPAL, {
+      mayDispatch: ["prn_ffffffffffffffffffff"],
       mayGrantReach: false,
     });
 
@@ -104,12 +141,12 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
     ).rejects.toThrow(/permission/i);
   });
 
-  test("refuses a grant written in another plane's namespace", async () => {
-    // The decision's rule from this side: a kaambaan value is not this plane's
-    // business, so it grants nothing here — while remaining a perfectly valid
-    // grant over there.
+  test("refuses a value that is not a principal id, rather than treating it as one", async () => {
+    // Namespacing is gone along with the pattern language: a value that is not
+    // this station's occupant is refused the same way whatever it looks like,
+    // whether it is shaped like the retired kaambaan namespace or anything else.
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await setGrant(USER, { mayDispatch: ["kaambaan:agt_anything"], mayGrantReach: false });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: ["kaambaan:agt_anything"], mayGrantReach: false });
 
     await expect(
       createSession({ stationId, userId: USER, mode: "default" })
@@ -117,14 +154,13 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
   });
 
   test("refuses the retired formats rather than honouring them", async () => {
-    // `hermes:*` was valid in CONTROL_PAIR_GRANTS, and `agentpod:hermes:*` was
-    // valid before a grant named a node. Neither may still match: the first
-    // would let a half-migrated deployment enforce two rules at once, and the
-    // second cannot say WHICH node it meant, which is the over-grant that shape
-    // exists to remove.
+    // `hermes:*` was valid in CONTROL_PAIR_GRANTS, `agentpod:hermes:*` was valid
+    // before a grant named a node, and `agentpod:*/hermes:*` was the node-
+    // qualified form itself. None of the three may still match: a grant is now
+    // an enumeration of principal ids, and none of these is one.
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await setGrant(USER, {
-      mayDispatch: ["hermes:*", "agentpod:hermes:*"],
+    await setGrant(USER_PRINCIPAL, {
+      mayDispatch: ["hermes:*", "agentpod:hermes:*", "agentpod:*/hermes:*"],
       mayGrantReach: false,
     });
 
@@ -143,23 +179,26 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
       createSession({ stationId, userId: USER, mode: "default" })
     ).rejects.toThrow(/permission/i);
 
-    // With a grant, the SAME call gets past the control and fails on readiness
-    // instead — which is what proves the refusal above came from the control
-    // and not from the node being unreachable.
-    await setGrant(USER, { mayDispatch: [`agentpod:${nodeName}/hermes:*`], mayGrantReach: false });
+    // With a grant naming the station's actual occupant, the SAME call gets
+    // past the control and fails on readiness instead — which is what proves
+    // the refusal above came from the control and not from the node being
+    // unreachable.
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await expect(
       createSession({ stationId, userId: USER, mode: "default" })
     ).rejects.toThrow(/offline|not ready|does not support/i);
   });
 
-  test("a grant for the same station key on another node does not reach this one", async () => {
-    // The defect that produced the node-qualified shape: station keys repeat
-    // across nodes — `opencode:c52ddf65` exists on two in production — so a
-    // permission for one host must not silently cover another.
+  test("a grant for another node's occupant of the same station key does not reach this one", async () => {
+    // The defect that produced the retired node-qualified shape: station keys
+    // repeat across nodes — `opencode:c52ddf65` exists on two in production —
+    // so a permission for one host's agent must not silently cover another
+    // host's agent, even one sitting at the identical key. The new matcher
+    // gets this for free from equality: the two are different principal ids.
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await setGrant(USER, {
-      mayDispatch: [`agentpod:some-other-host/${stationKey}`],
+    await setGrant(USER_PRINCIPAL, {
+      mayDispatch: [OTHER_AGENT_PRINCIPAL],
       mayGrantReach: false,
     });
 
@@ -168,13 +207,19 @@ describe("dispatch consults the control pair (#Phase 3)", () => {
     ).rejects.toThrow(/permission/i);
   });
 
-  test("a node wildcard reaches it, because that says every node out loud", async () => {
+  test("a wildcard no longer reaches anything, however it is written", async () => {
+    // BEHAVIOUR CHANGE from the retired scheme: `agentpod:*/hermes:*` used to
+    // be the explicit, opt-in way to say "every node, said out loud", and this
+    // test used to assert exactly that it got through. Decision
+    // 2026-08-30-an-agent-is-a-principal.md §3 deletes wildcards rather than
+    // narrowing them — there is no way left to express "every agent" in a
+    // grant, so this now refuses like any other non-matching value.
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: ["*", "prn_*"], mayGrantReach: false });
 
     await expect(
       createSession({ stationId, userId: USER, mode: "default" })
-    ).rejects.toThrow(/offline|not ready|does not support/i);
+    ).rejects.toThrow(/permission/i);
   });
 
   test("is not enforced when the switch is off, whatever the grants say", async () => {
@@ -196,7 +241,7 @@ describe("the route reports a denial as a refusal, not a gateway failure", () =>
     // will retry something that can never succeed — an authorization decision
     // hidden behind an infrastructure one.
     process.env.ENFORCE_CONTROL_PAIR = "true";
-    await deleteGrant(USER).catch(() => {});
+    await deleteGrant(USER_PRINCIPAL).catch(() => {});
 
     const app = new Hono();
     app.use("*", async (c, next) => {

--- a/apps/hub/tests/integration/enrollment-token-reach.test.ts
+++ b/apps/hub/tests/integration/enrollment-token-reach.test.ts
@@ -4,6 +4,7 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { enrollmentTokenRoutes } from "../../src/routes/enrollment-tokens";
 
 /**
@@ -15,16 +16,20 @@ import { enrollmentTokenRoutes } from "../../src/routes/enrollment-tokens";
  * person who added it put on it.
  *
  * It names no station, so the composition rule the station routes use has
- * nothing to match against. The rule here is narrower instead: you may grow a
- * fleet only if your authority already spans it.
+ * nothing to match against. The rule here is admin, full stop — see
+ * `services/grant-reach.ts`'s `requireFleetGrantReach` for why a wildcard
+ * dispatch grant can no longer say "spans the fleet".
  */
 
 const USER = "test-user-enroll-reach";
+const ADMIN_USER = "test-user-enroll-reach-admin";
 
-function app() {
+let USER_PRINCIPAL: string;
+
+function app(userId: string) {
   const a = new Hono();
   a.use("*", async (c, next) => {
-    c.set("user", { id: USER, role: "user" });
+    c.set("user", { id: userId, role: "user" });
     await next();
   });
   a.route("/", enrollmentTokenRoutes);
@@ -34,47 +39,46 @@ function app() {
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: USER, email: "enroll-reach@example.com", name: "ER" });
+  await createTestUser({
+    id: ADMIN_USER,
+    email: "enroll-reach-admin@example.com",
+    name: "ER Admin",
+    role: "admin",
+  });
+  USER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "enroll-reach-user", userId: USER });
+  await createPrincipal({ kind: "human", handle: "enroll-reach-admin", userId: ADMIN_USER });
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
 afterAll(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
   try {
-    await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
-    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+    await rawSql`DELETE FROM enrollment_tokens WHERE user_id IN (${USER}, ${ADMIN_USER})`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id IN (${USER}, ${ADMIN_USER})`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('enroll-reach-user', 'enroll-reach-admin')`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${USER}, ${ADMIN_USER})`;
   } catch {
     // cleanup only
   }
 });
 
-describe("growing the fleet requires fleet-wide authority", () => {
-  test("refused for a node-scoped principal", async () => {
-    // Their grant describes one machine. A machine they add is one it never
-    // described — and on a wildcard-free grant they could keep adding them.
-    await setGrant(USER, { mayDispatch: ["agentpod:one-box/hermes:*"], mayGrantReach: true });
-
-    const res = await app().request("/", { method: "POST" });
-    expect(res.status).toBe(403);
-    expect(await res.text()).toMatch(/add machines/i);
-  });
-
-  test("permitted when the principal's authority already spans the fleet", async () => {
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
-
-    const res = await app().request("/", { method: "POST" });
+describe("growing the fleet is an admin act", () => {
+  test("an admin may mint an enrollment token", async () => {
+    const res = await app(ADMIN_USER).request("/", { method: "POST" });
     expect(res.status).toBe(200);
     expect(((await res.json()) as { token: string }).token).toBeTruthy();
   });
 
-  test("refused without the boolean, however wide the scope", async () => {
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
-    expect((await app().request("/", { method: "POST" })).status).toBe(403);
-  });
+  test("a non-admin may not, however wide their grant", async () => {
+    // This is the exact case the wildcard used to permit: a dispatch pattern
+    // spanning every node, plus mayGrantReach. It used to be sufficient on its
+    // own. It no longer is — admin is the only thing that answers now.
+    await setGrant(USER_PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
 
-  test("refused for a principal with no grant at all", async () => {
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
-    expect((await app().request("/", { method: "POST" })).status).toBe(403);
+    const res = await app(USER).request("/", { method: "POST" });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toMatch(/add machines/i);
   });
 
   test("is a no-op when the pair is not enforced", async () => {
@@ -83,9 +87,8 @@ describe("growing the fleet requires fleet-wide authority", () => {
     const before = process.env.ENFORCE_CONTROL_PAIR;
     try {
       process.env.ENFORCE_CONTROL_PAIR = "false";
-      await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
 
-      const res = await app().request("/", { method: "POST" });
+      const res = await app(USER).request("/", { method: "POST" });
       expect(res.status).toBe(200);
     } finally {
       if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;

--- a/apps/hub/tests/integration/enrollment-token-reach.test.ts
+++ b/apps/hub/tests/integration/enrollment-token-reach.test.ts
@@ -70,11 +70,12 @@ describe("growing the fleet is an admin act", () => {
     expect(((await res.json()) as { token: string }).token).toBeTruthy();
   });
 
-  test("a non-admin may not, however wide their grant", async () => {
+  test("a non-admin may not, however permissive their grant", async () => {
     // This is the exact case the wildcard used to permit: a dispatch pattern
     // spanning every node, plus mayGrantReach. It used to be sufficient on its
-    // own. It no longer is — admin is the only thing that answers now.
-    await setGrant(USER_PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    // own. It no longer is — admin is the only thing that answers now, and
+    // there is no wildcard left to spell "every node" with anyway.
+    await setGrant(USER_PRINCIPAL, { mayDispatch: ["prn_ffffffffffffffffffff"], mayGrantReach: true });
 
     const res = await app(USER).request("/", { method: "POST" });
     expect(res.status).toBe(403);

--- a/apps/hub/tests/integration/grant-reach.test.ts
+++ b/apps/hub/tests/integration/grant-reach.test.ts
@@ -48,12 +48,21 @@ beforeAll(async () => {
     handle: "grant-reach-it-admin",
     userId: ADMIN_USER,
   });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "grant-reach-it-agent" });
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
   const tenant = await resolveTenantForUser(USER);
   await rawSql`
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${USER},
             'reach-box', 'reach-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
+  // requireGrantReach's scope check now compares a grant against the STATION'S
+  // OCCUPANT, not a node/station pattern — so the station this suite drives
+  // has to be a real row with a real occupant, not just a nodeId/stationKey pair.
+  await rawSql`DELETE FROM stations WHERE id = ${STATION_ID}`;
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, principal_id, adopted_at, created_at)
+    VALUES (${STATION_ID}, ${tenant}, ${USER}, ${NODE}, 'hermes', ${STATION.stationKey}, 'leaf', 'Analyst Echo',
+            ${AGENT_PRINCIPAL}, now(), now())`;
 
   // The guards are no-ops when the pair is off — which is itself asserted below.
   process.env.ENFORCE_CONTROL_PAIR = "true";
@@ -64,7 +73,8 @@ afterAll(async () => {
   try {
     await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${USER_PRINCIPAL}, ${ADMIN_PRINCIPAL})`;
     await rawSql`DELETE FROM principal_identities WHERE external_id IN (${USER}, ${ADMIN_USER})`;
-    await rawSql`DELETE FROM principals WHERE handle IN ('grant-reach-it-user', 'grant-reach-it-admin')`;
+    await rawSql`DELETE FROM stations WHERE id = ${STATION_ID}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('grant-reach-it-user', 'grant-reach-it-admin', 'grant-reach-it-agent')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id IN (${USER}, ${ADMIN_USER})`;
   } catch {
@@ -72,7 +82,12 @@ afterAll(async () => {
   }
 });
 
+const STATION_ID = "station_grant_reach";
 const STATION = { nodeId: NODE, stationKey: "hermes:analyst-echo" };
+/** The agent occupying STATION — the new matcher compares a grant against this, not a pattern. */
+let AGENT_PRINCIPAL: string;
+/** Some other agent, granted in a couple of tests to prove the scope check is real. */
+const OTHER_AGENT = "prn_ffffffffffffffffffff";
 
 async function denial(fn: () => Promise<void>): Promise<unknown> {
   try {
@@ -112,13 +127,13 @@ describe("the capability classification", () => {
 
 describe("requireGrantReach", () => {
   test("permits when the principal holds reach and the scope matches", async () => {
-    await setGrant(USER, { mayDispatch: ["agentpod:reach-box/hermes:*"], mayGrantReach: true });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
     expect(await denial(() => requireGrantReach(USER, STATION, "fs.write", "mutate"))).toBeNull();
   });
 
-  test("refuses without the boolean, however wide the dispatch scope", async () => {
+  test("refuses without the boolean, even though the dispatch scope covers it", async () => {
     // The whole point: dispatch permission is not permission to rewrite.
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     const e = await denial(() => requireGrantReach(USER, STATION, "fs.write", "mutate"));
     expect(isGrantReachDenied(e)).toBe(true);
@@ -126,26 +141,26 @@ describe("requireGrantReach", () => {
 
   test("refuses when the boolean is held but this station is out of scope", async () => {
     // One scope, shared with dispatch: you may rewrite only agents you may talk to.
-    await setGrant(USER, { mayDispatch: ["agentpod:other-box/hermes:*"], mayGrantReach: true });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: true });
 
     const e = await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"));
     expect(isGrantReachDenied(e)).toBe(true);
   });
 
   test("refuses a principal with no grant at all", async () => {
-    await deleteGrant(USER);
+    await deleteGrant(USER_PRINCIPAL);
     const e = await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"));
     expect(isGrantReachDenied(e)).toBe(true);
   });
 
   test("lets a read through even on a reach-bearing capability", async () => {
     // `cleanup` covers plan (read) and apply (destroys) under one word.
-    await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [], mayGrantReach: false });
     expect(await denial(() => requireGrantReach(USER, STATION, "cleanup", "read"))).toBeNull();
   });
 
   test("lets an open capability through even when mutating", async () => {
-    await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [], mayGrantReach: false });
     expect(await denial(() => requireGrantReach(USER, STATION, "lifecycle", "mutate"))).toBeNull();
   });
 
@@ -153,7 +168,7 @@ describe("requireGrantReach", () => {
     const before = process.env.ENFORCE_CONTROL_PAIR;
     try {
       process.env.ENFORCE_CONTROL_PAIR = "false";
-      await setGrant(USER, { mayDispatch: [], mayGrantReach: false });
+      await setGrant(USER_PRINCIPAL, { mayDispatch: [], mayGrantReach: false });
       expect(await denial(() => requireGrantReach(USER, STATION, "terminal", "mutate"))).toBeNull();
     } finally {
       if (before === undefined) delete process.env.ENFORCE_CONTROL_PAIR;
@@ -176,7 +191,7 @@ describe("requireFleetGrantReach", () => {
   test("a non-admin may not, however wide their grant", async () => {
     // The whole point of the change: a fleet-wide dispatch pattern plus
     // mayGrantReach used to be sufficient on its own. It no longer is.
-    await setGrant(USER_PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
 
     const e = await denial(() => requireFleetGrantReach(USER_PRINCIPAL));
     expect(isGrantReachDenied(e)).toBe(true);

--- a/apps/hub/tests/integration/grant-reach.test.ts
+++ b/apps/hub/tests/integration/grant-reach.test.ts
@@ -4,6 +4,7 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { setGrant, deleteGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import {
   REACH_BEARING,
@@ -23,11 +24,30 @@ import { isGrantReachDenied } from "../../src/services/control-pair";
  */
 
 const USER = "test-user-grant-reach";
+const ADMIN_USER = "test-user-grant-reach-it-admin";
 const NODE = "node_grant_reach";
+
+// requireFleetGrantReach takes a principal id, not a Better Auth user id —
+// these link USER and ADMIN_USER to one, the same way any real caller would
+// be linked, so "an admin may" and "a non-admin may not" mean something.
+let USER_PRINCIPAL: string;
+let ADMIN_PRINCIPAL: string;
 
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: USER, email: "grant-reach@example.com", name: "GR" });
+  await createTestUser({
+    id: ADMIN_USER,
+    email: "grant-reach-it-admin@example.com",
+    name: "GR Admin",
+    role: "admin",
+  });
+  USER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "grant-reach-it-user", userId: USER });
+  ADMIN_PRINCIPAL = await createPrincipal({
+    kind: "human",
+    handle: "grant-reach-it-admin",
+    userId: ADMIN_USER,
+  });
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
   const tenant = await resolveTenantForUser(USER);
   await rawSql`
@@ -42,9 +62,11 @@ beforeAll(async () => {
 afterAll(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
   try {
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${USER_PRINCIPAL}, ${ADMIN_PRINCIPAL})`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id IN (${USER}, ${ADMIN_USER})`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('grant-reach-it-user', 'grant-reach-it-admin')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
-    await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${USER}, ${ADMIN_USER})`;
   } catch {
     // cleanup only
   }
@@ -141,23 +163,22 @@ describe("requireGrantReach", () => {
 });
 
 describe("requireFleetGrantReach", () => {
-  test("permits a principal whose authority already spans the fleet", async () => {
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
-    expect(await denial(() => requireFleetGrantReach(USER))).toBeNull();
+  // The wildcard that used to encode "your authority spans the fleet" is
+  // gone, and a second scoped list was rejected as the asymmetric-grant
+  // hazard restated (2026-08-15-granting-reach-is-changing-an-agent). Admin
+  // is what is left, so these two facts are the whole rule now.
+
+  test("an admin may, even with no grant at all", async () => {
+    await deleteGrant(ADMIN_PRINCIPAL); // NO_GRANT is legal, and irrelevant to an admin
+    expect(await denial(() => requireFleetGrantReach(ADMIN_PRINCIPAL))).toBeNull();
   });
 
-  test("refuses a node-scoped principal, who could otherwise grow the fleet forever", async () => {
-    // Decision 4 counts *registering* an agent as granting reach: build the
-    // agent you want, then dispatch it. A machine added under a node-scoped
-    // grant is a machine that grant never described.
-    await setGrant(USER, { mayDispatch: ["agentpod:reach-box/hermes:*"], mayGrantReach: true });
+  test("a non-admin may not, however wide their grant", async () => {
+    // The whole point of the change: a fleet-wide dispatch pattern plus
+    // mayGrantReach used to be sufficient on its own. It no longer is.
+    await setGrant(USER_PRINCIPAL, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
 
-    const e = await denial(() => requireFleetGrantReach(USER));
+    const e = await denial(() => requireFleetGrantReach(USER_PRINCIPAL));
     expect(isGrantReachDenied(e)).toBe(true);
-  });
-
-  test("refuses fleet-wide dispatch without the boolean", async () => {
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
-    expect(isGrantReachDenied(await denial(() => requireFleetGrantReach(USER)))).toBe(true);
   });
 });

--- a/apps/hub/tests/integration/grants.test.ts
+++ b/apps/hub/tests/integration/grants.test.ts
@@ -3,6 +3,7 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { getGrant, setGrant, deleteGrant, listGrants, grantAllowsPrincipal, NO_GRANT } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 
 /**
  * Grants as data — the source of authority replacing `CONTROL_PAIR_GRANTS`.
@@ -13,19 +14,31 @@ import { getGrant, setGrant, deleteGrant, listGrants, grantAllowsPrincipal, NO_G
  * the move, and that the dangerous readings are all refused.
  */
 
-const ALICE = "test-user-grants-alice";
-const BOB = "test-user-grants-bob";
+const ALICE_USER = "test-user-grants-alice";
+const BOB_USER = "test-user-grants-bob";
+
+/**
+ * `principal_grants.principal_id` is a foreign key onto `principals.id` now,
+ * not a raw Better Auth user id — every row this suite writes has to be keyed
+ * by a real principal, the same as the store's own writer.
+ */
+let ALICE: string;
+let BOB: string;
 
 beforeAll(async () => {
   await ensurePgMigrations();
-  await createTestUser({ id: ALICE, email: "grants-alice@example.com", name: "Alice" });
-  await createTestUser({ id: BOB, email: "grants-bob@example.com", name: "Bob" });
+  await createTestUser({ id: ALICE_USER, email: "grants-alice@example.com", name: "Alice" });
+  await createTestUser({ id: BOB_USER, email: "grants-bob@example.com", name: "Bob" });
+  await rawSql`DELETE FROM principals WHERE handle IN ('grants-it-alice', 'grants-it-bob')`;
+  ALICE = await createPrincipal({ kind: "human", handle: "grants-it-alice", userId: ALICE_USER });
+  BOB = await createPrincipal({ kind: "human", handle: "grants-it-bob", userId: BOB_USER });
 });
 
 afterAll(async () => {
   try {
     await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${ALICE}, ${BOB})`;
-    await rawSql`DELETE FROM "user" WHERE id IN (${ALICE}, ${BOB})`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('grants-it-alice', 'grants-it-bob')`;
+    await rawSql`DELETE FROM "user" WHERE id IN (${ALICE_USER}, ${BOB_USER})`;
   } catch {
     // cleanup only
   }

--- a/apps/hub/tests/integration/grants.test.ts
+++ b/apps/hub/tests/integration/grants.test.ts
@@ -2,15 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
-import {
-  getGrant,
-  setGrant,
-  deleteGrant,
-  listGrants,
-  grantAllowsStation,
-  patternMatchesStation,
-  NO_GRANT,
-} from "../../src/services/grants";
+import { getGrant, setGrant, deleteGrant, listGrants, grantAllowsPrincipal, NO_GRANT } from "../../src/services/grants";
 
 /**
  * Grants as data — the source of authority replacing `CONTROL_PAIR_GRANTS`.
@@ -42,19 +34,19 @@ afterAll(async () => {
 describe("the grant store", () => {
   test("a principal with no row has no grant, which is not an unrestricted one", async () => {
     expect(await getGrant(BOB)).toBeNull();
-    expect(grantAllowsStation(null, "hermes:analyst-echo")).toBe(false);
-    expect(grantAllowsStation(NO_GRANT, "hermes:analyst-echo")).toBe(false);
+    expect(grantAllowsPrincipal(null, "prn_0123456789abcdef0123")).toBe(false);
+    expect(grantAllowsPrincipal(NO_GRANT, "prn_0123456789abcdef0123")).toBe(false);
   });
 
   test("round-trips a grant unchanged", async () => {
     await setGrant(ALICE, {
-      mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_7abfe2d7b3c64880"],
+      mayDispatch: ["prn_0123456789abcdef0123", "prn_ffffffffffffffffffff"],
       mayGrantReach: true,
     });
 
     const grant = await getGrant(ALICE);
     expect(grant).toEqual({
-      mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_7abfe2d7b3c64880"],
+      mayDispatch: ["prn_0123456789abcdef0123", "prn_ffffffffffffffffffff"],
       mayGrantReach: true,
     });
   });
@@ -63,10 +55,10 @@ describe("the grant store", () => {
     // One principal, one grant. Two rows would be two answers to a question that
     // must have one, and "which row wins" is not a question an authorization
     // check should ever ask.
-    await setGrant(ALICE, { mayDispatch: ["agentpod:hermes:analyst-echo"], mayGrantReach: false });
+    await setGrant(ALICE, { mayDispatch: ["prn_0123456789abcdef0123"], mayGrantReach: false });
 
     const grant = await getGrant(ALICE);
-    expect(grant!.mayDispatch).toEqual(["agentpod:hermes:analyst-echo"]);
+    expect(grant!.mayDispatch).toEqual(["prn_0123456789abcdef0123"]);
     expect(grant!.mayGrantReach).toBe(false);
 
     const all = await listGrants();
@@ -75,13 +67,13 @@ describe("the grant store", () => {
 
   test("refuses a grant missing half the pair", async () => {
     await expect(
-      setGrant(BOB, { mayDispatch: ["agentpod:hermes:*"] } as never)
+      setGrant(BOB, { mayDispatch: ["prn_0123456789abcdef0123"] } as never)
     ).rejects.toThrow(/both halves/i);
   });
 
   test("refuses a mayDispatch that is not an array of strings", async () => {
     await expect(
-      setGrant(BOB, { mayDispatch: "agentpod:hermes:*" as never, mayGrantReach: false })
+      setGrant(BOB, { mayDispatch: "prn_0123456789abcdef0123" as never, mayGrantReach: false })
     ).rejects.toThrow(/array/i);
   });
 
@@ -106,57 +98,6 @@ describe("the grant store", () => {
   });
 });
 
-describe("a grant names a node and a station", () => {
-  const on = (nodeName: string, stationKey: string) => ({ nodeName, stationKey });
-
-  test("matches an exact node and station", () => {
-    expect(patternMatchesStation("agentpod:molt-bot/hermes:analyst-echo", on("molt-bot", "hermes:analyst-echo"))).toBe(true);
-    expect(patternMatchesStation("agentpod:molt-bot/hermes:analyst-echo", on("superchotu", "hermes:analyst-echo"))).toBe(false);
-  });
-
-  test("distinguishes the same station key on different nodes", () => {
-    // The defect that produced this shape. `opencode:c52ddf65` exists on two
-    // nodes in production; a grant for one must not authorise the other, which
-    // is a different host with different credentials and a different workspace.
-    const pattern = "agentpod:9247e5a88cfa/opencode:c52ddf65";
-    expect(patternMatchesStation(pattern, on("9247e5a88cfa", "opencode:c52ddf65"))).toBe(true);
-    expect(patternMatchesStation(pattern, on("cloudchamber", "opencode:c52ddf65"))).toBe(false);
-  });
-
-  test("a node wildcard means every node, said out loud", () => {
-    // Fleet-wide permission is still expressible — it just has to be written
-    // rather than obtained by accident, which is what the old two-part form gave.
-    expect(patternMatchesStation("agentpod:*/hermes:*", on("molt-bot", "hermes:x"))).toBe(true);
-    expect(patternMatchesStation("agentpod:*/hermes:*", on("superchotu", "hermes:y"))).toBe(true);
-    expect(patternMatchesStation("agentpod:*/hermes:*", on("molt-bot", "openclaw:z"))).toBe(false);
-  });
-
-  test("a station wildcard is scoped to its node", () => {
-    expect(patternMatchesStation("agentpod:molt-bot/hermes:*", on("molt-bot", "hermes:anything"))).toBe(true);
-    expect(patternMatchesStation("agentpod:molt-bot/hermes:*", on("superchotu", "hermes:anything"))).toBe(false);
-  });
-
-  test("a station wildcard still does not cross the colon", () => {
-    expect(patternMatchesStation("agentpod:molt-bot/hermes:*", on("molt-bot", "openclaw:x"))).toBe(false);
-  });
-
-  test("the retired two-part form matches nothing", () => {
-    // `agentpod:hermes:*` cannot say which node it meant. Reading it as "any
-    // node" is precisely the over-grant this shape removes, so it is refused
-    // rather than generously interpreted.
-    expect(patternMatchesStation("agentpod:hermes:*", on("molt-bot", "hermes:x"))).toBe(false);
-    expect(patternMatchesStation("agentpod:hermes:analyst-echo", on("molt-bot", "hermes:analyst-echo"))).toBe(false);
-  });
-
-  test("ignores another plane's namespace rather than denying on it", () => {
-    expect(patternMatchesStation("kaambaan:agt_x", on("molt-bot", "hermes:x"))).toBe(false);
-    expect(patternMatchesStation("org-plane:agent:xyz", on("molt-bot", "hermes:x"))).toBe(false);
-    expect(
-      grantAllowsStation({ mayDispatch: ["kaambaan:agt_x"], mayGrantReach: false }, on("molt-bot", "hermes:x"))
-    ).toBe(false);
-  });
-
-  test("an unnamespaced value matches nothing", () => {
-    expect(patternMatchesStation("molt-bot/hermes:*", on("molt-bot", "hermes:x"))).toBe(false);
-  });
-});
+// The matcher itself — equality, no patterns, no namespace — is pure logic
+// with no database dependency, so its tests live beside it in
+// `src/services/grants.test.ts` rather than here among the DB-bound ones.

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -210,7 +210,9 @@ describe("an inbound room message", () => {
 
     expect(attached).toHaveLength(1);
     expect(attached[0]!.roomId).toBe(ROOM);
-    expect(attached[0]!.agentUser).toBe("@agent_inbound-box_openclaw-krishna:id.agentpod.dev");
+    // Built from the occupying agent's principal handle now, not from where
+    // the station runs.
+    expect(attached[0]!.agentUser).toBe("@agent_mx-inbound-it-agent:id.agentpod.dev");
     expect(attached[0]!.sessionId).toBe(prompts[0]!.sessionId);
   });
 

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -4,6 +4,7 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant, deleteGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { handleRoomMessage } from "../../src/services/matrix-as/inbound";
 import {
   clearPendingPermission,
@@ -33,6 +34,13 @@ const ROOM = "!inbound:id.agentpod.dev";
 const DOMAIN = "id.agentpod.dev";
 const OWNER_MXID = "@owner-inbound:id.agentpod.dev";
 const OTHER_MXID = "@other-inbound:id.agentpod.dev";
+
+let OWNER_PRINCIPAL: string;
+let OTHER_PRINCIPAL: string;
+/** The agent occupying STATION — the matcher compares a grant against this now. */
+let AGENT_PRINCIPAL: string;
+/** Some other agent, granted where a test wants to prove the scope check is real. */
+const OTHER_AGENT = "prn_ffffffffffffffffffff";
 
 let sent: Array<{ roomId: string; body: string }> = [];
 let created: Array<{ stationId: string; userId: string }> = [];
@@ -125,13 +133,19 @@ beforeAll(async () => {
   await rawSql`
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${OWNER}, 'inbound-box', 'inbound-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
-  await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
-    VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
-            '["acp"]'::jsonb, now(), now())`;
+  OWNER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "mx-inbound-it-owner", userId: OWNER });
+  OTHER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "mx-inbound-it-other", userId: OTHER });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "mx-inbound-it-agent" });
 
-  // Both principals are known to this hub by their Matrix ids.
-  for (const [p, mxid] of [[OWNER, OWNER_MXID], [OTHER, OTHER_MXID]] as const) {
+  await rawSql`
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
+    VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
+            '["acp"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
+
+  // Both principals are known to this hub by their Matrix ids. Keyed by the
+  // real principal id now — `principal_identities.principal_id` is a foreign
+  // key onto `principals.id`, not the Better Auth user id.
+  for (const [p, mxid] of [[OWNER_PRINCIPAL, OWNER_MXID], [OTHER_PRINCIPAL, OTHER_MXID]] as const) {
     await rawSql`DELETE FROM principal_identities WHERE principal_id = ${p}`;
     await rawSql`
       INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
@@ -164,9 +178,10 @@ afterAll(async () => {
   try {
     await rawSql`DELETE FROM acp_sessions WHERE id LIKE 'acps_mx_inbound_%'`;
     await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
-    await rawSql`DELETE FROM principal_identities WHERE principal_id IN (${OWNER}, ${OTHER})`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${OWNER}, ${OTHER})`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id IN (${OWNER_PRINCIPAL}, ${OTHER_PRINCIPAL})`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id IN (${OWNER_PRINCIPAL}, ${OTHER_PRINCIPAL})`;
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('mx-inbound-it-owner', 'mx-inbound-it-other', 'mx-inbound-it-agent')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id IN (${OWNER}, ${OTHER})`;
   } catch {
@@ -176,7 +191,7 @@ afterAll(async () => {
 
 describe("an inbound room message", () => {
   test("prompts the station when the sender's grant covers it", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
 
@@ -189,7 +204,7 @@ describe("an inbound room message", () => {
     // The gap that live verification found: a session was created and prompted
     // and the agent answered into a stream nobody was listening to. Both halves
     // had tests; the joint did not.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
 
@@ -203,7 +218,7 @@ describe("an inbound room message", () => {
     // Attachments live in memory. After a hub restart the session row survives
     // and the listener does not, so a room whose session predates the restart
     // would go permanently quiet.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "first"), deps());
     await handleRoomMessage(message(OWNER_MXID, "second"), deps());
@@ -213,7 +228,7 @@ describe("an inbound room message", () => {
   });
 
   test("does not attach when the message was refused", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
 
@@ -223,7 +238,7 @@ describe("an inbound room message", () => {
   test("refuses IN THE ROOM when the grant does not cover this station", async () => {
     // Silence would read as a broken agent and send the operator to the console,
     // the node and the harness — everywhere except the grant.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
 
@@ -235,11 +250,11 @@ describe("an inbound room message", () => {
   test("checks every message, not only the one that opened the session", async () => {
     // A room is shared. Without a per-message check, the first permitted person
     // to speak would open a session that everyone else in the room could drive.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     await handleRoomMessage(message(OWNER_MXID, "first"), deps());
     expect(prompts).toHaveLength(1);
 
-    await deleteGrant(OTHER);
+    await deleteGrant(OTHER_PRINCIPAL);
     await handleRoomMessage(message(OTHER_MXID, "and me"), deps());
 
     expect(prompts).toHaveLength(1);
@@ -256,7 +271,7 @@ describe("an inbound room message", () => {
   test("reuses the room's session instead of starting one per message", async () => {
     // A conversation is a conversation. One session per message would throw away
     // the agent's context between two consecutive sentences.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "first"), deps());
     await handleRoomMessage(message(OWNER_MXID, "second"), deps());
@@ -270,7 +285,7 @@ describe("an inbound room message", () => {
     // this the room keeps prompting a corpse and every bridged room dies
     // permanently at the first restart — the agent simply stops answering, with
     // 'Session not found or not active' as the only clue.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     await handleRoomMessage(message(OWNER_MXID, "first"), deps());
     const dead = prompts[0]!.sessionId;
 
@@ -284,7 +299,7 @@ describe("an inbound room message", () => {
   });
 
   test("says so when the station cannot be reached, rather than swallowing it", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     createFails = new Error("node offline");
 
     await handleRoomMessage(message(OWNER_MXID, "hi"), deps());
@@ -305,7 +320,7 @@ describe("an inbound room message", () => {
   test("stays out of a harness-mode station's room entirely", async () => {
     // That station answers for itself. Two answerers on one address is the
     // failure the mode exists to prevent.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     await rawSql`UPDATE stations SET matrix_identity_mode = 'harness' WHERE id = ${STATION}`;
 
     await handleRoomMessage(message(OWNER_MXID, "hi"), deps());
@@ -315,7 +330,7 @@ describe("an inbound room message", () => {
   });
 
   test("ignores anything that is not a text message", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(
       { type: "m.room.member", sender: OWNER_MXID, room_id: ROOM, content: { membership: "join" } },
@@ -327,7 +342,7 @@ describe("an inbound room message", () => {
   });
 
   test("ignores an empty message rather than prompting with nothing", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "   "), deps());
 
@@ -337,7 +352,7 @@ describe("an inbound room message", () => {
   test("passes the message through unchanged, including its exact text", async () => {
     // The prompt is the user's words. Trimming, prefixing or decorating them
     // would put the bridge's voice into the agent's input.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "deploy  the thing\nnow"), deps());
 
@@ -347,11 +362,11 @@ describe("an inbound room message", () => {
   test("prompts as the principal who sent it, not as the station's owner", async () => {
     // The ACP session belongs to whoever is talking, so the transcript and the
     // control pair both attribute the turn correctly.
-    await setGrant(OTHER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OTHER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OTHER_MXID, "hello"), deps());
 
-    expect(created[0]!.userId).toBe(OTHER);
+    expect(created[0]!.userId).toBe(OTHER_PRINCIPAL);
   });
 });
 
@@ -368,20 +383,20 @@ describe("answering a permission request from the room", () => {
     // While a permission is pending the session is PARKED — it cannot take a
     // prompt. Treating the answer as a message would lose the answer and fail
     // the prompt in the same breath.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     parkOn();
 
     await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
 
     expect(answered).toEqual([
-      { userId: OWNER, sessionId: "acps_parked", requestSeq: 7, optionId: "allow_once" },
+      { userId: OWNER_PRINCIPAL, sessionId: "acps_parked", requestSeq: 7, optionId: "allow_once" },
     ]);
     expect(created).toHaveLength(0);
     expect(prompts).toHaveLength(0);
   });
 
   test("the option's name answers it too", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     parkOn();
 
     await handleRoomMessage(message(OWNER_MXID, "Reject"), depsWithPermissions());
@@ -393,7 +408,7 @@ describe("answering a permission request from the room", () => {
     // "yes" against options named "Allow once" and "Allow always" does not say
     // which. Resolving it to the nearest-looking one is the failure this must
     // never have.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     parkOn();
 
     await handleRoomMessage(message(OWNER_MXID, "yes go ahead"), depsWithPermissions());
@@ -406,7 +421,7 @@ describe("answering a permission request from the room", () => {
 
   test("someone who may not dispatch the agent may not approve for it either", async () => {
     // Approving an action IS dispatching the agent, by another name.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:other/*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: false });
     parkOn();
 
     await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
@@ -418,7 +433,7 @@ describe("answering a permission request from the room", () => {
   test("a refused answer leaves the question standing", async () => {
     // A cleared question plus a failed answer would park the agent forever
     // with nothing able to release it.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
     parkOn();
     answerFails = new Error("No pending permission request.");
 
@@ -429,7 +444,7 @@ describe("answering a permission request from the room", () => {
   });
 
   test("an ordinary message is still an ordinary message when nothing is pending", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
 

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -56,6 +56,21 @@ let avatars: Array<{ userId: string; mxcUrl: string }> = [];
 let faces: Record<string, string> = {};
 let workspaceFiles: Record<string, { bytes: Uint8Array; contentType: string } | null> = {};
 
+/**
+ * The homeserver's own alias directory — what makes this fake capable of
+ * producing M_ROOM_IN_USE at all. A fake that mints a fresh room id on
+ * every `ensureRoom` call, whatever the alias, can never fail the way the
+ * real homeserver does when a caller creates a room under an alias that is
+ * already taken — which is exactly the shape of bug (fix round 3) that let
+ * a station-derived alias silently swallow a new occupant's room for two
+ * rounds running.
+ */
+let roomsByAlias = new Map<string, { roomId: string; members: Set<string> }>();
+/** Aliases this fake has reassigned away from the room that first held them —
+ *  the "reclaim" branch `client.ts` takes when the new creator was never a
+ *  member of the room already sitting at that alias. */
+let reclaimedAliases: string[] = [];
+
 function deps() {
   return {
     domain: DOMAIN,
@@ -68,7 +83,29 @@ function deps() {
         opts: { creator: string; name: string; topic: string; invite?: string; isDirect?: boolean }
       ) => {
         rooms.push({ alias, ...opts } as any);
-        return `!room${++roomCounter}:id.agentpod.dev`;
+
+        const existing = roomsByAlias.get(alias);
+        if (existing) {
+          // M_ROOM_IN_USE, real client.ts's own two branches:
+          if (existing.members.has(opts.creator)) {
+            // Already in that room — the ordinary restart. That room IS
+            // the answer.
+            return existing.roomId;
+          }
+          // Not a member — reclaim: the alias moves to a FRESH room as
+          // this creator, and the room it used to point at loses it. This
+          // is the consequence a principal-derived alias must make
+          // unreachable for an occupant change, not something to paper
+          // over in the fake.
+          reclaimedAliases.push(alias);
+          const roomId = `!room${++roomCounter}:id.agentpod.dev`;
+          roomsByAlias.set(alias, { roomId, members: new Set([opts.creator]) });
+          return roomId;
+        }
+
+        const roomId = `!room${++roomCounter}:id.agentpod.dev`;
+        roomsByAlias.set(alias, { roomId, members: new Set([opts.creator]) });
+        return roomId;
       },
       invite: async (_asUserId: string, roomId: string, invitee: string) => {
         invites.push({ roomId, invitee });
@@ -145,6 +182,8 @@ beforeEach(async () => {
   avatars = [];
   faces = {};
   workspaceFiles = {};
+  roomsByAlias = new Map();
+  reclaimedAliases = [];
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
   await rawSql`
     UPDATE stations SET bridge_matrix_id = NULL, matrix_identity_mode = 'bridge', matrix_id = NULL
@@ -173,7 +212,10 @@ describe("provisioning a station", () => {
     expect(registered[0]!.localpart).toBe(`agent_${KRISHNA_HANDLE}`);
     // The display name carries the readability a derived mxid does not have.
     expect(registered[0]!.displayName).toBe("krishna (openclaw @ prov-box)");
-    expect(rooms[0]!.alias).toBe("#agentpod_prov-box_openclaw-krishna:id.agentpod.dev");
+    // Occupant-derived, fix round 3 — the SAME localpart as the mxid above,
+    // not the station-keyed form: a room's address must not collide with a
+    // predecessor's if this occupant is ever replaced.
+    expect(rooms[0]!.alias).toBe(`#agentpod_agent_${KRISHNA_HANDLE}:id.agentpod.dev`);
   });
 
   test("records the room, with the tenant it belongs to", async () => {
@@ -182,7 +224,7 @@ describe("provisioning a station", () => {
     const row = await roomRow(OPENCLAW);
     expect(row!.room_id).toMatch(/^!room/);
     expect(row!.tenant_id).toBeTruthy();
-    expect(row!.alias).toBe("#agentpod_prov-box_openclaw-krishna:id.agentpod.dev");
+    expect(row!.alias).toBe(`#agentpod_agent_${KRISHNA_HANDLE}:id.agentpod.dev`);
   });
 
   test("records the identity it minted, without touching the harness column", async () => {
@@ -507,6 +549,22 @@ describe("occupancy changes — a new occupant must actually get a room", () => 
       SELECT principal_id FROM matrix_rooms WHERE room_id = ${krishnaRoom!.room_id}`;
     expect(krishnaRoomAfter!.principal_id).toBe(KRISHNA_PRINCIPAL);
 
+    // Fix round 3: the alias, not only the DB row, must not collide.
+    // `rooms[0]!.alias` is what THIS call asked the homeserver to create at
+    // — if it were still `bridgeAlias(nodeName, stationKey)`, it would be
+    // IDENTICAL to krishna's own room's alias, and the fake's alias
+    // directory (modelling real M_ROOM_IN_USE handling) would have taken
+    // the "not a member, reclaim" branch: deleting krishna's alias off his
+    // still-live room. It must not have.
+    expect(reclaimedAliases, "no alias was ever stolen from krishna's live room").toEqual([]);
+    expect(rooms[0]!.alias, "occupant-derived, not station-derived").toBe(
+      "#agentpod_agent_mx-provision-successor:id.agentpod.dev"
+    );
+    const [krishnaRoomRow] = await rawSql`SELECT alias FROM matrix_rooms WHERE room_id = ${krishnaRoom!.room_id}`;
+    expect(krishnaRoomRow!.alias, "krishna's own alias is unchanged").toBe(
+      "#agentpod_agent_mx-provision-krishna:id.agentpod.dev"
+    );
+
     // Station A now genuinely carries two rooms — the ordinary case since
     // fix round 1 dropped uniqueness from `matrix_rooms_station_idx`.
     const stationRooms = await rawSql`
@@ -515,6 +573,46 @@ describe("occupancy changes — a new occupant must actually get a room", () => 
 
     // Restore for any test after this one in the file.
     await rawSql`UPDATE stations SET principal_id = ${KRISHNA_PRINCIPAL} WHERE id = ${OPENCLAW}`;
+    await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${successorRoom!.room_id}`;
+  });
+
+  test("harness mode: a new occupant still gets its OWN room — the speaker never changes with occupancy, so only the alias fix keeps this from silently reusing the departed occupant's room", async () => {
+    // Harness mode's speaker is the station's own fixed identity
+    // (`s.harnessMxid`), identical before and after this reassignment — so
+    // this test isolates the alias as the ONLY thing standing between "a
+    // new room" and "M_ROOM_IN_USE answered by the SAME already-joined
+    // creator", which is precisely the harness-mode failure fix round 3
+    // closes: silent, with no error anywhere, because the fake homeserver's
+    // answer is a 200 naming a room that already exists.
+    await rawSql`
+      UPDATE stations SET matrix_identity_mode = 'harness', matrix_id = '@analyst-echo:id.agentpod.dev'
+      WHERE id = ${HERMES}`;
+
+    await provisionStation(HERMES, deps());
+    const [echoRoom] = await rawSql`
+      SELECT room_id, principal_id FROM matrix_rooms WHERE station_id = ${HERMES} AND principal_id = ${ECHO_PRINCIPAL}`;
+    expect(echoRoom).toBeTruthy();
+
+    await rawSql`UPDATE stations SET principal_id = ${SUCCESSOR_PRINCIPAL} WHERE id = ${HERMES}`;
+    rooms = [];
+
+    await provisionStation(HERMES, deps());
+
+    const [successorRoom] = await rawSql`
+      SELECT room_id, principal_id FROM matrix_rooms WHERE station_id = ${HERMES} AND principal_id = ${SUCCESSOR_PRINCIPAL}`;
+    expect(successorRoom, "the new occupant has its OWN bound room — not silently none at all").toBeTruthy();
+    expect(successorRoom!.room_id).not.toBe(echoRoom!.room_id);
+
+    const [echoRoomAfter] = await rawSql`
+      SELECT principal_id, alias FROM matrix_rooms WHERE room_id = ${echoRoom!.room_id}`;
+    expect(echoRoomAfter!.principal_id, "echo's own room is untouched").toBe(ECHO_PRINCIPAL);
+    expect(echoRoomAfter!.alias, "echo's own alias is unchanged").toBe(
+      `#agentpod_agent_${ECHO_HANDLE}:id.agentpod.dev`
+    );
+    expect(rooms[0]!.alias).toBe("#agentpod_agent_mx-provision-successor:id.agentpod.dev");
+
+    // Restore.
+    await rawSql`UPDATE stations SET principal_id = ${ECHO_PRINCIPAL} WHERE id = ${HERMES}`;
     await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${successorRoom!.room_id}`;
   });
 

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -440,3 +440,120 @@ describe("an agent that has not got its face yet", () => {
     expect(avatars).toHaveLength(1);
   });
 });
+
+describe("occupancy changes — a new occupant must actually get a room", () => {
+  // Fix round 2 on Task 5. A review traced the bug end to end: assigning a
+  // new occupant to a station whose room already belongs to a departed one
+  // leaves the new occupant unbound (the bind-on-assign write requires
+  // `principal_id IS NULL`, and the departed occupant's row is not null).
+  // `context()`'s old `leftJoin(matrixRooms, stationId)` — no `ORDER BY`, a
+  // single `[row]` — then answered `roomId: <the departed occupant's room>`
+  // for the STATION, so `provisionStation` believed a room already existed
+  // and never created one. Round 1 fixed the SYMPTOM (gates no longer post
+  // into that stranger's room); this closes the CAUSE — a room is actually
+  // provisioned for the new occupant.
+  //
+  // Driven through the REAL `provisionStation`, against a fake Matrix
+  // client — nothing here hand-inserts a `matrix_rooms` row for the new
+  // occupant. If `context()` regressed to the old join, `rooms` below would
+  // stay empty and this would fail.
+
+  let SUCCESSOR_PRINCIPAL: string;
+
+  beforeAll(async () => {
+    SUCCESSOR_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "mx-provision-successor" });
+  });
+
+  afterAll(async () => {
+    try {
+      await rawSql`DELETE FROM principals WHERE handle = 'mx-provision-successor'`;
+    } catch {
+      // cleanup only
+    }
+  });
+
+  test("a new occupant with no room of its own gets ONE actually provisioned — never a departed occupant's", async () => {
+    // krishna occupies OPENCLAW first, provisioned as always.
+    await provisionStation(OPENCLAW, deps());
+    const [krishnaRoom] = await rawSql`
+      SELECT room_id, principal_id FROM matrix_rooms WHERE station_id = ${OPENCLAW} AND principal_id = ${KRISHNA_PRINCIPAL}`;
+    expect(krishnaRoom).toBeTruthy();
+
+    // krishna moves on. Occupancy is exclusive as of fix round 1 — this
+    // single write is exactly what `agents-admin.ts`'s assign-is-a-move
+    // does to `stations.principal_id`; `matrix_rooms` is untouched by it,
+    // same as the real endpoint (its own bind-on-assign finds no unbound
+    // room here to bind).
+    await rawSql`UPDATE stations SET principal_id = ${SUCCESSOR_PRINCIPAL} WHERE id = ${OPENCLAW}`;
+
+    registered = [];
+    rooms = [];
+
+    // THE REAL PROVISIONING PATH.
+    await provisionStation(OPENCLAW, deps());
+
+    // A room was actually created — not silently skipped because a bare
+    // `leftJoin(stationId)` still saw krishna's old room sitting here.
+    expect(rooms).toHaveLength(1);
+    expect(registered.at(-1)!.localpart).toBe("agent_mx-provision-successor");
+
+    const [successorRoom] = await rawSql`
+      SELECT room_id, principal_id FROM matrix_rooms WHERE station_id = ${OPENCLAW} AND principal_id = ${SUCCESSOR_PRINCIPAL}`;
+    expect(successorRoom, "the new occupant has its OWN bound room").toBeTruthy();
+    expect(successorRoom!.room_id).not.toBe(krishnaRoom!.room_id);
+
+    // krishna's own room is untouched — still exists, still bound to krishna.
+    const [krishnaRoomAfter] = await rawSql`
+      SELECT principal_id FROM matrix_rooms WHERE room_id = ${krishnaRoom!.room_id}`;
+    expect(krishnaRoomAfter!.principal_id).toBe(KRISHNA_PRINCIPAL);
+
+    // Station A now genuinely carries two rooms — the ordinary case since
+    // fix round 1 dropped uniqueness from `matrix_rooms_station_idx`.
+    const stationRooms = await rawSql`
+      SELECT room_id FROM matrix_rooms WHERE station_id = ${OPENCLAW}`;
+    expect(stationRooms.length).toBe(2);
+
+    // Restore for any test after this one in the file.
+    await rawSql`UPDATE stations SET principal_id = ${KRISHNA_PRINCIPAL} WHERE id = ${OPENCLAW}`;
+    await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${successorRoom!.room_id}`;
+  });
+
+  test("re-filing under a space re-files the CURRENT occupant's room, never a departed occupant's", async () => {
+    // `fileByNode` (provision.ts) re-reads the room to hang it under a
+    // space — the second call site the same review found making the
+    // identical unordered-join mistake. Exercised here via a client that
+    // implements the space methods; `provisionStation` calls it on every
+    // run.
+    await provisionStation(OPENCLAW, deps());
+    const [krishnaRoom] = await rawSql`
+      SELECT room_id FROM matrix_rooms WHERE station_id = ${OPENCLAW} AND principal_id = ${KRISHNA_PRINCIPAL}`;
+
+    await rawSql`UPDATE stations SET principal_id = ${SUCCESSOR_PRINCIPAL} WHERE id = ${OPENCLAW}`;
+
+    const filed: Array<{ roomId: string; spaceRoomId: string }> = [];
+    const d = deps();
+    const spaceClient = {
+      ...d.client,
+      createSpace: async (_opts: { creator: string; name: string }) => `!space${++roomCounter}:id.agentpod.dev`,
+      addSpaceChild: async (_creator: string, spaceRoomId: string, childRoomId: string) => {
+        filed.push({ roomId: childRoomId, spaceRoomId });
+      },
+      removeSpaceChild: async () => {},
+    };
+
+    await provisionStation(OPENCLAW, { ...d, client: spaceClient });
+
+    const [successorRoom] = await rawSql`
+      SELECT room_id FROM matrix_rooms WHERE station_id = ${OPENCLAW} AND principal_id = ${SUCCESSOR_PRINCIPAL}`;
+    expect(successorRoom).toBeTruthy();
+
+    // Filed the NEW occupant's room — never krishna's, which stays put and
+    // unfiled by this run.
+    expect(filed.some((f) => f.roomId === successorRoom!.room_id)).toBe(true);
+    expect(filed.some((f) => f.roomId === krishnaRoom!.room_id)).toBe(false);
+
+    // Restore for any test after this one in the file.
+    await rawSql`UPDATE stations SET principal_id = ${KRISHNA_PRINCIPAL} WHERE id = ${OPENCLAW}`;
+    await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${successorRoom!.room_id}`;
+  });
+});

--- a/apps/hub/tests/integration/matrix-as-provision.test.ts
+++ b/apps/hub/tests/integration/matrix-as-provision.test.ts
@@ -3,6 +3,7 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
+import { createPrincipal } from "../../src/services/principals";
 import { provisionStation, provisionAll } from "../../src/services/matrix-as/provision";
 
 /**
@@ -19,6 +20,24 @@ const OPENCLAW = "station_mx_provision_openclaw";
 const HERMES = "station_mx_provision_hermes";
 const DOMAIN = "id.agentpod.dev";
 const OWNER_MXID = "@owner-provision:id.agentpod.dev";
+
+/**
+ * The handles the two agents are addressed by.
+ *
+ * An agent's mxid comes from its principal's immutable handle now, not from
+ * `(nodeName, stationKey)` — so these, and not the station keys, are what the
+ * expected localparts below are built from. The room ALIAS still names the
+ * node and the station, because a room is where work happens and the agent
+ * that happens to be in it can move.
+ */
+const KRISHNA_HANDLE = "mx-provision-krishna";
+const ECHO_HANDLE = "mx-provision-analyst-echo";
+const KRISHNA_MXID = `@agent_${KRISHNA_HANDLE}:${DOMAIN}`;
+
+/** The human's own principal, which is what a `prn_`-keyed identity hangs off. */
+let OWNER_PRINCIPAL: string;
+let KRISHNA_PRINCIPAL: string;
+let ECHO_PRINCIPAL: string;
 
 let registered: Array<{ localpart: string; displayName: string }> = [];
 let rooms: Array<{
@@ -84,6 +103,13 @@ async function stationRow(id: string) {
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: OWNER, email: "mx-provision@example.com", name: "Owner" });
+  OWNER_PRINCIPAL = await createPrincipal({
+    kind: "human",
+    handle: "mx-provision-owner",
+    userId: OWNER,
+  });
+  KRISHNA_PRINCIPAL = await createPrincipal({ kind: "agent", handle: KRISHNA_HANDLE });
+  ECHO_PRINCIPAL = await createPrincipal({ kind: "agent", handle: ECHO_HANDLE });
   const tenant = await resolveTenantForUser(OWNER);
 
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
@@ -93,18 +119,22 @@ beforeAll(async () => {
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${OWNER}, 'prov-box', 'prov-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${OPENCLAW}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
-            '["acp"]'::jsonb, now(), now())`;
+            '["acp"]'::jsonb, ${KRISHNA_PRINCIPAL}, now(), now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${HERMES}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:analyst-echo', 'leaf', 'analyst-echo',
-            '["acp"]'::jsonb, now(), now())`;
+            '["acp"]'::jsonb, ${ECHO_PRINCIPAL}, now(), now())`;
 
-  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+  // The owner's Matrix identity hangs off the owner's PRINCIPAL, which is what
+  // `principal_identities.principal_id` is a foreign key to. Keyed by the
+  // Better Auth id — as this fixture used to be — it is an FK violation, and
+  // before the FK existed it was a row nothing could ever find.
+  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER_PRINCIPAL} AND system = 'matrix'`;
   await rawSql`
     INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
-    VALUES ('pid_mx_provision', ${OWNER}, 'matrix', ${OWNER_MXID}, now())`;
+    VALUES ('pid_mx_provision', ${OWNER_PRINCIPAL}, 'matrix', ${OWNER_MXID}, now())`;
 });
 
 beforeEach(async () => {
@@ -124,9 +154,11 @@ beforeEach(async () => {
 afterAll(async () => {
   try {
     await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${OPENCLAW}, ${HERMES})`;
-    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
     await rawSql`DELETE FROM stations WHERE id IN (${OPENCLAW}, ${HERMES})`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`
+      DELETE FROM principals
+      WHERE handle IN ('mx-provision-owner', ${KRISHNA_HANDLE}, ${ECHO_HANDLE})`;
     await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
   } catch {
     // cleanup only
@@ -138,7 +170,7 @@ describe("provisioning a station", () => {
     await provisionStation(OPENCLAW, deps());
 
     expect(registered).toHaveLength(1);
-    expect(registered[0]!.localpart).toBe("agent_prov-box_openclaw-krishna");
+    expect(registered[0]!.localpart).toBe(`agent_${KRISHNA_HANDLE}`);
     // The display name carries the readability a derived mxid does not have.
     expect(registered[0]!.displayName).toBe("krishna (openclaw @ prov-box)");
     expect(rooms[0]!.alias).toBe("#agentpod_prov-box_openclaw-krishna:id.agentpod.dev");
@@ -157,7 +189,7 @@ describe("provisioning a station", () => {
     await provisionStation(OPENCLAW, deps());
 
     const row = await stationRow(OPENCLAW);
-    expect(row.bridge_matrix_id).toBe("@agent_prov-box_openclaw-krishna:id.agentpod.dev");
+    expect(row.bridge_matrix_id).toBe(KRISHNA_MXID);
     expect(row.matrix_id).toBeNull();
     expect(row.matrix_identity_mode).toBe("bridge");
   });
@@ -167,6 +199,13 @@ describe("provisioning a station", () => {
 
     // Invited at creation rather than afterwards: the flag that makes this a DM
     // rides on the invite's member event, and can only be set there.
+    //
+    // This is the assertion that catches the two-id-space bug. `stations.userId`
+    // is a Better Auth id and the owner's mxid hangs off their PRINCIPAL, so a
+    // lookup keyed on the user id finds nothing — for every station in the
+    // fleet, not just an unmapped one — and the only symptom is that
+    // `ensureRoom` quietly drops `invite` and `isDirect` and reports success.
+    // `provisionAll` runs at boot, so that was the fleet's whole Matrix surface.
     expect(rooms[0]!.invite).toBe(OWNER_MXID);
   });
 
@@ -186,7 +225,7 @@ describe("provisioning a station", () => {
   test("a station whose owner has no Matrix identity gets a room, not a DM", async () => {
     // Nobody to be direct WITH. The room still exists so the agent has somewhere
     // to be, and somebody can be invited later.
-    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER_PRINCIPAL} AND system = 'matrix'`;
 
     await provisionStation(OPENCLAW, deps());
 
@@ -195,7 +234,25 @@ describe("provisioning a station", () => {
 
     await rawSql`
       INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
-      VALUES ('pid_mx_provision', ${OWNER}, 'matrix', ${OWNER_MXID}, now())`;
+      VALUES ('pid_mx_provision', ${OWNER_PRINCIPAL}, 'matrix', ${OWNER_MXID}, now())`;
+  });
+
+  test("a station whose owner has no principal at all gets a room, not a DM", async () => {
+    // The other half of "no owner to be direct with": an owner who was never
+    // mapped to a principal. Fails the same way and must not fail louder — the
+    // agent still needs somewhere to be.
+    await rawSql`
+      DELETE FROM principal_identities
+      WHERE principal_id = ${OWNER_PRINCIPAL} AND system = 'better-auth'`;
+
+    await provisionStation(OPENCLAW, deps());
+
+    expect(rooms[0]!.isDirect).toBeFalsy();
+    expect(rooms[0]!.invite).toBeUndefined();
+
+    await rawSql`
+      INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
+      VALUES ('pid_mx_prov_ba', ${OWNER_PRINCIPAL}, 'better-auth', ${OWNER}, now())`;
   });
 
   test("provisions a hermes station exactly like every other", async () => {
@@ -203,7 +260,7 @@ describe("provisioning a station", () => {
     // carries the readability its old bespoke address used to.
     await provisionStation(HERMES, deps());
 
-    expect(registered[0]!.localpart).toBe("agent_prov-box_hermes-analyst-echo");
+    expect(registered[0]!.localpart).toBe(`agent_${ECHO_HANDLE}`);
     expect(registered[0]!.displayName).toBe("analyst-echo (hermes @ prov-box)");
   });
 
@@ -313,7 +370,7 @@ describe("an agent's face, if it has one", () => {
 
     expect(uploaded).toHaveLength(1);
     expect(avatars.at(-1)).toMatchObject({
-      userId: "@agent_prov-box_openclaw-krishna:id.agentpod.dev",
+      userId: KRISHNA_MXID,
       mxcUrl: "mxc://id.agentpod.dev/abc123",
     });
   });

--- a/apps/hub/tests/integration/matrix-as-queries.test.ts
+++ b/apps/hub/tests/integration/matrix-as-queries.test.ts
@@ -5,7 +5,12 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { createMatrixAsRoutes } from "../../src/routes/matrix-as";
-import { bridgeUserId, bridgeAlias } from "../../src/services/matrix-as/names";
+import {
+  bridgeUserId,
+  bridgeAlias,
+  bridgeAliasForHandle,
+} from "../../src/services/matrix-as/names";
+import { provisionStationForAlias } from "../../src/services/matrix-as/provision";
 import { createPrincipal } from "../../src/services/principals";
 
 /**
@@ -53,6 +58,7 @@ beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: USER, email: "matrix-queries@example.com", name: "MQ" });
   const tenant = await resolveTenantForUser(USER);
+  await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
   await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
   await rawSql`DELETE FROM principals WHERE handle = 'matrix-queries-it-agent'`;
@@ -68,6 +74,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   try {
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM principals WHERE handle = 'matrix-queries-it-agent'`;
@@ -136,6 +143,109 @@ describe("GET /_matrix/app/v1/rooms/:alias", () => {
     const otherNode = bridgeAlias("some-other-box", "openclaw:krishna", DOMAIN);
     const res = await get(`/rooms/${encodeURIComponent(otherNode)}`);
     expect(res.status).toBe(404);
+  });
+});
+
+/**
+ * The route's own alias resolution, with the REAL provisioning behind it.
+ *
+ * The block above hands the route an `onProvisionAlias` that only records —
+ * fine for asking "was provisioning called", useless for the bug fix round 4
+ * found, which lived in front of it: the route gated on the station-derived
+ * alias shape ALONE and answered `M_NOT_FOUND` before `onProvisionAlias`
+ * (which had been taught both shapes in round 3) ever ran. An occupied
+ * station's room alias is occupant-derived now, so the new branch was
+ * unreachable for precisely the shape it was added for, and a homeserver
+ * asking about an agent's alias for a room that did not exist yet got a 404
+ * instead of a room.
+ *
+ * So this wires the route to the real `provisionStationForAlias` — the same
+ * function `index.ts`'s bridge delegates to — with only the Matrix client
+ * faked. Nothing about the resolution or the provisioning is reproduced here.
+ */
+describe("GET /_matrix/app/v1/rooms/:alias — the real path, both alias shapes", () => {
+  const OCCUPANT_ALIAS = bridgeAliasForHandle("matrix-queries-it-agent", DOMAIN);
+
+  /** The homeserver's alias directory, so a second create at one alias is seen. */
+  let roomsByAlias: Map<string, string>;
+  let created: string[];
+
+  function realApp() {
+    return new Hono().route(
+      "/_matrix/app/v1",
+      createMatrixAsRoutes({
+        hsToken: HS_TOKEN,
+        domain: DOMAIN,
+        onEvent: async () => {},
+        onProvisionAlias: (alias: string) =>
+          provisionStationForAlias(alias, {
+            domain: DOMAIN,
+            client: {
+              ensureUser: async () => {},
+              ensureRoom: async (alias: string) => {
+                const existing = roomsByAlias.get(alias);
+                if (existing) return existing;
+                const roomId = `!queries-${roomsByAlias.size + 1}:${DOMAIN}`;
+                roomsByAlias.set(alias, roomId);
+                created.push(alias);
+                return roomId;
+              },
+              invite: async () => {},
+            },
+          }),
+      })
+    );
+  }
+
+  function realGet(path: string) {
+    return realApp().request(`/_matrix/app/v1${path}`, {
+      headers: { Authorization: `Bearer ${HS_TOKEN}` },
+    });
+  }
+
+  async function roomRows() {
+    return (await rawSql`
+      SELECT room_id, alias, principal_id FROM matrix_rooms WHERE station_id = ${STATION}
+    `) as unknown as Array<{ room_id: string; alias: string; principal_id: string | null }>;
+  }
+
+  test("an occupant-derived alias resolves and gets its room made; the legacy station-derived one still resolves to the same station", async () => {
+    roomsByAlias = new Map();
+    created = [];
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+
+    // The shape an occupied station's room carries now. 404 here — which is
+    // what the route answered before this fix — means the room behind an
+    // agent's own address can never be created on demand.
+    const occupant = await realGet(`/rooms/${encodeURIComponent(OCCUPANT_ALIAS)}`);
+    expect(occupant.status).toBe(200);
+
+    const afterOccupant = await roomRows();
+    expect(afterOccupant).toHaveLength(1);
+    expect(afterOccupant[0]!.alias).toBe(OCCUPANT_ALIAS);
+    // Bound to the occupant at creation — the room is the agent's, not the
+    // station's.
+    expect(afterOccupant[0]!.principal_id).toBe(AGENT_PRINCIPAL);
+    expect(created).toEqual([OCCUPANT_ALIAS]);
+
+    // And the legacy shape, which the 32 rooms already on the infra box are
+    // addressed by, must keep resolving — the fallback is the whole reason
+    // `stationForLocalpart` is still consulted at all. Same station, so
+    // provisioning is a no-op rather than a second room.
+    const legacy = await realGet(`/rooms/${encodeURIComponent(REAL_ALIAS)}`);
+    expect(legacy.status).toBe(200);
+
+    const afterLegacy = await roomRows();
+    expect(afterLegacy).toHaveLength(1);
+    expect(afterLegacy[0]!.room_id).toBe(afterOccupant[0]!.room_id);
+    expect(created).toEqual([OCCUPANT_ALIAS]);
+
+    // Widening what the route claims must not widen it to everything: an
+    // `agent_`-shaped alias with no principal behind it is a name somebody
+    // typed hopefully, and claiming it would let anyone conjure an agent.
+    const nobody = await realGet("/rooms/%23agentpod_agent_nobody-at-all%3Aid.agentpod.dev");
+    expect(nobody.status).toBe(404);
+    expect(created).toEqual([OCCUPANT_ALIAS]);
   });
 });
 

--- a/apps/hub/tests/integration/matrix-as-queries.test.ts
+++ b/apps/hub/tests/integration/matrix-as-queries.test.ts
@@ -6,6 +6,7 @@ import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { createMatrixAsRoutes } from "../../src/routes/matrix-as";
 import { bridgeUserId, bridgeAlias } from "../../src/services/matrix-as/names";
+import { createPrincipal } from "../../src/services/principals";
 
 /**
  * What the homeserver asks before it will let anyone talk to one of our users
@@ -25,6 +26,8 @@ const HS_TOKEN = "test-hs-token-queries";
 
 /** Rooms the bridge was asked to create, so provisioning can be asserted. */
 let provisioned: string[] = [];
+/** The agent occupying STATION — a user's mxid is built from its handle now. */
+let AGENT_PRINCIPAL: string;
 
 function app() {
   return new Hono().route(
@@ -52,26 +55,32 @@ beforeAll(async () => {
   const tenant = await resolveTenantForUser(USER);
   await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+  await rawSql`DELETE FROM principals WHERE handle = 'matrix-queries-it-agent'`;
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "matrix-queries-it-agent" });
   await rawSql`
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${USER}, 'query-box', 'query-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'openclaw', 'openclaw:krishna', 'leaf', 'krishna',
-            '["acp"]'::jsonb, now(), now())`;
+            '["acp"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
 });
 
 afterAll(async () => {
   try {
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM principals WHERE handle = 'matrix-queries-it-agent'`;
     await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
   } catch {
     // cleanup only
   }
 });
 
-const REAL_USER = bridgeUserId("query-box", "openclaw:krishna", DOMAIN);
+// A user's mxid is built from its occupying principal's immutable handle now
+// (`names.ts`'s `bridgeUserId`), not from `(nodeName, stationKey)` — only the
+// room ALIAS is still station-derived.
+const REAL_USER = bridgeUserId("matrix-queries-it-agent", DOMAIN);
 const REAL_ALIAS = bridgeAlias("query-box", "openclaw:krishna", DOMAIN);
 
 describe("GET /_matrix/app/v1/users/:userId", () => {

--- a/apps/hub/tests/integration/matrix-missions.test.ts
+++ b/apps/hub/tests/integration/matrix-missions.test.ts
@@ -5,6 +5,7 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { createMissionRoutes } from "../../src/routes/missions";
 
 /**
@@ -21,6 +22,11 @@ const NODE = "node_mission";
 const A = "station_mission_a";
 const B = "station_mission_b";
 const OWNER_MXID = "@owner-mission:id.agentpod.dev";
+
+let OWNER_PRINCIPAL: string;
+/** The agents occupying A and B — the matcher compares a grant against these now. */
+let AGENT_A: string;
+let AGENT_B: string;
 
 let rooms: Array<{ alias: string; name: string; invite?: string }> = [];
 let spaces: Array<{ name: string }> = [];
@@ -65,6 +71,9 @@ const post = (path: string, body: unknown) =>
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: OWNER, email: "mission@example.com", name: "Owner" });
+  OWNER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "mission-it-owner", userId: OWNER });
+  AGENT_A = await createPrincipal({ kind: "agent", handle: "mission-it-agent-a" });
+  AGENT_B = await createPrincipal({ kind: "agent", handle: "mission-it-agent-b" });
   const tenant = await resolveTenantForUser(OWNER);
   await rawSql`DELETE FROM matrix_mission_members`;
   await rawSql`DELETE FROM matrix_missions`;
@@ -73,16 +82,19 @@ beforeAll(async () => {
   await rawSql`
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${OWNER}, 'mission-box', 'mission-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
-  for (const [id, key] of [[A, "hermes:one"], [B, "openclaw:two"]] as const) {
+  for (const [id, key, agent] of [[A, "hermes:one", AGENT_A], [B, "openclaw:two", AGENT_B]] as const) {
     await rawSql`
-      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
       VALUES (${id}, ${tenant}, ${OWNER}, ${NODE}, ${key.split(":")[0]}, ${key}, 'leaf', ${key},
-              '["acp"]'::jsonb, now(), now())`;
+              '["acp"]'::jsonb, ${agent}, now(), now())`;
   }
-  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
+  // `principal_identities.principal_id` is a foreign key onto `principals.id`
+  // now, not the Better Auth user id — the row this route reads to invite the
+  // human back into their own mission has to be keyed by the real principal.
+  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER_PRINCIPAL}`;
   await rawSql`
     INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
-    VALUES ('pid_mission', ${OWNER}, 'matrix', ${OWNER_MXID}, now())`;
+    VALUES ('pid_mission', ${OWNER_PRINCIPAL}, 'matrix', ${OWNER_MXID}, now())`;
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
@@ -95,7 +107,7 @@ beforeEach(async () => {
   await rawSql`DELETE FROM matrix_missions`;
   await rawSql`DELETE FROM matrix_spaces`;
   await rawSql`UPDATE stations SET purpose = NULL WHERE node_id = ${NODE}`;
-  await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*", "agentpod:*/openclaw:*"], mayGrantReach: false });
+  await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_A, AGENT_B], mayGrantReach: false });
 });
 
 afterAll(async () => {
@@ -104,9 +116,10 @@ afterAll(async () => {
     await rawSql`DELETE FROM matrix_mission_members`;
     await rawSql`DELETE FROM matrix_missions`;
     await rawSql`DELETE FROM matrix_spaces`;
-    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER_PRINCIPAL}`;
     await rawSql`DELETE FROM stations WHERE id IN (${A}, ${B})`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('mission-it-owner', 'mission-it-agent-a', 'mission-it-agent-b')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
   } catch {
@@ -142,7 +155,8 @@ describe("POST /api/missions", () => {
   test("refuses a station the caller may not dispatch", async () => {
     // Putting an agent in a room is putting it to work. The grant that governs
     // dispatching it governs this too.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    // Covers A (agent-a) but not B (agent-b).
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_A], mayGrantReach: false });
 
     const res = await post("/missions", { name: "Half a mission", stationIds: [A, B] });
 

--- a/apps/hub/tests/integration/matrix-missions.test.ts
+++ b/apps/hub/tests/integration/matrix-missions.test.ts
@@ -91,7 +91,12 @@ beforeAll(async () => {
   // `principal_identities.principal_id` is a foreign key onto `principals.id`
   // now, not the Better Auth user id — the row this route reads to invite the
   // human back into their own mission has to be keyed by the real principal.
-  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER_PRINCIPAL}`;
+  // Only the 'matrix' row is cleared: `createPrincipal` above already wrote
+  // this principal's 'better-auth' row, and deleting every system's row for
+  // this principal_id would take that one with it — `principalForUser` would
+  // then find nobody, and the route would fail closed for a caller who really
+  // does have a principal.
+  await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER_PRINCIPAL} AND system = 'matrix'`;
   await rawSql`
     INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
     VALUES ('pid_mission', ${OWNER_PRINCIPAL}, 'matrix', ${OWNER_MXID}, now())`;
@@ -146,10 +151,13 @@ describe("POST /api/missions", () => {
     // would be an error on some homeservers and noise on all of them.
     await post("/missions", { name: "Q3 migration", stationIds: [A, B] });
 
+    // Built from each occupying agent's principal handle now, not from where
+    // the station runs. A (agent-a) is the first member in `stationIds`, so it
+    // speaks for the room and is never on its own invite list.
     const invitees = invited.map((i) => i.invitee);
-    expect(invitees).toContain("@agent_mission-box_openclaw-two:id.agentpod.dev");
+    expect(invitees).toContain("@agent_mission-it-agent-b:id.agentpod.dev");
     expect(invitees).toContain(OWNER_MXID);
-    expect(invitees).not.toContain("@agent_mission-box_hermes-one:id.agentpod.dev");
+    expect(invitees).not.toContain("@agent_mission-it-agent-a:id.agentpod.dev");
   });
 
   test("refuses a station the caller may not dispatch", async () => {

--- a/apps/hub/tests/integration/matrix-node-spaces.test.ts
+++ b/apps/hub/tests/integration/matrix-node-spaces.test.ts
@@ -3,6 +3,7 @@ import { ensurePgMigrations } from "../helpers/pg-migrations";
 import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
+import { createPrincipal } from "../../src/services/principals";
 import { provisionStation } from "../../src/services/matrix-as/provision";
 
 /**
@@ -22,6 +23,17 @@ const NODE = "node_purpose_spaces";
 const A = "station_ps_a";
 const B = "station_ps_b";
 const DOMAIN = "id.agentpod.dev";
+
+/**
+ * The owner's principal, and one agent per station.
+ *
+ * A station with no occupying agent has no handle and therefore no address to
+ * provision, so `provisionStation` returns before it files anything — which
+ * would make every assertion below pass vacuously. And the owner's mxid hangs
+ * off their principal, not their Better Auth id: `principal_identities` is a
+ * foreign key onto `principals.id` now.
+ */
+let OWNER_PRINCIPAL: string;
 
 interface Edge {
   space: string;
@@ -73,6 +85,11 @@ const setPurpose = (stationId: string, purpose: string | null) =>
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: OWNER, email: "purpose-spaces@example.com", name: "PS" });
+  OWNER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "ps-owner", userId: OWNER });
+  const agentFor: Record<string, string> = {
+    [A]: await createPrincipal({ kind: "agent", handle: "ps-agent-a" }),
+    [B]: await createPrincipal({ kind: "agent", handle: "ps-agent-b" }),
+  };
   const tenant = await resolveTenantForUser(OWNER);
   await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${A}, ${B})`;
   await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
@@ -86,12 +103,12 @@ beforeAll(async () => {
     [B, "openclaw:b"],
   ]) {
     await rawSql`
-      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
-      VALUES (${id}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', ${key}, 'leaf', ${key}, '["acp"]'::jsonb, now(), now())`;
+      INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
+      VALUES (${id}, ${tenant}, ${OWNER}, ${NODE}, 'openclaw', ${key}, 'leaf', ${key}, '["acp"]'::jsonb, ${agentFor[id!]!}, now(), now())`;
   }
   await rawSql`
     INSERT INTO principal_identities (id, principal_id, system, external_id, created_at)
-    VALUES ('pi_ps', ${OWNER}, 'matrix', ${"@owner-ps:" + DOMAIN}, now())
+    VALUES ('pi_ps', ${OWNER_PRINCIPAL}, 'matrix', ${"@owner-ps:" + DOMAIN}, now())
     ON CONFLICT DO NOTHING`;
 });
 
@@ -114,9 +131,9 @@ afterAll(async () => {
     const tenant = await resolveTenantForUser(OWNER);
     await rawSql`DELETE FROM matrix_rooms WHERE station_id IN (${A}, ${B})`;
     await rawSql`DELETE FROM matrix_spaces WHERE tenant_id = ${tenant}`;
-    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${OWNER}`;
     await rawSql`DELETE FROM stations WHERE node_id = ${NODE}`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('ps-owner', 'ps-agent-a', 'ps-agent-b')`;
     await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
   } catch {
     // cleanup only

--- a/apps/hub/tests/integration/principal-identities.test.ts
+++ b/apps/hub/tests/integration/principal-identities.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { ensurePgMigrations } from "../helpers/pg-migrations";
-import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
+import { createPrincipal } from "../../src/services/principals";
 import {
   linkIdentity,
   identitiesFor,
@@ -20,21 +20,30 @@ import {
  *
  * The station half already works: `stations.matrix_id` has been populated since
  * 2026-08-15 (14 Hermes stations). This is the principal half.
+ *
+ * These are principals, not Better Auth users. `principal_identities.principal_id`
+ * is a foreign key onto `principals.id` now: a Better Auth id in it is not a
+ * mapping keyed the old way, it is a row that cannot be written. A principal's
+ * Better Auth login is simply one more identity in this same table, which is
+ * what `createPrincipal({ userId })` links.
  */
 
-const USER_A = "test-user-identities-a";
-const USER_B = "test-user-identities-b";
+const HANDLE_A = "identities-it-a";
+const HANDLE_B = "identities-it-b";
+const HANDLE_C = "identities-it-c";
+let PRINCIPAL_A: string;
+let PRINCIPAL_B: string;
 
 beforeAll(async () => {
   await ensurePgMigrations();
-  await createTestUser({ id: USER_A, email: "identities-a@example.com", name: "A" });
-  await createTestUser({ id: USER_B, email: "identities-b@example.com", name: "B" });
+  await rawSql`DELETE FROM principals WHERE handle IN (${HANDLE_A}, ${HANDLE_B}, ${HANDLE_C})`;
+  PRINCIPAL_A = await createPrincipal({ kind: "human", handle: HANDLE_A });
+  PRINCIPAL_B = await createPrincipal({ kind: "human", handle: HANDLE_B });
 });
 
 afterAll(async () => {
   try {
-    await rawSql`DELETE FROM principal_identities WHERE principal_id IN (${USER_A}, ${USER_B})`;
-    await rawSql`DELETE FROM "user" WHERE id IN (${USER_A}, ${USER_B})`;
+    await rawSql`DELETE FROM principals WHERE handle IN (${HANDLE_A}, ${HANDLE_B}, ${HANDLE_C})`;
   } catch {
     // cleanup only
   }
@@ -42,10 +51,10 @@ afterAll(async () => {
 
 describe("principal identities", () => {
   test("links a principal to a Matrix id and resolves both directions", async () => {
-    await linkIdentity(USER_A, "matrix", "@olivia:id.agentpod.dev");
+    await linkIdentity(PRINCIPAL_A, "matrix", "@olivia:id.agentpod.dev");
 
-    expect(await principalByExternal("matrix", "@olivia:id.agentpod.dev")).toBe(USER_A);
-    expect(await externalIdFor(USER_A, "matrix")).toBe("@olivia:id.agentpod.dev");
+    expect(await principalByExternal("matrix", "@olivia:id.agentpod.dev")).toBe(PRINCIPAL_A);
+    expect(await externalIdFor(PRINCIPAL_A, "matrix")).toBe("@olivia:id.agentpod.dev");
   });
 
   test("answers unknown rather than guessing", async () => {
@@ -53,7 +62,7 @@ describe("principal identities", () => {
     // Matrix account and never will, and a bridge asking about one is not an
     // error condition.
     expect(await principalByExternal("matrix", "@nobody:id.agentpod.dev")).toBeNull();
-    expect(await externalIdFor(USER_B, "matrix")).toBeNull();
+    expect(await externalIdFor(PRINCIPAL_B, "matrix")).toBeNull();
   });
 
   test("refuses to let two principals claim one external identity", async () => {
@@ -62,24 +71,24 @@ describe("principal identities", () => {
     // when it matters — attributing a human's approval, which must carry its
     // sender or kaambaan's separation-of-duties check is void.
     await expect(
-      linkIdentity(USER_B, "matrix", "@olivia:id.agentpod.dev")
+      linkIdentity(PRINCIPAL_B, "matrix", "@olivia:id.agentpod.dev")
     ).rejects.toThrow();
 
-    expect(await principalByExternal("matrix", "@olivia:id.agentpod.dev")).toBe(USER_A);
+    expect(await principalByExternal("matrix", "@olivia:id.agentpod.dev")).toBe(PRINCIPAL_A);
   });
 
   test("a principal has at most one identity per system", async () => {
     // The reverse direction needs a single answer too: "which mxid do I message
     // this principal at" cannot return three.
     await expect(
-      linkIdentity(USER_A, "matrix", "@olivia-alt:id.agentpod.dev")
+      linkIdentity(PRINCIPAL_A, "matrix", "@olivia-alt:id.agentpod.dev")
     ).rejects.toThrow();
   });
 
   test("holds several systems for one principal", async () => {
-    await linkIdentity(USER_A, "kaambaan", "usr_kaambaan_a");
+    await linkIdentity(PRINCIPAL_A, "kaambaan", "usr_kaambaan_a");
 
-    const all = await identitiesFor(USER_A);
+    const all = await identitiesFor(PRINCIPAL_A);
     expect(all.map((i) => i.system).sort()).toEqual(["kaambaan", "matrix"]);
   });
 
@@ -87,21 +96,21 @@ describe("principal identities", () => {
     // A typo'd system name would create a mapping nothing ever reads — a row
     // that looks like a link and is not one.
     await expect(
-      linkIdentity(USER_B, "matrix-ish" as never, "@b:id.agentpod.dev")
+      linkIdentity(PRINCIPAL_B, "matrix-ish" as never, "@b:id.agentpod.dev")
     ).rejects.toThrow();
   });
 
   test("refuses an empty external id", async () => {
-    await expect(linkIdentity(USER_B, "matrix", "")).rejects.toThrow();
+    await expect(linkIdentity(PRINCIPAL_B, "matrix", "")).rejects.toThrow();
   });
 
   test("unlinking is idempotent and scoped to one system", async () => {
-    await unlinkIdentity(USER_A, "kaambaan");
-    expect(await externalIdFor(USER_A, "kaambaan")).toBeNull();
+    await unlinkIdentity(PRINCIPAL_A, "kaambaan");
+    expect(await externalIdFor(PRINCIPAL_A, "kaambaan")).toBeNull();
     // Still there — unlinking one system must not touch another.
-    expect(await externalIdFor(USER_A, "matrix")).toBe("@olivia:id.agentpod.dev");
+    expect(await externalIdFor(PRINCIPAL_A, "matrix")).toBe("@olivia:id.agentpod.dev");
 
-    await unlinkIdentity(USER_A, "kaambaan"); // again: no throw
+    await unlinkIdentity(PRINCIPAL_A, "kaambaan"); // again: no throw
   });
 
   test("deleting a principal takes its identities with it", async () => {
@@ -109,10 +118,10 @@ describe("principal identities", () => {
     // identity outliving its principal is a mapping to nothing that still
     // occupies its external id, so the next person to link that mxid is
     // refused for a reason nobody can see.
-    await createTestUser({ id: "test-user-identities-c", email: "c@example.com", name: "C" });
-    await linkIdentity("test-user-identities-c", "matrix", "@gone:id.agentpod.dev");
+    const gone = await createPrincipal({ kind: "human", handle: HANDLE_C });
+    await linkIdentity(gone, "matrix", "@gone:id.agentpod.dev");
 
-    await rawSql`DELETE FROM "user" WHERE id = 'test-user-identities-c'`;
+    await rawSql`DELETE FROM principals WHERE id = ${gone}`;
 
     expect(await principalByExternal("matrix", "@gone:id.agentpod.dev")).toBeNull();
   });

--- a/apps/hub/tests/integration/resolve-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/resolve-matrix-identity.test.ts
@@ -5,6 +5,7 @@ import { rawSql } from "../../src/db/drizzle";
 import { mintEnrollmentToken, enrollNode } from "../../src/services/enrollment";
 import { adoptStations, listAdopted } from "../../src/services/station-registry";
 import { linkIdentity } from "../../src/services/principal-identities";
+import { createPrincipal } from "../../src/services/principals";
 import { resolveMatrixId } from "../../src/services/matrix-identity";
 
 /**
@@ -24,13 +25,27 @@ import { resolveMatrixId } from "../../src/services/matrix-identity";
 
 const USER = "test-user-mxresolve";
 const AGENT_MXID = "@onboarding-olivia:id.agentpod.dev";
-const CLASHER = "test-user-mxresolve-clash";
+
+/**
+ * The principals behind the two humans here.
+ *
+ * `resolveMatrixId` answers with a PRINCIPAL id, and `principal_identities` is
+ * keyed by one — a Better Auth id in that column is a foreign-key violation,
+ * not an older spelling of the same thing. `USER` stays a Better Auth id
+ * because that is what enrolment and adoption take.
+ */
+const USER_HANDLE = "mxresolve-it-user";
+const CLASH_HANDLE = "mxresolve-it-clash";
+let USER_PRINCIPAL = "";
+let CLASHER = "";
 let nodeId = "";
 let stationId = "";
 
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: USER, email: "mxresolve@example.com", name: "MX" });
+  await rawSql`DELETE FROM principals WHERE handle IN (${USER_HANDLE}, ${CLASH_HANDLE})`;
+  USER_PRINCIPAL = await createPrincipal({ kind: "human", handle: USER_HANDLE, userId: USER });
 
   // Enrolled and adopted through the real services rather than hand-written
   // INSERTs. A fixture that writes its own rows has to guess the schema, and a
@@ -67,7 +82,7 @@ afterAll(async () => {
     await rawSql`DELETE FROM stations WHERE node_id = ${nodeId}`;
     await rawSql`DELETE FROM nodes WHERE id = ${nodeId}`;
     await rawSql`DELETE FROM enrollment_tokens WHERE user_id = ${USER}`;
-    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM principals WHERE handle IN (${USER_HANDLE}, ${CLASH_HANDLE})`;
     await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
   } catch {
     // cleanup only
@@ -85,12 +100,12 @@ describe("resolveMatrixId", () => {
   });
 
   test("resolves a person's mxid to their principal", async () => {
-    await linkIdentity(USER, "matrix", "@rakesh:id.agentpod.dev");
+    await linkIdentity(USER_PRINCIPAL, "matrix", "@rakesh:id.agentpod.dev");
 
     const found = await resolveMatrixId("@rakesh:id.agentpod.dev");
     expect(found?.kind).toBe("principal");
     if (found?.kind !== "principal") throw new Error("unreachable");
-    expect(found.principalId).toBe(USER);
+    expect(found.principalId).toBe(USER_PRINCIPAL);
   });
 
   test("answers null for an mxid nobody claims", async () => {
@@ -104,7 +119,7 @@ describe("resolveMatrixId", () => {
     // External ids are opaque per system. A kaambaan id shaped like an mxid
     // names the same person in a different namespace, which is not the same
     // claim — and must not resolve a Matrix sender.
-    await linkIdentity(USER, "kaambaan", "@lookalike:id.agentpod.dev");
+    await linkIdentity(USER_PRINCIPAL, "kaambaan", "@lookalike:id.agentpod.dev");
 
     expect(await resolveMatrixId("@lookalike:id.agentpod.dev")).toBeNull();
   });
@@ -115,7 +130,7 @@ describe("resolveMatrixId", () => {
     // off a host by the node agent, one written by an operator. Silently
     // preferring either would attribute a human's approval to an agent, or an
     // agent's output to a human.
-    await createTestUser({ id: CLASHER, email: "clash@example.com", name: "Clash" });
+    CLASHER = await createPrincipal({ kind: "human", handle: CLASH_HANDLE });
     await linkIdentity(CLASHER, "matrix", AGENT_MXID);
 
     const found = await resolveMatrixId(AGENT_MXID);
@@ -128,8 +143,7 @@ describe("resolveMatrixId", () => {
     expect(found.stationId).toBe(stationId);
     expect(found.principalId).toBe(CLASHER);
 
-    await rawSql`DELETE FROM principal_identities WHERE principal_id = ${CLASHER}`;
-    await rawSql`DELETE FROM "user" WHERE id = ${CLASHER}`;
+    await rawSql`DELETE FROM principals WHERE id = ${CLASHER}`;
 
     // And with the clash removed it resolves cleanly again.
     expect((await resolveMatrixId(AGENT_MXID))?.kind).toBe("station");

--- a/apps/hub/tests/integration/station-cleanup-reach.test.ts
+++ b/apps/hub/tests/integration/station-cleanup-reach.test.ts
@@ -5,6 +5,7 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { stationCleanupRoutes } from "../../src/routes/station-cleanup";
 import { stationChangesetRoutes } from "../../src/routes/station-changeset";
 import { stationLifecycleRoutes } from "../../src/routes/station-lifecycle";
@@ -24,6 +25,10 @@ const USER = "test-user-cleanup-reach";
 const NODE = "node_cleanup_reach";
 const STATION = "station_cleanup_reach";
 
+let USER_PRINCIPAL: string;
+/** The agent occupying STATION — the matcher compares a grant against this now. */
+let AGENT_PRINCIPAL: string;
+
 function mount(routes: Hono) {
   const a = new Hono();
   a.use("*", async (c, next) => {
@@ -37,6 +42,8 @@ function mount(routes: Hono) {
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: USER, email: "cleanup-reach@example.com", name: "CR" });
+  USER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "cleanup-reach-it-user", userId: USER });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "cleanup-reach-it-agent" });
   const tenant = await resolveTenantForUser(USER);
   await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
@@ -44,9 +51,9 @@ beforeAll(async () => {
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${USER}, 'cleanup-box', 'cleanup-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'hermes', 'hermes:cleanup', 'leaf', 'Cleanup',
-            '["cleanup","changeset","lifecycle"]'::jsonb, now(), now())`;
+            '["cleanup","changeset","lifecycle"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
@@ -55,7 +62,9 @@ afterAll(async () => {
   try {
     await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id = ${USER}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('cleanup-reach-it-user', 'cleanup-reach-it-agent')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
   } catch {
@@ -73,7 +82,7 @@ function post(routes: Hono, path: string, body: Record<string, unknown> = {}) {
 
 /** Dispatch as wide as it goes, and no reach — the principal this control is for. */
 async function dispatchOnly() {
-  await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+  await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 }
 
 describe("cleanup splits on the effect, not the capability", () => {

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -132,7 +132,10 @@ describe("POST /api/stations/:id/matrix/identity", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { mxid: string; alias: string; mode: string };
-    expect(body.mxid).toBe("@agent_sm-box_hermes-analyst-echo:id.agentpod.dev");
+    // The mxid is built from the occupying agent's principal handle now, not
+    // from where the station runs (`charter` → the-mission decisions on an
+    // agent-is-a-principal); the alias, below, is still station-derived.
+    expect(body.mxid).toBe("@agent_station-matrix-it-agent:id.agentpod.dev");
     expect(body.alias).toBe("#agentpod_sm-box_hermes-analyst-echo:id.agentpod.dev");
     expect(body.mode).toBe("bridge");
     expect(provisioned).toEqual([STATION]);

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -5,6 +5,7 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { createStationMatrixRoutes } from "../../src/routes/station-matrix";
 import { MatrixUserInUse } from "../../src/services/matrix-as/client";
 
@@ -26,6 +27,12 @@ const OWNER = "test-user-station-matrix";
 const NODE = "node_station_matrix";
 const STATION = "station_station_matrix";
 const DOMAIN = "id.agentpod.dev";
+
+let OWNER_PRINCIPAL: string;
+/** The agent occupying STATION — the matcher compares a grant against this now. */
+let AGENT_PRINCIPAL: string;
+/** Some other agent, granted where a test wants to prove the scope check is real. */
+const OTHER_AGENT = "prn_ffffffffffffffffffff";
 
 let provisioned: string[] = [];
 let issued: Array<{ localpart: string }> = [];
@@ -78,6 +85,8 @@ const post = (path: string) => app().request(`/api${path}`, { method: "POST" });
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: OWNER, email: "station-matrix@example.com", name: "Owner" });
+  OWNER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "station-matrix-it-owner", userId: OWNER });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "station-matrix-it-agent" });
   const tenant = await resolveTenantForUser(OWNER);
   await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
   await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
@@ -86,9 +95,9 @@ beforeAll(async () => {
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${OWNER}, 'sm-box', 'sm-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:analyst-echo', 'leaf', 'analyst-echo',
-            '["acp"]'::jsonb, now(), now())`;
+            '["acp"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
@@ -106,8 +115,10 @@ afterAll(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
   try {
     await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id = ${OWNER}`;
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('station-matrix-it-owner', 'station-matrix-it-agent')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
   } catch {
@@ -131,7 +142,7 @@ describe("POST /api/stations/:id/matrix/identity", () => {
   });
 
   test("does not need mayGrantReach, because it grants nothing", async () => {
-    await setGrant(OWNER, { mayDispatch: [], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [], mayGrantReach: false });
 
     expect((await post(`/stations/${STATION}/matrix/identity`)).status).toBe(200);
   });
@@ -152,7 +163,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
   test("requires mayGrantReach, because a credential IS reach", async () => {
     // Dispatch permission is not enough: handing an agent an access token is
     // the definition of granting it reach.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);
 
@@ -161,13 +172,13 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
   });
 
   test("requires the station to be in scope as well", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: true });
 
     expect((await post(`/stations/${STATION}/matrix/credentials`)).status).toBe(403);
   });
 
   test("mints a token and flips the station to harness mode", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);
 
@@ -181,7 +192,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
   });
 
   test("never writes the token it just issued into a log", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
 
     await post(`/stations/${STATION}/matrix/credentials`);
 
@@ -193,7 +204,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
   test("rotates rather than failing when the identity already exists", async () => {
     // The identity is provisioned long before anyone asks for credentials, so
     // "already registered" is the normal case, not an error.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
     identityExists = true;
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);
@@ -211,7 +222,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
     // not a 500, and not a silent no-op that leaves a harness without a token.
     canRotate = false;
     identityExists = true;
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);
 
@@ -225,7 +236,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
     // simply does not hold its own credentials. Branching on the mode sent every
     // station on a real deployment down the register path, where all 32 of them
     // failed M_USER_IN_USE and the operator saw a 500.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
     await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
     identityExists = true;
 
@@ -238,7 +249,7 @@ describe("POST /api/stations/:id/matrix/credentials", () => {
   });
 
   test("registers, without rotating, when the identity is genuinely new", async () => {
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
     identityExists = false;
 
     const res = await post(`/stations/${STATION}/matrix/credentials`);

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -132,11 +132,15 @@ describe("POST /api/stations/:id/matrix/identity", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { mxid: string; alias: string; mode: string };
-    // The mxid is built from the occupying agent's principal handle now, not
-    // from where the station runs (`charter` → the-mission decisions on an
-    // agent-is-a-principal); the alias, below, is still station-derived.
+    // The mxid is built from the occupying agent's principal handle, not from
+    // where the station runs (`charter` → the-mission decisions on an
+    // agent-is-a-principal) — and so, since fix round 3, is the room's alias.
+    // This asserted the station-derived `#agentpod_sm-box_hermes-analyst-echo`
+    // until fix round 5, which is an address no room this endpoint can answer
+    // for has ever held: it 409s below unless the station HAS an occupant, and
+    // an occupied station's room is created at `bridgeAliasForHandle`.
     expect(body.mxid).toBe("@agent_station-matrix-it-agent:id.agentpod.dev");
-    expect(body.alias).toBe("#agentpod_sm-box_hermes-analyst-echo:id.agentpod.dev");
+    expect(body.alias).toBe("#agentpod_agent_station-matrix-it-agent:id.agentpod.dev");
     expect(body.mode).toBe("bridge");
     expect(provisioned).toEqual([STATION]);
     // Issuing an identity is the appservice acting in its own namespace. No
@@ -159,6 +163,29 @@ describe("POST /api/stations/:id/matrix/identity", () => {
   test("404s for a station that is not this principal's", async () => {
     const res = await post("/stations/station_does_not_exist/matrix/identity");
     expect(res.status).toBe(404);
+  });
+
+  test("reports the alias the station's room is ACTUALLY reachable at, not one re-derived here", async () => {
+    // A room that already exists, at an address neither derivation would
+    // produce today — an ordinary state on the deployed box, where the 32
+    // live rooms were created before a room's alias followed its occupant.
+    // Re-deriving would misreport every one of them; the stored alias is the
+    // only thing that is true about where the room actually is.
+    const tenant = await resolveTenantForUser(OWNER);
+    const storedAlias = "#agentpod_sm-box_hermes-analyst-echo-legacy:id.agentpod.dev";
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+    await rawSql`
+      INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, principal_id, created_at)
+      VALUES (${"!sm-legacy:" + DOMAIN}, ${tenant}, ${STATION}, ${storedAlias}, ${AGENT_PRINCIPAL}, now())`;
+
+    try {
+      const body = (await (await post(`/stations/${STATION}/matrix/identity`)).json()) as {
+        alias: string;
+      };
+      expect(body.alias).toBe(storedAlias);
+    } finally {
+      await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+    }
   });
 });
 

--- a/apps/hub/tests/integration/station-matrix-say.test.ts
+++ b/apps/hub/tests/integration/station-matrix-say.test.ts
@@ -75,9 +75,15 @@ beforeAll(async () => {
     INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:cron-carl', 'leaf', 'cron-carl',
             '["acp"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
+  // `principal_id` bound at insert — fix round 2 on Task 5: `station-say.ts`
+  // resolves a room through `station-room.ts` now, which answers for an
+  // OCCUPIED station only with a room actually bound to that occupant
+  // (never a bare `station_id` match). A room seeded here without it would
+  // read as "not yet provisioned" and 409, which is not what this fixture
+  // means to represent.
   await rawSql`
-    INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
-    VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', now())`;
+    INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, principal_id, created_at)
+    VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', ${AGENT_PRINCIPAL}, now())`;
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
@@ -147,8 +153,8 @@ describe("POST /api/stations/:id/matrix/say", () => {
 
     const tenant = await resolveTenantForUser(OWNER);
     await rawSql`
-      INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
-      VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', now())`;
+      INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, principal_id, created_at)
+      VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', ${AGENT_PRINCIPAL}, now())`;
   });
 
   test("stays out of the way when the harness answers for itself", async () => {

--- a/apps/hub/tests/integration/station-matrix-say.test.ts
+++ b/apps/hub/tests/integration/station-matrix-say.test.ts
@@ -5,6 +5,7 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { createStationSayRoutes } from "../../src/routes/station-say";
 
 /**
@@ -24,6 +25,12 @@ const OWNER = "test-user-say";
 const NODE = "node_say";
 const STATION = "station_say";
 const ROOM = "!say:id.agentpod.dev";
+
+let OWNER_PRINCIPAL: string;
+/** The agent occupying STATION — the matcher compares a grant against this now. */
+let AGENT_PRINCIPAL: string;
+/** Some other agent, granted where a test wants to prove the scope check is real. */
+const OTHER_AGENT = "prn_ffffffffffffffffffff";
 
 let sent: Array<{ userId: string; roomId: string; body: string }> = [];
 
@@ -55,6 +62,8 @@ const say = (body: unknown, stationId = STATION) =>
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: OWNER, email: "say@example.com", name: "Owner" });
+  OWNER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "station-say-it-owner", userId: OWNER });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "station-say-it-agent" });
   const tenant = await resolveTenantForUser(OWNER);
   await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
   await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
@@ -63,9 +72,9 @@ beforeAll(async () => {
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${OWNER}, 'say-box', 'say-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${STATION}, ${tenant}, ${OWNER}, ${NODE}, 'hermes', 'hermes:cron-carl', 'leaf', 'cron-carl',
-            '["acp"]'::jsonb, now(), now())`;
+            '["acp"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
   await rawSql`
     INSERT INTO matrix_rooms (room_id, tenant_id, station_id, alias, created_at)
     VALUES (${ROOM}, ${tenant}, ${STATION}, '#agentpod_say-box_hermes-cron-carl:id.agentpod.dev', now())`;
@@ -74,7 +83,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   sent = [];
-  await setGrant(OWNER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+  await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
   await rawSql`UPDATE stations SET matrix_identity_mode = 'bridge' WHERE id = ${STATION}`;
 });
 
@@ -82,8 +91,10 @@ afterAll(async () => {
   delete process.env.ENFORCE_CONTROL_PAIR;
   try {
     await rawSql`DELETE FROM matrix_rooms WHERE room_id = ${ROOM}`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${OWNER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id = ${OWNER}`;
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('station-say-it-owner', 'station-say-it-agent')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id = ${OWNER}`;
   } catch {
@@ -107,7 +118,7 @@ describe("POST /api/stations/:id/matrix/say", () => {
   test("needs a grant covering the station, like dispatching it does", async () => {
     // Speaking as an agent is speaking AS it. Anyone who may not dispatch this
     // agent must not be able to put words in its mouth.
-    await setGrant(OWNER, { mayDispatch: ["agentpod:*/openclaw:*"], mayGrantReach: false });
+    await setGrant(OWNER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: false });
 
     expect((await say({ body: "hello" })).status).toBe(403);
     expect(sent).toHaveLength(0);

--- a/apps/hub/tests/integration/station-matrix-say.test.ts
+++ b/apps/hub/tests/integration/station-matrix-say.test.ts
@@ -110,7 +110,9 @@ describe("POST /api/stations/:id/matrix/say", () => {
     expect(sent).toHaveLength(1);
     expect(sent[0]).toMatchObject({
       roomId: ROOM,
-      userId: "@agent_say-box_hermes-cron-carl:id.agentpod.dev",
+      // Built from the occupying agent's principal handle now, not from
+      // where the station runs.
+      userId: "@agent_station-say-it-agent:id.agentpod.dev",
       body: "Morning report: 3 tasks done, 1 blocked.",
     });
   });

--- a/apps/hub/tests/integration/station-writes-reach.test.ts
+++ b/apps/hub/tests/integration/station-writes-reach.test.ts
@@ -5,6 +5,7 @@ import { createTestUser } from "../helpers/database";
 import { rawSql } from "../../src/db/drizzle";
 import { resolveTenantForUser } from "../../src/auth/tenant";
 import { setGrant } from "../../src/services/grants";
+import { createPrincipal } from "../../src/services/principals";
 import { stationWriteRoutes } from "../../src/routes/station-writes";
 
 /**
@@ -20,6 +21,12 @@ const USER = "test-user-writes-reach";
 const NODE = "node_writes_reach";
 const STATION = "station_writes_reach";
 
+let USER_PRINCIPAL: string;
+/** The agent occupying STATION — the matcher compares a grant against this now. */
+let AGENT_PRINCIPAL: string;
+/** Some other agent, granted where a test wants to prove the scope check is real. */
+const OTHER_AGENT = "prn_ffffffffffffffffffff";
+
 function app() {
   const a = new Hono();
   a.use("*", async (c, next) => {
@@ -33,6 +40,8 @@ function app() {
 beforeAll(async () => {
   await ensurePgMigrations();
   await createTestUser({ id: USER, email: "writes-reach@example.com", name: "WR" });
+  USER_PRINCIPAL = await createPrincipal({ kind: "human", handle: "writes-reach-it-user", userId: USER });
+  AGENT_PRINCIPAL = await createPrincipal({ kind: "agent", handle: "writes-reach-it-agent" });
   const tenant = await resolveTenantForUser(USER);
   await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
   await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
@@ -40,9 +49,9 @@ beforeAll(async () => {
     INSERT INTO nodes (id, tenant_id, user_id, name, hostname, os, arch, cpu_count, status, secret_hash, created_at)
     VALUES (${NODE}, ${tenant}, ${USER}, 'writes-box', 'writes-box', 'linux', 'amd64', 2, 'online', 'x', now())`;
   await rawSql`
-    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, adopted_at, created_at)
+    INSERT INTO stations (id, tenant_id, user_id, node_id, harness, station_key, kind, display_name, capabilities, principal_id, adopted_at, created_at)
     VALUES (${STATION}, ${tenant}, ${USER}, ${NODE}, 'hermes', 'hermes:writes', 'leaf', 'Writes',
-            '["fs.write"]'::jsonb, now(), now())`;
+            '["fs.write"]'::jsonb, ${AGENT_PRINCIPAL}, now(), now())`;
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
@@ -51,7 +60,9 @@ afterAll(async () => {
   try {
     await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
     await rawSql`DELETE FROM stations WHERE id = ${STATION}`;
-    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER}`;
+    await rawSql`DELETE FROM principal_grants WHERE principal_id = ${USER_PRINCIPAL}`;
+    await rawSql`DELETE FROM principal_identities WHERE external_id = ${USER}`;
+    await rawSql`DELETE FROM principals WHERE handle IN ('writes-reach-it-user', 'writes-reach-it-agent')`;
     await rawSql`DELETE FROM nodes WHERE id = ${NODE}`;
     await rawSql`DELETE FROM "user" WHERE id = ${USER}`;
   } catch {
@@ -77,8 +88,8 @@ function post(path: string, body: Record<string, unknown>) {
 describe("fs mutations require reach", () => {
   for (const [path, body] of MUTATIONS) {
     test(`${path} is refused without mayGrantReach`, async () => {
-      // Wide dispatch, no reach: exactly the principal this control exists for.
-      await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+      // In scope, no reach: exactly the principal this control exists for.
+      await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
       const res = await post(path, body);
 
@@ -89,7 +100,7 @@ describe("fs mutations require reach", () => {
   }
 
   test("is refused when reach is held but the station is out of scope", async () => {
-    await setGrant(USER, { mayDispatch: ["agentpod:other-box/hermes:*"], mayGrantReach: true });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [OTHER_AGENT], mayGrantReach: true });
     expect((await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" })).status).toBe(403);
   });
 
@@ -97,7 +108,7 @@ describe("fs mutations require reach", () => {
     // An attempt refused and recorded nowhere is indistinguishable from an
     // attempt nobody made — which is what an operator is trying to tell apart.
     await rawSql`DELETE FROM station_audit WHERE user_id = ${USER}`;
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: false });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" });
 
@@ -110,7 +121,7 @@ describe("fs mutations require reach", () => {
   test("the capability gate still answers first, because the two refusals mean different things", async () => {
     // "This station cannot" and "you may not" send an operator to different
     // places. Reordering these would send them to the wrong one.
-    await setGrant(USER, { mayDispatch: ["agentpod:*/hermes:*"], mayGrantReach: true });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
     await rawSql`UPDATE stations SET capabilities = '[]'::jsonb WHERE id = ${STATION}`;
 
     const res = await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" });
@@ -123,7 +134,7 @@ describe("fs mutations require reach", () => {
   test("a principal with reach in scope gets past the gate", async () => {
     // Past the gate is as far as this suite goes: there is no live node, so the
     // broker answers "node offline" (409). What matters is that it is not 403.
-    await setGrant(USER, { mayDispatch: ["agentpod:writes-box/hermes:*"], mayGrantReach: true });
+    await setGrant(USER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
 
     const res = await post("fs/write", { path: "a.txt", content: "x", encoding: "utf8" });
     expect(res.status).not.toBe(403);

--- a/apps/hub/tests/unit/jwt-issuer.test.ts
+++ b/apps/hub/tests/unit/jwt-issuer.test.ts
@@ -36,6 +36,7 @@ describe("the token claim contract (#332)", () => {
 
     const payload = await buildTokenPayload({
       user: { id: "user_abc123" },
+      resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
       loadGrant: async () => null,
     });
@@ -53,6 +54,7 @@ describe("the token claim contract (#332)", () => {
     const { buildTokenPayload } = await import("../../src/auth/jwt-claims");
     const payload = await buildTokenPayload({
       user: { id: "user_abc123" },
+      resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
       loadGrant: async () => null,
     });
@@ -71,6 +73,7 @@ describe("the token claim contract (#332)", () => {
     const { buildTokenPayload } = await import("../../src/auth/jwt-claims");
     const payload = await buildTokenPayload({
       user: { id: "user_abc123" },
+      resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
       loadGrant: async () => ({
         mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
@@ -90,6 +93,7 @@ describe("the token claim contract (#332)", () => {
     const { buildTokenPayload } = await import("../../src/auth/jwt-claims");
     const payload = await buildTokenPayload({
       user: { id: "user_abc123" },
+      resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
       loadGrant: async () => null,
     });
@@ -104,6 +108,7 @@ describe("the token claim contract (#332)", () => {
     const { buildTokenPayload } = await import("../../src/auth/jwt-claims");
     const payload = await buildTokenPayload({
       user: { id: "user_abc123" },
+      resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
       loadGrant: async () => null,
     });
@@ -116,6 +121,7 @@ describe("the token claim contract (#332)", () => {
     const { buildTokenPayload } = await import("../../src/auth/jwt-claims");
     const payload = await buildTokenPayload({
       user: { id: "user_abc123" },
+      resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
       loadGrant: async () => null,
     });
@@ -133,6 +139,7 @@ describe("the token claim contract (#332)", () => {
     await expect(
       buildTokenPayload({
         user: { id: "user_abc123" },
+        resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
         resolveTenant: async () => null as unknown as string,
         loadGrant: async () => null,
       })

--- a/apps/hub/tests/unit/jwt-issuer.test.ts
+++ b/apps/hub/tests/unit/jwt-issuer.test.ts
@@ -75,13 +75,21 @@ describe("the token claim contract (#332)", () => {
       user: { id: "user_abc123" },
       resolvePrincipal: async () => ({ id: "prn_test0123456789abcdef", kind: "human" as const }),
       resolveTenant: async () => "fleet_0123456789abcdef0123",
+      // Bare principal ids, which is what a grant value is now: one agent, by
+      // its own id, matched by equality. The namespaced patterns that used to
+      // sit here (`agentpod:<node>/<key>`, `kaambaan:<agentId>`) are deleted,
+      // and a literal in the issuer's own test is how a retired form outlives
+      // the code that read it.
       loadGrant: async () => ({
-        mayDispatch: ["agentpod:hermes:*", "kaambaan:agt_x"],
+        mayDispatch: ["prn_a0b1c2d3e4f5a6b7c8d9", "prn_112233445566778899aa"],
         mayGrantReach: true,
       }),
     });
 
-    expect(payload.mayDispatch).toEqual(["agentpod:hermes:*", "kaambaan:agt_x"]);
+    expect(payload.mayDispatch).toEqual([
+      "prn_a0b1c2d3e4f5a6b7c8d9",
+      "prn_112233445566778899aa",
+    ]);
     expect(payload.mayGrantReach).toBe(true);
   });
 

--- a/docs/strategy/2026-08-13-ecosystem-identity-decisions.md
+++ b/docs/strategy/2026-08-13-ecosystem-identity-decisions.md
@@ -1,205 +1,31 @@
 # Ecosystem identity — decisions
 
-**Status:** accepted 2026-08-13.
-**Scope:** AgentPod, kaambaan, supermessage, and the unbuilt Organization/Matrix layers.
-**Supersedes in part:** the Identity/Authz assumptions in `synthetic_organization_platform_strategy` (12 Aug 2026), and the shape of MT-1 (#145) in this repo.
+> **Moved. This file is a pointer, not a document.**
+>
+> The four decisions live in
+> **`SuperJackfruitLabs/charter` → `decisions/2026-08-13-ecosystem-identity.md`**,
+> where they have been maintained since 2026-08-14. What was here was a
+> byte-identical copy left behind by the move, and it sat two weeks out of date:
+> the charter original now carries a "superseded in part" header recording that
+> the MAS clause, the token-issuer question and the tenancy question have all
+> been answered since, and that Decision 3 described an entity the schema could
+> not represent until 2026-08-30.
+>
+> Emptied on 2026-08-30 rather than deleted, because three things link here —
+> `docs/README.md`, `fixtures/ecosystem-identity/README.md` and
+> `apps/hub/src/db/schema/tenants.ts` — and a pointer is more use to a reader
+> than a 404.
+>
+> **Why it does not live in this repository.** charter's README is explicit:
+> these are not AgentPod's decisions. They bind three products, and they sat in
+> `docs/strategy/` only because they needed *a* repository. Keeping a second copy
+> here made one product arbitrarily authoritative over an agreement three must
+> hold, and the copy drifted exactly as predicted — which is the argument for the
+> move restated as evidence.
 
-This records four decisions taken in conversation, the evidence behind them, and what
-they change. Two of them contradict what is currently written down, which is the reason
-this file exists: five strategy claims were found to have been written from documentation
-rather than code on 2026-08-13 alone, and a decision nobody wrote down is the next one.
+See also, in the same repository:
 
----
-
-## Where the three products actually stood, 2026-08-13
-
-Established by reading the code, not the docs. Where docs and code disagreed, the code won.
-
-| | AgentPod | kaambaan | supermessage |
-|---|---|---|---|
-| Runtime | Bun + Hono + Drizzle/Postgres | Cloudflare Worker + D1 + Durable Objects | Tauri + Rust, a desktop client |
-| Auth library | Better Auth | **none** — ~250 lines of hand-rolled Web Crypto | matrix-rust-sdk |
-| Human auth | Better Auth session | custom HMAC cookie (not a JWT), GitHub OAuth as client | `m.login.password` to Synapse |
-| Service auth | one static `API_TOKEN` → one `DEFAULT_USER_ID` | impersonate an *agent*: opaque `kbn_` bearer, non-expiring | none — it is a client, not a service |
-| Tenancy | **none** — no `organizationId` anywhere | **structural** — `tenant_id` predicates + `${tenantId}:${boardId}` DO naming | per-homeserver |
-| Authorization | none | scopes stored and **discarded**; roles written once, read never | none |
-
-Three consequences worth keeping in view:
-
-- **No auth library can be shared.** Bun/Postgres, Workers/D1 and Rust/Tauri have no
-  common runtime. The only shareable thing is a **protocol**, which argues for signed
-  tokens with published keys over kaambaan's current opaque-hash-lookup — that model
-  validates by a database round-trip on a hash it stored itself, and structurally cannot
-  verify a token minted anywhere else.
-- **kaambaan's MCP surface is not a precedent.** It answers 401 with
-  `WWW-Authenticate` and serves RFC 9728 protected-resource metadata, but there is no
-  authorization server behind it: no `/authorize`, no `/token`, no PKCE, no audience
-  validation. A compliant client follows the challenge and dead-ends. Its docs claim
-  otherwise. The reusable part is the *shape*, not the implementation.
-- **kaambaan's tenant isolation is the strongest thing in either codebase** and is the
-  pattern AgentPod lacks entirely.
-
----
-
-## Decision 1 — supermessage acts only through Matrix
-
-supermessage keeps its own Matrix identity. Actions taken there — approving a gate,
-starting a run — travel as **Matrix events**, which the Application Service translates
-into kaambaan or AgentPod calls. supermessage never calls suite APIs directly and holds
-no suite credential.
-
-**Why.** It keeps exactly one credential on an end-user device, and it keeps
-"independent Matrix client" true rather than "works, but half the buttons don't". It also
-removes an entire product from the identity problem: whatever the suite decides about
-principals, supermessage needs no change.
-
-**It is already built for this.** `src/lib/components/customEvents.ts` is a renderer
-registry with zero renderers registered, whose own comment says it *"does not — and must
-not — invent those schemas"*. And `id.agentpod.dev` already advertises
-`m.login.application_service`, the flow an Application Service uses to act as its virtual
-users. Both halves of the seam exist and are empty.
-
-**Consequence.** The Application Service becomes the only place suite authority lives on
-the chat path. Deep integration is richer rendering plus actions-as-events — not API
-access.
-
----
-
-## Decision 2 — when a human acts, the human is the actor
-
-The Application Service calls kaambaan and AgentPod **on behalf of** the human, carrying
-both the actor (the AS) and the subject (the human). It never substitutes its own
-identity for theirs.
-
-**Why, concretely.** `board-do.ts` enforces separation of duties: a gate decision where
-`decidedBy` equals the agent that produced the work returns 403. If the AS called with a
-single service credential, every gate decision in the suite would be "decided by the
-bridge" — the check would quietly stop meaning anything and every approval would attribute
-to one account. This is the same failure already present in run verbs, which are
-authorized by lease rather than identity, so any agent token in a tenant can drive another
-agent's run and have the cost metered against the original agent.
-
-**Consequence.** The `mxid → Principal` mapping must exist and be trustworthy before the
-bridge can be honest — minted by an explicit link, never inferred from a localpart or a
-matching email. This makes the identity layer a **prerequisite**, not a P1 nicety.
-An unlinked Matrix user in a room is a case the AS must handle explicitly.
-
----
-
-## Decision 3 — agents have their own reach, not delegated reach
-
-An agent's authority is its own, granted to it as a principal. It is **not** a projection
-of whoever dispatched it.
-
-**This contradicts the platform strategy**, which asks for *"short-lived tokens tied to
-principal, task/run and scope"* and delegation-shaped authority. The contradiction is
-deliberate.
-
-**Why.** An agent can then hold reach no human has — a deploy agent with production
-credentials nobody carries, a scanner that reads every repository while no individual
-does. Autonomy stops being a shadow of a person, which is the honest model if agents are
-org members rather than tools. It also survives the human: a delegated run dies when a
-session expires or someone leaves; an agent with its own reach keeps working, which is
-what anything scheduled requires.
-
-**What it costs, and these are not hypothetical.**
-
-1. **Escalation becomes a path rather than an impossibility.** If I may dispatch an agent
-   whose reach exceeds mine, I have that reach by proxy. Delegation makes this
-   structurally impossible; standing authority makes it a policy question.
-2. **Revocation loses its natural handle.** There is no "revoke the human and everything
-   downstream withers". Agent grants must be revoked directly — and kaambaan is weakest
-   exactly here: `agent_tokens.revoked_at` exists and **nothing writes to it**; the only
-   real revocation is deleting the agent, which breaks its metering history.
-3. **Attribution must carry both** the agent's authority and who dispatched it, or "the
-   deploy agent did it" hides "because a human asked at 3am". Cheap in the token and the
-   run row from the start; expensive to retrofit.
-
----
-
-## Decision 4 — the control pair, and where it lives
-
-Because of Decision 3, two checks carry the weight that delegation would otherwise have
-carried:
-
-1. **Who may dispatch which agent.**
-2. **Who may grant an agent its reach.**
-
-Both are required. Dispatch control alone is decorative: anyone who can register an agent
-and grant it production credentials does not need permission to dispatch anything — they
-build the agent they want.
-
-**Both are owned by the Organization plane**, whose ownership already includes
-*"Principal, Team, Role, objective, identity mappings, authority"*. Not the work plane:
-a check living in kaambaan would only cover board-driven work, and the most common path
-today — provisioning straight at AgentPod over its API or console — would be unguarded.
-A control with a hole that shape is not a control.
-
-**Enforcement is local; the token is the carrier.** The Organization plane is
-authoritative for the grant; the claim rides in the token the caller already presents;
-AgentPod checks it before dispatching and kaambaan checks it before routing a claim.
-Neither plane keeps its own copy of the rule, and both **fail closed** when the claim is
-absent. This is deliberately not a policy-service call in the hot path — *"do not spawn
-seventeen services"*.
-
-**Interim, so this does not block on an unbuilt plane.** The grant may live as static
-configuration in each plane, provided it is the **same shape** as the eventual claim, so
-adopting a real issuer is a data move rather than a redesign. This mirrors the pattern
-already blessed for credentials: *"make static secret injection explicit and auditable
-until dynamic issuance exists."*
-
-**Be clear about what this is.** Neither product enforces any authorization today. This
-is not harmonising two systems — it is introducing the first real authorization check in
-the suite. Keep it to one claim checked at two boundaries, rather than arriving with a
-policy engine.
-
----
-
-## What follows from these, and what does not
-
-**Reach is expressed as capability, not credential.** Namespaced ids
-(`github.pull_request.review`), each carrying provider implementations, risk
-classification, required credential and policy metadata. Reach is then a composition:
-capability (what kind of action) × relationship (on which objects) × policy (under what
-conditions). Credential requirement is *metadata on the capability*, which is what lets a
-broker issue something scoped rather than hand out a stored secret.
-
-**Two engines, not one, and neither is its own layer.** Relationship authorization
-(OpenFGA/SpiceDB) answers "can this principal reach this object". Policy evaluation
-(OPA/Cedar) answers "is this allowed under these conditions". The runtime keeps the final
-veto because it is closest to the ground truth, and a denial must be reported back as
-structured work activity, never silently dropped.
-
-**Availability is never inferred from a declaration.** The catalog owns what a capability
-*means*; AgentPod owns what a station can *do*; the join happens at query time. This is
-not a principle but a scar: `acp` was advertised because two binaries resolved, and
-produced a Chat tab that 502s on every provisioned Pi station; the posture scanner graded
-machines "A" without opening the files it claimed to check.
-
-**MT-1 (#145) changes shape.** As written it mints an org model inside AgentPod via the
-Better Auth organization plugin. The Organization plane owns principals and identity
-mappings; AgentPod should consume them and keep only scoping on its own rows. Building it
-as specified means migrating it later.
-
-### Not decided here
-
-- **Who issues tokens** — the Organization plane, AgentPod's hub, or
-  matrix-authentication-service. Note MAS is required for OIDC on Matrix anyway, and
-  adopting it **breaks supermessage the day it lands**: supermessage requests no refresh
-  token and has no re-auth-on-401 path, which works only because Synapse tokens are
-  long-lived. That work is coupled to the IdP decision, not after it.
-- **Tenancy.** kaambaan pins every principal to exactly one tenant at the storage layer;
-  AgentPod has no tenant concept at all. Unifying means retrofitting tenancy into AgentPod
-  or accepting a mapping table. This is the largest remaining modelling decision and
-  should be made deliberately rather than discovered during bridge work.
-- **How two repos share one contract.** Principal ids, the run join key and event schemas
-  must mean the same thing in a Bun/Postgres hub and a Workers/D1 board, in separate repos
-  with separate release cadences. A published package couples two deploy pipelines; this
-  codebase has already kept five hand-written Go mirrors of zod schemas honest with
-  golden-fixture round-trip tests and no drift, which is evidence that a shared fixture
-  suite may be enough.
-
-### Constraint worth remembering
-
-supermessage bans GPL/AGPL/LGPL runtime dependencies. Any shared component that reaches
-that repo must be MIT/Apache-2.0/BSD, or MPL-2.0 used unmodified.
+- `decisions/2026-08-30-an-agent-is-a-principal.md` — what Decision 3 needed
+- `decisions/2026-08-30-matrix-identity-without-mas.md` — why the MAS clause fell
+- `decisions/2026-08-15-one-issuer-and-offline-verification.md` — who issues
+- `decisions/2026-08-15-tenancy-is-local-and-mapped.md` — the tenancy answer

--- a/docs/superpowers/plans/2026-08-15-organization-layer.md
+++ b/docs/superpowers/plans/2026-08-15-organization-layer.md
@@ -1,5 +1,19 @@
 # Building the Organization layer
 
+> **Superseded 2026-08-30. Nothing below is edited.**
+>
+> This plan is built on the supermessage/MAS coupling — *"that coupling is real
+> and unchanged"* — and it is not. matrix-authentication-service is not part of
+> this suite: the premise was a fact about Synapse, replaced by tuwunel on
+> 2026-08-16, the day after the decision that recorded it. See
+> `charter → decisions/2026-08-30-matrix-identity-without-mas.md`.
+>
+> The Organization plane's design now lives in
+> `docs/superpowers/specs/2026-08-30-organization-plane-design.md`, under two
+> charter decisions — an agent is a principal, and Matrix identity without MAS —
+> and under a frame this plan predates: nothing is in production, so the work
+> builds destinations rather than migration paths.
+
 **Status:** Written 2026-08-15 as a plan; **most of it was then built the same
 day**, which is why this header exists. The phase bodies below are left as
 written — they are the reasoning, and rewriting them to match the outcome would

--- a/docs/superpowers/plans/2026-08-30-slice-a-agent-is-a-principal.md
+++ b/docs/superpowers/plans/2026-08-30-slice-a-agent-is-a-principal.md
@@ -1,0 +1,1181 @@
+# Slice A — an agent is a principal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the suite a principal that can be an agent, so one agent has one id across all three planes.
+
+**Architecture:** A `principals` table becomes the parent of identities and grants, replacing `user.id` as the thing they key on. An agent's Matrix id is minted from its immutable `handle` instead of from the node and station it happens to run on. A grant names one principal id and matches by equality, so the two per-plane values and their wildcards are deleted rather than deprecated.
+
+**Tech Stack:** Bun · Hono · Drizzle/Postgres (hub) · Cloudflare Workers/D1 (kaambaan) · zod (shared contract) · `bun test` and `vitest`
+
+**Spec:** `docs/superpowers/specs/2026-08-30-organization-plane-design.md` §2. The agreements it implements are `charter → decisions/2026-08-30-an-agent-is-a-principal.md` and `2026-08-30-matrix-identity-without-mas.md`.
+
+## Global Constraints
+
+- **Nothing is in production.** Build destinations, not migration paths: cut over, re-seed, delete the old form rather than deprecating it. A breaking change costs a rebuild.
+- **Product independence is not migration scaffolding.** A standalone kaambaan must boot with no hub. `NULL` external mappings stay legal everywhere.
+- **Id grammar is a cross-repo contract.** New prefixes use `prefixedId` → `^<prefix>_[0-9a-f]{20}$`. kaambaan's own id schema is `^<prefix>_[A-Za-z0-9]{6,}$`, which has **no hyphen** — so never mint a hyphenated UUID for anything that crosses the seam. `agentpod.station` already does and is a known scar; do not add a second.
+- **TDD.** Every task writes the failing test first and watches it fail.
+- **The hub's DB-backed tests cannot run on the dev machine** (no Docker, nothing on 5434). ~64 fail locally for that reason alone. Verify a baseline with `git stash -u` before believing a new failure. Migration and schema tests are proven in CI against its pg16 container.
+
+## File Structure
+
+**Create**
+- `apps/hub/src/utils/ids.ts` — `prefixedId`, shared. Today it is a private const in `enrollment.ts:12`.
+- `apps/hub/src/db/schema/organization.ts` — `organizations`, `principals`.
+- `apps/hub/src/services/principals.ts` — mint, read, and the station-occupancy join.
+- `apps/hub/scripts/seed-agent-principals.ts` — one-time, idempotent.
+- `apps/hub/scripts/migrate-agent-mxids.ts` — one-time, idempotent, and the only irreversible step.
+
+**Modify**
+- `packages/contract/src/ids.ts` · `fixtures/ecosystem-identity/id_grammar.json` · `token_claims.json`
+- `apps/hub/src/db/schema/identities.ts` · `grants.ts` · `stations.ts`
+- `apps/hub/src/auth/jwt-claims.ts` · `apps/hub/src/services/grants.ts` · `grant-reach.ts` · `matrix-as/names.ts`
+- kaambaan `apps/api/migrations/` · `apps/api/src/db/catalog.ts` · `apps/api/src/auth/hub-jwt.ts`
+
+---
+
+### Task 1: The id grammar for a principal and an organisation
+
+**Files:**
+- Modify: `packages/contract/src/ids.ts`
+- Modify: `fixtures/ecosystem-identity/id_grammar.json`
+- Test: `packages/contract/src/ecosystem-identity.test.ts`
+
+**Interfaces:**
+- Consumes: `truncatedUuidId(prefix)`, already in `ids.ts`
+- Produces: `PrincipalId`, `OrganizationId` — zod schemas accepting `^prn_[0-9a-f]{20}$` and `^org_[0-9a-f]{20}$`
+
+- [ ] **Step 1: Add the corpus entries.** In `fixtures/ecosystem-identity/id_grammar.json`, append to `entities`:
+
+```json
+{
+  "entity": "agentpod.principal",
+  "owner": "agentpod",
+  "prefix": "prn",
+  "grammar": "^prn_[0-9a-f]{20}$",
+  "grammarSource": "agentpod packages/contract/src/ids.ts — PrincipalId",
+  "mintedAs": "^prn_[0-9a-f]{20}$",
+  "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId()",
+  "note": "Twenty lowercase hex, deliberately NOT a hyphenated UUID like agentpod.station: kaambaan's id schema is ^<prefix>_[A-Za-z0-9]{6,}$, whose alphabet has no hyphen, and a principal id crosses that seam on every grant.",
+  "accept": [
+    { "value": "prn_0123456789abcdef0123", "mint": true },
+    { "value": "prn_ffffffffffffffffffff", "mint": true }
+  ],
+  "reject": [
+    "prn_0123456789abcdef012",
+    "prn_0123456789ABCDEF0123",
+    "prn_01234567-89ab-cdef-0123-456789abcdef",
+    "principal_0123456789abcdef0123",
+    "prn_"
+  ]
+},
+{
+  "entity": "agentpod.organization",
+  "owner": "agentpod",
+  "prefix": "org",
+  "grammar": "^org_[0-9a-f]{20}$",
+  "grammarSource": "agentpod packages/contract/src/ids.ts — OrganizationId",
+  "mintedAs": "^org_[0-9a-f]{20}$",
+  "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId()",
+  "note": "Minted by the hub, which IS the Organization plane until the plane is extracted. tenants.external_id carries this value with external_source = 'org-plane'.",
+  "accept": [{ "value": "org_0123456789abcdef0123", "mint": true }],
+  "reject": ["org_0123456789abcdef012", "org_0123456789ABCDEF0123", "org_"]
+},
+{
+  "entity": "kaambaan.gate",
+  "owner": "kaambaan",
+  "prefix": "gate",
+  "grammar": "^gate_[A-Za-z0-9]{6,}$",
+  "grammarSource": "kaambaan apps/api/src/board/board-do.ts createGate() — newId('gate')",
+  "mintedAs": "^gate_[A-Za-z0-9]{16}$",
+  "mintSource": "kaambaan newId('gate')",
+  "note": "Absent from this corpus until 2026-08-30 although it crosses a repo boundary on every projected approval. kaambaan#34's sketch proposed `gat_`, which is why this entry exists.",
+  "accept": [{ "value": "gate_4e8b1c2d3f4a5b6c", "mint": true }],
+  "reject": ["gat_4e8b1c2d3f4a5b6c", "gate_", "gate_short"]
+}
+```
+
+- [ ] **Step 2: Write the failing test.** The corpus test is table-driven; add the schemas to its map. In `packages/contract/src/ecosystem-identity.test.ts`, add to the imports and to the entity→schema table used by the existing round-trip:
+
+```typescript
+import { PrincipalId, OrganizationId } from "./ids";
+// in the entity → schema map used by the corpus round-trip:
+"agentpod.principal": PrincipalId,
+"agentpod.organization": OrganizationId,
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+Run: `cd packages/contract && bun test src/ecosystem-identity.test.ts`
+Expected: FAIL — `PrincipalId` is not exported from `./ids`.
+
+- [ ] **Step 4: Add the validators.** In `packages/contract/src/ids.ts`, beside `TenantId`:
+
+```typescript
+/** A suite principal — a human, an agent, or a service. */
+export const PrincipalId = truncatedUuidId("prn");
+
+/** An organisation. Minted by the hub until the Organization plane is extracted. */
+export const OrganizationId = truncatedUuidId("org");
+```
+
+- [ ] **Step 5: Run it and watch it pass**
+
+Run: `cd packages/contract && bun test src/ecosystem-identity.test.ts`
+Expected: PASS. `kaambaan.gate` has no agentpod-side validator and is checked by kaambaan in Task 10; the corpus tolerates an entity a repo does not map.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contract/src/ids.ts packages/contract/src/ecosystem-identity.test.ts fixtures/ecosystem-identity/id_grammar.json
+git commit -m "feat(contract): a principal and an organisation have an id grammar
+
+Twenty hex, not a hyphenated UUID: a principal id crosses the kaambaan seam on
+every grant, and kaambaan's id schema has no hyphen in its alphabet.
+agentpod.station already violates that and is a known scar; this does not add a
+second. Also adds kaambaan.gate, absent since it started crossing a repo
+boundary — kaambaan#34's sketch said 'gat_', which is what the corpus is for."
+```
+
+---
+
+### Task 2: `organizations` and `principals`
+
+**Files:**
+- Create: `apps/hub/src/utils/ids.ts`
+- Create: `apps/hub/src/db/schema/organization.ts`
+- Modify: `apps/hub/src/db/schema/index.ts`, `apps/hub/src/services/enrollment.ts:12`
+- Test: `apps/hub/src/db/schema/organization.test.ts`
+
+**Interfaces:**
+- Produces: `organizations`, `principals` Drizzle tables; `BOOTSTRAP_ORG_ID`; `prefixedId(prefix: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { prefixedId } from "../../utils/ids";
+import { BOOTSTRAP_ORG_ID, PRINCIPAL_KINDS } from "./organization";
+
+describe("principal ids and kinds", () => {
+  test("a minted principal id matches the shared grammar", () => {
+    // The corpus is the contract; a minter that drifts from it fails at the
+    // seam rather than here, which is far more expensive to diagnose.
+    expect(prefixedId("prn")).toMatch(/^prn_[0-9a-f]{20}$/);
+  });
+
+  test("the bootstrap organisation is a fixed id, not a random one", () => {
+    // Same reason tenants.BOOTSTRAP_TENANT_ID is a literal: a fresh deploy and
+    // the live hub must agree on it, which a random value cannot guarantee.
+    expect(BOOTSTRAP_ORG_ID).toBe("org_00000000000000000000");
+  });
+
+  test("kind is closed, and includes the one that did not exist", () => {
+    expect(PRINCIPAL_KINDS).toEqual(["human", "agent", "service"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/db/schema/organization.test.ts`
+Expected: FAIL — cannot resolve `../../utils/ids`.
+
+- [ ] **Step 3: Extract the id minter**
+
+Create `apps/hub/src/utils/ids.ts`:
+
+```typescript
+/**
+ * Prefixed ids, one minter.
+ *
+ * Was a private const in `services/enrollment.ts`, which is why `station-registry`
+ * grew a second, incompatible shape (a hyphenated UUID that kaambaan's own id
+ * schema rejects — see `fixtures/ecosystem-identity/id_grammar.json`,
+ * `agentpod.station`). One exported minter is how that stops happening again.
+ */
+export const prefixedId = (prefix: string): string =>
+  `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
+```
+
+In `apps/hub/src/services/enrollment.ts`, delete the local const and import it:
+
+```typescript
+import { prefixedId } from "../utils/ids";
+```
+
+- [ ] **Step 4: Add the schema**
+
+Create `apps/hub/src/db/schema/organization.ts`:
+
+```typescript
+/**
+ * The Organization plane's tables, living in the hub until the plane is extracted.
+ *
+ * `charter → decisions/2026-08-30-an-agent-is-a-principal.md`. The hub already
+ * IS the issuer; it is the Organization plane on the same terms, and extraction
+ * moves these rows without changing their meaning. That is what
+ * `2026-08-15-one-issuer-and-offline-verification` meant by "only the issuer
+ * URL changes".
+ */
+import { sql } from "drizzle-orm";
+import { pgTable, text, timestamp, uniqueIndex, check } from "drizzle-orm/pg-core";
+
+/** Fixed, for the same reason `BOOTSTRAP_TENANT_ID` is: a fresh deploy and the
+ *  live hub must agree, and a random id cannot guarantee that. */
+export const BOOTSTRAP_ORG_ID = "org_00000000000000000000";
+
+export const PRINCIPAL_KINDS = ["human", "agent", "service"] as const;
+export type PrincipalKind = (typeof PRINCIPAL_KINDS)[number];
+
+export const organizations = pgTable(
+  "organizations",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [check("organizations_id_is_org", sql`${t.id} LIKE 'org\\_%'`)]
+);
+
+export const principals = pgTable(
+  "principals",
+  {
+    id: text("id").primaryKey(),
+    /**
+     * Explicit, never inferred from which identities exist. An agent with no
+     * identities linked yet is still an agent, and inference would default it
+     * to human — which is the one wrong answer that fails open.
+     */
+    kind: text("kind").notNull(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    /**
+     * Immutable, and what an agent's mxid is built from. `display_name` moves;
+     * this does not, exactly as Matrix separates an mxid from a displayname.
+     */
+    handle: text("handle").notNull(),
+    displayName: text("display_name"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    check("principals_id_is_prn", sql`${t.id} LIKE 'prn\\_%'`),
+    check("principals_kind_known", sql`${t.kind} IN ('human','agent','service')`),
+    /** One handle, one principal: it is an address, and two claimants make the
+     *  mxid it produces ambiguous. */
+    uniqueIndex("principals_org_handle_idx").on(t.orgId, t.handle),
+  ]
+);
+```
+
+Export both from `apps/hub/src/db/schema/index.ts` — the tenant guard enumerates the schema barrel rather than a whitelist, so a table missing from it fails that test rather than failing silently.
+
+- [ ] **Step 5: Generate the migration, and seed the bootstrap org in it**
+
+Run: `cd apps/hub && bun run db:generate`
+
+Then hand-edit the generated SQL to append:
+
+```sql
+INSERT INTO organizations (id, name) VALUES ('org_00000000000000000000', 'Super Jackfruit Labs')
+  ON CONFLICT (id) DO NOTHING;
+
+UPDATE tenants
+   SET external_id = 'org_00000000000000000000', external_source = 'org-plane'
+ WHERE id = 'fleet_00000000000000000000' AND external_id IS NULL;
+```
+
+The `UPDATE` is the point: `tenants.external_id` / `external_source` shipped on 2026-08-14 for exactly this and have never held a value.
+
+- [ ] **Step 6: Run the test and the tenant guard**
+
+Run: `cd apps/hub && bun test src/db/schema/organization.test.ts`
+Expected: PASS.
+Run: `cd apps/hub && bun test src/db/tenant-scope.test.ts`
+Expected: PASS — needs Postgres, so **this one is proven in CI** if the dev machine has no database.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/hub/src/utils/ids.ts apps/hub/src/db/schema/organization.ts apps/hub/src/db/schema/organization.test.ts apps/hub/src/db/schema/index.ts apps/hub/src/services/enrollment.ts apps/hub/src/db/drizzle-migrations/
+git commit -m "feat(hub): organizations and principals, and the columns built for them get used
+
+The hub is the Organization plane until the plane is extracted, on the same
+terms it is already the issuer. tenants.external_id / external_source shipped
+2026-08-14 for this and have held NULL ever since; this migration fills them.
+
+prefixedId moves out of enrollment.ts, where being private is how
+station-registry came to mint a second, incompatible id shape."
+```
+
+---
+
+### Task 3: Identities and grants key on a principal
+
+**Files:**
+- Modify: `apps/hub/src/db/schema/identities.ts`, `apps/hub/src/db/schema/grants.ts`
+- Create: `apps/hub/src/services/principals.ts`
+- Test: `apps/hub/src/services/principals.test.ts`
+
+**Interfaces:**
+- Consumes: `principals`, `organizations`, `BOOTSTRAP_ORG_ID`, `prefixedId`
+- Produces: `createPrincipal({kind, handle, displayName?}): Promise<string>`, `principalForUser(userId: string): Promise<string | null>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { createPrincipal, principalForUser } from "./principals";
+
+describe("principals", () => {
+  test("mints an agent principal with a grammar-valid id", async () => {
+    const id = await createPrincipal({ kind: "agent", handle: "writer-quill" });
+    expect(id).toMatch(/^prn_[0-9a-f]{20}$/);
+  });
+
+  test("refuses a second principal on the same handle", async () => {
+    await createPrincipal({ kind: "agent", handle: "analyst-echo" });
+    // A handle is an address: two claimants make the mxid it produces ambiguous.
+    expect(createPrincipal({ kind: "agent", handle: "analyst-echo" })).rejects.toThrow();
+  });
+
+  test("finds the principal behind a Better Auth user", async () => {
+    const id = await createPrincipal({ kind: "human", handle: "rakesh", userId: "usr-uuid-here" });
+    expect(await principalForUser("usr-uuid-here")).toBe(id);
+  });
+
+  test("a user with no principal resolves to null, never to a default", async () => {
+    // Falling back would hand one principal's authority to an unmapped caller.
+    expect(await principalForUser("usr-nobody")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/services/principals.test.ts`
+Expected: FAIL — cannot resolve `./principals`.
+
+- [ ] **Step 3: Re-point the two foreign keys**
+
+In `apps/hub/src/db/schema/identities.ts` and `grants.ts`, change the reference and the import:
+
+```typescript
+import { principals } from "./organization";
+// ...
+principalId: text("principal_id")
+  .notNull()
+  .references(() => principals.id, { onDelete: "cascade" }),
+```
+
+In `identities.ts`, add `better-auth` to the allowed systems:
+
+```typescript
+export const IDENTITY_SYSTEMS = ["better-auth", "matrix", "kaambaan", "agentpod", "org-plane"] as const;
+```
+
+- [ ] **Step 4: Write the service**
+
+Create `apps/hub/src/services/principals.ts`:
+
+```typescript
+import { and, eq } from "drizzle-orm";
+
+import { db } from "../db/drizzle";
+import { principalIdentities } from "../db/schema/identities";
+import { BOOTSTRAP_ORG_ID, principals, type PrincipalKind } from "../db/schema/organization";
+import { prefixedId } from "../utils/ids";
+
+export async function createPrincipal(input: {
+  kind: PrincipalKind;
+  handle: string;
+  displayName?: string;
+  /** When present, links the Better Auth user as this principal's login identity. */
+  userId?: string;
+}): Promise<string> {
+  const id = prefixedId("prn");
+  await db.insert(principals).values({
+    id,
+    kind: input.kind,
+    orgId: BOOTSTRAP_ORG_ID,
+    handle: input.handle,
+    displayName: input.displayName ?? null,
+  });
+  if (input.userId) {
+    await db.insert(principalIdentities).values({
+      id: crypto.randomUUID(),
+      principalId: id,
+      system: "better-auth",
+      externalId: input.userId,
+    });
+  }
+  return id;
+}
+
+/**
+ * The principal behind a Better Auth user, or null.
+ *
+ * Null rather than a fallback: an unmapped caller must fail closed, for the same
+ * reason `buildTokenPayload` refuses to mint a token when no tenant resolves.
+ */
+export async function principalForUser(userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ principalId: principalIdentities.principalId })
+    .from(principalIdentities)
+    .where(
+      and(eq(principalIdentities.system, "better-auth"), eq(principalIdentities.externalId, userId))
+    )
+    .limit(1);
+  return row?.principalId ?? null;
+}
+```
+
+- [ ] **Step 5: Generate the migration, and backfill the human in it**
+
+Run: `cd apps/hub && bun run db:generate`, then append to the generated SQL:
+
+```sql
+-- One row today. Mint a principal for each existing user and carry the
+-- identities and grants that pointed at it.
+INSERT INTO principals (id, kind, org_id, handle, display_name)
+SELECT 'prn_' || substr(replace(gen_random_uuid()::text, '-', ''), 1, 20),
+       'human', 'org_00000000000000000000',
+       lower(regexp_replace(split_part(u.email, '@', 1), '[^a-z0-9._=/-]', '-', 'g')),
+       u.name
+  FROM "user" u;
+
+INSERT INTO principal_identities (id, principal_id, system, external_id)
+SELECT gen_random_uuid()::text, p.id, 'better-auth', u.id
+  FROM "user" u
+  JOIN principals p ON p.handle = lower(regexp_replace(split_part(u.email, '@', 1), '[^a-z0-9._=/-]', '-', 'g'));
+
+UPDATE principal_identities pi SET principal_id = p.id
+  FROM principal_identities bi JOIN principals p ON p.id = bi.principal_id
+ WHERE bi.system = 'better-auth' AND pi.principal_id = bi.external_id;
+
+UPDATE principal_grants g SET principal_id = p.id
+  FROM principal_identities bi JOIN principals p ON p.id = bi.principal_id
+ WHERE bi.system = 'better-auth' AND g.principal_id = bi.external_id;
+```
+
+Run the two `UPDATE`s **before** the migration adds the new foreign keys, or they will be rejected.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cd apps/hub && bun test src/services/principals.test.ts`
+Expected: PASS. Needs Postgres; in CI if the dev machine has none.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/hub/src/db/schema/identities.ts apps/hub/src/db/schema/grants.ts apps/hub/src/services/principals.ts apps/hub/src/services/principals.test.ts apps/hub/src/db/drizzle-migrations/
+git commit -m "feat(hub): identities and grants key on a principal, not on a user
+
+charter decisions/2026-08-13-ecosystem-identity.md Decision 3 rests on an agent
+holding authority 'as a principal'. Both tables keyed on user.id, so a principal
+was structurally a human and the entity that decision describes could not exist.
+
+Better Auth's user becomes one identity of one kind of principal, reached
+through principal_identities like any other system. Not a user row per agent:
+user requires email and emailVerified, and filling those with placeholders to
+satisfy an auth library is MT-1's mistake wearing a different hat."
+```
+
+---
+
+### Task 4: `principalKind` stops being a literal
+
+**Files:**
+- Modify: `apps/hub/src/auth/jwt-claims.ts:58-81`
+- Test: `apps/hub/src/auth/jwt-claims.test.ts`
+
+**Interfaces:**
+- Consumes: `principalForUser`, `principals`
+- Produces: `buildTokenPayload` emitting `sub` = principal id and a real `principalKind`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("an agent's token says it is an agent, and names the principal", async () => {
+  const payload = await buildTokenPayload({
+    user: { id: "usr-uuid" },
+    resolvePrincipal: async () => ({ id: "prn_0123456789abcdef0123", kind: "agent" }),
+    resolveTenant: async () => "fleet_00000000000000000000",
+    loadGrant: async () => ({ mayDispatch: [], mayGrantReach: false }),
+  });
+  expect(payload.principalKind).toBe("agent");
+  expect(payload.sub).toBe("prn_0123456789abcdef0123");
+});
+
+test("refuses to mint for a caller with no principal", async () => {
+  // Same shape as the no-tenant refusal below it: a token that verifies but
+  // names nobody is not a weaker caller, it is an unattributable one.
+  expect(
+    buildTokenPayload({ user: { id: "usr-unmapped" }, resolvePrincipal: async () => null })
+  ).rejects.toThrow(/no principal/);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/auth/jwt-claims.test.ts`
+Expected: FAIL — `principalKind` is `"human"` and `sub` is the user id.
+
+- [ ] **Step 3: Implement**
+
+In `apps/hub/src/auth/jwt-claims.ts`, replace the hardcoded literal:
+
+```typescript
+export interface BuildPayloadInput {
+  user: { id: string };
+  resolveTenant?: (userId: string) => Promise<string | null>;
+  loadGrant?: (principalId: string) => Promise<{ mayDispatch: string[]; mayGrantReach: boolean } | null>;
+  resolvePrincipal?: (userId: string) => Promise<{ id: string; kind: PrincipalKind } | null>;
+}
+
+export async function buildTokenPayload(input: BuildPayloadInput): Promise<TokenPayload> {
+  const principal = await (input.resolvePrincipal ?? defaultResolvePrincipal)(input.user.id);
+  if (!principal) {
+    throw new Error(`refusing to mint a token for ${input.user.id}: no principal resolved`);
+  }
+
+  const tenant = await (input.resolveTenant ?? resolveTenantForUser)(input.user.id);
+  if (!tenant) {
+    throw new Error(`refusing to mint a token for ${input.user.id}: no tenant resolved`);
+  }
+
+  const grant = await (input.loadGrant ?? getGrant)(principal.id);
+
+  return {
+    sub: principal.id,
+    principalKind: principal.kind,
+    tenant,
+    mayDispatch: grant?.mayDispatch ?? [],
+    mayGrantReach: grant?.mayGrantReach ?? false,
+  };
+}
+```
+
+`resolveTenantForUser` keeps its signature — it ignores its argument today and returns `BOOTSTRAP_TENANT_ID`, so it needs no change in this slice.
+
+**A cross-repo consequence to know about rather than discover.** `sub` stops
+being a Better Auth user UUID and becomes `prn_…`. kaambaan does not validate its
+shape — `hub-jwt.ts:179` checks only that it is a non-empty string — so
+verification is unaffected. But `sub` is what a hub-token gate resolution writes
+to `gates.decided_by`, so that column's values change form. Nothing migrates the
+four rows already there, and nothing needs to: they are pre-production, and
+`charter → decisions/2026-08-30-a-gate-closes-over-chat.md` already records
+"kaambaan's audit trail gains foreign ids" as an accepted cost. Do not add a
+backfill for them.
+
+- [ ] **Step 4: Run and watch it pass**
+
+Run: `cd apps/hub && bun test src/auth/jwt-claims.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/auth/jwt-claims.ts apps/hub/src/auth/jwt-claims.test.ts
+git commit -m "feat(hub): a token names its principal, and says what kind it is
+
+principalKind was the literal \"human\" beside a comment describing an exchange
+path that did not exist. sub becomes the principal id, so a claim means the same
+thing whoever holds it — which is the whole basis for an agent ever carrying one."
+```
+
+---
+
+### Task 5: A station knows which agent occupies it
+
+**Files:**
+- Modify: `apps/hub/src/db/schema/stations.ts`
+- Create: `apps/hub/scripts/seed-agent-principals.ts`
+- Test: `apps/hub/src/services/principals.test.ts`
+
+**Interfaces:**
+- Produces: `stations.principalId` (nullable text → `principals.id`)
+
+**Note — a deliberate refinement of the decision's sketch.** The decision lists the `agentpod` link among `principal_identities`. Occupancy is put on `stations` instead: `principal_identities` is *a record of sameness* — an mxid, a kaambaan agent id — and where an agent happens to run is not sameness. A column also keeps the grant check synchronous, since every caller already holds the station row.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("a station with no agent has no principal, and that is legal", async () => {
+  const s = await stationRow("stn-unoccupied");
+  expect(s.principalId).toBeNull();
+});
+
+test("seeding gives every adopted station an agent principal, and is idempotent", async () => {
+  const first = await seedAgentPrincipals();
+  const second = await seedAgentPrincipals();
+  expect(first.created).toBeGreaterThan(0);
+  expect(second.created).toBe(0); // re-running must not mint a second identity
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/services/principals.test.ts`
+Expected: FAIL — `principalId` is not a column; `seedAgentPrincipals` is not defined.
+
+- [ ] **Step 3: Add the column**
+
+In `apps/hub/src/db/schema/stations.ts`:
+
+```typescript
+/**
+ * The agent that occupies this station, if any.
+ *
+ * Nullable and it stays nullable: a station nobody has assigned is a machine,
+ * not an agent, and it is dispatchable by nobody — which is the behaviour change
+ * charter decisions/2026-08-30-an-agent-is-a-principal.md §3 names.
+ *
+ * Here rather than in `principal_identities` because occupancy is not sameness.
+ * A principal's identities say who it also is; this says where it currently runs.
+ */
+principalId: text("principal_id").references(() => principals.id, { onDelete: "set null" }),
+```
+
+Run `bun run db:generate`.
+
+- [ ] **Step 4: Write the seed script**
+
+Create `apps/hub/scripts/seed-agent-principals.ts`:
+
+```typescript
+/**
+ * One agent principal per adopted station — the one-time backfill for a fleet
+ * that predates principals. Idempotent: a station that already has one is left
+ * alone, so this is safe to re-run after adopting more stations.
+ *
+ * After this, creating an agent is a deliberate act and station adoption LINKS
+ * to an existing principal rather than implying one.
+ */
+import { eq, isNull } from "drizzle-orm";
+
+import { db } from "../src/db/drizzle";
+import { nodes } from "../src/db/schema/nodes";
+import { stations } from "../src/db/schema/stations";
+import { createPrincipal } from "../src/services/principals";
+
+/** `guild` + `hermes:writer-quill` → `writer-quill`; falls back to the whole key. */
+const handleFor = (stationKey: string): string => {
+  const tail = stationKey.includes(":") ? stationKey.slice(stationKey.indexOf(":") + 1) : stationKey;
+  return tail.toLowerCase().replace(/[^a-z0-9._=/-]/g, "-");
+};
+
+export async function seedAgentPrincipals(): Promise<{ created: number }> {
+  const rows = await db
+    .select({ id: stations.id, key: stations.stationKey, node: nodes.name })
+    .from(stations)
+    .innerJoin(nodes, eq(nodes.id, stations.nodeId))
+    .where(isNull(stations.principalId));
+
+  let created = 0;
+  for (const s of rows) {
+    // Two nodes can carry the same station key — `opencode:c52ddf65` did — so
+    // the handle is qualified when the bare one is taken.
+    let handle = handleFor(s.key);
+    try {
+      const principalId = await createPrincipal({ kind: "agent", handle, displayName: s.key });
+      await db.update(stations).set({ principalId }).where(eq(stations.id, s.id));
+    } catch {
+      handle = `${s.node}-${handle}`;
+      const principalId = await createPrincipal({ kind: "agent", handle, displayName: s.key });
+      await db.update(stations).set({ principalId }).where(eq(stations.id, s.id));
+    }
+    created++;
+  }
+  return { created };
+}
+```
+
+- [ ] **Step 5: Run and watch it pass**
+
+Run: `cd apps/hub && bun test src/services/principals.test.ts`
+Expected: PASS. Postgres-backed; CI if unavailable locally.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/db/schema/stations.ts apps/hub/scripts/seed-agent-principals.ts apps/hub/src/services/principals.test.ts apps/hub/src/db/drizzle-migrations/
+git commit -m "feat(hub): a station records which agent occupies it
+
+Occupancy is a station attribute, not a record of sameness — principal_identities
+says who a principal ALSO is, and where an agent runs is not that. It also keeps
+the grant check synchronous, since every caller already holds the station row.
+
+Nullable, permanently: an unassigned station is a machine, and dispatchable by
+nobody. The seed is idempotent and qualifies a handle by node when a bare key
+collides, which opencode:c52ddf65 did on two nodes in production."
+```
+
+---
+
+### Task 6: Growing the fleet becomes an admin act
+
+**Files:**
+- Modify: `apps/hub/src/services/grant-reach.ts:157-172`
+- Test: `apps/hub/src/services/grant-reach.test.ts`
+
+**Interfaces:**
+- Consumes: the admin middleware already guarding `/api/admin/grants`
+- **Ordered before the matcher collapse on purpose.** `requireFleetGrantReach` is the last
+  consumer of `AGENTPOD_NS`, which Task 7 deletes. Doing Task 7 first leaves the tree
+  uncompilable between the two tasks.
+- Produces: `requireFleetGrantReach(userId)` refusing anyone who is not an admin
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("a non-admin cannot mint an enrollment token, however wide their grant", async () => {
+  // The wildcard that encoded "your authority spans the fleet" no longer
+  // exists. A second scoped list was rejected by
+  // 2026-08-15-granting-reach-is-changing-an-agent, so this is admin.
+  await expect(requireFleetGrantReach("prn_0123456789abcdef0123")).rejects.toThrow(GrantReachDenied);
+});
+
+test("an admin may", async () => {
+  await expect(requireFleetGrantReach(ADMIN_PRINCIPAL)).resolves.toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/services/grant-reach.test.ts`
+Expected: FAIL — the current implementation looks for a `*/` prefix that can no longer be written.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+/**
+ * Growing a fleet is an admin act.
+ *
+ * This used to require `mayGrantReach` plus a dispatch value whose node half was
+ * `*` — "you may grow a fleet only if your authority already spans it". With no
+ * wildcards there is no way to say "spans", and
+ * 2026-08-15-granting-reach-is-changing-an-agent explicitly rejected a second
+ * scoped list as the asymmetric-grant hazard restated. Admin is the honest
+ * remaining answer, and /api/admin/grants is already guarded that way.
+ */
+export async function requireFleetGrantReach(principalId: string): Promise<void> {
+  if (!isControlPairEnforced()) return;
+  if (await isAdminPrincipal(principalId)) return;
+  log.warn("fleet-level reach refused: not an admin", { principalId });
+  throw new GrantReachDenied(principalId, "fleet", null);
+}
+```
+
+- [ ] **Step 4: Run and watch it pass**
+
+Run: `cd apps/hub && bun test src/services/grant-reach.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub/src/services/grant-reach.ts apps/hub/src/services/grant-reach.test.ts
+git commit -m "feat(hub): growing the fleet is an admin act
+
+The wildcard encoded 'your authority spans the fleet' and wildcards are gone. A
+second scoped list was already rejected as the asymmetric-grant hazard, so admin
+is what is left — and it is where the grant escape hatch already lives."
+```
+
+---
+
+### Task 7: A grant names one principal, and matches by equality
+
+**Files:**
+- Modify: `apps/hub/src/services/grants.ts:110-190`
+- Modify: `apps/hub/src/routes/missions.ts:117`, `station-say.ts:71`, `services/grant-reach.ts:92,137`, `services/acp-sessions.ts:668`, `services/matrix-as/inbound.ts:177`
+- Modify: `fixtures/ecosystem-identity/token_claims.json`
+- Test: `apps/hub/src/services/grants.test.ts`
+
+**Interfaces:**
+- Consumes: `stations.principalId`
+- Produces: `grantAllowsPrincipal(grant: Grant | null, principalId: string | null): boolean`. `segmentMatches`, `patternMatchesStation` and `AGENTPOD_NS` are **deleted**.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { grantAllowsPrincipal } from "./grants";
+
+const grant = (ids: string[]) => ({ mayDispatch: ids, mayGrantReach: false });
+
+describe("a grant names one principal", () => {
+  test("allows exactly the principal it names", () => {
+    expect(grantAllowsPrincipal(grant(["prn_0123456789abcdef0123"]), "prn_0123456789abcdef0123")).toBe(true);
+  });
+
+  test("no grant is not an unrestricted grant", () => {
+    expect(grantAllowsPrincipal(null, "prn_0123456789abcdef0123")).toBe(false);
+  });
+
+  test("an unassigned station is dispatchable by nobody", () => {
+    expect(grantAllowsPrincipal(grant(["prn_0123456789abcdef0123"]), null)).toBe(false);
+  });
+
+  test("ignores a value from another plane rather than denying on it", () => {
+    // A claim is read by more planes over time, not fewer. Refusing an
+    // unrecognised value breaks every time one is added.
+    expect(grantAllowsPrincipal(grant(["tm_editors", "prn_0123456789abcdef0123"]), "prn_0123456789abcdef0123")).toBe(true);
+  });
+
+  test("there is no wildcard", () => {
+    // agentpod:*/hermes matched a root station that should never have existed,
+    // and hermes:* silently spanned nodes. A pattern matches things nobody
+    // intended; an enumeration cannot.
+    expect(grantAllowsPrincipal(grant(["*"]), "prn_0123456789abcdef0123")).toBe(false);
+    expect(grantAllowsPrincipal(grant(["prn_*"]), "prn_0123456789abcdef0123")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/services/grants.test.ts`
+Expected: FAIL — `grantAllowsPrincipal` is not exported.
+
+- [ ] **Step 3: Replace the matcher**
+
+In `apps/hub/src/services/grants.ts`, delete `segmentMatches`, `patternMatchesStation`, `grantAllowsStation`, `StationRef` and `AGENTPOD_NS`, and add:
+
+```typescript
+/**
+ * Does this grant permit dispatching to this principal?
+ *
+ * Equality, and deliberately nothing more. `charter →
+ * decisions/2026-08-30-an-agent-is-a-principal.md` §3 removed patterns because
+ * they matched things nobody intended: `hermes:*` silently spanned nodes, and
+ * `agentpod:*/hermes` reached a root station that should never have existed.
+ *
+ * `null` — a station with no agent — is refused, not allowed. An unassigned
+ * station is a machine, not an agent.
+ *
+ * An unrecognised value is ignored rather than denied: a claim is read by more
+ * planes over time, and a plane that refused what it did not understand would
+ * break each time one was added.
+ */
+export function grantAllowsPrincipal(grant: Grant | null, principalId: string | null): boolean {
+  if (!grant || !principalId) return false;
+  return grant.mayDispatch.includes(principalId);
+}
+```
+
+- [ ] **Step 4: Update the six call sites.** Each already holds the station row; pass its `principalId`. For example, `apps/hub/src/routes/station-say.ts:71`:
+
+```typescript
+const allowed = grantAllowsPrincipal(grant, station.principalId);
+```
+
+Do the same at `missions.ts:117` (the station list gains `principalId`), `grant-reach.ts:92` and `:137`, `acp-sessions.ts:668`, and `matrix-as/inbound.ts:177`.
+
+- [ ] **Step 5: Update the shared claim fixture.** In `fixtures/ecosystem-identity/token_claims.json`, `mayDispatch` values become bare principal ids; add a reject case for a wildcard so the removal is pinned across repos, not merely done here.
+
+- [ ] **Step 6: Run the suites**
+
+Run: `cd apps/hub && bun test src/services/grants.test.ts src/services/grant-reach.test.ts`
+Expected: PASS.
+Run: `cd packages/contract && bun test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/hub/src/services/grants.ts apps/hub/src/services/grants.test.ts apps/hub/src/routes/ apps/hub/src/services/ fixtures/ecosystem-identity/token_claims.json
+git commit -m "feat(hub): a grant names one principal, and there are no wildcards
+
+Both per-plane values are deleted rather than deprecated — nothing is in
+production, so the destination is built directly instead of a third value and a
+retirement phase.
+
+Wildcards go because they matched things nobody intended: hermes:* silently
+spanned nodes, and agentpod:*/hermes reached a root station that should never
+have existed and was removed on 2026-08-30. Grants become enumerations, which is
+'said out loud' taken to its conclusion — and when a list becomes unwieldy, that
+is earned evidence that Teams are real."
+```
+
+---
+
+### Task 8: An agent's mxid comes from its handle
+
+**Files:**
+- Modify: `apps/hub/src/services/matrix-as/names.ts:32-55`
+- Test: `apps/hub/src/services/matrix-as/names.test.ts`
+
+**Interfaces:**
+- Produces: `bridgeLocalpart(handle: string): string`, `bridgeUserId(handle: string, domain: string): string`. Every caller passes a handle instead of `(nodeName, stationKey)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("an agent's address survives moving between nodes", () => {
+  // The principle the strategy states twice: an agent is an identity, a station
+  // is a location. Derived from node+station, moving an agent made it a
+  // different person in chat.
+  expect(bridgeUserId("writer-quill", "id.agentpod.dev")).toBe("@agent_writer-quill:id.agentpod.dev");
+});
+
+test("still lands inside the exclusive @agent_.* namespace", () => {
+  // Outside it the appservice may not act — a 403 that arrives later and elsewhere.
+  expect(bridgeLocalpart("Writer Quill")).toMatch(/^agent_[a-z0-9._=/-]+$/);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test src/services/matrix-as/names.test.ts`
+Expected: FAIL — `bridgeUserId` takes three arguments.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+export function bridgeLocalpart(handle: string): string {
+  return `agent_${clean(handle)}`;
+}
+
+export function bridgeUserId(handle: string, domain: string): string {
+  return `@${bridgeLocalpart(handle)}:${domain}`;
+}
+```
+
+Keep `localpartFor(nodeName, stationKey)` — `bridgeAlias` still uses it, and an alias is a room's address rather than an agent's.
+
+- [ ] **Step 4: Update callers.** `matrix-as/gates.ts` (in `projectGate` and `roomAgentUser`), `provision.ts`, `activity.ts`, `outbound.ts`. Each resolves the station's `principalId` → `principals.handle`.
+
+- [ ] **Step 5: Run the suite**
+
+Run: `cd apps/hub && bun test src/services/matrix-as`
+Expected: PASS — 287 tests in this area were green before the change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/services/matrix-as/
+git commit -m "feat(hub): an agent's Matrix address comes from its handle, not its station
+
+bridgeUserId(nodeName, stationKey, domain) made an agent's chat identity a
+function of where it ran: move it and it became a different person, with new DM
+rooms and its history left behind. The strategy states the opposite principle
+twice. Rooms are migrated separately and none are recreated."
+```
+
+---
+
+### Task 9: Migrate the 32 rooms
+
+**Files:**
+- Create: `apps/hub/scripts/migrate-agent-mxids.ts`
+- Modify: `apps/hub/src/db/schema/matrix.ts` (`matrixRooms.principalId`)
+- Test: `apps/hub/scripts/migrate-agent-mxids.test.ts`
+
+**Interfaces:**
+- Consumes: `stations.principalId`, `principals.handle`, `bridgeUserId(handle, domain)`
+- Produces: `migrateAgentMxids(deps): Promise<{ migrated: number; skipped: number }>`
+
+**This is the only irreversible step in slice A.** No room is deleted and no history is lost — Matrix keeps messages from departed members.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("the new user joins the existing room and the old one leaves", async () => {
+  const acts: string[] = [];
+  await migrateAgentMxids({
+    rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
+    join: async (u, r) => { acts.push(`join ${u} ${r}`); },
+    leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
+    setDirect: async (u, r) => { acts.push(`direct ${u} ${r}`); },
+  });
+  // Join BEFORE leave: the reverse leaves the room briefly with no agent in it.
+  expect(acts).toEqual([
+    "join @agent_writer-quill:h !r:h",
+    "direct @agent_writer-quill:h !r:h",
+    "leave @agent_guild_hermes-writer-quill:h !r:h",
+  ]);
+});
+
+test("is idempotent — a room already migrated is skipped", async () => {
+  const r = await migrateAgentMxids({ rooms: async () => [], join: fail, leave: fail, setDirect: fail });
+  expect(r.migrated).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/hub && bun test scripts/migrate-agent-mxids.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+/**
+ * Re-address 32 DM rooms from station-derived users to principal-derived ones.
+ *
+ * No room is deleted and no history is lost: Matrix keeps messages from members
+ * who have left. The AS owns the whole `@agent_.*` namespace, so the new user
+ * joins without an invite.
+ *
+ * The step that is easy to miss is `m.direct`. `provision.ts` creates these with
+ * `isDirect`, and that flag rides on the OWNER'S invite — so the account data
+ * names the OLD mxid. Skip this and 32 rooms quietly stop being DMs in the
+ * client: still there, still readable, no longer under People.
+ */
+export interface MxidMigrationDeps {
+  rooms(): Promise<Array<{ roomId: string; handle: string; oldUserId: string }>>;
+  join(userId: string, roomId: string): Promise<void>;
+  leave(userId: string, roomId: string): Promise<void>;
+  setDirect(userId: string, roomId: string): Promise<void>;
+}
+
+export async function migrateAgentMxids(
+  deps: MxidMigrationDeps,
+  domain = process.env.MATRIX_DOMAIN ?? "id.agentpod.dev"
+): Promise<{ migrated: number; skipped: number }> {
+  let migrated = 0;
+  let skipped = 0;
+  for (const room of await deps.rooms()) {
+    const next = bridgeUserId(room.handle, domain);
+    if (next === room.oldUserId) { skipped++; continue; }
+    // Join first. Leaving first would leave the room with no agent in it, and a
+    // crash between the two would leave it that way permanently.
+    await deps.join(next, room.roomId);
+    await deps.setDirect(next, room.roomId);
+    await deps.leave(room.oldUserId, room.roomId);
+    migrated++;
+  }
+  return { migrated, skipped };
+}
+```
+
+Add `principalId` to `matrixRooms` and re-key from `stationId` in the same migration.
+
+- [ ] **Step 4: Run and watch it pass**
+
+Run: `cd apps/hub && bun test scripts/migrate-agent-mxids.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Rehearse before the fleet.** Run against **one** scratch station's room on the live homeserver, confirm in a client that the room still appears under People with its history, then run the rest.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/scripts/migrate-agent-mxids.ts apps/hub/scripts/migrate-agent-mxids.test.ts apps/hub/src/db/schema/matrix.ts apps/hub/src/db/drizzle-migrations/
+git commit -m "feat(hub): re-address the fleet's DM rooms to principal-derived users
+
+Membership, not recreation: the new user joins, the old one leaves, its messages
+stay. Join before leave, because the reverse leaves a room with no agent in it
+and a crash between the two makes that permanent.
+
+The m.direct fix-up is the easy miss — the DM flag rides on the owner's invite,
+so the account data names the old mxid and the rooms quietly stop being DMs."
+```
+
+---
+
+### Task 10: kaambaan maps its agents onto principals
+
+**Files:**
+- Create: `apps/api/migrations/000X_agents_external_id.sql`
+- Modify: `apps/api/src/db/catalog.ts:144-156`, `apps/api/src/auth/hub-jwt.ts`
+- Test: `apps/api/test/agent-external-mapping.test.ts`
+
+**Interfaces:**
+- Produces: `agents.external_id`, `agents.external_source`; `findAgentByExternal(db, source, externalId)`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { setupCatalog } from './helpers/catalog';
+import { createAgent, findAgentByExternal } from '../src/db/catalog';
+
+beforeAll(setupCatalog);
+
+describe('an agent maps to a suite principal', () => {
+  it('finds a local agent by the principal it maps to', async () => {
+    const a = await createAgent(env.DB, 'tnt_a', { name: 'Forge', capabilities: ['research'] });
+    await env.DB.prepare(`UPDATE agents SET external_id = ?, external_source = 'org-plane' WHERE id = ?`)
+      .bind('prn_0123456789abcdef0123', a.id).run();
+    const found = await findAgentByExternal(env.DB, 'org-plane', 'prn_0123456789abcdef0123');
+    expect(found?.agentId).toBe(a.id);
+  });
+
+  it('an unmapped agent is the normal state, not a fault', async () => {
+    // A standalone board must boot with no hub in existence. NULL stays legal.
+    const a = await createAgent(env.DB, 'tnt_b', { name: 'Solo', capabilities: [] });
+    expect(await findAgentByExternal(env.DB, 'org-plane', 'prn_nope')).toBeNull();
+    expect(a.id).toMatch(/^agt_/);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/api && pnpm vitest run test/agent-external-mapping.test.ts`
+Expected: FAIL — no such column `external_id`; `findAgentByExternal` is not exported.
+
+- [ ] **Step 3: Migration**
+
+```sql
+-- The same manoeuvre tenants already carries: a local id plus an optional
+-- mapping to the same real thing elsewhere. NULL is the normal state — a
+-- standalone board must work with no hub in existence.
+ALTER TABLE agents ADD COLUMN external_id TEXT;
+ALTER TABLE agents ADD COLUMN external_source TEXT;
+CREATE UNIQUE INDEX agents_external_idx ON agents (external_source, external_id);
+```
+
+- [ ] **Step 4: Implement the lookup**
+
+```typescript
+export async function findAgentByExternal(
+  db: D1Database,
+  source: string,
+  externalId: string,
+): Promise<{ tenantId: string; agentId: string; capabilities: string[] } | null> {
+  const row = await db
+    .prepare(
+      `SELECT tenant_id AS tenantId, id AS agentId, capabilities_json AS caps
+         FROM agents WHERE external_source = ? AND external_id = ?`,
+    )
+    .bind(source, externalId)
+    .first<{ tenantId: string; agentId: string; caps: string }>();
+  if (!row) return null;
+  return { tenantId: row.tenantId, agentId: row.agentId, capabilities: JSON.parse(row.caps) };
+}
+```
+
+- [ ] **Step 5: Run and watch it pass**
+
+Run: `cd apps/api && pnpm vitest run test/agent-external-mapping.test.ts`
+Expected: PASS.
+Run: `cd apps/api && pnpm vitest run && pnpm typecheck`
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/ apps/api/src/db/catalog.ts apps/api/test/agent-external-mapping.test.ts
+git commit -m "feat(api): an agent can map to a suite principal
+
+The same manoeuvre tenants already carries, and NULL stays the normal state:
+a standalone board must boot with no hub in existence. This is product
+independence, not migration scaffolding — the distinction the rest of this
+slice depends on."
+```
+
+---
+
+## Verification before slice A is called done
+
+- [ ] `cd packages/contract && bun test` — the corpus round-trip, both repos' view
+- [ ] `cd apps/hub && bun test src/services src/auth src/routes` — compare failures against a `git stash -u` baseline; DB-backed ones are CI's job
+- [ ] `cd apps/api && pnpm vitest run && pnpm typecheck` — kaambaan green
+- [ ] **The exit test, on the fleet:** a gate reaches the phone, is approved, and the board records the human — with the agent's mxid derived from its principal and the grant naming one id. If the 2026-08-30 exit test passes unchanged over the new spine, the slice is honest.

--- a/docs/superpowers/plans/2026-08-31-slice-b-agents-exchange.md
+++ b/docs/superpowers/plans/2026-08-31-slice-b-agents-exchange.md
@@ -1,0 +1,253 @@
+# Slice B — agents exchange, they do not hold — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An agent obtains a short-lived suite token that names it as a principal, and either plane can revoke that ability.
+
+**Architecture:** A node exchanges its existing `<nodeId>:<nodeSecret>` for a short-lived token scoped to one station it hosts, minted for that station's occupying principal. Nothing new is stored long-lived. kaambaan learns to resolve an agent-kind hub token to its own agent, and a suspended principal stops exchanging everywhere.
+
+**Tech Stack:** Bun · Hono · Drizzle/Postgres (hub) · Cloudflare Workers/D1 (kaambaan) · SvelteKit (console) · `bun test` and `vitest`
+
+**Spec:** `docs/superpowers/specs/2026-08-30-organization-plane-design.md` §3, under `charter → decisions/2026-08-30-an-agent-is-a-principal.md` Decision 4.
+
+## Global Constraints
+
+- **Nothing is in production.** Destinations, not migration paths. A breaking change costs a rebuild.
+- **`kbn_` stays permanently.** It is kaambaan's native agent credential and a standalone kaambaan must boot with no hub. The hub token is the *federated* path, dual **by design** — not migration debt.
+- **No refresh tokens, ever.** An expired agent token is re-exchanged against the credential the node already holds. `TOKEN_TTL` is 5 minutes and *"the expiry IS the revocation SLA"*.
+- **Capabilities never travel in the claim.** They are kaambaan's vocabulary; the token names a principal and kaambaan looks up its own agent row. `2026-08-15-a-grant-names-an-agent-per-plane` calls the alternative "a trap".
+- **An assertion must never carry authority the person's own token would not** — claims come from the same `buildTokenPayload` for every path.
+- **Postgres is available.** `open -a Docker && docker start agentpod-test-postgres`, then run with `DATABASE_URL=postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod` plus `NODE_ENV=test API_TOKEN=test-token SESSION_SECRET=test-session-secret-32-chars-long ENCRYPTION_KEY='test-encryption-key-32-bytes!!!!'`. Baseline **1579 pass / 0 fail**. **Run the suite twice without resetting** — a fixture that only passes once is the defect this project just spent a day finding.
+- **TDD.** Failing test first, watched fail.
+
+## File Structure
+
+**Create**
+- `apps/hub/src/routes/station-token.ts` — the exchange endpoint.
+- `apps/hub/src/routes/station-token.test.ts`
+
+**Modify**
+- `apps/hub/src/db/schema/organization.ts` — `principals.suspendedAt`
+- `apps/hub/src/services/principals.ts` — suspension read/write
+- `apps/hub/src/auth/jwt-claims.ts` — refuse a suspended principal
+- `apps/hub/src/index.ts` — mount the route
+- kaambaan `apps/api/src/auth/resolve.ts` — an agent-kind hub token resolves an agent
+- kaambaan `apps/api/src/db/catalog.ts` + a route — the `revoked_at` write
+- `apps/console/src/routes/admin/grants/+page.svelte` — suspend/restore
+
+---
+
+### Task 1: A principal can be suspended
+
+**Files:**
+- Modify: `apps/hub/src/db/schema/organization.ts`, `apps/hub/src/services/principals.ts`, `apps/hub/src/auth/jwt-claims.ts`
+- Test: `apps/hub/src/services/principals.test.ts`
+
+**Interfaces:**
+- Consumes: `principals`, `principalById(id)`, `buildTokenPayload`
+- Produces: `principals.suspendedAt`; `suspendPrincipal(id)`, `restorePrincipal(id)`; `principalById` returns `{ id, kind, suspendedAt }`
+
+**Why suspension rather than deletion.** Deleting a principal cascades its identities and grants away, so it destroys the audit trail exactly when someone wants to read it. `2026-08-13` Decision 3 named revocation as one of the three costs of agents holding their own reach; this is the lever that pays it.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("a suspended principal cannot be minted for", async () => {
+  const id = await createPrincipal({ kind: "agent", handle: `t-${crypto.randomUUID().slice(0, 8)}` });
+  await suspendPrincipal(id);
+  // Fail closed, and for a reason a reader can act on — not the same message
+  // as "no principal", which means something different.
+  expect(buildTokenPayload({ principalId: id })).rejects.toThrow(/suspended/);
+});
+
+test("restoring lets it mint again", async () => {
+  const id = await createPrincipal({ kind: "agent", handle: `t-${crypto.randomUUID().slice(0, 8)}` });
+  await suspendPrincipal(id);
+  await restorePrincipal(id);
+  const payload = await buildTokenPayload({ principalId: id });
+  expect(payload.sub).toBe(id);
+});
+```
+
+Note the unique handles: fixtures in this repo must survive a second run against the same database.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test src/services/principals.test.ts`
+Expected: FAIL — `suspendPrincipal` is not exported.
+
+- [ ] **Step 3: Add the column**
+
+```typescript
+/**
+ * When this principal stopped being allowed to act, if it has.
+ *
+ * A timestamp rather than a boolean: "since when" is the first question asked
+ * of a suspension, and a boolean cannot answer it. NULL is the normal state.
+ */
+suspendedAt: timestamp("suspended_at"),
+```
+
+Run `bun run db:generate`. **Read the emitted SQL before committing it** — this repo's snapshot has drifted before, and a generated migration once dropped foreign keys by names that did not exist.
+
+- [ ] **Step 4: Implement**
+
+```typescript
+export async function suspendPrincipal(id: string): Promise<void> {
+  await db.update(principals).set({ suspendedAt: new Date() }).where(eq(principals.id, id));
+}
+
+export async function restorePrincipal(id: string): Promise<void> {
+  await db.update(principals).set({ suspendedAt: null }).where(eq(principals.id, id));
+}
+```
+
+`principalById` returns `suspendedAt` alongside `id` and `kind`, and `buildTokenPayload` throws when it is set — on **both** subject paths, the session one and the principal one.
+
+- [ ] **Step 5: Run the tests, then run them again without resetting the database**
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/hub/src/db/schema/organization.ts apps/hub/src/services/principals.ts apps/hub/src/auth/jwt-claims.ts apps/hub/src/services/principals.test.ts apps/hub/src/db/drizzle-migrations/
+git commit -m "feat(hub): a principal can be suspended, and a suspended one mints nothing
+
+Deleting a principal cascades its identities and grants away, destroying the
+audit trail exactly when someone wants to read it. A timestamp rather than a
+boolean, because 'since when' is the first question anyone asks."
+```
+
+---
+
+### Task 2: A node exchanges for one of its stations
+
+**Files:**
+- Create: `apps/hub/src/routes/station-token.ts`, `apps/hub/src/routes/station-token.test.ts`
+- Modify: `apps/hub/src/index.ts`
+
+**Interfaces:**
+- Consumes: `verifyNodeCredential(nodeId, nodeSecret)`, `stations.principalId`, `buildTokenPayload({ principalId })`, `principals.suspendedAt`
+- Produces: `POST /api/nodes/:nodeId/stations/:stationId/token` → `{ token, expiresIn }`
+
+**The credential, decided by the operator.** A station holds no secret of its own. The node already holds `<nodeId>:<nodeSecret>` and already proves which stations it hosts, so it exchanges on a station's behalf. Follow the scheme at `apps/hub/src/routes/nodes.ts:249-258` exactly rather than inventing a second one.
+
+**Every refusal here fails closed:** a bad node credential, a station that belongs to a different node, a station with no occupying principal, and a suspended principal. The third is not an error condition — it is the ordinary state of an unassigned station, and it must say so distinctly.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("mints for the station's occupant, naming the principal and its kind", async () => {
+  const res = await app.request(`/api/nodes/${nodeId}/stations/${stationId}/token`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+  });
+  expect(res.status).toBe(200);
+  const claims = decodeJwt((await res.json()).token);
+  expect(claims.sub).toBe(agentPrincipalId);
+  expect(claims.principalKind).toBe("agent");
+});
+
+test("refuses a station hosted by a different node", async () => {
+  // The node proves who it is, not what it may reach. Without this check any
+  // node could mint for any agent in the fleet.
+  const res = await app.request(`/api/nodes/${nodeId}/stations/${otherNodesStation}/token`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+  });
+  expect(res.status).toBe(403);
+});
+
+test("refuses a station with no occupying principal, distinctly", async () => {
+  const res = await app.request(`/api/nodes/${nodeId}/stations/${unoccupied}/token`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+  });
+  expect(res.status).toBe(409);
+});
+
+test("refuses a suspended principal", async () => {
+  await suspendPrincipal(agentPrincipalId);
+  const res = await app.request(`/api/nodes/${nodeId}/stations/${stationId}/token`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${nodeId}:${nodeSecret}` },
+  });
+  expect(res.status).toBe(403);
+});
+
+test("refuses a wrong node secret", async () => {
+  const res = await app.request(`/api/nodes/${nodeId}/stations/${stationId}/token`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${nodeId}:wrong` },
+  });
+  expect(res.status).toBe(401);
+});
+```
+
+**Test harness:** these are Hono route tests — build a `new Hono()` and drive it with
+`app.request(path, init)`, following `apps/hub/src/routes/kaambaan-push.test.ts:55,62`.
+`decodeJwt` from `jose` reads the minted claims, as `src/auth/service-signing.test.ts` does.
+
+- [ ] **Step 2: Run it and watch it fail** — route not mounted, 404.
+- [ ] **Step 3: Implement the route**, mounted under `/api` (Bearer passes the CSRF middleware, so unlike the HMAC-signed `kaambaan-push` receiver this does not need `/public`). Sign with the same `buildTokenPayload` a human's token uses, so an agent can never carry authority its grant does not give.
+- [ ] **Step 4: Run the tests, then run them again without resetting**
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 3: kaambaan resolves an agent-kind hub token
+
+**Files:**
+- Modify: kaambaan `apps/api/src/auth/resolve.ts`
+- Test: kaambaan `apps/api/test/hub-token-agent.test.ts`
+
+**Interfaces:**
+- Consumes: `verifyHubToken` (already reads `principalKind`, `hub-jwt.ts:179`), `findAgentByExternal(db, 'org-plane', sub)` (built in slice A)
+- Produces: `resolveHubAgent(request, env): Promise<AgentPrincipal | null>`
+
+**This is the hot path.** Every claim goes through it. A `kbn_` token must keep working unchanged — it is kaambaan's native credential and a standalone board depends on it.
+
+- [ ] **Step 1: Write the failing test** — an agent-kind hub token whose `sub` maps to a local agent resolves to that agent with its own capabilities; one whose `sub` maps to nothing is refused; a human-kind token does **not** resolve as an agent; a `kbn_` token is unaffected.
+- [ ] **Step 2: Run it and watch it fail**
+- [ ] **Step 3: Implement.** Capabilities come from the local `agents` row, never from the claim.
+- [ ] **Step 4: Run `pnpm vitest run && pnpm typecheck`** — baseline 398 pass / 0 fail, and this repo needs no database, so anything red is real.
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 4: Revoking a kaambaan agent token
+
+**Files:**
+- Modify: kaambaan `apps/api/src/db/catalog.ts`, and the agents route
+- Test: kaambaan `apps/api/test/agent-token-revocation.test.ts`
+
+**The read side is already live** — `findAgentByTokenHash` filters `WHERE at.revoked_at IS NULL` on every agent request (`catalog.ts:152`). Only the write is missing, so this is an endpoint, not a system. `2026-08-13` Decision 3 says kaambaan is "weakest exactly here".
+
+- [ ] **Step 1: Write the failing test** — revoking a token makes the next request with it fail; another token for the same agent still works; revoking twice is not an error.
+- [ ] **Step 2: Run it and watch it fail**
+- [ ] **Step 3: Implement `revokeAgentToken` and its route**, authorised as a human act.
+- [ ] **Step 4: Run the suite and typecheck**
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 5: Suspend and restore from the console
+
+**Files:**
+- Modify: `apps/console/src/routes/admin/grants/+page.svelte`, `apps/console/src/lib/api/grants.ts`, `apps/hub/src/routes/admin-grants.ts`
+- Test: `apps/hub/src/routes/admin-grants-route.test.ts`
+
+The principals directory added in slice A already lists `{id, kind, handle, displayName}`. Add `suspendedAt` to it, show the state, and offer suspend/restore — guarded by `adminMiddleware` like the rest of `/api/admin/*`.
+
+- [ ] **Step 1: Write the failing route test** — a non-admin cannot suspend; an admin can; the directory reports the state.
+- [ ] **Step 2: Run it and watch it fail**
+- [ ] **Step 3: Implement the endpoint and the console control.** Keep it small — a state and two buttons, not a new page.
+- [ ] **Step 4: Run the hub suite twice, plus `svelte-check`**
+- [ ] **Step 5: Commit**
+
+---
+
+## Verification before slice B is called done
+
+- [ ] Hub: **1579+ pass / 0 fail**, run **twice without resetting the database**
+- [ ] kaambaan: `pnpm vitest run && pnpm typecheck` green
+- [ ] Console: `svelte-check` 0 errors
+- [ ] **The exit test:** a node exchanges for one of its stations, kaambaan accepts the resulting token as that agent and applies the agent's own capabilities, and suspending the principal makes the next exchange fail — proving revocation reaches across the plane boundary, which is what `2026-08-13` Decision 3 said agents holding their own reach would cost.

--- a/docs/superpowers/plans/2026-08-31-slice-c-creating-an-agent.md
+++ b/docs/superpowers/plans/2026-08-31-slice-c-creating-an-agent.md
@@ -1,0 +1,174 @@
+# Slice C — creating an agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An operator can create an agent and put it on a station without running SQL, and can move it later without it losing its name or its conversation.
+
+**Architecture:** Adoption keeps leaving `stations.principal_id` null; the console makes that visible and offers one click to fix it. Reassignment moves the agent's *room* with it, which finally gives `matrix_rooms.principal_id` the writer slice A left it without. kaambaan gains the mapping field and the revoke button its own endpoint has been waiting for.
+
+**Tech Stack:** Bun · Hono · Drizzle/Postgres (hub) · SvelteKit (console, kaambaan web) · Cloudflare Workers/D1 (kaambaan) · `bun test` and `vitest`
+
+**Spec:** `docs/superpowers/specs/2026-08-31-creating-an-agent-design.md`
+
+## Global Constraints
+
+- **Postgres is available and every suite runs TWICE without resetting.** `open -a Docker && docker start agentpod-test-postgres`, then `NODE_ENV=test DATABASE_URL='postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod' API_TOKEN=test-token SESSION_SECRET=test-session-secret-32-chars-long ENCRYPTION_KEY='test-encryption-key-32-bytes!!!!' bun test`. A fixture that passes once and fails on a re-run is the defect this project lost a day to. Report both counts, always.
+- **Read the SQL `bun run db:generate` emits before committing it.** A generated migration on this branch already dropped foreign keys by names that did not exist; the hub could not have started.
+- **A handle is immutable.** An agent's Matrix address derives from it. Changing one silently renames a person.
+- **`stations.principal_id` stays nullable and `matrix_rooms.station_id` stays.** The production reconciliation sweep joins on the latter (slice A, Ruling 4).
+- **Every new endpoint sits behind `authMiddleware` then `adminMiddleware`.** No exemptions carved.
+- Nothing is in production: destinations, not migration paths.
+- TDD: failing test first, watched fail.
+
+## File Structure
+
+**Create** — `apps/hub/src/routes/agents-admin.ts` (+ test); `apps/console/src/routes/agents/AgentCreate.svelte`
+**Modify** — `apps/hub/src/services/principals.ts`, `db/schema/matrix.ts`, `services/matrix-as/gates.ts`, `routes/admin.ts`; `apps/console/src/routes/agents/+page.svelte`, `lib/api/*`; kaambaan `apps/api/src/db/catalog.ts`, `src/index.ts`, `apps/web/src/lib/api.ts`, `lib/components/BoardScreen.svelte`
+
+---
+
+### Task 1: Rotate a signing key (spike)
+
+**Files:** Create `docs/superpowers/specs/2026-08-31-key-rotation-spike-findings.md`
+
+**This is a spike: the output is an answer, not code you keep.** Anything built is throwaway and must be labelled so.
+
+Verification is offline, so *"the expiry IS the revocation SLA"* and a key that cannot rotate cleanly is the only revocation lever the suite has, failing silently. `servicePublicJwks()` already publishes retired keys deliberately (`service-signing.ts`) — check the `jwt` plugin's `jwks` table behaves the same way.
+
+- [ ] **Step 1:** Against the local Postgres, mint a token and record its `kid`.
+- [ ] **Step 2:** Rotate the signing key.
+- [ ] **Step 3:** Confirm the **old token still verifies** until it expires — retiring a key must not invalidate tokens already issued. `agentpod#331` established that offline verification means no consumer asks the issuer anything.
+- [ ] **Step 4:** Confirm the new key appears in JWKS, that a newly minted token carries the new `kid`, and that kaambaan's verifier accepts it (`apps/api/src/auth/hub-jwt.ts` caches JWKS for 10 minutes — say what that means for rotation timing).
+- [ ] **Step 5:** Confirm nothing signs with the retired key afterwards.
+- [ ] **Step 6:** Write findings — what worked, what did not, and what it means for extraction. Commit the findings only.
+
+---
+
+### Task 2: Create and assign an agent — the hub
+
+**Files:** Create `apps/hub/src/routes/agents-admin.ts`, `agents-admin.test.ts`; modify `apps/hub/src/services/principals.ts`, `routes/admin.ts`
+
+**Interfaces:**
+- Consumes: `createPrincipal`, `principalById`, `suspendPrincipal`, `stations`, `principals`
+- Produces: `POST /api/admin/agents` `{handle, displayName?}` → the created principal; `PUT /api/admin/stations/:stationId/agent` `{principalId}` → assigns; `DELETE` the same → unassigns
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+test("creates an agent principal with the handle given", async () => {
+  const res = await app.request("/api/admin/agents", {
+    method: "POST", headers: adminHeaders,
+    body: JSON.stringify({ handle: `writer-${unique}`, displayName: "Writer Quill" }),
+  });
+  expect(res.status).toBe(201);
+  expect((await res.json()).id).toMatch(/^prn_[0-9a-f]{20}$/);
+});
+
+test("refuses a handle already taken", async () => {
+  // A handle becomes an mxid localpart. Two claimants make the address ambiguous,
+  // which is why principals_org_handle_idx exists — surface it as a 409, not a 500.
+  await createPrincipal({ kind: "agent", handle: taken });
+  const res = await app.request("/api/admin/agents", {
+    method: "POST", headers: adminHeaders, body: JSON.stringify({ handle: taken }),
+  });
+  expect(res.status).toBe(409);
+});
+
+test("refuses a handle that cannot be an mxid localpart", async () => {
+  const res = await app.request("/api/admin/agents", {
+    method: "POST", headers: adminHeaders, body: JSON.stringify({ handle: "Writer Quill!" }),
+  });
+  expect(res.status).toBe(400);
+});
+
+test("assigning makes the station dispatchable, unassigning makes it nobody's", async () => {
+  await app.request(`/api/admin/stations/${stationId}/agent`, {
+    method: "PUT", headers: adminHeaders, body: JSON.stringify({ principalId }),
+  });
+  expect((await stationRow(stationId)).principalId).toBe(principalId);
+  await app.request(`/api/admin/stations/${stationId}/agent`, { method: "DELETE", headers: adminHeaders });
+  expect((await stationRow(stationId)).principalId).toBeNull();
+});
+
+test("a non-admin can do none of it", async () => {
+  for (const req of [createReq, assignReq, unassignReq]) {
+    expect((await app.request(req.path, { ...req, headers: userHeaders })).status).toBe(403);
+  }
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail** — routes not mounted, 404.
+- [ ] **Step 3: Implement.** Validate the handle against the same character class `clean()` in `matrix-as/names.ts` uses, so a handle that would be silently mangled into an mxid is refused up front instead. Assigning a suspended principal is refused.
+- [ ] **Step 4: Run the suite twice, no reset. Report both.**
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 3: The console — create, assign, and show what is unassigned
+
+**Files:** Modify `apps/console/src/routes/agents/+page.svelte`, `apps/console/src/lib/api/*`; create `AgentCreate.svelte` + tests
+
+**Interfaces:** Consumes Task 2's three endpoints.
+
+**The point of this task is the visibility, not the form.** A station with no principal is dispatchable by nobody, and today that is invisible — `gate-sweep.ts` counts only `sent`, so a fleet-wide refusal produces no error line and the console shows healthy stations. That invisibility is why the deploy runbook needs remembered manual steps.
+
+- [ ] **Step 1: Write the failing component tests** — an unassigned station renders as unassigned and not merely healthy; the create action pre-fills the handle from the station key; a taken handle surfaces the 409 as a readable message rather than a generic failure.
+- [ ] **Step 2: Run and watch fail.**
+- [ ] **Step 3: Implement.** Follow the empty-state lesson from slice A's final review: a bare "0 of 0" with no explanation is a finding. Say what an empty or unassigned state means.
+- [ ] **Step 4:** `pnpm svelte-check` (0 errors) and the console vitest — the console has **132 pre-existing failures** unrelated to this work; confirm that number is unchanged rather than treating it as new.
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 4: kaambaan — link a principal, and revoke a token
+
+**Files:** Modify kaambaan `apps/api/src/db/catalog.ts`, `src/index.ts`, `apps/web/src/lib/api.ts`, `apps/web/src/lib/components/BoardScreen.svelte`; tests alongside
+
+**Interfaces:**
+- Consumes: `setAgentExternalMapping` (exists, no caller), `revokeAgentToken` (exists, no button)
+- Produces: a route to set the mapping; UI for both
+
+**`revokeAgentToken` shipped in slice B and no human can reach it.** The spec asked for *"an endpoint and a console button"*; only the endpoint was built. `decisions/2026-08-13-ecosystem-identity.md` Decision 3 names this lever as kaambaan's specific weakness.
+
+- [ ] **Step 1: Write the failing tests** — setting the mapping makes `resolveHubAgent` resolve that agent (prove through the resolver, not by reading the column); revoking through the UI's path makes the **next request** with that token fail; a non-human credential can do neither.
+- [ ] **Step 2: Run and watch fail.**
+- [ ] **Step 3: Implement**, on the agent list already in `BoardScreen.svelte`. Revoking is destructive and irreversible — give it a confirmation.
+- [ ] **Step 4:** `pnpm vitest run && pnpm typecheck`. Baseline **413 pass / 0 fail**, clean. This repo needs no database, so anything red is real.
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 5: Reassignment — the room follows the agent
+
+**Files:** Modify `apps/hub/src/routes/agents-admin.ts`, `apps/hub/src/services/matrix-as/gates.ts`, `apps/hub/src/db/schema/matrix.ts`, `apps/hub/scripts/migrate-agent-mxids.ts` (comments only)
+
+**Interfaces:** Produces a writer for `matrix_rooms.principal_id`; `roomForCard` and `roomAgentUser` resolve through the principal.
+
+**This closes slice A's finding I2.** `matrix_rooms.principal_id` was added for exactly this and left with no writer, alongside **two comments that falsely claim something backfills it** — `db/schema/matrix.ts:56-58` and `scripts/migrate-agent-mxids.ts:44-48`. Correct both.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("a reassigned agent keeps its room, its id, and its history", async () => {
+  // The whole reason the mxid comes from a handle rather than a station.
+  const roomBefore = await roomForStation(stationA);
+  await reassign(principalId, { from: stationA, to: stationB });
+  expect(await roomForPrincipal(principalId)).toBe(roomBefore);   // same room id
+});
+
+test("station_id is not dropped — the sweep deployed on infra joins on it", async () => {
+  expect((await roomRow(roomBefore)).stationId).not.toBeNull();
+});
+```
+
+- [ ] **Step 2: Run and watch fail.**
+- [ ] **Step 3: Implement.** Write `principal_id` on reassignment and backfill existing rows from their station's current occupant in the same migration. `roomForCard` becomes card → dispatch → station → principal → room. **Keep `station_id` and keep the old join working** until a later slice retires it deliberately.
+- [ ] **Step 4: Run the suite twice, no reset.** The approvals path is covered by existing tests — a regression there is the thing this task must not cause.
+- [ ] **Step 5: Commit**
+
+---
+
+## Verification before slice C is called done
+
+- [ ] hub: **0 fail**, run twice without resetting; kaambaan **0 fail** + clean typecheck; console `svelte-check` 0 errors with its 132 pre-existing failures unchanged
+- [ ] **The exit test, by hand:** adopt a station, create an agent for it in one action in the console, and watch a gate reach that agent's room — **with no SQL run at any point.** That is precisely what slices A and B cannot do today, and it is the whole reason this slice exists.

--- a/docs/superpowers/specs/2026-08-30-organization-plane-design.md
+++ b/docs/superpowers/specs/2026-08-30-organization-plane-design.md
@@ -1,0 +1,195 @@
+# The Organization plane — implementation design
+
+**Date:** 2026-08-30
+**Status:** Designed, unbuilt.
+**The agreements this implements** are
+`charter → decisions/2026-08-30-an-agent-is-a-principal.md` and
+`charter → decisions/2026-08-30-matrix-identity-without-mas.md`. Read them
+first. They settle what a principal is, where an agent's Matrix identity comes
+from, what a grant names, how an agent gets a token, and what all of it costs.
+This document holds only what they deliberately do not: what changes in which
+repository, in what order, and how it is tested.
+
+**The frame.** Nothing in this suite is in production and nothing goes into real
+use until the stack is autonomous end to end. That is not a caveat, it is a
+design input: **build destinations, not migration paths.** Cut over rather than
+dual-run, re-seed rather than backfill, one canonical id rather than a third
+value and a retirement phase. A breaking change costs a rebuild, not an
+incident.
+
+The one thing it does not license: **product independence is not migration
+scaffolding.** A standalone kaambaan must still boot with no hub in existence.
+`NULL` mappings stay.
+
+---
+
+## 1. The shape
+
+```
+                  Organization plane  (C — Better Auth in its own right)
+                  principals · identities · grants · user/session/jwks
+                          │  issues, offline-verifiable
+        ┌─────────────────┼──────────────────┐
+        ▼                 ▼                  ▼
+   AgentPod hub       kaambaan          supermessage
+   fleet · stations   boards · agents   the client
+   tenants(ext→org)   tenants(ext→org)  @agent_<handle>
+                      agents(ext→prn)
+```
+
+Three slices, in order. **A** gives the suite the entity it has been describing
+and could not represent. **B** makes it load-bearing. **C** moves it to where
+the ownership map says it belongs.
+
+## 2. A — an agent is a principal
+
+### 2.1 agentpod hub
+
+1. **`principals`** — `id (prn_)`, `kind`, `org_id`, `handle`, `display_name`.
+   `handle` is immutable and unique; it is what an mxid is built from.
+2. **Re-point two foreign keys.** `principal_identities.principal_id` and
+   `principal_grants.principal_id` move from `user.id` to `principals.id`.
+   Backfill is one row today. Take the FK — a dangling grant in an
+   authorization table is an orphan nothing would catch.
+3. **`user` becomes an identity.** A `better-auth` row in
+   `principal_identities`, reached like any other system.
+4. **`principalKind` stops being a literal.** Read `principals.kind`.
+5. **`resolveTenantForUser` resolves through the principal.** 21 references
+   across 16 files; most keep their signature and the hop moves inside.
+6. **Seed agent principals from the fleet** — a one-time script over the 32
+   stations. After it, creating an agent is a deliberate act and station
+   adoption *links* to an existing principal rather than implying one.
+
+### 2.2 The mxid migration — the only irreversible step in A
+
+`bridgeUserId(nodeName, stationKey, domain)` becomes
+`bridgeUserId(handle, domain)`. For each of the 32 rooms:
+
+1. register `@agent_<handle>:<domain>` and **join the existing room** — the AS
+   owns the whole `@agent_.*` namespace, so no invite is needed;
+2. the station-derived user leaves; **its messages stay** — Matrix keeps
+   history from departed members;
+3. re-point the alias;
+4. re-key `matrix_rooms` from `station_id` to `principal_id`;
+5. **fix up `m.direct`.** The room was created with `isDirect` and the flag
+   rides on the owner's invite (`provision.ts`), so the account data names the
+   **old** mxid. Skip this and 32 rooms quietly stop being DMs in the client.
+
+**No room is deleted and no history is lost.** Write it as one idempotent
+script, and run it against a scratch station before the fleet.
+
+### 2.3 kaambaan
+
+`agents` gains `external_id` / `external_source`, the pair `tenants` already
+carries. `NULL` for a standalone board.
+
+### 2.4 The contract
+
+- `fixtures/ecosystem-identity/id_grammar.json` — add `prn_`. **Also add
+  `gate`**, absent entirely, flagged in the approvals worklog and never done;
+  it crosses a repo boundary now, and `gat_`/`gate_` confusion in kaambaan#34's
+  sketch is what the grammar exists to prevent.
+- `token_claims.json` — `mayDispatch` becomes a list of bare principal ids.
+- **Both existing matchers are deleted, not deprecated.** No third value, no
+  retirement phase.
+
+Fleet enrollment becomes an admin act, because the wildcard that encoded
+"your authority spans the fleet" no longer exists.
+
+## 3. B — exchange
+
+1. **An exchange endpoint** taking a `kbn_` token or a station credential,
+   returning a short-lived token with `sub = prn_…`, `principalKind: "agent"`,
+   claims from the same `buildTokenPayload` a human's uses. `Bearer` passes the
+   CSRF middleware, so `/api` is fine — unlike the HMAC-signed push receiver,
+   which is why that one lives under `/public`.
+2. **No refresh.** The agent re-exchanges against the credential it already
+   holds. Nothing new is stored.
+3. **The revocation write.** The read side is live —
+   `findAgentByTokenHash` filters `WHERE revoked_at IS NULL` on every agent
+   request — so this is an endpoint and a console button, not a system.
+   Suspending a principal must fail every exchange, whichever plane issued the
+   credential.
+4. **kaambaan's auth gains a branch**, and it is the riskiest change in the
+   program: `resolveHubUser` returns a `UserPrincipal`, and an agent-kind token
+   must resolve to an `AgentPrincipal` instead — on the path every claim takes.
+   **Capabilities are not in the claim** (`2026-08-15-a-grant-names-an-agent-per-plane`
+   calls that a trap: two vocabularies, one word). The token names the
+   principal; kaambaan looks up its own agent row for capabilities.
+
+## 4. C — the plane
+
+**Gates, in order:**
+
+1. **agentpod#333** — Better Auth 1.6.26 hub / 1.4.6 console. Blocks C outright;
+   now just an upgrade.
+2. **The spike**, below.
+
+**Then:** stand up Better Auth with `jwt` + `admin`. **Not `organization`** — it
+ships a second org model beside `principals`, which is MT-1's mistake relocated.
+It is enabled when grant-list length argues for Teams.
+
+Move `user`, `session`, `account`, `verification`, `jwks` and the three
+principal tables. **Re-seed by script, then delete the tables from the hub.** One
+user, ~14 agent principals, a handful of grants. No dual-run.
+
+`tenants` stays in each product. `tenants.external_source = 'org-plane'` finally
+carries the org id it was built for on 2026-08-14.
+
+**The constraint C must satisfy, and it should be a test:** everything needed to
+authorize a request is in the claim. No synchronous call to the plane on any
+authorization path — `2026-08-13` is absolute that enforcement is local and the
+token is the carrier, *"explicitly not a policy-service call in the hot path."*
+
+**The exception, named in the decision:** resolving an inbound Matrix sender to
+a principal is not a token path and is not blunted by offline verification.
+Approvals will depend on the plane being up.
+
+## 5. The spike — first, before anything is written into the plan
+
+Two probes, both cheap, both gating:
+
+1. **Rotate a `jwt` signing key end to end.** Untested, and it is the only
+   revocation lever a JWT has: verification is offline, so *"the expiry IS the
+   revocation SLA"* and a key that cannot rotate cleanly fails silently.
+2. **Can tuwunel's `m.login.token` be driven by an external issuer?** The live
+   server advertises `{"type":"m.login.token","get_login_token":true}`. If yes,
+   the Organization plane authenticates a human and mints a Matrix login token —
+   no OIDC, no MAS, no second password store, and the last identity silo closes.
+   If no, Matrix keeps its own credential for humans and
+   `principal_identities` stays the join, which already works.
+
+Findings land here before the plan is written, the way
+`2026-08-16-tuwunel-appservice-spike-findings.md` preceded the appservice design.
+
+## 6. Tests
+
+**Contract.** Fixture round-trip in each repo — the mechanism already keeping
+five hand-written Go mirrors of zod schemas honest, aimed across a repo boundary.
+
+**A.** A grant naming a principal authorizes that agent on both planes; an
+unrecognised id is ignored, never denied; a station with no principal is
+dispatchable by nobody; an agent's mxid survives a station change; the room
+migration is idempotent and leaves `m.direct` correct.
+
+**B.** An expired agent token re-exchanges; a suspended principal cannot
+exchange; a revoked credential cannot exchange; an agent token resolves to an
+`AgentPrincipal` on kaambaan and to nothing on a human-only route.
+
+**C.** No authorization path calls the plane — asserted, not assumed. A plane
+outage degrades sign-in and approvals and nothing else.
+
+**The exit test.** A gate reaches a phone, is approved, and the board records the
+human — with the Organization plane holding the identity, the agent's mxid
+derived from its principal, and the grant naming one id. That is the 2026-08-30
+exit test again, over the new spine. If it passes unchanged, the extraction was
+honest.
+
+## 7. Explicitly not in this program
+
+- **Teams, Roles, Objectives.** The differentiated part of this plane and
+  hypotheses one operator cannot validate. The trigger is grant-list length.
+- **MAS.** Not deferred — out. See the decision.
+- **Many:1 org→fleet.** Four triggers named in
+  `2026-08-15-tenancy-is-local-and-mapped`; none has fired.
+- **Retiring `kbn_`.** It is kaambaan's native credential, permanently.

--- a/docs/superpowers/specs/2026-08-30-organization-plane-design.md
+++ b/docs/superpowers/specs/2026-08-30-organization-plane-design.md
@@ -41,12 +41,30 @@ Three slices, in order. **A** gives the suite the entity it has been describing
 and could not represent. **B** makes it load-bearing. **C** moves it to where
 the ownership map says it belongs.
 
+**Each slice is its own implementation plan and its own series of PRs.** This is
+one design because the three share a spine and a decision; it is not one plan.
+A alone touches four repositories, and the first PR in it — the fixture plus the
+`principals` table and its backfill — changes no behaviour and nothing reads it
+yet.
+
 ## 2. A — an agent is a principal
 
 ### 2.1 agentpod hub
 
 1. **`principals`** — `id (prn_)`, `kind`, `org_id`, `handle`, `display_name`.
    `handle` is immutable and unique; it is what an mxid is built from.
+
+   **What `org_id` holds before the plane exists**, because "the organisation"
+   is otherwise undefined for the whole of A and B: **the hub mints `org_` ids
+   from the first migration**, and `tenants.external_id` /
+   `external_source = 'org-plane'` maps fleet → org immediately. The hub *is*
+   the Organization plane until C moves it, exactly as it is already the issuer.
+   C then moves rows whose meaning does not change — which is the whole reason
+   `2026-08-15-one-issuer` could say *"only the issuer URL changes"*.
+
+   The alternative — a nullable `org_id` backfilled at C — would make A and B
+   depend on a column that means nothing yet, and would put a data change inside
+   the riskiest slice.
 2. **Re-point two foreign keys.** `principal_identities.principal_id` and
    `principal_grants.principal_id` move from `user.id` to `principals.id`.
    Backfill is one row today. Take the FK — a dangling grant in an
@@ -123,7 +141,9 @@ Fleet enrollment becomes an admin act, because the wildcard that encoded
 
 1. **agentpod#333** — Better Auth 1.6.26 hub / 1.4.6 console. Blocks C outright;
    now just an upgrade.
-2. **The spike**, below.
+2. **The spike** (§5). It runs *first of everything*, not merely before C — its
+   findings belong in the plan rather than in a surprise during the cutover —
+   but C is the slice that cannot start until it has answered.
 
 **Then:** stand up Better Auth with `jwt` + `admin`. **Not `organization`** — it
 ships a second org model beside `principals`, which is MT-1's mistake relocated.

--- a/docs/superpowers/specs/2026-08-31-creating-an-agent-design.md
+++ b/docs/superpowers/specs/2026-08-31-creating-an-agent-design.md
@@ -1,0 +1,148 @@
+# Creating an agent — implementation design
+
+**Date:** 2026-08-31
+**Status:** Designed, unbuilt.
+**Replaces slice C** of `docs/superpowers/specs/2026-08-30-organization-plane-design.md` §4.
+**Agreements it serves:** `charter → decisions/2026-08-30-an-agent-is-a-principal.md`,
+whose §"Where agent principals come from" says creating an agent is *"a deliberate act,
+not a side effect of a machine appearing"* — and which nothing has implemented.
+
+---
+
+## 1. Why slice C was reshaped
+
+§4 said: clear two gates, then extract the Organization plane into its own Better Auth
+deployable. **Both gates cleared themselves, and clearing them dissolved the slice.**
+
+- **agentpod#333 (Better Auth version skew) is stale, not open.** `pnpm-lock.yaml`
+  resolves a single `better-auth@1.6.28` and both `package.json` files declare `^1.6.28`.
+  The 1.6.26 / 1.4.6 skew the issue describes no longer exists.
+- **`oidc-provider` has no consumer anywhere in the suite.** It was in the plan for MAS
+  to delegate to, and `decisions/2026-08-30-matrix-identity-without-mas.md` removed MAS.
+
+So extraction now means standing up *exactly the configuration the hub already runs* —
+`bearer`, `admin`, `jwt`, `customSession` — in a second process. A relocation, not a
+construction, buying no function on the day it lands.
+
+**And it does not decompose cleanly yet.** `buildTokenPayload` reads `principals` and
+`principal_grants`; the station exchange reads `stations.principal_id`. Extraction puts
+those on opposite sides of a process boundary, so either the hub calls the plane inside
+every mint — every agent, every five minutes, plus every gate approval, which
+`decisions/2026-08-13-ecosystem-identity.md` forbids as *"a policy-service call in the
+hot path"* — or the plane takes ownership of station data, which the ownership map
+forbids from the other direction.
+
+**Meanwhile slices A and B do not work without manual SQL.** An agent principal exists
+only if someone runs a seed script; `agents.external_id` only if someone writes a row by
+hand. This document builds what both slices deferred, twice. Extraction stays a URL
+change, which is what every decision was shaped to keep it.
+
+## 2. The shape
+
+```
+adoption            →  station with principal_id NULL      (already true)
+console shows it    →  "unassigned", not merely healthy    NEW  §4
+one click           →  create agent + assign               NEW  §3
+reassign            →  the agent moves; room follows       NEW  §6
+kaambaan links it   →  agents.external_id                  NEW  §5
+kaambaan revokes    →  the button slice B never built      NEW  §5
+```
+
+## 3. Creating and assigning — agentpod
+
+An agent is a `principals` row, `kind = 'agent'`, with an **immutable** `handle` (its
+Matrix address derives from it) and a mutable `display_name`. Three acts:
+
+- **create** — writes `principals`. Handle pre-filled from the station key when created
+  in a station's context, and validated: it becomes an mxid localpart and cannot change.
+- **assign** — writes `stations.principal_id`. The station becomes dispatchable.
+- **reassign** — §6.
+
+Endpoints under `/api/admin`, guarded by `authMiddleware` then `adminMiddleware` like
+everything else there. The console surfaces them from the existing `/agents` page and
+from the station view.
+
+**Adoption is not changed.** It continues to leave `principal_id` null. That was the
+operator's choice between three options, and it keeps creating an agent deliberate while
+making the common case one click.
+
+## 4. Making "unassigned" visible
+
+The operational reason this slice exists. A station with no occupying principal is
+**dispatchable by nobody** — correct behaviour — and today it is invisible:
+`gate-sweep.ts` counts only `status === "sent"`, so a fleet-wide refusal produces no
+error line and the console shows healthy stations.
+
+That invisibility is why `estate/runbooks/deploy-the-organization-plane.md` needs §5 and
+§6 as remembered manual steps. Make the state visible and the runbook step becomes a
+state you can see.
+
+## 5. kaambaan — the mapping, and the button slice B never built
+
+Both go on the agent list already in `apps/web/src/lib/components/BoardScreen.svelte`,
+which creates agents and mints their `kbn_` tokens today.
+
+- **Link to a suite principal** — sets `external_id` / `external_source = 'org-plane'`.
+  This is what lets `resolveHubAgent` resolve slice B's agent-kind hub token to a local
+  agent. `setAgentExternalMapping` exists in `db/catalog.ts` and has no caller.
+- **Revoke a token.** Slice B built `revokeAgentToken` and its route; the spec asked for
+  *"an endpoint and a console button"* and **the button was never built**. The lever
+  `2026-08-13` Decision 3 named as kaambaan's specific weakness is reachable only by
+  curl. Give it the confirmation such a control deserves.
+
+## 6. Reassignment, and the column with no writer
+
+Moving an agent between stations is what the handle-derived mxid was for: the address
+and the conversation survive the move.
+
+A room is currently the **station's** — `matrix_rooms.station_id`, which `gates.ts`
+(`roomForCard`, `roomAgentUser`) joins on. Under that model a moved agent inherits the
+new station's room and abandons its history, which is the opposite of the point.
+
+So the room becomes the **agent's**. `matrix_rooms.principal_id` was added by slice A for
+exactly this and left with **no writer** — recorded as finding I2 in that slice's final
+review, alongside two comments that falsely claim something backfills it. This closes it.
+
+- Reassignment writes `matrix_rooms.principal_id`.
+- The gate path resolves card → dispatch → station → principal → room.
+- **`station_id` stays.** Ruling 4 of slice A: the reconciliation sweep deployed on infra
+  joins on it, and dropping it inside this slice would break the approvals chain that is
+  its own exit test.
+- The two false comments are corrected.
+
+## 7. The rotation spike — first
+
+Nothing has ever rotated a `jwt` signing key end to end. Verification is offline, so
+*"the expiry IS the revocation SLA"* and a key that cannot rotate cleanly is the only
+revocation lever the suite has, failing silently.
+
+Rotate one. Confirm the old key keeps verifying its outstanding tokens, the new key is
+published in JWKS and accepted by kaambaan, and nothing signs with the retired key
+afterwards. Findings land here, the way
+`2026-08-16-tuwunel-appservice-spike-findings.md` preceded the appservice design.
+
+It goes first because it is cheap and because a broken rotation changes what extraction
+costs — before anything else depends on the issuer.
+
+## 8. Tests
+
+Postgres is available; **every suite runs twice without resetting the database.** A
+fixture that only passes once is the defect this project has already lost a day to.
+
+- Creating an agent with a taken handle is refused; a handle is immutable once set.
+- Assigning makes a station dispatchable; unassigning makes it dispatchable by nobody.
+- Reassigning moves the room: the same room id, the same history, a new occupant.
+- kaambaan: linking a principal makes `resolveHubAgent` resolve that agent; revoking a
+  token makes the **next request** with it fail, not merely a column change.
+- **The exit test:** adopt a station, create an agent for it in one action, and watch a
+  gate reach that agent's room — with no SQL run by hand at any point. That is the thing
+  slices A and B cannot do today.
+
+## 9. Explicitly not in this slice
+
+- **Extracting the plane.** Deferred deliberately; still a URL change.
+- **Teams, Roles, Objectives.** Product hypotheses one operator cannot validate. The
+  trigger remains grant-list length.
+- **Retiring `kbn_`.** kaambaan's permanent native credential.
+- **A second organisation.** `2026-08-15-tenancy-is-local-and-mapped` names four
+  triggers; none has fired.

--- a/docs/superpowers/specs/2026-08-31-key-rotation-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-31-key-rotation-spike-findings.md
@@ -1,0 +1,140 @@
+# Can a jwt signing key be rotated cleanly, end to end? — spike findings
+
+**Date:** 2026-08-31
+**Question:** verification is offline (agentpod#331) — consumers never ask the
+issuer anything, so key rotation is the *only* lever that retires signing
+authority at all. Does it actually work, cleanly, end to end?
+**Answer: yes, for Better Auth's `jwt` plugin — but there is a real window
+(up to 10 minutes) where a freshly rotated key's tokens are rejected by
+kaambaan's verifier, not because rotation is broken but because that
+verifier's cache does not refetch on an unknown `kid`.**
+**Status:** spike complete. Nothing here is kept code — two throwaway scripts
+(`apps/hub/tmp-rotation-spike*.ts`, `apps/api/tmp-hub-jwt-spike.ts` in
+kaambaan) were written, run, and deleted; neither repo has any diff.
+
+## Method
+
+Ran against the local Postgres (`agentpod-test-postgres`, `agentpod` db — the
+`rehearsal` copy was never touched). Two throwaway scripts:
+
+1. **In agentpod** (`apps/hub`), driving `auth.api.signJWT` directly — the
+   same `jwt` plugin code path `GET /api/auth/token` uses, minus session
+   middleware — against the real `jwks` table, migrated fresh.
+2. **In kaambaan** (`apps/api`), calling the real, unmodified
+   `verifyHubToken` from `src/auth/hub-jwt.ts` with an injected `fetch`, so
+   the 10-minute cache behaviour under test is the actual shipped code, not a
+   reproduction of it.
+
+The first script wrote tokens and JWKS documents to a JSON handoff file in the
+scratchpad, which the second script read. That file and both scripts were
+deleted after the run; `git status` in both repos is clean.
+
+Rotation itself was done the way `apps/hub/src/db/schema/auth.ts`'s own
+comment prescribes for this table: mark the current key's `expiresAt` in the
+past. Better Auth's `signJWT` (`node_modules/better-auth/dist/plugins/jwt/sign.mjs`)
+checks `!key || (key.expiresAt && key.expiresAt < now)` on the latest key and,
+if true, calls `createJwk()` to mint a fresh one before signing — this is the
+library's own rotation trigger, not something this spike invented.
+
+## What was run, and what it returned
+
+**1. Mint token #1.** `kid=Fa0MFuAbe01ph94MDGerq64KjSFIH5AW` (values vary per
+run; shown from the kaambaan-handoff run). One row in `jwks`, `expiresAt`
+null.
+
+**2. Rotate.** `UPDATE jwks SET "expiresAt" = now() - interval '1 second'
+WHERE id = <kid1>`. Next `signJWT` call **observed** to insert a second row
+and sign with it: `kid=VoRQlov9sZJbOMMGNT67eVH87PSYykRC`. The `jwks` table
+after rotation held both rows — the old one with a past `expiresAt`, the new
+one with `expiresAt` null.
+
+**3. Old token still verifies.** `jwtVerify(token1, …)` against the
+post-rotation JWKS (both keys published) **succeeded** — observed directly.
+`GET /api/auth/jwks` publishes every row whose `expiresAt + gracePeriod
+(default 30 days)` has not passed (`better-auth/dist/plugins/jwt/index.mjs`),
+so a row going past-`expiresAt` does not stop it being published — it only
+flips `signJWT`'s "mint a new one" trigger. **This is the same behaviour as
+`servicePublicJwks()`** in `service-signing.ts`, which does the equivalent by
+filtering on `retiredAt IS NULL` for signing while still returning every row's
+public half. Better Auth's `jwks` table and agentpod's own
+`service_signing_keys` table implement the identical policy — publish
+everything, sign with only the newest live one — independently.
+
+One asymmetry worth naming: `service_signing_keys.retiredAt` exists in the
+schema but **nothing in the codebase sets it** (checked by grep — only the
+`isNull(retiredAt)` read in `activeKey()`). That table's rotation lever is
+designed-for but not wired to any operational trigger today. Out of scope for
+this spike (it mints service assertions, not the session tokens kaambaan's
+`hub-jwt.ts` verifies) but worth flagging since the spike went looking.
+
+**4. New key published; new token carries new `kid`; kaambaan's verifier
+accepts it — with a real caveat.**
+
+- `GET /api/auth/jwks` after rotation **observed** to list both kids.
+- Token #2, minted after rotation, **observed** to carry `kid2` in its
+  header.
+- Feeding token #2 to kaambaan's real `verifyHubToken()` with a *cold* cache
+  (freshly reset, or a mock `fetch` returning the post-rotation JWKS)
+  **observed** to succeed and return the expected claims.
+- Feeding token #2 to the same `verifyHubToken()` while its cache was **warm
+  from before the rotation** (only `kid1` known) **observed to return
+  `null`** — rejected — even though the mock `fetch` passed to that call
+  would have returned the correct post-rotation JWKS *if consulted*. It
+  wasn't consulted. Reading `hub-jwt.ts` explains why: `keySet()` only
+  refetches when `now - cached.fetchedAt >= JWKS_TTL_MS` (10 minutes); it does
+  not refetch on an unrecognised `kid`. That's a deliberate choice documented
+  in the file (`createRemoteJWKSet`'s auto-refetch-on-miss produces unhandled
+  rejections, so it was replaced with a fixed-TTL cache) — but its consequence
+  is exactly what was observed here.
+
+So: **rotation on the issuer side is immediate and clean — publish-then-sign,
+nothing deleted, no outage.** What is *not* immediate is kaambaan noticing the
+new key. A token minted between the moment of rotation and the moment
+kaambaan's cache next refreshes is rejected as if it were invalid, for up to
+10 minutes, purely because the verifier hasn't looked again — not because
+anything is wrong with the token or the key. Operationally this means: **after
+rotating, wait up to 10 minutes before minting tokens a caller needs verified
+immediately** (or accept that some minted in that window will need a retry
+once the cache turns over — there is no user-visible corruption, just a
+delayed-accept window). This window applies only to *newly* minted tokens; a
+token already in flight, signed before rotation, verifies the entire time
+(confirmed above), so the window is a lag in adopting the new key, never a gap
+in accepting the old one.
+
+**5. Nothing signs with the retired key afterwards.** A third `signJWT` call,
+with no further DB change, **observed** to reuse `kid2` (the post-rotation
+key) again — not `kid1`. `signJWT` always asks for the *latest* row by
+`createdAt`, so once a newer key exists, the retired one is never selected for
+signing again, only for verification of what it already signed.
+
+## What was inferred, not observed
+
+- The 10-minute figure itself (`JWKS_TTL_MS = 10 * 60 * 1000`) was read from
+  source, not independently timed — the spike forced the cache-cold and
+  cache-warm branches directly rather than waiting out a real 10 minutes.
+- Better Auth's 30-day JWKS `gracePeriod` default was read from source
+  (`options?.jwks?.gracePeriod ?? 3600 * 24 * 30`) and not exercised — no
+  scenario here waited 30 days to see a key actually drop out of
+  `/api/auth/jwks`. The mechanism (filter by `expiresAt + gracePeriod`) was
+  confirmed by reading the deployed library code, not by running out the
+  clock.
+
+## Environment notes
+
+- `agentpod` test database (`agentpod`, not `rehearsal`) was used throughout.
+  Its `jwks` table was cleared at the start and end of the run by the
+  throwaway scripts (`DELETE FROM jwks`) — no full `DROP DATABASE` reset was
+  needed or performed.
+- Full suite re-run after cleanup: **1608 pass / 0 fail**, matching baseline
+  exactly, no database reset required to get there.
+
+## Bottom line
+
+Key rotation on the hub's `jwt` plugin works exactly as its own schema comment
+promises: insert the newer key, let old tokens drain, and the retired one
+keeps verifying until it expires — a routine rotation is not a fleet-wide
+outage. The one real sharp edge is on the consumer side: kaambaan's 10-minute
+JWKS cache means a rotation is not instantly safe for *new* tokens — there is
+a window, up to 10 minutes wide, where a token minted right after rotation is
+wrongly rejected until kaambaan's cache catches up. That is a known,
+observed, fixed-size lag, not a rotation failure.

--- a/fixtures/ecosystem-identity/id_grammar.json
+++ b/fixtures/ecosystem-identity/id_grammar.json
@@ -321,7 +321,7 @@
       "grammar": "^prn_[0-9a-f]{20}$",
       "grammarSource": "agentpod packages/contract/src/ids.ts — PrincipalId",
       "mintedAs": "^prn_[0-9a-f]{20}$",
-      "mintSource": "NONE — nothing in apps/hub/src mints a principal id yet, and no such statement has existed at any commit. The grammar is reserved and validated ahead of its first writer; Task 2 introduces apps/hub/src/utils/ids.ts and this citation becomes a file:line then.",
+      "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId() — `prefixedId('prn')`. Not yet called anywhere: the minter exists ahead of its first writer, which is Task 3.",
       "note": "A suite principal — human, agent or service — the type `agentpod.user`'s bare UUID never was. Twenty lowercase hex, deliberately NOT a hyphenated UUID like agentpod.station: kaambaan's id schema is ^<prefix>_[A-Za-z0-9]{6,}$, whose alphabet has no hyphen, and a principal id crosses that seam on every grant.",
       "accept": [
         { "value": "prn_0123456789abcdef0123", "mint": true },
@@ -344,7 +344,7 @@
       "grammar": "^org_[0-9a-f]{20}$",
       "grammarSource": "agentpod packages/contract/src/ids.ts — OrganizationId",
       "mintedAs": "^org_[0-9a-f]{20}$",
-      "mintSource": "NONE — nothing in apps/hub/src mints an organization id yet, and no such statement has existed at any commit. The grammar is reserved and validated ahead of its first writer; Task 2 introduces apps/hub/src/utils/ids.ts and this citation becomes a file:line then.",
+      "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId() — `prefixedId('org')`. Not yet called anywhere: the minter exists ahead of its first writer, which is Task 3. The migration's bootstrap row is deterministic (BOOTSTRAP_ORG_ID), not minted — the same exception tenants.ts documents for BOOTSTRAP_TENANT_ID.",
       "note": "Minted by the hub, which IS the Organization plane until the plane is extracted. tenants.external_id carries this value with external_source = 'org-plane'.",
       "accept": [
         { "value": "org_0123456789abcdef0123", "mint": true }

--- a/fixtures/ecosystem-identity/id_grammar.json
+++ b/fixtures/ecosystem-identity/id_grammar.json
@@ -312,6 +312,68 @@
         { "value": "f47ac10b-58cc-4372-a567", "reason": "too-short" },
         { "value": "", "reason": "empty" }
       ]
+    },
+
+    {
+      "entity": "agentpod.principal",
+      "owner": "agentpod",
+      "prefix": "prn",
+      "grammar": "^prn_[0-9a-f]{20}$",
+      "grammarSource": "agentpod packages/contract/src/ids.ts — PrincipalId",
+      "mintedAs": "^prn_[0-9a-f]{20}$",
+      "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId()",
+      "note": "A suite principal — human, agent or service — the type `agentpod.user`'s bare UUID never was. Twenty lowercase hex, deliberately NOT a hyphenated UUID like agentpod.station: kaambaan's id schema is ^<prefix>_[A-Za-z0-9]{6,}$, whose alphabet has no hyphen, and a principal id crosses that seam on every grant.",
+      "accept": [
+        { "value": "prn_0123456789abcdef0123", "mint": true },
+        { "value": "prn_ffffffffffffffffffff", "mint": true }
+      ],
+      "reject": [
+        { "value": "org_0123456789abcdef0123", "reason": "other-entity", "note": "an AgentPod organization id, minted from the same 20-hex family" },
+        { "value": "prn_0123456789abcdef012", "reason": "too-short" },
+        { "value": "prn_0123456789ABCDEF0123", "reason": "wrong-alphabet", "note": "uppercase hex is never minted" },
+        { "value": "prn_01234567-89ab-cdef-0123-456789abcdef", "reason": "wrong-alphabet", "note": "hyphenated UUID — the family kaambaan's declared alphabet would reject on arrival, exactly the agentpod.station scar this entity does not repeat" },
+        { "value": "principal_0123456789abcdef0123", "reason": "wrong-prefix", "note": "the spelled-out word, not the declared prefix" },
+        { "value": "prn_", "reason": "prefix-only" }
+      ]
+    },
+
+    {
+      "entity": "agentpod.organization",
+      "owner": "agentpod",
+      "prefix": "org",
+      "grammar": "^org_[0-9a-f]{20}$",
+      "grammarSource": "agentpod packages/contract/src/ids.ts — OrganizationId",
+      "mintedAs": "^org_[0-9a-f]{20}$",
+      "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId()",
+      "note": "Minted by the hub, which IS the Organization plane until the plane is extracted. tenants.external_id carries this value with external_source = 'org-plane'.",
+      "accept": [
+        { "value": "org_0123456789abcdef0123", "mint": true }
+      ],
+      "reject": [
+        { "value": "prn_0123456789abcdef0123", "reason": "other-entity", "note": "an AgentPod principal id, minted from the same 20-hex family" },
+        { "value": "org_0123456789abcdef012", "reason": "too-short" },
+        { "value": "org_0123456789ABCDEF0123", "reason": "wrong-alphabet", "note": "uppercase hex is never minted" },
+        { "value": "org_", "reason": "prefix-only" }
+      ]
+    },
+
+    {
+      "entity": "kaambaan.gate",
+      "owner": "kaambaan",
+      "prefix": "gate",
+      "grammar": "^gate_[A-Za-z0-9]{6,}$",
+      "grammarSource": "kaambaan apps/api/src/board/board-do.ts createGate() — newId('gate')",
+      "mintedAs": "^gate_[A-Za-z0-9]{16}$",
+      "mintSource": "kaambaan newId('gate')",
+      "note": "Absent from this corpus until 2026-08-30 although it crosses a repo boundary on every projected approval. kaambaan#34's sketch proposed `gat_`, which is why this entry exists — the prefix registry below already claims `gate` for kaambaan, but no entity carried its grammar until now.",
+      "accept": [
+        { "value": "gate_4e8b1c2d3f4a5b6c", "mint": true }
+      ],
+      "reject": [
+        { "value": "gat_4e8b1c2d3f4a5b6c", "reason": "wrong-prefix", "note": "kaambaan#34's rejected sketch" },
+        { "value": "gate_", "reason": "prefix-only" },
+        { "value": "gate_short", "reason": "too-short" }
+      ]
     }
   ],
 

--- a/fixtures/ecosystem-identity/id_grammar.json
+++ b/fixtures/ecosystem-identity/id_grammar.json
@@ -321,7 +321,7 @@
       "grammar": "^prn_[0-9a-f]{20}$",
       "grammarSource": "agentpod packages/contract/src/ids.ts — PrincipalId",
       "mintedAs": "^prn_[0-9a-f]{20}$",
-      "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId()",
+      "mintSource": "NONE — nothing in apps/hub/src mints a principal id yet, and no such statement has existed at any commit. The grammar is reserved and validated ahead of its first writer; Task 2 introduces apps/hub/src/utils/ids.ts and this citation becomes a file:line then.",
       "note": "A suite principal — human, agent or service — the type `agentpod.user`'s bare UUID never was. Twenty lowercase hex, deliberately NOT a hyphenated UUID like agentpod.station: kaambaan's id schema is ^<prefix>_[A-Za-z0-9]{6,}$, whose alphabet has no hyphen, and a principal id crosses that seam on every grant.",
       "accept": [
         { "value": "prn_0123456789abcdef0123", "mint": true },
@@ -344,7 +344,7 @@
       "grammar": "^org_[0-9a-f]{20}$",
       "grammarSource": "agentpod packages/contract/src/ids.ts — OrganizationId",
       "mintedAs": "^org_[0-9a-f]{20}$",
-      "mintSource": "agentpod apps/hub/src/utils/ids.ts prefixedId()",
+      "mintSource": "NONE — nothing in apps/hub/src mints an organization id yet, and no such statement has existed at any commit. The grammar is reserved and validated ahead of its first writer; Task 2 introduces apps/hub/src/utils/ids.ts and this citation becomes a file:line then.",
       "note": "Minted by the hub, which IS the Organization plane until the plane is extracted. tenants.external_id carries this value with external_source = 'org-plane'.",
       "accept": [
         { "value": "org_0123456789abcdef0123", "mint": true }

--- a/fixtures/ecosystem-identity/token_claims.json
+++ b/fixtures/ecosystem-identity/token_claims.json
@@ -1,8 +1,8 @@
 {
   "corpus": "ecosystem-identity/token-claims",
-  "version": 4,
-  "authoredAt": "2026-08-15",
-  "authoredFrom": "code and two runs: the claim shape was observed in a token issued by better-auth 1.6.26 and verified from a Cloudflare Worker (agentpod#331), and the control pair moved from reserved to issued when grants became data the issuer can read (principal_grants); `act` added 2026-08-30 when the Application Service gained the ability to assert a human it had never met, on the strength of a Matrix message and a principal_identities row",
+  "version": 5,
+  "authoredAt": "2026-08-30",
+  "authoredFrom": "code and two runs: the claim shape was observed in a token issued by better-auth 1.6.26 and verified from a Cloudflare Worker (agentpod#331), and the control pair moved from reserved to issued when grants became data the issuer can read (principal_grants); `act` added 2026-08-30 when the Application Service gained the ability to assert a human it had never met, on the strength of a Matrix message and a principal_identities row; `mayDispatch` became bare `prn_…` ids matched by equality on 2026-08-30, when an agent became a principal and the two namespaced, pattern-matched forms were deleted rather than deprecated (charter decisions/2026-08-30-an-agent-is-a-principal.md §3)",
   "purpose": "One issuer, and every other plane verifies offline against a JWKS (charter decisions/2026-08-15-one-issuer-and-offline-verification.md). The moment a second plane reads a claim, the claim's NAME is a contract: a rename in the hub is a silent authorization failure in kaambaan, which fails in the direction that looks like the caller having no permission. This corpus is what makes that a failing test instead.",
   "howToRead": {
     "issued": "Claims the issuer MUST put in every token, and consumers may rely on. A missing one is a malformed token. NOTE the difference between a claim that is ABSENT and one that is EMPTY: absent means this issuer does not speak the control pair, empty (`[]` / `false`) means this principal is permitted nothing. Reading the first as the second would let an old issuer silently authorise everything.",
@@ -46,18 +46,17 @@
     {
       "claim": "mayDispatch",
       "type": "string[]",
-      "meaning": "First half of the control pair — which agents this principal may dispatch. Values are NAMESPACED by plane, and AgentPod's also name a node: `agentpod:<nodeName>/<stationKey>`, `kaambaan:<agentId>`.",
+      "meaning": "First half of the control pair — which agents this principal may dispatch. Values are bare principal ids, matched by EQUALITY. A grant no longer names an agent per plane with a namespaced pattern; it enumerates the `prn_…` ids of the agents it covers.",
       "required": true,
-      "grammar": "^[a-z][a-z0-9-]*:.+$",
+      "grammar": "^prn_[0-9a-f]{20}$",
+      "crossRef": "id_grammar.json → agentpod.principal",
       "valueRules": {
-        "namespaced": "Every value carries a plane prefix. An UNPREFIXED value matches nothing anywhere — that was the retired CONTROL_PAIR_GRANTS format, and letting it keep working would mean a half-migrated deployment enforcing two different rules depending on which reader ran.",
-        "unknownNamespaceIsIgnored": "A consumer IGNORES a namespace it does not recognise; it must never deny on one. A plane that refused what it did not understand would break the day a third plane appeared, and a claim is read by more planes over time, not fewer.",
-        "wildcard": "One trailing `*` per segment. In the station half it may not cross the `:` it was written inside, so `hermes:*` never reaches an OpenClaw station.",
+        "equality": "A value matches a principal id if and only if it is that id, character for character. There is no pattern language: `*` is not a wildcard here, it is a string that will never equal a real id. Patterns were deleted, not deprecated, because they matched things nobody intended — `hermes:*` silently spanned nodes, and `agentpod:*/hermes` reached a root station that should never have existed and was removed on 2026-08-30.",
+        "unrecognisedIsIgnored": "A consumer IGNORES a value that is not a `prn_…` id; it must never deny on one. A claim is read by more planes over time, and a plane that refused what it did not understand would break the day a third one appeared. The `prn_` prefix is the namespace now, so 'ignore an unrecognised value, never deny it' keeps working with no separate namespace grammar to check it against.",
         "emptyDenies": "`[]` is a decision, and the decision is no. It is what an operator writes to suspend someone without deleting their grant.",
-        "agentpodNamesANode": "A station key is NOT unique across the fleet — uniqueness is (node, key), and `opencode:c52ddf65` exists on two nodes in production. So an agentpod value names both: `agentpod:molt-bot/hermes:*` is Hermes stations on molt-bot, `agentpod:*/hermes:*` is Hermes stations anywhere. A two-part value (`agentpod:hermes:*`) cannot say which node it meant and MATCHES NOTHING — reading it as 'any node' is the over-grant this shape removes.",
-        "nodeNamesAreUnique": "Within a tenant, by construction: enrolment suffixes a hostname collision (`molt-bot`, `molt-bot-2`) and a unique index enforces it. Names rather than ids because a grant must be readable by whoever writes it."
+        "unassignedStationIsNobodys": "A station occupied by no principal has no id to enumerate, so no grant can name it — it is dispatchable by nobody. That is a behaviour change from the per-plane, wildcard-bearing form this claim used to carry."
       },
-      "source": "charter decisions/2026-08-15-a-grant-names-an-agent-per-plane.md"
+      "source": "charter decisions/2026-08-30-an-agent-is-a-principal.md §3"
     },
     {
       "claim": "mayGrantReach",
@@ -116,16 +115,12 @@
       "why": "A token that verifies but names no tenant is not a weaker caller, it is an unresolvable one. Refuse it rather than falling back to a default boundary."
     },
     {
-      "case": "unprefixed-mayDispatch-value",
-      "why": "`hermes:*` with no plane prefix. The retired format; it must match nothing rather than be read as this plane's."
-    },
-    {
       "case": "mayDispatch-absent",
       "why": "A token from an issuer that predates the control pair. A consumer must not treat absence as an empty grant, nor as an unrestricted one — it means the issuer cannot answer, and the consumer decides its own posture."
     },
     {
-      "case": "agentpod-value-without-a-node",
-      "why": "`agentpod:hermes:*` — the two-part form. It names no node, and station keys repeat across nodes, so it must match nothing rather than be read as fleet-wide."
+      "case": "wildcard-mayDispatch-value",
+      "why": "`*` or `prn_*` in mayDispatch. Patterns were deleted on 2026-08-30, not deprecated: a grant is now an enumeration of principal ids, matched by equality, and a wildcard string simply fails that check — it must never be read as 'every agent' or 'every agent of this shape'. `agentpod:*/hermes` reaching a root station that should never have existed is the evidence this removal answers."
     }
   ],
   "conditional": [

--- a/packages/contract/src/ecosystem-identity.test.ts
+++ b/packages/contract/src/ecosystem-identity.test.ts
@@ -36,6 +36,8 @@ import {
   AcpSessionId,
   AcpRunId,
   UserId,
+  PrincipalId,
+  OrganizationId,
 } from "./ids";
 import { Run, RunState, TERMINAL_RUN_STATES, INTERRUPTED_RUN_STATES } from "./run";
 import { CARD_PROMPT_VERSION, CardPrompt, renderCardPrompt } from "./card-prompt";
@@ -100,10 +102,17 @@ const VALIDATORS: Record<string, ZodType> = {
   "agentpod.acpSession": AcpSessionId,
   "agentpod.acpRun": AcpRunId,
   "agentpod.user": UserId,
+  "agentpod.principal": PrincipalId,
+  "agentpod.organization": OrganizationId,
 };
 
 /** Entities AgentPod deliberately has no validator for. Empty, and a decision each time. */
-const SKIPPED: readonly string[] = [];
+const SKIPPED: readonly string[] = [
+  // Owned by kaambaan and crosses a repo boundary on every projected approval,
+  // but nothing on AgentPod's side consumes a gate id today — there is no
+  // agentpod-side validator to map it to. Revisit if AgentPod ever reads one.
+  "kaambaan.gate",
+];
 
 describe("ecosystem identity corpus — coverage", () => {
   test("every corpus entity is either validated or explicitly skipped", () => {

--- a/packages/contract/src/ids.ts
+++ b/packages/contract/src/ids.ts
@@ -127,6 +127,26 @@ const uuidSuffixedId = (prefix: string) =>
  */
 export const TenantId = truncatedUuidId("fleet");
 
+/**
+ * A suite principal — a human, an agent, or a service.
+ *
+ * 20-hex family, not the hyphenated one: this id crosses the kaambaan seam on
+ * every grant, and kaambaan's own id schema (`^<prefix>_[A-Za-z0-9]{6,}$`) has
+ * no hyphen in its alphabet. `agentpod.station` already mints a hyphenated
+ * UUID and is a known scar recorded in the corpus; this does not add a second.
+ *
+ * Distinct from `UserId` above, which is Better Auth's bare-UUID row and stays
+ * that way — this is the new, type-legible id a principal is minted with.
+ */
+export const PrincipalId = truncatedUuidId("prn");
+
+/**
+ * An organisation. Minted by the hub, which IS the Organization plane until
+ * the plane is extracted into its own service — see `TenantId`'s doc comment
+ * for why AgentPod and kaambaan each keep a local tenant in the meantime.
+ */
+export const OrganizationId = truncatedUuidId("org");
+
 export const NodeId = truncatedUuidId("node");
 export const RuntimeId = truncatedUuidId("rt");
 /**


### PR DESCRIPTION
Creating an agent, and putting it in a station, becomes something an operator does in the console — with no SQL at any point. That sentence is the whole of this branch, and the last task is the one that makes it true.

Three slices, built in order:

**A — an agent is a principal.** Principals become their own entity rather than a shape borrowed from users. An agent's Matrix address derives from its **handle**, not its station key, which is what lets a room follow the agent when it moves. Grants collapse to one value with no wildcards; agents re-exchange rather than carrying refresh tokens. `charter → decisions/2026-08-30-an-agent-is-a-principal.md`

**B — agents exchange.** A station mints a token on its node's existing secret, on the station's behalf, and kaambaan resolves it as an agent rather than a human.

**C — creating an agent.** The console gains the act itself: mint a principal, put it in a station, move it, take it out — and the room follows the agent, which closes slice A's finding that `matrix_rooms.principal_id` shipped with no writer.

### Two decisions worth reading before the diff

**Occupancy is exclusive.** One principal, one station. Nobody had ruled on this, so the schema quietly assumed both answers at once: `stations.principal_id` permitted a principal in two stations while `matrix_rooms_principal_idx` permitted it one room. Assignment is now a **move** that vacates the previous station in the same transaction, enforced by a partial unique index rather than by convention.

**Failing closed beats answering wrongly.** `roomAgentUser` returns null for a room it cannot attribute, instead of falling back to the station's current occupant — which had the wrong agent replying in a departed agent's room. Migration `0062` then binds the rooms that legitimately deserve an answer, so failing closed does not mean going silent.

### What the reviews caught

Five fix rounds on the last task, each finding something the last had not:

- the fallback handed a new occupant the **departed agent's room**, and `@agent_P` answered for `@agent_Q`
- fixing that turned it into *"the new occupant gets no room at all, silently, forever"*
- the alias was still station-derived, so the new room reused the old one's alias — harness mode silently returned the wrong room, bridge mode **deleted the alias off a live room**
- assignment never called `provisionStation`, so on a default bridge-mode station the whole chain produced no room and reported `no-room`, which the sweep did not count

That last one is the point of the branch, and it was invisible to a fully green suite because every test in the area called `provisionStation` by hand — the exact step production omitted. The exit test now drives adopt → assign → gate with no manual provisioning, and fails with `Expected: "sent" / Received: "no-room"` when the fix is reverted.

`gate-sweep.ts` now counts what it could **not** deliver, not only what it sent. It was introduced on this branch, so it shipped both that bug and the detector that could not see it.

### Verification

- hub **1646 pass / 0 fail**, run twice with no reset between
- console **652 pass**, `svelte-check` 0 errors — the 132 failures are pre-existing, in 11 unrelated files, unchanged
- `apps/hub`'s `tsc --noEmit` has 15 errors, byte-identical at this HEAD and at the merge-base; all predate the branch
- migrations `0060`–`0062` executed from the shipped files against a scratch database with hand-seeded colliding data, not only against an empty one — an empty database has nothing to dedupe

### Not done here, each needing its own decision

- the live room migration (`--apply` against the 32 rooms) has never been run
- the infra deploy
- the plan's by-hand exit test, which needs a live hub and homeserver
- `findTenantByExternal`'s unordered `.first()` under a shared fleet (predates the branch; this branch raises its exposure)
- the assign endpoint's synchronous homeserver round-trip has no timeout
- no CI step migrates a fresh database

Pairs with kaambaan `feat/agent-is-a-principal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr
