### PR TITLE
The room migration invites before it joins, because the rooms are private

### DIFF
--- a/apps/hub/scripts/migrate-agent-mxids-run.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.test.ts
@@ -221,6 +221,7 @@ describe("buildMigrationDeps — m.direct is read-modify-write, and never fatal"
   function client(overrides: Partial<DirectClient> = {}, accountData: Record<string, unknown> = {}) {
     const state = { written: null as Record<string, unknown> | null };
     const c: DirectClient = {
+      invite: overrides.invite ?? (async () => {}),
       join: overrides.join ?? (async () => {}),
       leave: overrides.leave ?? (async () => {}),
       getAccountData:
@@ -311,6 +312,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
   test("dry run reports the room and calls no client method at all", async () => {
     let calls = 0;
     const c: DirectClient = {
+      invite: async () => {},
       join: async () => { calls++; },
       leave: async () => { calls++; },
       getAccountData: async () => { calls++; return null; },
@@ -329,6 +331,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
   test("applying runs join, then setDirect, then leave, in that order", async () => {
     const acts: string[] = [];
     const c: DirectClient = {
+      invite: async (as, r, invitee) => { acts.push(`invite ${as} ${r} ${invitee}`); },
       join: async (u, r) => { acts.push(`join ${u} ${r}`); },
       leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
       getAccountData: async () => null,
@@ -340,6 +343,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     expect(result.applied).toBe(true);
     expect(result.migrated).toBe(1);
     expect(acts).toEqual([
+      `invite ${OLD_USER} ${ROW.roomId} ${NEW_USER}`,
       `join ${NEW_USER} ${ROW.roomId}`,
       // setAccountData is called as the OWNER, not the agent — m.direct is
       // the human's own account data, not the agent's.
@@ -354,6 +358,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
   test("a refused m.direct write does not stop leave from running, and is reported per room", async () => {
     const acts: string[] = [];
     const c: DirectClient = {
+      invite: async (as, r, invitee) => { acts.push(`invite ${as} ${r} ${invitee}`); },
       join: async (u, r) => { acts.push(`join ${u} ${r}`); },
       leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
       getAccountData: async () => null,
@@ -366,7 +371,11 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
 
     // leave still ran, and the room still counts as migrated: membership
     // moved correctly even though the DM flag could not be fixed.
-    expect(acts).toEqual([`join ${NEW_USER} ${ROW.roomId}`, `leave ${OLD_USER} ${ROW.roomId}`]);
+    expect(acts).toEqual([
+      `invite ${OLD_USER} ${ROW.roomId} ${NEW_USER}`,
+      `join ${NEW_USER} ${ROW.roomId}`,
+      `leave ${OLD_USER} ${ROW.roomId}`,
+    ]);
     expect(result.migrated).toBe(1);
     expect(result.failures).toEqual([]);
     expect(result.results).toEqual([
@@ -381,6 +390,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     ];
     let joinCalls = 0;
     const c: DirectClient = {
+      invite: async () => {},
       join: async (_u, roomId) => {
         joinCalls++;
         if (roomId === ROW.roomId) throw new Error("rate limited");
@@ -416,6 +426,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
       },
     });
     const c: DirectClient = {
+      invite: async () => {},
       join: async () => {},
       leave: async () => {},
       getAccountData: async () => null,

--- a/apps/hub/scripts/migrate-agent-mxids-run.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.ts
@@ -284,6 +284,12 @@ export async function describeRooms(deps: DescribeDeps): Promise<DescribeRoomsRe
 
 /** What `buildMigrationDeps` needs from a live (or fake) Matrix client. */
 export interface DirectClient {
+  /**
+   * Invite, acting as an existing member. Not optional: these rooms are
+   * invite-only, and the live homeserver refused an uninvited join for all 32
+   * of them with `403 M_FORBIDDEN ... cannot join a room that is not \`public\``.
+   */
+  invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
   join(userId: string, roomId: string): Promise<void>;
   leave(userId: string, roomId: string): Promise<void>;
   getAccountData(userId: string, type: string): Promise<Record<string, unknown> | null>;
@@ -316,6 +322,7 @@ export function buildMigrationDeps(
 
   const deps: MxidMigrationDeps = {
     rooms: async () => rooms.map((r) => ({ roomId: r.roomId, handle: r.handle, oldUserId: r.oldUserId })),
+    invite: (asUserId, roomId, invitee) => client.invite(asUserId, roomId, invitee),
     join: (userId, roomId) => client.join(userId, roomId),
     leave: (userId, roomId) => client.leave(userId, roomId),
     async setDirect(newUserId, roomId) {
@@ -410,11 +417,15 @@ export async function runMigration(
 
   for (const room of rooms) {
     try {
+      // Spread `deps` rather than naming its fields. This loop used to pick out
+      // `join`, `leave` and `setDirect` by hand, so when `invite` was added to
+      // `MxidMigrationDeps` it reached `buildMigrationDeps` and stopped here —
+      // silently, because a missing dependency is only a runtime error once the
+      // room it would have served is already being migrated. Only `rooms` is
+      // overridden, because this loop drives one room at a time.
       const r = await migrateAgentMxids({
+        ...deps,
         rooms: async () => [{ roomId: room.roomId, handle: room.handle, oldUserId: room.oldUserId }],
-        join: deps.join,
-        leave: deps.leave,
-        setDirect: deps.setDirect,
       });
       migrated += r.migrated;
       skipped += r.skipped;

--- a/apps/hub/scripts/migrate-agent-mxids.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.test.ts
@@ -13,30 +13,57 @@ const fail = async () => {
   throw new Error("must not be called");
 };
 
-test("the new user joins the existing room and the old one leaves", async () => {
+test("the new user is invited, joins, and the old one leaves — in that order", async () => {
   const acts: string[] = [];
   await migrateAgentMxids({
     rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
+    invite: async (as, r, invitee) => { acts.push(`invite ${as} ${r} ${invitee}`); },
     join: async (u, r) => { acts.push(`join ${u} ${r}`); },
     leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
     setDirect: async (u, r) => { acts.push(`direct ${u} ${r}`); },
   });
+  // INVITE before join: these rooms are invite-only, and an uninvited join is
+  // refused with `403 M_FORBIDDEN ... cannot join a room that is not \`public\``.
+  // That is not hypothetical — it is what the live homeserver answered for all
+  // 32 rooms, while this file's fakes happily accepted a bare join.
+  //
+  // The inviter is the OLD user: it is still a member and created the room, so
+  // it holds the power level to invite. The new user has neither.
+  //
   // Join BEFORE leave: the reverse leaves the room briefly with no agent in it.
   expect(acts).toEqual([
+    "invite @agent_guild_hermes-writer-quill:h !r:h @agent_writer-quill:h",
     "join @agent_writer-quill:h !r:h",
     "direct @agent_writer-quill:h !r:h",
     "leave @agent_guild_hermes-writer-quill:h !r:h",
   ]);
 });
 
+test("a room is never joined without an invite first", async () => {
+  // The regression that shipped: a join with no preceding invite. Asserted on
+  // its own so it fails loudly if the invite is ever dropped as redundant.
+  let invited = false;
+  await migrateAgentMxids({
+    rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
+    invite: async () => { invited = true; },
+    join: async () => {
+      expect(invited).toBe(true);
+    },
+    leave: async () => {},
+    setDirect: async () => {},
+  });
+  expect(invited).toBe(true);
+});
+
 test("is idempotent — a room already migrated is skipped", async () => {
-  const r = await migrateAgentMxids({ rooms: async () => [], join: fail, leave: fail, setDirect: fail });
+  const r = await migrateAgentMxids({ rooms: async () => [], invite: fail, join: fail, leave: fail, setDirect: fail });
   expect(r.migrated).toBe(0);
 });
 
 test("a room whose new address matches its recorded one is skipped, not re-sent", async () => {
   const r = await migrateAgentMxids({
     rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_writer-quill:h" }],
+    invite: fail,
     join: fail,
     leave: fail,
     setDirect: fail,

--- a/apps/hub/scripts/migrate-agent-mxids.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.ts
@@ -9,9 +9,20 @@
  *
  * **No room is deleted and no history is lost.** A room id is stable; only its
  * membership changes. The new virtual user joins the existing room and the old
- * one leaves; Matrix keeps every message from a member who has departed. The
- * AS owns the whole `@agent_.*` namespace, so the new user joins without an
- * invite.
+ * one leaves; Matrix keeps every message from a member who has departed.
+ *
+ * ## The new user must be invited first
+ *
+ * An earlier version of this note claimed the AS owning the whole `@agent_.*`
+ * namespace meant the new user could join without an invite. That is wrong, and
+ * it was wrong against the live homeserver on every one of 32 rooms:
+ *
+ *     403 M_FORBIDDEN Auth check failed: cannot join a room that is not `public`
+ *
+ * Namespace ownership lets the appservice ACT AS a user; it does not exempt that
+ * user from a room's join rules. These rooms are invite-only DMs, so the new
+ * user is invited by the OLD one — which is still a member, and created the room,
+ * so it has the power level to invite — and only then joins.
  *
  * ## Join before leave
  *
@@ -83,7 +94,12 @@ import { bridgeUserId } from "../src/services/matrix-as/names";
 export interface MxidMigrationDeps {
   /** Every room still needing this, or already done — see the skip rule above. */
   rooms(): Promise<Array<{ roomId: string; handle: string; oldUserId: string }>>;
-  /** Join as the new user. The AS owns `@agent_.*`, so no invite is needed. */
+  /**
+   * Invite the new user, acting as the old one. Required: these rooms are
+   * invite-only, and an uninvited join is refused with `M_FORBIDDEN`.
+   */
+  invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  /** Join as the new user, once invited. */
   join(userId: string, roomId: string): Promise<void>;
   /** Leave as the old user, once the new one is in and `m.direct` points at it. */
   leave(userId: string, roomId: string): Promise<void>;
@@ -109,6 +125,10 @@ export async function migrateAgentMxids(
       skipped++;
       continue;
     }
+    // Invite before joining: the room is invite-only, and the old user is the
+    // only member with the power to let the new one in. Both calls tolerate
+    // "already done", so a re-run after a partial failure is safe.
+    await deps.invite(room.oldUserId, room.roomId, next);
     // Join first. Leaving first would leave the room with no agent in it, and
     // a crash between the two would leave it that way permanently.
     await deps.join(next, room.roomId);


### PR DESCRIPTION
Found during the live deploy of the organization plane. §7's room migration failed on **all 32 rooms**:

```
403 M_FORBIDDEN Auth check failed: cannot join a room that is not `public`
```

The script claimed, in two separate comments, that owning the `@agent_.*` namespace let the new user join without an invite. Namespace ownership lets the appservice **act as** a user; it does not exempt that user from a room's join rules. These rooms are invite-only DMs.

The new user is now invited by the **old** one — still a member, and the room's creator, so it holds the power level to invite — and only then joins. Verified against the live homeserver before the code was written: invite `200`, join `200`, and the new user is now a member of a room it had been refused from.

### Why no test caught it

The fakes accepted a bare join, so every test passed while the real server refused every call. The ordering test now asserts the invite, and a second test asserts on its own that a join is never reached without one — so dropping the invite as redundant fails loudly.

### A second defect, same shape

`runMigration` rebuilt its deps object per room by naming three fields by hand. So `invite` reached `buildMigrationDeps` and was silently dropped one layer later — a missing dependency only becomes a runtime error once the room it would have served is already being migrated. It now spreads `deps` and overrides only `rooms`, so the next dependency added cannot vanish the same way.

That is the same failure shape this slice hit four times: a fix landing one layer inside the entry point that actually serves it.

### Verification

- hub **1647 pass / 0 fail**, run twice with no reset
- the invite/join pair confirmed against the live homeserver, on a real room

Nothing was lost on the failed run — the migration only adds and removes room members, and it failed before changing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr