### PR TITLE
Prompt and answer as the owner too, not only create

### DIFF
--- a/apps/hub/src/services/matrix-as/inbound.ts
+++ b/apps/hub/src/services/matrix-as/inbound.ts
@@ -233,8 +233,10 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
     }
 
     try {
+      // The station's owner, for the same reason `createSession` takes it:
+      // `requireLive` scopes on the session's `user_id`, a Better Auth id.
       await deps.acp.answerPermission(
-        principalId,
+        room.stationUserId,
         waiting.sessionId,
         waiting.requestSeq,
         optionId
@@ -304,7 +306,13 @@ export async function handleRoomMessage(event: InboundEvent, deps: InboundDeps):
 
     // The user's words, unchanged. Trimming or decorating them would put the
     // bridge's voice into the agent's input.
-    await deps.acp.promptSession(principalId, sessionId, text);
+    // The owner again, not the principal: `promptSession` resolves the live
+    // session with `requireLive(userId, sessionId)`. Passing a `prn_…` meant
+    // the session was created correctly and then could not be prompted —
+    // "Session not found or not active." The same defect as the station
+    // lookup, one call later; it survived the first fix because only the
+    // createSession site was corrected.
+    await deps.acp.promptSession(room.stationUserId, sessionId, text);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     log.error("matrix message could not reach the station", {

--- a/apps/hub/tests/integration/matrix-as-inbound.test.ts
+++ b/apps/hub/tests/integration/matrix-as-inbound.test.ts
@@ -205,6 +205,12 @@ describe("an inbound room message", () => {
     expect(created[0]!.userId).not.toBe(OWNER_PRINCIPAL);
     expect(prompts).toHaveLength(1);
     expect(prompts[0]!.text).toBe("status?");
+    // `promptSession` scopes on the session's user the same way the station
+    // lookup does. The fake recorded this id from the beginning and nothing
+    // asserted it, so the bridge could create a session correctly and then be
+    // unable to prompt it.
+    expect(prompts[0]!.userId).toBe(OWNER);
+    expect(prompts[0]!.userId).not.toBe(OWNER_PRINCIPAL);
   });
 
 
@@ -414,8 +420,12 @@ describe("answering a permission request from the room", () => {
 
     await handleRoomMessage(message(OWNER_MXID, "1"), depsWithPermissions());
 
+    // The OWNER, not the principal: `answerPermission` resolves the live
+    // session with `requireLive(userId, sessionId)`, scoped on a Better Auth
+    // id. This assertion named the principal and passed, while in production
+    // the same value produced "Session not found or not active."
     expect(answered).toEqual([
-      { userId: OWNER_PRINCIPAL, sessionId: "acps_parked", requestSeq: 7, optionId: "allow_once" },
+      { userId: OWNER, sessionId: "acps_parked", requestSeq: 7, optionId: "allow_once" },
     ]);
     expect(created).toHaveLength(0);
     expect(prompts).toHaveLength(0);


### PR DESCRIPTION
Immediate follow-up to #399, found by the same live room.

#399 fixed `createSession` and shipped. It was **one of three call sites** passing a principal id where a Better Auth id is required — the other two sit one and nine lines away. So the room created its session correctly and then died on the very next call:

```
matrix message could not reach the station
error: "Session not found or not active."
```

`promptSession` and `answerPermission` both resolve the live session with `requireLive(userId, sessionId)`, scoped exactly the way `getStation` is.

### Why the suite stayed green, again

The test fakes have recorded `userId` for both calls since they were written. **Nothing ever asserted it.** So the suite proved that *something* was prompted, never that it was prompted as anyone in particular — the same shape as #399, where the fake accepted any id.

Both assertions now name the owner, and each fails when its own call site is reverted — verified separately, not as a pair.

- hub **1648 pass / 0 fail**, twice with no reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr