### PR TITLE
The bridge opens a session as the station's owner, not as the sender

### DIFF
--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -104,6 +104,7 @@ async function roomContext(roomId: string) {
       roomId: matrixRooms.roomId,
       sessionId: matrixRooms.acpSessionId,
       stationId: stations.id,
+      stationUserId: stations.userId,
       stationKey: stations.stationKey,
       identityMode: stations.matrixIdentityMode,
       nodeName: nodes.name,
@@ -270,9 +271,23 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
       // One session per room, not per message: a conversation is a
       // conversation, and a session per message would throw away the agent's
       // context between two consecutive sentences.
+      // The station's OWNER, not the sender's principal. `createSession` looks
+      // the station up with `getStation(userId, stationId)`, which scopes on
+      // `stations.user_id` — a Better Auth id. Passing a `prn_…` matched no
+      // row, so every bridged room failed with "Station not found." after the
+      // hub had already received, resolved and authorised the message.
+      //
+      // Authorisation still belongs to the principal: the control-pair check
+      // above is what decides whether this sender may dispatch this agent, and
+      // it must stay that way — a grant can cover a station its holder does not
+      // own. What this line settles is only which user the station is read as.
+      //
+      // The cost, recorded rather than hidden: `acp_sessions.user_id` now names
+      // the owner, so a transcript no longer says WHICH principal asked. That
+      // needs its own column, not this one doing two jobs.
       const session = await deps.acp.createSession({
         stationId: room.stationId,
-        userId: principalId,
+        userId: room.stationUserId,
         mode: "default",
       });
       sessionId = session.id;

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -152,6 +152,7 @@ beforeAll(async () => {
       VALUES (${`pid_${p}`}, ${p}, 'matrix', ${mxid}, now())`;
   }
 
+
   process.env.ENFORCE_CONTROL_PAIR = "true";
 });
 
@@ -196,9 +197,16 @@ describe("an inbound room message", () => {
     await handleRoomMessage(message(OWNER_MXID, "status?"), deps());
 
     expect(created).toHaveLength(1);
+    // The station is scoped on `stations.user_id`, a Better Auth id. Asserting
+    // only that A session was created is what let the bridge pass a `prn_…`
+    // here and fail on every real room: `getStation` matched nothing, and the
+    // hub reported "Station not found." for a message it had just authorised.
+    expect(created[0]!.userId).toBe(OWNER);
+    expect(created[0]!.userId).not.toBe(OWNER_PRINCIPAL);
     expect(prompts).toHaveLength(1);
     expect(prompts[0]!.text).toBe("status?");
   });
+
 
   test("attaches the room to the session, or the answer has nowhere to go", async () => {
     // The gap that live verification found: a session was created and prompted
@@ -361,14 +369,30 @@ describe("an inbound room message", () => {
     expect(prompts[0]!.text).toBe("deploy  the thing\nnow");
   });
 
-  test("prompts as the principal who sent it, not as the station's owner", async () => {
-    // The ACP session belongs to whoever is talking, so the transcript and the
-    // control pair both attribute the turn correctly.
+  test("opens the session as the station's OWNER, even when another principal sent it", async () => {
+    // This test used to assert the opposite — that the session is opened as the
+    // sending principal, "so the transcript and the control pair both attribute
+    // the turn correctly". The intent was right and the mechanism was not:
+    // `createSession` resolves the station with `getStation(userId, stationId)`,
+    // which scopes on `stations.user_id`. A `prn_…` matches no row there, so in
+    // production EVERY bridged room answered "Station not found." for a message
+    // the hub had already received, resolved and authorised. The fake here
+    // accepted any id, which is why the suite stayed green while no real room
+    // worked.
+    //
+    // Authorisation is still the principal's: OTHER_PRINCIPAL dispatches this
+    // station on a grant, and is not its owner. Only the station LOOKUP uses
+    // the owner.
+    //
+    // What is genuinely lost is attribution — `acp_sessions.user_id` no longer
+    // records which principal asked. That needs its own column rather than this
+    // one serving two masters, and it is written down as a gap, not fixed here.
     await setGrant(OTHER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: false });
 
     await handleRoomMessage(message(OTHER_MXID, "hello"), deps());
 
-    expect(created[0]!.userId).toBe(OTHER_PRINCIPAL);
+    expect(created[0]!.userId).toBe(OWNER);
+    expect(created[0]!.userId).not.toBe(OTHER_PRINCIPAL);
   });
 });
 


### PR DESCRIPTION
Found live, minutes after the organization plane deploy: **every bridge-mode room was dead** — 18 of 32 stations. Harness-mode rooms masked it by returning earlier in the handler.

The hub received the message, resolved the room, and authorised it against the grant, then:

```
matrix message could not reach the station
stationKey: openclaw:krishna   error: "Station not found."
```

`createSession` resolves a station with `getStation(userId, stationId)`, scoped on `stations.user_id` — a Better Auth id. Since slice A the inbound path carries a `prn_…` from `resolveMatrixId` and passed it straight through. It matched no row, for any room, for any sender.

### What did and didn't change

Authorisation is untouched and still belongs to the principal — the control pair decides who may dispatch, and a grant can cover a station its holder does not own. Only the station **lookup** uses the owner.

### Why the suite was green

A test asserted the old behaviour deliberately — *"prompts as the principal who sent it, not as the station's owner"* — with the stated intent that the transcript attribute the turn correctly. The intent was right; the mechanism was not, because `acp_sessions.user_id` is the same column `getStation` scopes on. Its fake `createSession` accepted any id, so nothing noticed.

That test now asserts what production requires. Both it and the main prompt test fail when the fix is reverted — verified.

### Recorded, not fixed

`acp_sessions.user_id` no longer records **which** principal asked. Attribution needs its own column rather than that one serving two masters.

- hub **1648 pass / 0 fail**, twice with no reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr