### PR TITLE
Don't re-invite a user who is already in the room

### DIFF
--- a/apps/hub/scripts/migrate-agent-mxids-run.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.test.ts
@@ -222,6 +222,7 @@ describe("buildMigrationDeps — m.direct is read-modify-write, and never fatal"
     const state = { written: null as Record<string, unknown> | null };
     const c: DirectClient = {
       invite: overrides.invite ?? (async () => {}),
+      isJoined: async () => false,
       join: overrides.join ?? (async () => {}),
       leave: overrides.leave ?? (async () => {}),
       getAccountData:
@@ -313,6 +314,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     let calls = 0;
     const c: DirectClient = {
       invite: async () => {},
+      isJoined: async () => false,
       join: async () => { calls++; },
       leave: async () => { calls++; },
       getAccountData: async () => { calls++; return null; },
@@ -332,6 +334,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     const acts: string[] = [];
     const c: DirectClient = {
       invite: async (as, r, invitee) => { acts.push(`invite ${as} ${r} ${invitee}`); },
+      isJoined: async () => false,
       join: async (u, r) => { acts.push(`join ${u} ${r}`); },
       leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
       getAccountData: async () => null,
@@ -359,6 +362,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     const acts: string[] = [];
     const c: DirectClient = {
       invite: async (as, r, invitee) => { acts.push(`invite ${as} ${r} ${invitee}`); },
+      isJoined: async () => false,
       join: async (u, r) => { acts.push(`join ${u} ${r}`); },
       leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
       getAccountData: async () => null,
@@ -391,6 +395,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     let joinCalls = 0;
     const c: DirectClient = {
       invite: async () => {},
+      isJoined: async () => false,
       join: async (_u, roomId) => {
         joinCalls++;
         if (roomId === ROW.roomId) throw new Error("rate limited");
@@ -427,6 +432,7 @@ describe("runMigration — a refused m.direct still lets leave run, and failures
     });
     const c: DirectClient = {
       invite: async () => {},
+      isJoined: async () => false,
       join: async () => {},
       leave: async () => {},
       getAccountData: async () => null,

--- a/apps/hub/scripts/migrate-agent-mxids-run.ts
+++ b/apps/hub/scripts/migrate-agent-mxids-run.ts
@@ -290,6 +290,7 @@ export interface DirectClient {
    * of them with `403 M_FORBIDDEN ... cannot join a room that is not \`public\``.
    */
   invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  isJoined(userId: string, roomId: string): Promise<boolean>;
   join(userId: string, roomId: string): Promise<void>;
   leave(userId: string, roomId: string): Promise<void>;
   getAccountData(userId: string, type: string): Promise<Record<string, unknown> | null>;
@@ -323,6 +324,7 @@ export function buildMigrationDeps(
   const deps: MxidMigrationDeps = {
     rooms: async () => rooms.map((r) => ({ roomId: r.roomId, handle: r.handle, oldUserId: r.oldUserId })),
     invite: (asUserId, roomId, invitee) => client.invite(asUserId, roomId, invitee),
+    isJoined: (userId, roomId) => client.isJoined(userId, roomId),
     join: (userId, roomId) => client.join(userId, roomId),
     leave: (userId, roomId) => client.leave(userId, roomId),
     async setDirect(newUserId, roomId) {

--- a/apps/hub/scripts/migrate-agent-mxids.test.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.test.ts
@@ -18,6 +18,7 @@ test("the new user is invited, joins, and the old one leaves — in that order",
   await migrateAgentMxids({
     rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
     invite: async (as, r, invitee) => { acts.push(`invite ${as} ${r} ${invitee}`); },
+    isJoined: async () => false,
     join: async (u, r) => { acts.push(`join ${u} ${r}`); },
     leave: async (u, r) => { acts.push(`leave ${u} ${r}`); },
     setDirect: async (u, r) => { acts.push(`direct ${u} ${r}`); },
@@ -46,6 +47,7 @@ test("a room is never joined without an invite first", async () => {
   await migrateAgentMxids({
     rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
     invite: async () => { invited = true; },
+    isJoined: async () => false,
     join: async () => {
       expect(invited).toBe(true);
     },
@@ -56,7 +58,8 @@ test("a room is never joined without an invite first", async () => {
 });
 
 test("is idempotent — a room already migrated is skipped", async () => {
-  const r = await migrateAgentMxids({ rooms: async () => [], invite: fail, join: fail, leave: fail, setDirect: fail });
+  const r = await migrateAgentMxids({ rooms: async () => [], invite: fail,
+    isJoined: async () => false, join: fail, leave: fail, setDirect: fail });
   expect(r.migrated).toBe(0);
 });
 
@@ -64,9 +67,29 @@ test("a room whose new address matches its recorded one is skipped, not re-sent"
   const r = await migrateAgentMxids({
     rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_writer-quill:h" }],
     invite: fail,
+    isJoined: async () => false,
+    isJoined: async () => false,
     join: fail,
     leave: fail,
     setDirect: fail,
   });
   expect(r).toEqual({ migrated: 0, skipped: 1 });
+});
+
+test("a room whose new user is already joined is not invited again", async () => {
+  // The half-migrated case: a previous run (or a hand-run probe) already put the
+  // new user in the room. Matrix refuses to invite a member — `403 ... cannot
+  // invite user that is joined or banned` — so re-running would fail on exactly
+  // the rooms an earlier run had already fixed. Found on the live fleet, on the
+  // one room of 32 that had been migrated by hand first.
+  const acts: string[] = [];
+  await migrateAgentMxids({
+    rooms: async () => [{ roomId: "!r:h", handle: "writer-quill", oldUserId: "@agent_guild_hermes-writer-quill:h" }],
+    isJoined: async () => true,
+    invite: async () => { acts.push("invite"); },
+    join: async () => { acts.push("join"); },
+    leave: async () => { acts.push("leave"); },
+    setDirect: async () => { acts.push("direct"); },
+  });
+  expect(acts).toEqual(["join", "direct", "leave"]);
 });

--- a/apps/hub/scripts/migrate-agent-mxids.ts
+++ b/apps/hub/scripts/migrate-agent-mxids.ts
@@ -99,6 +99,14 @@ export interface MxidMigrationDeps {
    * invite-only, and an uninvited join is refused with `M_FORBIDDEN`.
    */
   invite(asUserId: string, roomId: string, invitee: string): Promise<void>;
+  /**
+   * Is the new user already in the room? Gates the invite: Matrix refuses to
+   * invite a member with `403 ... cannot invite user that is joined or banned`,
+   * so a re-run over a partially migrated fleet would fail on exactly the rooms
+   * a previous run had already fixed. Asked rather than inferred from the error,
+   * because that one message conflates "joined" (done) with "banned" (not done).
+   */
+  isJoined(userId: string, roomId: string): Promise<boolean>;
   /** Join as the new user, once invited. */
   join(userId: string, roomId: string): Promise<void>;
   /** Leave as the old user, once the new one is in and `m.direct` points at it. */
@@ -126,9 +134,12 @@ export async function migrateAgentMxids(
       continue;
     }
     // Invite before joining: the room is invite-only, and the old user is the
-    // only member with the power to let the new one in. Both calls tolerate
-    // "already done", so a re-run after a partial failure is safe.
-    await deps.invite(room.oldUserId, room.roomId, next);
+    // only member with the power to let the new one in. Skipped when the new
+    // user is already a member, which is what makes a re-run over a partially
+    // migrated fleet safe.
+    if (!(await deps.isJoined(next, room.roomId))) {
+      await deps.invite(room.oldUserId, room.roomId, next);
+    }
     // Join first. Leaving first would leave the room with no agent in it, and
     // a crash between the two would leave it that way permanently.
     await deps.join(next, room.roomId);


### PR DESCRIPTION
Follow-up to #397, found on the live fleet.

#397 made the room migration invite before joining. But Matrix refuses to invite an existing member:

```
403 M_FORBIDDEN Auth check failed: cannot invite user that is joined or banned
```

So a re-run fails on exactly the rooms an earlier run already fixed. 31 of 32 rooms migrated cleanly; the one failure was the room migrated by hand while diagnosing #397.

#397's commit message claimed both calls tolerate "already done". They do not. This is that claim made true.

The invite is gated on **membership**, not on swallowing the error — that single message conflates "joined" (done) with "banned" (emphatically not done), so inferring success from it would be wrong.

- hub **1648 pass / 0 fail**, twice with no reset
- new test covers the half-migrated room: already joined → invite skipped, join/direct/leave still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr