### PR TITLE
The invariant asks the handle, because bridge_matrix_id never held it

### DIFF
--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -169,14 +169,19 @@ export type StationRow = {
   capabilities: string[] | null;
   matrixId: string | null;
   /**
-   * What the appservice minted for this station — never re-derived from
-   * `(nodeName, stationKey)` here, only read. For a bridge-mode station this
-   * is the whole identity; for a harness-mode station it is the account
-   * `matrixId` is converging toward (or has already reached).
+   * What the appservice minted for this station — never re-derived here, only
+   * read, and for a harness-mode station **not** the address it is moving
+   * toward.
    *
-   * `matrixId <> bridgeMatrixId` is the fleet's own signal that a station is
-   * running under a retired identity (`db/schema/stations.ts`'s invariant) —
-   * not a status field, because none was added.
+   * This used to say `matrixId <> bridgeMatrixId` was the fleet's signal that
+   * a station runs under a retired identity. It is not: `provision.ts` fills
+   * the column from `names.ts`'s `stationSpeaker`, which for a harness station
+   * answers the harness's OWN mxid — so on the fleet the two columns agree,
+   * both holding the retired station-derived address, and everything that
+   * compared them read "converged" for exactly the 14 stations that had not
+   * moved. Whether a station is on its principal's address is a question about
+   * the agent's HANDLE, which the browser cannot derive; ask the hub
+   * (`stationMoveState` below).
    */
   bridgeMatrixId: string | null;
   /**
@@ -262,24 +267,34 @@ export const authorizeMove = (stationId: string) =>
 /**
  * Where the HUB says a station stands in the §1 invariant.
  *
- * Three of the four states are derivable in the browser from `matrixId` and
- * `bridgeMatrixId`, and the fourth is not: `waiting` means an authorization
- * is outstanding, and that record lives only in the hub. Before this the
- * panel's "waiting for the node" was component-local state that died on
- * reload — so the one state §6 asks an operator to WATCH was the one thing a
- * refresh threw away.
+ * **Only one of these states is derivable in the browser** — `bridge`, which
+ * is `matrixId === null` and nothing else. Every other one turns on the
+ * address the station's occupying principal's HANDLE implies, and the console
+ * holds neither the handle nor the homeserver domain to build it. The panel
+ * used to derive three of them by comparing `matrixId` with `bridgeMatrixId`,
+ * which answers a different question and answered it wrong for every station
+ * on the fleet (see `StationRow.bridgeMatrixId`).
  *
- * `converged` still means only that the two columns agree. It is not a health
- * check, and nothing in this payload is one: whether a station's identity can
- * actually post in its room is a Matrix fact in neither column, and the hub's
- * gate sweep is what checks it.
+ * `waiting` was never derivable at all: an authorization record lives only in
+ * the hub, so a component-local flag died on reload and the one state §6 asks
+ * an operator to WATCH was the one a refresh threw away.
+ *
+ * `converged` means the station answers as its principal's address, and
+ * nothing more. It is not a health check, and nothing in this payload is one:
+ * whether a station's identity can actually post in its room is a Matrix fact
+ * in no column at all, and the hub's gate sweep is what checks it.
  */
 export type StationMoveState =
   | { status: "unknown" }
   | { status: "bridge" }
   | { status: "converged"; mxid: string }
+  /**
+   * Harness mode, nobody occupying the station: no handle, so no address to
+   * move to and no move to offer. Not `converged`, and not a blank.
+   */
+  | { status: "no-agent"; runningAs: string }
   | { status: "waiting"; runningAs: string; willBecome: string; since: string }
-  | { status: "retired-identity"; runningAs: string; willBecome: string | null };
+  | { status: "retired-identity"; runningAs: string; willBecome: string };
 
 export const stationMoveState = (stationId: string) =>
   http<StationMoveState>(`/api/stations/${stationId}/matrix/move-state`);

--- a/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte
+++ b/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte
@@ -155,13 +155,42 @@
     if (!id || station.matrixId === null) return;
     if (askedFor === id) return;
     askedFor = id;
+
+    // **Everything below this line describes ONE station, so a new station
+    // starts from nothing.** The route reuses this component across stations
+    // — `[stationId]/+page.svelte` is one page, not one per station — so
+    // without this reset an operator who opens B after A reads A's answer
+    // until B's arrives: A's `willBecome` in the sentence, and A's move
+    // behind the button. Clicking it authorises B to move to an address
+    // derived from A's agent. `unanswered` was worse still: write-once-true,
+    // so one unreachable hub latched "Couldn't ask the hub" onto every
+    // station visited for the rest of the session.
+    //
+    // `phase` and its two companions go with them for the same reason: a
+    // click on A must not leave B saying it is waiting for a node to redeem
+    // an authorisation nobody minted for it.
+    hubState = null;
+    unanswered = false;
+    phase = "idle";
+    waitingSince = null;
+    expiresAt = null;
+    error = null;
+
     let live = true;
     void moveState(id)
       .then((s) => {
+        // The answer to a question about a station this panel has since
+        // navigated away from. `live` is cleared by the cleanup below when
+        // the effect re-runs, which is the only reason a late reply cannot
+        // overwrite the state the reset above just cleared.
         if (!live) return;
         hubState = s;
         // A click in flight, or one that already set the local waiting state,
-        // outranks a reply about how things stood before it.
+        // outranks a reply about how things stood before it. Ruling 17's
+        // guard, kept: the control now renders only after an answer, so a
+        // click can no longer overtake this panel's own request for the same
+        // station — but it costs one comparison, and any future change that
+        // renders the control earlier restores the race it was written for.
         if (phase !== "idle") return;
         if (s.status === "waiting") {
           waitingSince = s.since;

--- a/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte
+++ b/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte
@@ -3,24 +3,39 @@
    * The §1 invariant, made visible and actionable
    * (`docs/superpowers/specs/2026-09-01-uniform-matrix-identity-design.md` §6).
    *
-   * There is no status column for this — `matrixId` (what the harness reports)
-   * and `bridgeMatrixId` (what the appservice minted) are read straight off the
-   * station row:
+   * **Where the states come from, and why they stopped coming from here.**
+   * This panel used to read two columns off the station row —
    *
    *   matrixId === null           → bridge mode, the appservice speaks for it
    *   matrixId === bridgeMatrixId → converged
    *   otherwise                   → running under a retired identity
    *
-   * **Converged is not "healthy".** Room membership is a Matrix fact that lives
-   * in neither column — a station can hold the right credential and still be
-   * unable to post (a gate `failed` outcome, `M_FORBIDDEN`, is how that shows
-   * up, counted by the sweep). This panel says only what the two columns know:
-   * that the identity switched. Judging whether it can actually speak is the
-   * hub's own gate sweep's job — its logs, its tally of non-`sent` outcomes —
-   * not this component's, and not any console view, because the console has
-   * none for that yet (§6 called for one; no task built it). Pointing an
-   * operator at a UI element that doesn't exist would recreate, in the
-   * console, exactly the silence this slice exists to remove.
+   * — and the middle line is not true. `bridgeMatrixId` is what the appservice
+   * minted, and for a harness station `provision.ts` writes the station's OWN
+   * address into it. On the fleet all 14 harness stations carry
+   * `matrixId === bridgeMatrixId`, both holding the old station-derived
+   * address, so this panel showed every one of them as converged and offered
+   * nobody the move. The feature was invisible and inert.
+   *
+   * The question the panel means to ask is *"is this agent on its principal's
+   * address?"*, and only the agent's handle answers that. The browser holds no
+   * handle and no homeserver domain, so it cannot derive that address — **the
+   * hub says it**, through `matrix/move-state`, and this panel renders what it
+   * is told rather than re-deriving three of the four states from a column
+   * that answers a different question. `matrixId === null` is the one part of
+   * the invariant a raw column really does settle, so bridge mode is still
+   * answered here, without a round trip.
+   *
+   * **Converged is not "healthy".** Room membership is a Matrix fact that no
+   * column and no state here carries — a station can hold the right credential
+   * and still be unable to post (a gate `failed` outcome, `M_FORBIDDEN`, is
+   * how that shows up, counted by the sweep). This panel says only that the
+   * identity switched. Judging whether it can actually speak is the hub's own
+   * gate sweep's job — its logs, its tally of non-`sent` outcomes — not this
+   * component's, and not any console view, because the console has none for
+   * that yet (§6 called for one; no task built it). Pointing an operator at a
+   * UI element that doesn't exist would recreate, in the console, exactly the
+   * silence this slice exists to remove.
    *
    * **The move is fire-and-forget.** `authorize-move` puts the new identity in
    * the room and signals the node, but the node adopts on its own time — or
@@ -28,13 +43,6 @@
    * So a successful call does not end this panel's job: it moves to "waiting
    * for the node", with the control still live, because re-authorizing IS the
    * retry. A control that vanishes on click is the failure to avoid.
-   *
-   * **And "waiting" is the hub's answer, not this component's memory.** The
-   * three states above are the two columns; waiting is not, because it is
-   * derived from an authorization record that lives only in the hub. It used
-   * to be local `$state` set by a click, which meant a reload — or a second
-   * operator, or a second tab — saw a station that looked untouched. So the
-   * panel asks `matrix/move-state` on mount and adopts `waiting` from it.
    */
 
   import { Button } from "$lib/components/ui/button";
@@ -45,12 +53,18 @@
   } from "$lib/api/client";
 
   interface StationIdentity {
-    // Optional: the converged/bridge states never call authorize() and so
-    // never need it — only a station actually rendering the control has to
-    // supply one.
-    id?: string;
+    id: string;
+    /**
+     * What the harness reports it answers as. Null is bridge mode and is the
+     * one state this component still decides for itself — `matrix_id IS NULL`
+     * means the appservice speaks for the station, and no address needs
+     * deriving to know it.
+     *
+     * `bridgeMatrixId` is deliberately NOT read here, or accepted: it is what
+     * the appservice minted, not what this station's principal implies, and
+     * comparing against it is the defect this panel carried.
+     */
     matrixId: string | null;
-    bridgeMatrixId: string | null;
   }
 
   interface Props {
@@ -59,16 +73,20 @@
     authorize?: (stationId: string) => Promise<{ expiresAt: string }>;
     /**
      * Where the hub says this station stands. Injectable for the same reason.
-     * Only `waiting` is read from it — the other three states are the two
-     * columns above, and re-deriving them here from a second source would be
-     * two places for the same fact to be wrong.
+     * Every state but bridge mode is read from it, because every one of them
+     * turns on an address only the hub can build.
      */
     moveState?: (stationId: string) => Promise<StationMoveState>;
   }
 
   let { station, authorize = defaultAuthorizeMove, moveState = defaultMoveState }: Props = $props();
 
-  type IdentityState = "bridge" | "converged" | "retired";
+  /** What the hub last said, or null while nothing has been heard. */
+  let hubState = $state<StationMoveState | null>(null);
+  /** The hub could not be asked. Distinct from "not asked yet" — see below. */
+  let unanswered = $state(false);
+
+  type IdentityState = "bridge" | "converged" | "retired" | "no-agent" | "unasked" | "pending";
 
   // Named identityState, not state: a local binding literally named `state`
   // collides with Svelte's `$state` rune (`$state<Phase>(...)` below reads as
@@ -77,10 +95,29 @@
   const identityState = $derived<IdentityState>(
     station.matrixId === null
       ? "bridge"
-      : station.matrixId === station.bridgeMatrixId
-        ? "converged"
-        : "retired"
+      : unanswered
+        ? "unasked"
+        : hubState === null
+          ? "pending"
+          : hubState.status === "converged"
+            ? "converged"
+            : hubState.status === "no-agent"
+              ? "no-agent"
+              : hubState.status === "waiting" || hubState.status === "retired-identity"
+                ? "retired"
+                : // `bridge` (the row changed under us) and `unknown` (the
+                  // station is gone) are both "nothing to offer here".
+                  hubState.status === "bridge"
+                  ? "bridge"
+                  : "unasked"
   );
+
+  /** The address the station answers as today, as the hub reports it. */
+  const runningAs = $derived(
+    hubState && "runningAs" in hubState ? hubState.runningAs : station.matrixId
+  );
+  /** The address its principal's handle implies — the hub's answer, never ours. */
+  const willBecome = $derived(hubState && "willBecome" in hubState ? hubState.willBecome : null);
 
   type Phase = "idle" | "authorizing" | "waiting";
 
@@ -91,19 +128,18 @@
   let waitingSince = $state<string | null>(null);
 
   /**
-   * Ask the hub whether this station is already waiting.
+   * Ask the hub where this station stands.
    *
-   * The three states above come off the station row; `waiting` cannot,
-   * because it is derived from an authorization record the browser never
-   * sees. Until this ran, "waiting for the node" existed only as the local
-   * flag a click set — so a reload, a second tab, or a different operator saw
-   * a station that looked as though nobody had touched it, and §6's "a
-   * station stuck there is the signal that a harness did not restart" was not
-   * something anyone could actually observe.
+   * Not an optional embellishment any more: `waiting` was always the hub's to
+   * answer, because it is derived from an authorization record the browser
+   * never sees — and now `converged` and `retired-identity` are too, because
+   * both turn on the address the occupying principal's handle implies and the
+   * browser has neither the handle nor the domain to build it.
    *
-   * A failure here is deliberately silent: it costs the operator the waiting
-   * line, and must not put an error banner on a panel whose control still
-   * works. The three column-derived states are unaffected either way.
+   * A failure therefore costs more than it used to, and must say so: without
+   * an answer this panel does not know whether a move is available, and
+   * offering one anyway would be a control built on the guess this component
+   * was just relieved of.
    */
   // Deliberately NOT `$state`: it is a record of what has been asked, not a
   // thing to render, and a reactive one written inside the effect below would
@@ -114,22 +150,26 @@
 
   $effect(() => {
     const id = station.id;
-    if (!id || identityState !== "retired") return;
+    // Bridge mode is the column's own answer, and there is nothing to offer
+    // for it — no request, and none of the states below.
+    if (!id || station.matrixId === null) return;
     if (askedFor === id) return;
     askedFor = id;
     let live = true;
     void moveState(id)
       .then((s) => {
+        if (!live) return;
+        hubState = s;
         // A click in flight, or one that already set the local waiting state,
         // outranks a reply about how things stood before it.
-        if (!live || phase !== "idle") return;
+        if (phase !== "idle") return;
         if (s.status === "waiting") {
           waitingSince = s.since;
           phase = "waiting";
         }
       })
       .catch(() => {
-        // See above: no banner for a state that is only ever additional.
+        if (live) unanswered = true;
       });
     return () => {
       live = false;
@@ -164,9 +204,9 @@
   <div class="rounded-lg border p-4 space-y-3" data-testid="matrix-identity-panel">
     <p class="text-sm">
       This agent is running under a <strong>retired identity</strong>: it
-      authenticates as <code class="font-mono break-all">{station.matrixId}</code>,
+      authenticates as <code class="font-mono break-all">{runningAs}</code>,
       but its account is now
-      <code class="font-mono break-all">{station.bridgeMatrixId}</code>.
+      <code class="font-mono break-all">{willBecome}</code>.
     </p>
 
     {#if error}
@@ -192,10 +232,32 @@
   <div class="rounded-lg border p-4" data-testid="matrix-identity-panel">
     <p class="text-sm text-muted-foreground">
       This agent's identity has switched to
-      <code class="font-mono break-all">{station.matrixId}</code>. Whether it can
+      <code class="font-mono break-all">{runningAs}</code>. Whether it can
       actually post in its room is a separate fact neither column carries — the
       hub's own gate sweep is the one thing that checks it, in its logs and its
       tally of non-<code class="font-mono">sent</code> outcomes, not here.
+    </p>
+  </div>
+{:else if identityState === "no-agent"}
+  <!--
+    No agent occupies this station, so there is no handle, so there is no
+    address to move it to. Said rather than left blank: a station answering as
+    an mxid no principal owns is a thing an operator needs to see, and offering
+    a move with no target would be a button that can only fail.
+  -->
+  <div class="rounded-lg border p-4" data-testid="matrix-identity-panel">
+    <p class="text-sm text-muted-foreground">
+      This station answers as <code class="font-mono break-all">{runningAs}</code>,
+      but no agent occupies it — so there is no identity of its own to move it
+      to. Assign an agent first.
+    </p>
+  </div>
+{:else if identityState === "unasked"}
+  <div class="rounded-lg border p-4" data-testid="matrix-identity-panel">
+    <p class="text-sm text-muted-foreground" role="status">
+      Couldn't ask the hub where this agent's Matrix identity stands, so no
+      move is offered here. The address it would move to is derived from its
+      agent's handle, which only the hub can build.
     </p>
   </div>
 {/if}

--- a/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte.test.ts
@@ -2,15 +2,28 @@
  * MatrixIdentityPanel.svelte.test.ts
  *
  * The §1 invariant (`db/schema/stations.ts`, design
- * `docs/superpowers/specs/2026-09-01-uniform-matrix-identity-design.md` §6) has
- * no status column — it's read off two existing ones:
+ * `docs/superpowers/specs/2026-09-01-uniform-matrix-identity-design.md` §6)
+ * asks one question — **is this agent on its principal's address?** — and only
+ * the agent's handle answers it.
+ *
+ * These tests used to be written the other way round, against two columns:
  *
  *   matrixId === null              → bridge mode, nothing to do
- *   matrixId === bridgeMatrixId    → converged (NOT "healthy" — room
- *                                     membership lives in neither column, so
- *                                     this panel only says the identity switched)
- *   matrixId !== bridgeMatrixId    → running under a retired identity, and
- *                                     the one control this panel exists for
+ *   matrixId === bridgeMatrixId    → converged
+ *   matrixId !== bridgeMatrixId    → running under a retired identity
+ *
+ * and every fixture set `bridgeMatrixId` to the handle-derived address, which
+ * is what the design assumed and what production does not do. `provision.ts`
+ * writes `bridge_matrix_id` from `stationSpeaker`, and for a harness station
+ * that is the harness's OWN mxid — so on the fleet all 14 harness stations
+ * have both columns holding the same retired, station-derived address, this
+ * panel called every one of them converged, and the move it exists to offer
+ * could never be started by anyone. The tests passed throughout, because the
+ * fixtures were the assumption rather than the fleet.
+ *
+ * So the states now come from the hub (`matrix/move-state`), which is the only
+ * place that can build the address a handle implies. `matrixId === null` is
+ * still answered here, because that half of the invariant really is a column.
  *
  * The move itself is fire-and-forget on the hub's side (Task 3): authorizing
  * only signals the node, and convergence is observed later. So the control
@@ -28,19 +41,48 @@ afterEach(cleanup);
 
 const OLD = "@agent_guild_hermes-writer-quill:matrix.example.org";
 const NEW = "@agent_writer-quill:matrix.example.org";
-const RETIRED = { id: "station_1", matrixId: OLD, bridgeMatrixId: NEW };
 
-test("a station on a retired identity says so, naming both addresses", () => {
-  render(MatrixIdentityPanel, { station: { matrixId: OLD, bridgeMatrixId: NEW } });
-  expect(screen.getByText(/retired identity/i)).toBeTruthy();
+/**
+ * A station exactly as the fleet has it: answering as the station-derived
+ * address, with `bridge_matrix_id` holding that SAME address — which is why
+ * nothing in this component may be handed that column any more. All the panel
+ * gets is the station's id and what its harness reports.
+ */
+const RETIRED = { id: "station_1", matrixId: OLD };
+
+/** The hub's answer for such a station: a move is available, and here is its target. */
+const saysRetired = () =>
+  vi.fn().mockResolvedValue({ status: "retired-identity", runningAs: OLD, willBecome: NEW });
+
+test("a station the hub says is on a retired identity says so, naming both addresses", async () => {
+  const moveState = saysRetired();
+  render(MatrixIdentityPanel, { station: RETIRED, moveState });
+
+  expect(await screen.findByText(/retired identity/i)).toBeTruthy();
   expect(screen.getByText(OLD)).toBeTruthy();
+  // The address it is moving to comes from the hub, which derived it from the
+  // agent's handle. The browser could not have built this string.
   expect(screen.getByText(NEW)).toBeTruthy();
+  expect(moveState).toHaveBeenCalledWith(RETIRED.id);
+});
+
+test("a station whose two columns agree on the OLD address is still offered the move", async () => {
+  // The defect, from the console's side. `bridgeMatrixId` is not a prop any
+  // more, so the only way this panel can call a station converged is if the
+  // HUB says so — and for this station the hub says `retired-identity`,
+  // because the address the agent's handle implies is not the one it answers
+  // as. The old panel, handed `{matrixId: OLD, bridgeMatrixId: OLD}`, showed
+  // "identity has switched" and no control at all.
+  render(MatrixIdentityPanel, { station: RETIRED, moveState: saysRetired() });
+
+  expect(await screen.findByRole("button", { name: /move to its own identity/i })).toBeTruthy();
+  expect(screen.queryByText(/identity has switched/i)).toBeNull();
 });
 
 test("the move control calls authorize-move, then shows waiting for the node", async () => {
   const authorize = vi.fn().mockResolvedValue({ expiresAt: "2026-09-01T12:00:00Z" });
-  render(MatrixIdentityPanel, { station: RETIRED, authorize });
-  await fireEvent.click(screen.getByRole("button", { name: /move to its own identity/i }));
+  render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState: saysRetired() });
+  await fireEvent.click(await screen.findByRole("button", { name: /move to its own identity/i }));
   expect(authorize).toHaveBeenCalledWith(RETIRED.id);
   expect(screen.getByText(/waiting for the node/i)).toBeTruthy();
 });
@@ -57,8 +99,8 @@ test("a 403 from the grant gate is shown verbatim", async () => {
           "reach, which your grant does not permit for this agent."
       )
     );
-  render(MatrixIdentityPanel, { station: RETIRED, authorize });
-  await fireEvent.click(screen.getByRole("button", { name: /move to its own identity/i }));
+  render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState: saysRetired() });
+  await fireEvent.click(await screen.findByRole("button", { name: /move to its own identity/i }));
   expect(
     await screen.findByText(/redeem its own matrix credential is granting it reach/i)
   ).toBeTruthy();
@@ -73,36 +115,57 @@ test("a 409 naming the harness with no profile writer is shown verbatim", async 
     .mockRejectedValue(
       new Error("codex has no Matrix profile writer yet, so this station cannot move to its own identity.")
     );
-  render(MatrixIdentityPanel, { station: RETIRED, authorize });
-  await fireEvent.click(screen.getByRole("button", { name: /move to its own identity/i }));
+  render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState: saysRetired() });
+  await fireEvent.click(await screen.findByRole("button", { name: /move to its own identity/i }));
   expect(await screen.findByText(/codex has no matrix profile writer yet/i)).toBeTruthy();
 });
 
-test("a converged station shows no control", () => {
-  render(MatrixIdentityPanel, { station: { matrixId: NEW, bridgeMatrixId: NEW } });
+test("a converged station shows no control", async () => {
+  const moveState = vi.fn().mockResolvedValue({ status: "converged", mxid: NEW });
+  render(MatrixIdentityPanel, { station: { id: "station_1", matrixId: NEW }, moveState });
+  expect(await screen.findByText(/identity has switched/i)).toBeTruthy();
   expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
 });
 
-// ─── The two states the brief's table names but doesn't spell a test for ──────
+// ─── The states the brief's table names but doesn't spell a test for ──────────
 
-test("a bridge-mode station (matrixId null) renders nothing", () => {
+test("a bridge-mode station (matrixId null) renders nothing, and asks nothing", () => {
+  // The one state a raw column really does settle: `matrix_id IS NULL` means
+  // the appservice speaks for the station. No round trip, no box.
+  const moveState = vi.fn();
   const { container } = render(MatrixIdentityPanel, {
-    station: { matrixId: null, bridgeMatrixId: NEW },
+    station: { id: "station_1", matrixId: null },
+    moveState,
   });
   expect(container.textContent?.trim()).toBe("");
+  expect(moveState).not.toHaveBeenCalled();
 });
 
-test("a converged station never claims to be healthy", () => {
-  render(MatrixIdentityPanel, { station: { matrixId: NEW, bridgeMatrixId: NEW } });
+test("a converged station never claims to be healthy", async () => {
+  const moveState = vi.fn().mockResolvedValue({ status: "converged", mxid: NEW });
+  render(MatrixIdentityPanel, { station: { id: "station_1", matrixId: NEW }, moveState });
+  await screen.findByText(/identity has switched/i);
   for (const word of [/healthy/i, /\bok\b/i, /✓/]) {
     expect(screen.queryByText(word)).toBeNull();
   }
 });
 
+test("a station with no occupying agent is told so, and offered no move", async () => {
+  // No agent means no handle means no address to move to. The hub says so
+  // rather than the panel guessing, and a station answering as an mxid no
+  // principal owns is a thing an operator must see rather than a blank.
+  const moveState = vi.fn().mockResolvedValue({ status: "no-agent", runningAs: OLD });
+  render(MatrixIdentityPanel, { station: RETIRED, moveState });
+
+  expect(await screen.findByText(/no agent occupies it/i)).toBeTruthy();
+  expect(screen.getByText(OLD)).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
+});
+
 test("the control survives a successful authorize — re-authorizing is the retry", async () => {
   const authorize = vi.fn().mockResolvedValue({ expiresAt: "2026-09-01T12:00:00Z" });
-  render(MatrixIdentityPanel, { station: RETIRED, authorize });
-  await fireEvent.click(screen.getByRole("button", { name: /move to its own identity/i }));
+  render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState: saysRetired() });
+  await fireEvent.click(await screen.findByRole("button", { name: /move to its own identity/i }));
   // Waiting is not a dead end: the control that just fired is still there.
   expect(screen.getByRole("button", { name: /move to its own identity/i })).toBeTruthy();
   expect(screen.getByRole("button", { name: /move to its own identity/i })).not.toHaveProperty(
@@ -111,14 +174,7 @@ test("the control survives a successful authorize — re-authorizing is the retr
   );
 });
 
-// ─── "waiting" is the hub's answer, not this component's memory ───────────────
-//
-// Three of the four states are the two columns on the station row. `waiting`
-// is not: it means an authorization is outstanding, and that record lives only
-// in the hub. It used to be local `$state` set by a click, so a reload — or a
-// second operator, or a second tab — saw a station that looked untouched, and
-// §6's "a station stuck there is the signal that a harness did not restart"
-// was not a thing anybody could observe.
+// ─── The hub is the source, not this component's memory ───────────────────────
 
 test("a station the hub says is waiting shows waiting on first render, with no click", async () => {
   const moveState = vi.fn().mockResolvedValue({
@@ -137,11 +193,7 @@ test("a station the hub says is waiting shows waiting on first render, with no c
 });
 
 test("a station nobody has asked to move shows the control and no waiting line", async () => {
-  const moveState = vi.fn().mockResolvedValue({
-    status: "retired-identity",
-    runningAs: OLD,
-    willBecome: NEW,
-  });
+  const moveState = saysRetired();
   render(MatrixIdentityPanel, { station: RETIRED, moveState });
 
   expect(await screen.findByRole("button", { name: /move to its own identity/i })).toBeTruthy();
@@ -149,25 +201,22 @@ test("a station nobody has asked to move shows the control and no waiting line",
   expect(screen.queryByText(/waiting for the node/i)).toBeNull();
 });
 
-test("a hub that cannot answer costs the waiting line and nothing else", async () => {
-  // The waiting state is only ever ADDITIONAL information. Turning its
-  // absence into an error banner would make a panel whose control works fine
-  // look broken.
+test("a hub that cannot answer says so rather than offering a move it cannot describe", async () => {
+  // This used to assert that a failed fetch "costs the waiting line and
+  // nothing else", with the control still rendered — which was defensible
+  // while three states came off the row. They do not: without the hub's
+  // answer this panel does not know whether there is a move to offer, or what
+  // address it would end at, and a control built on that guess is the defect
+  // this whole change removes. Saying nothing at all would be the other half
+  // of the same silence, so it says what it could not find out.
   const moveState = vi.fn().mockRejectedValue(new Error("hub unreachable"));
   render(MatrixIdentityPanel, { station: RETIRED, moveState });
 
+  expect(await screen.findByText(/couldn't ask the hub/i)).toBeTruthy();
   await vi.waitFor(() => expect(moveState).toHaveBeenCalled());
+  // Not an alarm — nothing is broken, one question went unanswered.
   expect(screen.queryByRole("alert")).toBeNull();
-  expect(screen.getByRole("button", { name: /move to its own identity/i })).toBeTruthy();
-});
-
-test("a converged station is not asked about a move it is not in", async () => {
-  const moveState = vi.fn().mockResolvedValue({ status: "converged", mxid: NEW });
-  render(MatrixIdentityPanel, { station: { matrixId: NEW, bridgeMatrixId: NEW }, moveState });
-  // `converged` still means only that the two columns agree — and they are
-  // read here, not fetched. Asking the hub as well would be a second source
-  // for a fact the row already settles.
-  expect(moveState).not.toHaveBeenCalled();
+  expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
 });
 
 test("a click's waiting state is not overwritten by a slower answer about how things stood before it", async () => {
@@ -185,6 +234,11 @@ test("a click's waiting state is not overwritten by a slower answer about how th
   // mid-click must not be adopted while the click's own request (`authorize`)
   // is still outstanding. Both promises are held open here so the race is
   // real: `moveState` settles WHILE `authorize` is still pending.
+  //
+  // The click has to be reachable before the hub has answered anything, which
+  // is why the panel renders the control off the FIRST answer and keeps it
+  // through the second: this test resolves the mount request only after the
+  // button has been pressed, so the first answer here is a rendered one.
   const STALE_SINCE = "2020-01-01T00:00:00Z";
   let settleMoveState: (s: unknown) => void = () => {};
   const moveState = vi.fn().mockReturnValue(
@@ -198,14 +252,29 @@ test("a click's waiting state is not overwritten by a slower answer about how th
       settleAuthorize = resolve;
     })
   );
-  render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState });
+  const { rerender } = render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState });
+
+  // Nothing is offered until the hub has answered — the panel no longer
+  // guesses from a column.
+  expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
+  settleMoveState({ status: "retired-identity", runningAs: OLD, willBecome: NEW });
+  await vi.waitFor(() =>
+    expect(screen.getByRole("button", { name: /move to its own identity/i })).toBeTruthy()
+  );
 
   await fireEvent.click(screen.getByRole("button", { name: /move to its own identity/i }));
   expect(screen.getByRole("button", { name: /authorizing/i })).toBeTruthy();
 
-  // The hub answers the MOUNT's question — a stale `waiting`, from before
-  // this click — while `authorize` is still outstanding.
-  settleMoveState({ status: "waiting", runningAs: OLD, willBecome: NEW, since: STALE_SINCE });
+  // A SECOND answer to the same question — a stale `waiting`, from before this
+  // click — lands while `authorize` is still outstanding.
+  let settleAgain: (s: unknown) => void = () => {};
+  moveState.mockReturnValueOnce(
+    new Promise((resolve) => {
+      settleAgain = resolve;
+    })
+  );
+  await rerender({ station: { id: "station_2", matrixId: OLD }, authorize, moveState });
+  settleAgain({ status: "waiting", runningAs: OLD, willBecome: NEW, since: STALE_SINCE });
   await tick();
 
   // Still authorizing: the in-flight click outranks a reply about the past.

--- a/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte.test.ts
+++ b/apps/console/src/lib/components/stations/MatrixIdentityPanel.svelte.test.ts
@@ -66,13 +66,14 @@ test("a station the hub says is on a retired identity says so, naming both addre
   expect(moveState).toHaveBeenCalledWith(RETIRED.id);
 });
 
-test("a station whose two columns agree on the OLD address is still offered the move", async () => {
+test("only the hub can call a station converged — the panel never decides that from a row", async () => {
   // The defect, from the console's side. `bridgeMatrixId` is not a prop any
   // more, so the only way this panel can call a station converged is if the
   // HUB says so — and for this station the hub says `retired-identity`,
   // because the address the agent's handle implies is not the one it answers
-  // as. The old panel, handed `{matrixId: OLD, bridgeMatrixId: OLD}`, showed
-  // "identity has switched" and no control at all.
+  // as. The old panel, handed the fleet's real row
+  // (`{matrixId: OLD, bridgeMatrixId: OLD}`), showed "identity has switched"
+  // and no control at all.
   render(MatrixIdentityPanel, { station: RETIRED, moveState: saysRetired() });
 
   expect(await screen.findByRole("button", { name: /move to its own identity/i })).toBeTruthy();
@@ -219,74 +220,106 @@ test("a hub that cannot answer says so rather than offering a move it cannot des
   expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
 });
 
-test("a click's waiting state is not overwritten by a slower answer about how things stood before it", async () => {
-  // Reviewer's finding (fix-wave-2, Ruling 17): this test used to resolve the
-  // mount's `moveState` fetch with `status: "retired-identity"` — a status
-  // the guarded callback never acts on regardless of the `phase !== "idle"`
-  // guard it claimed to pin, since the callback only writes anything when
-  // `s.status === "waiting"`. The reviewer removed the guard and all 13
-  // tests, including this one, still passed.
-  //
-  // The guard's actual job: the operator clicks while the mount's own
-  // `moveState` request is still in flight. That request describes how
-  // things stood BEFORE the click — including a `since` from whatever
-  // authorization existed then — and a `status: "waiting"` reply arriving
-  // mid-click must not be adopted while the click's own request (`authorize`)
-  // is still outstanding. Both promises are held open here so the race is
-  // real: `moveState` settles WHILE `authorize` is still pending.
-  //
-  // The click has to be reachable before the hub has answered anything, which
-  // is why the panel renders the control off the FIRST answer and keeps it
-  // through the second: this test resolves the mount request only after the
-  // button has been pressed, so the first answer here is a rendered one.
-  const STALE_SINCE = "2020-01-01T00:00:00Z";
-  let settleMoveState: (s: unknown) => void = () => {};
-  const moveState = vi.fn().mockReturnValue(
-    new Promise((resolve) => {
-      settleMoveState = resolve;
-    })
-  );
-  let settleAuthorize: (r: { expiresAt: string }) => void = () => {};
-  const authorize = vi.fn().mockReturnValue(
-    new Promise((resolve) => {
-      settleAuthorize = resolve;
-    })
-  );
-  const { rerender } = render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState });
+// ─── One panel, many stations: nothing may follow you from the last one ───────
+//
+// `[stationId]/+page.svelte` is ONE page reused across stations, so this
+// component is not remounted when an operator moves from A to B. Everything it
+// learned about A therefore has to be cleared when B arrives, or B is rendered
+// with A's answer until its own turns up.
 
-  // Nothing is offered until the hub has answered — the panel no longer
-  // guesses from a column.
+test("a hub failure on one station does not follow you to the next", async () => {
+  // `unanswered` used to be write-once-true: one unreachable hub, and every
+  // station visited afterwards in the same session claimed the hub could not
+  // be asked — with its move hidden behind that claim.
+  const moveState = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("hub unreachable"))
+    .mockResolvedValueOnce({ status: "retired-identity", runningAs: OLD, willBecome: NEW });
+
+  const { rerender } = render(MatrixIdentityPanel, { station: RETIRED, moveState });
+  expect(await screen.findByText(/couldn't ask the hub/i)).toBeTruthy();
+
+  await rerender({ station: { id: "station_2", matrixId: OLD }, moveState });
+
+  expect(await screen.findByRole("button", { name: /move to its own identity/i })).toBeTruthy();
+  expect(screen.queryByText(/couldn't ask the hub/i)).toBeNull();
+  expect(moveState).toHaveBeenNthCalledWith(2, "station_2");
+});
+
+test("a station is never rendered with the previous station's answer", async () => {
+  // The serious half. An operator lands on B, reads A's target address in the
+  // sentence, and presses A's move — on B. Nothing may be offered for a
+  // station this panel has not yet been told anything about.
+  const B_TARGET = "@agent_analyst-echo:matrix.example.org";
+  let settleSecond: (s: unknown) => void = () => {};
+  const moveState = vi
+    .fn()
+    .mockResolvedValueOnce({ status: "retired-identity", runningAs: OLD, willBecome: NEW })
+    .mockReturnValueOnce(
+      new Promise((resolve) => {
+        settleSecond = resolve;
+      })
+    );
+
+  const { rerender } = render(MatrixIdentityPanel, { station: RETIRED, moveState });
+  expect(await screen.findByText(NEW)).toBeTruthy();
+
+  await rerender({ station: { id: "station_2", matrixId: OLD }, moveState });
+
+  // The hub has not answered for station_2 yet: no address, no control, and
+  // above all not station_1's.
+  expect(screen.queryByText(NEW)).toBeNull();
   expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
-  settleMoveState({ status: "retired-identity", runningAs: OLD, willBecome: NEW });
-  await vi.waitFor(() =>
-    expect(screen.getByRole("button", { name: /move to its own identity/i })).toBeTruthy()
-  );
 
-  await fireEvent.click(screen.getByRole("button", { name: /move to its own identity/i }));
-  expect(screen.getByRole("button", { name: /authorizing/i })).toBeTruthy();
+  settleSecond({ status: "retired-identity", runningAs: OLD, willBecome: B_TARGET });
+  expect(await screen.findByText(B_TARGET)).toBeTruthy();
+});
 
-  // A SECOND answer to the same question — a stale `waiting`, from before this
-  // click — lands while `authorize` is still outstanding.
-  let settleAgain: (s: unknown) => void = () => {};
-  moveState.mockReturnValueOnce(
-    new Promise((resolve) => {
-      settleAgain = resolve;
-    })
-  );
+test("a click on one station does not leave the next one claiming to be waiting", async () => {
+  // `phase` is per-station too: authorising A must not make B say it is
+  // waiting for a node to redeem an authorisation nobody minted for it.
+  const authorize = vi.fn().mockResolvedValue({ expiresAt: "2026-09-01T12:00:00Z" });
+  const moveState = vi
+    .fn()
+    .mockResolvedValue({ status: "retired-identity", runningAs: OLD, willBecome: NEW });
+
+  const { rerender } = render(MatrixIdentityPanel, { station: RETIRED, authorize, moveState });
+  await fireEvent.click(await screen.findByRole("button", { name: /move to its own identity/i }));
+  expect(screen.getByText(/waiting for the node/i)).toBeTruthy();
+
   await rerender({ station: { id: "station_2", matrixId: OLD }, authorize, moveState });
-  settleAgain({ status: "waiting", runningAs: OLD, willBecome: NEW, since: STALE_SINCE });
+
+  await screen.findByRole("button", { name: /move to its own identity/i });
+  expect(screen.queryByText(/waiting for the node/i)).toBeNull();
+});
+
+test("an answer about the station you left never lands on the one you are looking at", async () => {
+  // What is left of Ruling 17's guard once the control renders only after an
+  // answer: a click can no longer overtake this panel's own request for the
+  // same station, so the reachable version of "a reply about the past" is a
+  // reply about a DIFFERENT station, arriving after the move to this one. The
+  // effect's cleanup is what drops it — without that, A's late answer would
+  // overwrite the state B's arrival just cleared, which is the same leak by a
+  // slower route.
+  let settleFirst: (s: unknown) => void = () => {};
+  const moveState = vi
+    .fn()
+    .mockReturnValueOnce(
+      new Promise((resolve) => {
+        settleFirst = resolve;
+      })
+    )
+    .mockResolvedValueOnce({ status: "converged", mxid: NEW });
+
+  const { rerender } = render(MatrixIdentityPanel, { station: RETIRED, moveState });
+  await rerender({ station: { id: "station_2", matrixId: NEW }, moveState });
+  expect(await screen.findByText(/identity has switched/i)).toBeTruthy();
+
+  // station_1's answer, arriving late. It must change nothing about station_2.
+  settleFirst({ status: "retired-identity", runningAs: OLD, willBecome: NEW });
   await tick();
 
-  // Still authorizing: the in-flight click outranks a reply about the past.
-  // Without the guard, `phase` would flip to `"waiting"` here — before the
-  // click's own request has even resolved — and this stale `since` would be
-  // what the operator sees.
-  expect(screen.getByRole("button", { name: /authorizing/i })).toBeTruthy();
-  expect(screen.queryByText(/waiting for the node/i)).toBeNull();
-
-  settleAuthorize({ expiresAt: "2026-09-01T12:00:00Z" });
-  await vi.waitFor(() => expect(screen.getByText(/waiting for the node/i)).toBeTruthy());
-  // The click's own answer is what's shown, not the stale one that arrived
-  // mid-flight.
-  expect(screen.queryByText(new Date(STALE_SINCE).toLocaleString())).toBeNull();
+  expect(screen.getByText(/identity has switched/i)).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
+  expect(screen.queryByText(/retired identity/i)).toBeNull();
 });

--- a/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
+++ b/apps/console/src/routes/nodes/[id]/stations/[stationId]/+page.svelte
@@ -286,20 +286,19 @@
         />
       </div>
       <!--
-        The §1 invariant — matrixId vs bridgeMatrixId — is a station-level fact,
-        not a tab's. It sits here, outside the tab bar, precisely so switching
-        tabs can never unmount it out from under an authorization the operator
-        just fired off (design §6; the panel itself renders nothing in bridge
-        mode, so bridge-mode stations show no empty box).
+        The §1 invariant — is this agent on its principal's address? — is a
+        station-level fact, not a tab's. It sits here, outside the tab bar,
+        precisely so switching tabs can never unmount it out from under an
+        authorization the operator just fired off (design §6; the panel itself
+        renders nothing in bridge mode, so bridge-mode stations show no empty
+        box).
+
+        `bridgeMatrixId` is deliberately not passed: it is what the appservice
+        minted, not what this agent's handle implies, and the panel asks the
+        hub for the states that turn on the difference.
       -->
       <div class="mb-4">
-        <MatrixIdentityPanel
-          station={{
-            id: station.id,
-            matrixId: station.matrixId,
-            bridgeMatrixId: station.bridgeMatrixId,
-          }}
-        />
+        <MatrixIdentityPanel station={{ id: station.id, matrixId: station.matrixId }} />
       </div>
     {/if}
     {@render stationPanels()}

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -224,9 +224,10 @@ if (matrixBridge) {
   const identityMove = { domain: matrixBridge.config.domain, client: matrixBridge.client };
 
   // What the node reports on every detect, and the only thing that may set
-  // the irreversible last step of a move going: `matrix_id = bridge_matrix_id`
-  // is convergence (design §1), and until it holds, the station keeps working
-  // under the identity it already has. The registration itself lives in
+  // the irreversible last step of a move going: convergence is `matrix_id`
+  // becoming the address the station's occupying principal's handle implies
+  // (design §1), and until it holds, the station keeps working under the
+  // identity it already has. The registration itself lives in
   // `wireConvergenceListener` (`identity-move.ts`) rather than inline here,
   // so it has a unit test that does not need to boot this whole file to run.
   wireConvergenceListener(identityMove);
@@ -314,7 +315,7 @@ if (matrixBridge) {
       // The four states of §1's invariant, for the console's panel. Same
       // function `moveInProgress` reads, so the operator's view and the gate
       // sweep's attribution can never disagree about what `waiting` means.
-      moveState: (stationId) => moveState(stationId),
+      moveState: (stationId) => moveState(stationId, matrixBridge.config.domain),
     }),
   );
 

--- a/apps/hub/src/services/matrix-as/gates.ts
+++ b/apps/hub/src/services/matrix-as/gates.ts
@@ -360,7 +360,7 @@ export async function projectGate(
     // than becoming a false `false`. The extra lookup is on the failure path
     // only — `roomForCard` already answered for the ordinary one.
     const stationId = await dispatchedStationId(tenantId, d.boardId, d.cardId);
-    const midMove = stationId ? await moveInProgress(stationId) : undefined;
+    const midMove = stationId ? await moveInProgress(stationId, deps.domain) : undefined;
     log.info("gate has no room to appear in", {
       gateId: d.gateId,
       cardId: d.cardId,
@@ -401,7 +401,7 @@ export async function projectGate(
     // occupying agent could never be re-attempted — the sweep would see the
     // claimed row and conclude it had already been handled.
     await releaseClaim(d.gateId);
-    const midMove = await moveInProgress(found.stationId);
+    const midMove = await moveInProgress(found.stationId, deps.domain);
     log.warn("gate's station has no occupying agent; claim released", {
       gateId: d.gateId,
       stationKey: found.stationKey,
@@ -432,7 +432,7 @@ export async function projectGate(
     // authorisation and convergence is waiting, not broken, and a sweep that
     // reports the two as the same thing is how a move gets mistaken for the
     // outage it exists to avoid.
-    const midMove = await moveInProgress(found.stationId);
+    const midMove = await moveInProgress(found.stationId, deps.domain);
     log.warn("gate's station answers for itself but has reported no Matrix identity; claim released", {
       gateId: d.gateId,
       stationKey: found.stationKey,
@@ -491,7 +491,7 @@ export async function projectGate(
     // The claim has to go, or this gate can never be projected again — the
     // sweep would see a row and conclude it had been handled.
     await db.delete(matrixGateEvents).where(eq(matrixGateEvents.gateId, d.gateId));
-    const midMove = await moveInProgress(found.stationId);
+    const midMove = await moveInProgress(found.stationId, deps.domain);
     log.warn("gate event was not accepted; claim released", {
       gateId: d.gateId,
       stationId: found.stationId,

--- a/apps/hub/src/services/matrix-as/hooks.ts
+++ b/apps/hub/src/services/matrix-as/hooks.ts
@@ -47,8 +47,10 @@ export function notifyStationsAdopted(stationIds: string[]): void {
  *
  * The other half of the ordered identity move
  * (`matrix-as/identity-move.ts`, design §4 step 5): convergence is the node
- * reporting `bridge_matrix_id`, and it is the ONLY thing that may trigger the
- * one irreversible step. `station-registry` is the place that hears every
+ * reporting the address its occupying principal's handle implies — never what
+ * `bridge_matrix_id` holds, which for a harness station is the address it is
+ * moving OFF — and it is the ONLY thing that may trigger the one irreversible
+ * step. `station-registry` is the place that hears every
  * `detect`, and it must go on knowing nothing about Matrix — so it announces
  * the report and whoever cares listens, exactly as adoption does above.
  *

--- a/apps/hub/src/services/matrix-as/identity-move.ts
+++ b/apps/hub/src/services/matrix-as/identity-move.ts
@@ -17,8 +17,10 @@
  *     while the OLD identity is still a member and still working;
  *  3. the node redeems the authorisation, writes the profile, restarts;
  *  4. the harness comes up as `@agent_<handle>` — *already a member*;
- *  5. the node reports the new mxid and **`onNodeReportedMatrixId`** sees
- *     `matrix_id = bridge_matrix_id`, which is what convergence means (§1);
+ *  5. the node reports the new mxid and **`onNodeReportedMatrixId`** sees that
+ *     `matrix_id` is now the address the occupying principal's handle implies,
+ *     which is what convergence means (§1, and `targetIdentity` below for why
+ *     it is the handle that is asked and not `bridge_matrix_id`);
  *  6. only then does **`retireOldIdentity`** take the old account out of the
  *     room, record it against the same principal, and retire its credential.
  *
@@ -102,8 +104,6 @@ interface MovingStation {
   principalId: string | null;
   /** What the harness reports it answers as today. Null in bridge mode. */
   matrixId: string | null;
-  /** What the appservice minted — the address this move ends at. */
-  bridgeMatrixId: string | null;
 }
 
 async function loadStation(stationId: string): Promise<MovingStation | null> {
@@ -112,12 +112,44 @@ async function loadStation(stationId: string): Promise<MovingStation | null> {
       id: stations.id,
       principalId: stations.principalId,
       matrixId: stations.matrixId,
-      bridgeMatrixId: stations.bridgeMatrixId,
     })
     .from(stations)
     .where(eq(stations.id, stationId))
     .limit(1);
   return row ?? null;
+}
+
+/**
+ * The address this station's occupant implies — where the move ends, and the
+ * only thing convergence may be measured against.
+ *
+ * **This used to be `stations.bridge_matrix_id`, and that column cannot answer
+ * the question.** It records the identity the appservice minted, which for a
+ * harness station is written from `names.ts`'s `stationSpeaker` — and
+ * `stationSpeaker` correctly returns the harness's OWN mxid there. So the
+ * column holds "what this station already is", not "what the appservice would
+ * mint for its occupant", and on the live fleet all 14 harness stations carry
+ * `matrix_id = bridge_matrix_id = ` their old station-derived address. Every
+ * comparison against it therefore read "converged" for exactly the stations
+ * this file exists to move, the console offered none of them the move, and
+ * nothing could ever start. Every test passed because every fixture set the
+ * column to the handle-derived value — which is what the design assumed and
+ * what `provision.ts` does not do.
+ *
+ * The question the invariant means to ask is *"is this station on its
+ * principal's address?"*, and only the handle answers that. So it is asked of
+ * the handle, through the same `bridgeUserId` derivation the rest of the
+ * bridge uses. `bridge_matrix_id` keeps its stated meaning and is not
+ * redefined, not backfilled, and no longer read here.
+ *
+ * Null means the station has no occupying principal, so it has no handle and
+ * therefore no address to move to. That is a real answer — such a station is
+ * not movable — and never patched over with the station-derived form, which
+ * is the identity this slice exists to retire.
+ */
+async function targetIdentity(station: MovingStation, domain: string): Promise<string | null> {
+  const handle = station.principalId ? await principalHandle(station.principalId) : null;
+  return handle ? bridgeUserId(handle, domain) : null;
 }
 
 /**
@@ -161,10 +193,16 @@ export type PreJoinOutcome =
   /** It was already a member — a re-run, and the reason the invite is skipped. */
   | { status: "already"; roomId: string; newMxid: string }
   | { status: "unknown-station" }
-  /** No occupying agent, so no handle, so no address to move to. */
+  /**
+   * No occupying agent, so no handle, so no address to move to.
+   *
+   * There is no separate "the appservice never minted one" refusal any more:
+   * the target is the address the occupant's HANDLE implies, and a station
+   * with a handle always has one. That refusal existed only because this read
+   * `bridge_matrix_id`, whose emptiness said nothing about whether the station
+   * could move.
+   */
   | { status: "no-agent" }
-  /** The appservice has never minted this station an identity. */
-  | { status: "no-identity" }
   | { status: "no-room" }
   | { status: "ambiguous-room"; candidates: string[] }
   /**
@@ -184,8 +222,6 @@ export function preJoinRefusal(outcome: PreJoinOutcome): string | null {
       return "This station no longer exists.";
     case "no-agent":
       return "This station has no occupying agent, so there is nothing to move to its own identity.";
-    case "no-identity":
-      return "This station has no Matrix identity of its own yet, so there is nothing to move it to.";
     case "no-room":
       return "This station has no Matrix room, so there is nowhere to put its new identity before the harness switches.";
     case "ambiguous-room":
@@ -222,25 +258,16 @@ export async function preJoinNewIdentity(
   const station = await loadStation(stationId);
   if (!station) return { status: "unknown-station" };
 
-  const handle = station.principalId ? await principalHandle(station.principalId) : null;
-  if (!handle) return { status: "no-agent" };
-
-  // The address the appservice actually minted, not one re-derived here. A
-  // derived address is a claim about what SHOULD exist; this move has to act
-  // on the account that does — `provision.ts` is what registered it.
-  const newMxid = station.bridgeMatrixId;
-  if (!newMxid) return { status: "no-identity" };
-
-  const derived = bridgeUserId(handle, deps.domain);
-  if (derived !== newMxid) {
-    // Not fatal — the minted address is still the real one — but it means the
-    // handle and the account have drifted apart, which is worth a line.
-    log.warn("a station's minted identity is not the one its handle implies", {
-      stationId,
-      minted: newMxid,
-      derived,
-    });
-  }
+  // Where the move ENDS, derived from the occupant's handle — see
+  // `targetIdentity`. This read `station.bridgeMatrixId`, on the reasoning
+  // that acting on the account the appservice really minted beats acting on
+  // one re-derived here. The reasoning was sound and the column was the wrong
+  // one: for a harness station `bridge_matrix_id` holds the station's OWN
+  // address, so the pre-join invited and joined the identity the station is
+  // moving off — a no-op that reports `already` for every station on the
+  // fleet.
+  const newMxid = await targetIdentity(station, deps.domain);
+  if (!newMxid) return { status: "no-agent" };
 
   const choice = await roomToMove(stationId);
   if (choice.status !== "room") return choice;
@@ -361,7 +388,14 @@ export async function retireOldIdentity(
   const station = await loadStation(stationId);
   if (!station) return { status: "unknown-station" };
 
-  if (!oldMxid || oldMxid === station.matrixId || oldMxid === station.bridgeMatrixId) {
+  // The address the station is moving TO, handle-derived (`targetIdentity`).
+  // The guard below compared against `bridge_matrix_id`, which on the fleet IS
+  // the old station-derived address — so the one identity a real retirement is
+  // ever called on was the one this refused to touch, and step 6 could not run
+  // even if everything before it had.
+  const target = await targetIdentity(station, deps.domain);
+
+  if (!oldMxid || oldMxid === station.matrixId || oldMxid === target) {
     log.warn("refusing to retire the identity a station currently answers as", {
       stationId,
       oldMxid,
@@ -384,19 +418,22 @@ export async function retireOldIdentity(
     // across that gap would be a remembered claim about membership rather
     // than a checked one. A stale carried id and a changed room set fail the
     // same way; this question catches both.
-    // `?? bridgeMatrixId` is the bridge-mode fallback: a station with no
-    // `matrix_id` is one the appservice speaks for, and its `bridge_matrix_id`
-    // IS the account in the room.
+    // `?? target` is the bridge-mode fallback: a station with no `matrix_id`
+    // is one the appservice speaks for, and it speaks as the occupant's
+    // handle-derived address — the same thing `names.ts`'s `stationSpeaker`
+    // answers in bridge mode, and what `provision.ts` therefore wrote into
+    // `bridge_matrix_id` for such a station. Read off the handle rather than
+    // off that column so the fallback and the guard above ask one question.
     //
     // **That is safe here only because of the guard above**, and the coupling
     // is load-bearing enough to say out loud: the live-identity check already
-    // refused when `oldMxid === station.bridgeMatrixId`, so by this line the
-    // identity being retired can never be the one this fallback resolves to.
-    // Without that guard this would ask "is the account I am about to remove
-    // still in the room?", get `true`, and take it out — which is the mute
-    // station this whole file exists to prevent. Anyone loosening the guard
-    // above has to give this line its own check.
-    const speaker = station.matrixId ?? station.bridgeMatrixId;
+    // refused when `oldMxid === target`, so by this line the identity being
+    // retired can never be the one this fallback resolves to. Without that
+    // guard this would ask "is the account I am about to remove still in the
+    // room?", get `true`, and take it out — which is the mute station this
+    // whole file exists to prevent. Anyone loosening the guard above has to
+    // give this line its own check.
+    const speaker = station.matrixId ?? target;
     if (!speaker || !(await deps.client.isJoined(speaker, roomId))) {
       log.error(
         "refusing to retire an identity out of a room the station cannot speak in — " +
@@ -496,12 +533,16 @@ export type ConvergenceOutcome =
 /**
  * The node has reported what its harness answers as. Is that convergence?
  *
- * `matrix_id = bridge_matrix_id` is the whole test (§1's invariant), and it is
- * deliberately the ONLY thing that triggers the irreversible step. A harness
- * that never restarts, an adapter that wrote the wrong file, a credential the
- * harness ignored — all of them show up here as "not this address", and all of
- * them leave the station working under its old identity with both accounts in
- * the room.
+ * "Is this the address the occupant's handle implies" is the whole test (§1's
+ * invariant, as `targetIdentity` restates it), and it is deliberately the ONLY
+ * thing that triggers the irreversible step. A harness that never restarts, an
+ * adapter that wrote the wrong file, a credential the harness ignored — all of
+ * them show up here as "not this address", and all of them leave the station
+ * working under its old identity with both accounts in the room.
+ *
+ * Asked of the handle rather than of `bridge_matrix_id`: on the fleet that
+ * column holds the station's own old address, so a harness that had done
+ * nothing at all reported exactly what this used to call convergence.
  *
  * Called before `station-registry` writes the reported value, because the
  * value it is about to overwrite is the only record of who the old identity
@@ -515,8 +556,9 @@ export async function onNodeReportedMatrixId(
   const station = await loadStation(stationId);
   if (!station) return { status: "unknown-station" };
 
-  if (!mxid || !station.bridgeMatrixId || mxid !== station.bridgeMatrixId) {
-    return { status: "not-converged", reported: mxid, expected: station.bridgeMatrixId };
+  const target = await targetIdentity(station, deps.domain);
+  if (!mxid || !target || mxid !== target) {
+    return { status: "not-converged", reported: mxid, expected: target };
   }
 
   const oldMxid = station.matrixId;
@@ -560,18 +602,32 @@ export function wireConvergenceListener(deps: IdentityMoveDeps): void {
 // ─── What an operator (and the gate sweep) can see ────────────────────────────
 
 /**
- * Where a station stands in §1's invariant — the three states §6 renders, and
- * the one the fleet could not answer on 2026-08-31.
+ * Where a station stands in §1's invariant — the states §6 renders, and the
+ * one the fleet could not answer on 2026-08-31.
  *
- * Derived from two existing columns plus the authorisation record; there is no
- * "moving" flag, because a flag is a fourth place for this to be wrong.
+ * Derived from `matrix_id`, the occupant's handle and the authorisation
+ * record; there is no "moving" flag, because a flag is a fourth place for this
+ * to be wrong — and no longer any reading of `bridge_matrix_id`, because that
+ * column answered a different question than the one this asks
+ * (`targetIdentity`).
  */
 export type MoveState =
   | { status: "unknown" }
   /** `matrix_id IS NULL` — the appservice speaks for it, and always did. */
   | { status: "bridge" }
-  /** `matrix_id = bridge_matrix_id` — harness mode, converged. */
+  /** `matrix_id` IS the address the occupant's handle implies — converged. */
   | { status: "converged"; mxid: string }
+  /**
+   * Harness mode with nobody occupying the station: there is no handle, so
+   * there is no address to move to, and this station is not movable at all.
+   *
+   * A real answer rather than an omission, and distinct from
+   * `retired-identity` on purpose: the console must not offer a move it has
+   * no target for, and must not silently render nothing either — a station
+   * answering as an address no principal owns is a thing an operator needs to
+   * be told about, not a blank.
+   */
+  | { status: "no-agent"; runningAs: string }
   /**
    * Authorised and not yet converged. **Waiting, not broken** (Ruling 9): the
    * broker signal is fire-and-forget, so a station sits here from the moment an
@@ -581,12 +637,15 @@ export type MoveState =
    */
   | { status: "waiting"; runningAs: string; willBecome: string; since: Date }
   /**
-   * `matrix_id <> bridge_matrix_id` with no live authorisation behind it: the
-   * station is running under a retired identity and nobody has asked for it to
-   * move. That is the fleet's condition for all 14 harness stations today, and
-   * it is a thing to do, not a fault.
+   * The station answers as something other than its principal's address, with
+   * no live authorisation behind it: it is running under a retired identity
+   * and nobody has asked for it to move. That is the fleet's condition for all
+   * 14 harness stations today, and it is a thing to do, not a fault.
+   *
+   * `willBecome` is never null here — a station with no handle is `no-agent`
+   * above, and reaches this branch not at all.
    */
-  | { status: "retired-identity"; runningAs: string; willBecome: string | null };
+  | { status: "retired-identity"; runningAs: string; willBecome: string };
 
 /**
  * An authorisation counts as a move in flight while it can still lead to one:
@@ -619,28 +678,33 @@ async function liveAuthorization(
   return row ?? null;
 }
 
-export async function moveState(stationId: string): Promise<MoveState> {
+export async function moveState(stationId: string, domain: string): Promise<MoveState> {
   const station = await loadStation(stationId);
   if (!station) return { status: "unknown" };
   if (!station.matrixId) return { status: "bridge" };
-  if (station.matrixId === station.bridgeMatrixId) {
+
+  // The question this whole state machine means to ask — "is this station on
+  // its principal's address?" — and only the handle answers it. Compared
+  // against `bridge_matrix_id` until 2026-09-01, which made every harness
+  // station on the fleet read `converged` while sitting on the very identity
+  // it was supposed to leave: the console offered nobody a move, and no move
+  // could start. See `targetIdentity`.
+  const target = await targetIdentity(station, domain);
+  if (!target) return { status: "no-agent", runningAs: station.matrixId };
+  if (station.matrixId === target) {
     return { status: "converged", mxid: station.matrixId };
   }
 
   const authorization = await liveAuthorization(stationId);
-  if (authorization && station.bridgeMatrixId) {
+  if (authorization) {
     return {
       status: "waiting",
       runningAs: station.matrixId,
-      willBecome: station.bridgeMatrixId,
+      willBecome: target,
       since: authorization.createdAt,
     };
   }
-  return {
-    status: "retired-identity",
-    runningAs: station.matrixId,
-    willBecome: station.bridgeMatrixId,
-  };
+  return { status: "retired-identity", runningAs: station.matrixId, willBecome: target };
 }
 
 /**
@@ -669,8 +733,8 @@ const STALLED_MOVE_BOUND_MS = 15 * 60 * 1000;
  * excuse the fault it just saw", and the two questions get different
  * answers once a redeemed authorisation is old enough (Ruling 19).
  */
-export async function moveInProgress(stationId: string): Promise<boolean> {
-  const state = await moveState(stationId);
+export async function moveInProgress(stationId: string, domain: string): Promise<boolean> {
+  const state = await moveState(stationId, domain);
   if (state.status !== "waiting") return false;
 
   const authorization = await liveAuthorization(stationId);

--- a/apps/hub/tests/integration/identity-move.test.ts
+++ b/apps/hub/tests/integration/identity-move.test.ts
@@ -213,8 +213,18 @@ async function speakerFor(stationId: string): Promise<string | null> {
 
 /**
  * A station as the fleet actually has it today: harness mode, answering as a
- * station-derived address, with the principal-derived one already minted
- * beside it, and one room bound to its occupant.
+ * station-derived address, and one room bound to its occupant.
+ *
+ * **`bridge_matrix_id` is that same station-derived address, because that is
+ * what production writes.** `provision.ts` fills the column from `names.ts`'s
+ * `stationSpeaker`, which for a harness station correctly answers the
+ * harness's OWN mxid — so all 14 harness stations on the fleet carry
+ * `matrix_id = bridge_matrix_id = @agent_<node>_<stationKey>`, and the
+ * principal-derived address appears in neither column. This fixture used to
+ * set the column to `NEW_MXID`, the handle-derived address, which is what the
+ * design ASSUMED and what nothing on the fleet does: every test here passed
+ * while the feature was inert against every real station, because the state
+ * machine read "converged" for all of them.
  *
  * A real room on a real homeserver, created the way `provision.ts` creates
  * one — `preset: "private_chat"`, i.e. invite-only, which is the whole reason
@@ -239,7 +249,7 @@ async function stationMidFleet(label: string): Promise<{ roomId: string; oldMxid
   await rawSql`
     UPDATE stations
        SET matrix_id = ${issued.userId},
-           bridge_matrix_id = ${NEW_MXID},
+           bridge_matrix_id = ${issued.userId},
            matrix_identity_mode = 'harness'
      WHERE id = ${STATION}`;
   await rawSql`DELETE FROM principal_identities WHERE principal_id = ${AGENT_PRINCIPAL}`;
@@ -357,7 +367,12 @@ live("the ordered move, against a real homeserver", () => {
 
     const outcome = await preJoinNewIdentity(STATION, deps());
 
-    expect(outcome.status).toBe("joined");
+    // `joined`, and specifically NOT `already`: the address put in the room is
+    // the one the occupant's handle implies, not the one `bridge_matrix_id`
+    // carries — which for this station, as for all 14 on the fleet, is the
+    // address it is already answering as. Targeting the column made the
+    // pre-join a no-op that reported success.
+    expect(outcome).toMatchObject({ status: "joined", newMxid: NEW_MXID, oldMxid });
     const members = await roomMembers(roomId, NEW_MXID);
     expect(members).toContain(NEW_MXID);
     // Nothing is mute at any point: the harness is still logged in as the old
@@ -518,13 +533,13 @@ live("the ordered move, against a real homeserver", () => {
     // stuck.
     expect(outcome.status).toBe("sent");
     expect(sent.every((x) => x.userId === oldMxid && x.roomId === roomId)).toBe(true);
-    expect(await moveInProgress(STATION)).toBe(true);
+    expect(await moveInProgress(STATION, DOMAIN)).toBe(true);
   });
 
   test("a station answering as an mxid its room does not contain is not silent", async () => {
     // Fix round 2, and the state this slice itself can create: converged on
-    // paper — `matrix_id` IS `bridge_matrix_id`, so `moveState` says
-    // `converged` and `stationSpeaker` is non-null — while the room contains
+    // paper — `matrix_id` IS the address the handle implies, so `moveState`
+    // says `converged` and `stationSpeaker` is non-null — while the room contains
     // only the old identity. Every existing signal reads healthy here:
     // `no-speaker` cannot happen, the send 403s, and `projectGate` used to
     // throw with its claim already taken, after which every later pass
@@ -534,7 +549,7 @@ live("the ordered move, against a real homeserver", () => {
     const { roomId, oldMxid } = await stationMidFleet("mute");
     await rawSql`UPDATE stations SET matrix_id = ${NEW_MXID} WHERE id = ${STATION}`;
     expect(await roomMembers(roomId, oldMxid)).not.toContain(NEW_MXID);
-    expect((await moveState(STATION)).status).toBe("converged");
+    expect((await moveState(STATION, DOMAIN)).status).toBe("converged");
 
     const cardId = `crd_${RUN}_mute`;
     const gateId = `gate_${RUN}_mute`;
@@ -577,7 +592,7 @@ describe("a station whose room choice is ambiguous refuses the move", () => {
              (${"!amb-b-" + RUN}, ${TENANT}, ${STATION}, ${"#amb-b-" + RUN}, now() - interval '1 day')`;
     await rawSql`
       UPDATE stations SET matrix_id = ${"@agent_old_" + RUN + ":" + DOMAIN},
-                          bridge_matrix_id = ${NEW_MXID},
+                          bridge_matrix_id = ${"@agent_old_" + RUN + ":" + DOMAIN},
                           matrix_identity_mode = 'harness'
        WHERE id = ${STATION}`;
 
@@ -616,8 +631,15 @@ describe("a station whose room choice is ambiguous refuses the move", () => {
       VALUES (${"!amb2-a-" + RUN}, ${TENANT}, ${STATION}, ${"#amb2-a-" + RUN}, now() - interval '2 days'),
              (${"!amb2-b-" + RUN}, ${TENANT}, ${STATION}, ${"#amb2-b-" + RUN}, now() - interval '1 day')`;
     const stale = `@agent_stale_${RUN}:${DOMAIN}`;
+    // Converged, in the shape production converges in: `matrix_id` is the
+    // principal's address and `bridge_matrix_id` still holds the retired,
+    // station-derived one — the column records what the appservice minted and
+    // nothing erases it. Retirement is therefore called on the very address
+    // that column carries, which the live-identity guard refused outright
+    // while it compared against `bridge_matrix_id`: step 6 could not run on
+    // any real station.
     await rawSql`
-      UPDATE stations SET matrix_id = ${NEW_MXID}, bridge_matrix_id = ${NEW_MXID},
+      UPDATE stations SET matrix_id = ${NEW_MXID}, bridge_matrix_id = ${stale},
                           matrix_identity_mode = 'harness'
        WHERE id = ${STATION}`;
 
@@ -657,37 +679,120 @@ describe("a station whose room choice is ambiguous refuses the move", () => {
 });
 
 describe("what a station mid-move looks like", () => {
+  test("a station whose minted column holds its OWN address still needs a move", async () => {
+    // The defect the live exit test found, in one assertion.
+    //
+    // On the fleet, `provision.ts` writes `bridge_matrix_id` from
+    // `stationSpeaker`, and for a harness station that correctly answers the
+    // harness's own mxid. So all 14 of them carry
+    // `matrix_id = bridge_matrix_id = ` the OLD station-derived address, while
+    // the principal's handle implies a different one entirely. A state machine
+    // that compares the two columns therefore reads "converged" for every
+    // station it exists to move: the console offered nobody the move, and
+    // nothing could ever start.
+    //
+    // The question is "is this station on its PRINCIPAL's address?", and only
+    // the handle answers it. Nothing here is a Matrix claim — it is what the
+    // hub says about rows — so no homeserver is involved.
+    await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
+    await rawSql`DELETE FROM matrix_rooms WHERE station_id = ${STATION}`;
+    const fleetMxid = `@agent_im-box-${RUN}_hermes-echo-${RUN}:${DOMAIN}`;
+    await rawSql`
+      UPDATE stations SET matrix_id = ${fleetMxid},
+                          bridge_matrix_id = ${fleetMxid},
+                          matrix_identity_mode = 'harness'
+       WHERE id = ${STATION}`;
+
+    const state = await moveState(STATION, DOMAIN);
+
+    expect(state.status).toBe("retired-identity");
+    expect(state).toMatchObject({ runningAs: fleetMxid, willBecome: NEW_MXID });
+    // And nothing about the two columns agreeing may be read as convergence:
+    // a node reporting the address it always had has done nothing, and must
+    // not set the irreversible step going.
+    const reported = await onNodeReportedMatrixId(STATION, fleetMxid, {
+      domain: DOMAIN,
+      client: {
+        invite: async () => {
+          throw new Error("nothing may be moved for a station that has not converged");
+        },
+        join: async () => {
+          throw new Error("nothing may be moved for a station that has not converged");
+        },
+        leave: async () => {
+          throw new Error("nothing may be retired for a station that has not converged");
+        },
+        isJoined: async () => {
+          throw new Error("nothing may be retired for a station that has not converged");
+        },
+        retireAccount: async () => {
+          throw new Error("nothing may be retired for a station that has not converged");
+        },
+      },
+    });
+    expect(reported).toEqual({
+      status: "not-converged",
+      reported: fleetMxid,
+      expected: NEW_MXID,
+    });
+  });
+
+  test("a station with no occupying agent has no address to move to, and says so", async () => {
+    // A station nobody occupies has no handle, so there is no address its
+    // principal implies and no move to offer — but it is not `converged`
+    // either, and it must not crash the question. `bridge` is reserved for
+    // `matrix_id IS NULL`, so this needs a state of its own.
+    await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
+    const orphanMxid = `@agent_orphan_${RUN}:${DOMAIN}`;
+    await rawSql`
+      UPDATE stations SET matrix_id = ${orphanMxid}, bridge_matrix_id = ${orphanMxid},
+                          principal_id = NULL, matrix_identity_mode = 'harness'
+       WHERE id = ${STATION}`;
+
+    try {
+      expect(await moveState(STATION, DOMAIN)).toEqual({
+        status: "no-agent",
+        runningAs: orphanMxid,
+      });
+      // …and the gate sweep must not read that as a move in flight, or every
+      // later fault on an unoccupied station gets excused by one.
+      expect(await moveInProgress(STATION, DOMAIN)).toBe(false);
+    } finally {
+      await rawSql`UPDATE stations SET principal_id = ${AGENT_PRINCIPAL} WHERE id = ${STATION}`;
+    }
+  });
+
   test("a station between authorisation and convergence is waiting, not broken", async () => {
     // Ruling 9: the operator's feedback is asynchronous by design, so this
     // state has to be DERIVABLE — it is what the console renders, and what
     // was missing on 2026-08-31 when nothing could answer "how far has this
-    // got". Derived from two existing columns and the authorisation record;
-    // there is no "moving" flag to go stale.
+    // got". Derived from `matrix_id`, the occupant's handle and the
+    // authorisation record; there is no "moving" flag to go stale.
     await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
     await rawSql`
       UPDATE stations SET matrix_id = ${"@agent_old_" + RUN + ":" + DOMAIN},
-                          bridge_matrix_id = ${NEW_MXID},
+                          bridge_matrix_id = ${"@agent_old_" + RUN + ":" + DOMAIN},
                           matrix_identity_mode = 'harness'
        WHERE id = ${STATION}`;
 
     // Nobody has asked for a move: this is the fleet's condition for all 14
     // harness stations today. A thing to do, not a fault.
-    expect((await moveState(STATION)).status).toBe("retired-identity");
+    expect((await moveState(STATION, DOMAIN)).status).toBe("retired-identity");
 
     await mintCredentialAuthorization(STATION);
-    expect((await moveState(STATION)).status).toBe("waiting");
+    expect((await moveState(STATION, DOMAIN)).status).toBe("waiting");
 
     // An authorisation that expires unredeemed is §4's "nothing happened",
     // and the station drops back to the state an operator authorises from —
     // which is what keeps re-authorising available as the retry.
     await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
     await mintCredentialAuthorization(STATION, { ttlMs: -1 });
-    expect((await moveState(STATION)).status).toBe("retired-identity");
+    expect((await moveState(STATION, DOMAIN)).status).toBe("retired-identity");
 
     // And convergence ends the move without anything having to say so.
     await rawSql`UPDATE stations SET matrix_id = ${NEW_MXID} WHERE id = ${STATION}`;
-    expect((await moveState(STATION)).status).toBe("converged");
-    expect(await moveInProgress(STATION)).toBe(false);
+    expect((await moveState(STATION, DOMAIN)).status).toBe("converged");
+    expect(await moveInProgress(STATION, DOMAIN)).toBe(false);
   });
 
   test("a stalled move stays `waiting` forever, but stops being excused past 15 minutes", async () => {
@@ -704,7 +809,7 @@ describe("what a station mid-move looks like", () => {
     const oldMxid = "@agent_old_" + RUN + ":" + DOMAIN;
     await rawSql`
       UPDATE stations SET matrix_id = ${oldMxid},
-                          bridge_matrix_id = ${NEW_MXID},
+                          bridge_matrix_id = ${oldMxid},
                           matrix_identity_mode = 'harness'
        WHERE id = ${STATION}`;
     await mintCredentialAuthorization(STATION);
@@ -714,8 +819,8 @@ describe("what a station mid-move looks like", () => {
     await rawSql`
       UPDATE matrix_credential_authorizations SET used_at = now() - interval '5 minutes'
        WHERE station_id = ${STATION}`;
-    expect((await moveState(STATION)).status).toBe("waiting");
-    expect(await moveInProgress(STATION)).toBe(true);
+    expect((await moveState(STATION, DOMAIN)).status).toBe("waiting");
+    expect(await moveInProgress(STATION, DOMAIN)).toBe(true);
 
     // Redeemed 20 minutes ago: past the bound. `moveState` still reports
     // `waiting` — nothing about the console's view changed — but the sweep
@@ -723,8 +828,8 @@ describe("what a station mid-move looks like", () => {
     await rawSql`
       UPDATE matrix_credential_authorizations SET used_at = now() - interval '20 minutes'
        WHERE station_id = ${STATION}`;
-    expect((await moveState(STATION)).status).toBe("waiting");
-    expect(await moveInProgress(STATION)).toBe(false);
+    expect((await moveState(STATION, DOMAIN)).status).toBe("waiting");
+    expect(await moveInProgress(STATION, DOMAIN)).toBe(false);
 
     await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
   });
@@ -739,7 +844,7 @@ describe("what a station mid-move looks like", () => {
     await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
     await rawSql`
       UPDATE stations SET matrix_id = ${"@agent_old_" + RUN + ":" + DOMAIN},
-                          bridge_matrix_id = ${NEW_MXID},
+                          bridge_matrix_id = ${"@agent_old_" + RUN + ":" + DOMAIN},
                           matrix_identity_mode = 'harness'
        WHERE id = ${STATION}`;
 

--- a/apps/hub/tests/integration/station-matrix-identity.test.ts
+++ b/apps/hub/tests/integration/station-matrix-identity.test.ts
@@ -110,7 +110,7 @@ function app() {
       inFlightSignals.push(signalled);
       return signalled;
     },
-    moveState: (stationId: string) => moveState(stationId),
+    moveState: (stationId: string) => moveState(stationId, DOMAIN),
     log: (line: string) => logged.push(line),
   });
 
@@ -578,8 +578,15 @@ describe("POST /api/stations/:id/matrix/authorize-move", () => {
     }
 
     beforeEach(async () => {
+      // The fleet's own shape: `bridge_matrix_id` holds the SAME
+      // station-derived address the harness answers as, because that is what
+      // `provision.ts` writes for a harness station (`stationSpeaker` returns
+      // the harness's own mxid there). It used to be seeded with `NEW_MXID` —
+      // the handle-derived address — which is what the design assumed and
+      // what production has never contained, so this whole flow was proven
+      // only against a database no fleet has.
       await rawSql`
-        UPDATE stations SET matrix_id = ${OLD_MXID}, bridge_matrix_id = ${NEW_MXID}
+        UPDATE stations SET matrix_id = ${OLD_MXID}, bridge_matrix_id = ${OLD_MXID}
         WHERE id = ${STATION}`;
       await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
       await rawSql`DELETE FROM principal_identities WHERE principal_id = ${AGENT_PRINCIPAL}`;
@@ -603,14 +610,18 @@ describe("POST /api/stations/:id/matrix/authorize-move", () => {
         await Promise.all(inFlightSignals);
 
         // §1's invariant, now true — and reached without anything in this test
-        // touching `onNodeReportedMatrixId`.
+        // touching `onNodeReportedMatrixId`. The station answers as the
+        // address its occupying principal's handle implies; that, and not
+        // agreement between two columns, is what convergence means.
+        // `bridge_matrix_id` is untouched by the move and still holds the
+        // retired address, exactly as its schema comment says it will.
         const [row] = (await rawSql`
           SELECT matrix_id, bridge_matrix_id FROM stations WHERE id = ${STATION}`) as Array<{
           matrix_id: string;
           bridge_matrix_id: string;
         }>;
         expect(row!.matrix_id).toBe(NEW_MXID);
-        expect(row!.matrix_id).toBe(row!.bridge_matrix_id);
+        expect(row!.bridge_matrix_id).toBe(OLD_MXID);
 
         // Step 6 ran, on the old identity and only on it.
         expect(retired).toContainEqual({ userId: OLD_MXID, op: "retire" });
@@ -728,6 +739,13 @@ describe("POST /api/stations/:id/matrix/authorize-move", () => {
    * four and nothing could read any of them — the console re-derived three
    * from raw columns and could not see `waiting` at all, because the
    * authorisation it is derived from lives only here.
+   *
+   * **Every fixture below now carries the fleet's own `bridge_matrix_id`** —
+   * the station-derived address, the same one `matrix_id` holds — because
+   * that is what `provision.ts` writes for a harness station. Seeding it with
+   * the handle-derived address is what let this endpoint answer `converged`
+   * in a test and `converged` in production for opposite reasons, and offer
+   * the fleet's 14 harness stations no move at all.
    */
   describe("GET /api/stations/:id/matrix/move-state", () => {
     const OLD_MXID = "@agent_guild_hermes-analyst-echo:id.agentpod.dev";
@@ -749,11 +767,15 @@ describe("POST /api/stations/:id/matrix/authorize-move", () => {
 
     test("a station running under a retired identity, with nobody having asked it to move", async () => {
       await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
-      await rawSql`UPDATE stations SET matrix_id = ${OLD_MXID}, bridge_matrix_id = ${NEW_MXID} WHERE id = ${STATION}`;
+      await rawSql`UPDATE stations SET matrix_id = ${OLD_MXID}, bridge_matrix_id = ${OLD_MXID} WHERE id = ${STATION}`;
       const res = await getState(`/stations/${STATION}/matrix/move-state`);
       expect(await res.json()).toMatchObject({
         status: "retired-identity",
         runningAs: OLD_MXID,
+        // Named by the hub, from the occupying principal's handle. The console
+        // cannot derive this — it holds no handle and no domain — which is
+        // why the hub has to say it rather than leave the browser comparing
+        // two columns that agree on the wrong answer.
         willBecome: NEW_MXID,
       });
     });
@@ -764,7 +786,7 @@ describe("POST /api/stations/:id/matrix/authorize-move", () => {
       // answer it after a reload.
       await setGrant(OWNER_PRINCIPAL, { mayDispatch: [AGENT_PRINCIPAL], mayGrantReach: true });
       await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
-      await rawSql`UPDATE stations SET matrix_id = ${OLD_MXID}, bridge_matrix_id = ${NEW_MXID} WHERE id = ${STATION}`;
+      await rawSql`UPDATE stations SET matrix_id = ${OLD_MXID}, bridge_matrix_id = ${OLD_MXID} WHERE id = ${STATION}`;
       connectionManager.unregister(NODE); // offline: authorised, nothing adopts
 
       expect((await post(`/stations/${STATION}/matrix/authorize-move`)).status).toBe(200);
@@ -777,9 +799,12 @@ describe("POST /api/stations/:id/matrix/authorize-move", () => {
       });
     });
 
-    test("converged means the two columns agree — and says nothing about health", async () => {
+    test("converged means the station answers as its principal — and says nothing about health", async () => {
+      // `bridge_matrix_id` still holds the retired address here, as it does on
+      // every station that has actually moved: the column is what the
+      // appservice minted, and the move never rewrites it.
       await rawSql`DELETE FROM matrix_credential_authorizations WHERE station_id = ${STATION}`;
-      await rawSql`UPDATE stations SET matrix_id = ${NEW_MXID}, bridge_matrix_id = ${NEW_MXID} WHERE id = ${STATION}`;
+      await rawSql`UPDATE stations SET matrix_id = ${NEW_MXID}, bridge_matrix_id = ${OLD_MXID} WHERE id = ${STATION}`;
       const res = await getState(`/stations/${STATION}/matrix/move-state`);
       const body = (await res.json()) as Record<string, unknown>;
       expect(body).toEqual({ status: "converged", mxid: NEW_MXID });

--- a/apps/node-agent/internal/gateway/matrixadopt.go
+++ b/apps/node-agent/internal/gateway/matrixadopt.go
@@ -152,9 +152,9 @@ type MatrixAdoptDeps struct {
 	// (descriptor/hermes.go, issue #273): that profile is a VIEW onto the
 	// agent the root gateway already runs, not a separately startable thing,
 	// and starting it would put a second gateway on one messaging identity.
-	// Such a station still has matrix_id != bridge_matrix_id, so the console
-	// offers it the move — which is why the refusal has to live here, on the
-	// side that knows what the station is.
+	// Such a station still answers as something other than the address its
+	// agent's handle implies, so the console offers it the move — which is why
+	// the refusal has to live here, on the side that knows what the station is.
 	CapabilitiesFor CapabilityLookupFunc
 
 	// WriterFor resolves the ProfileWriteFunc for a harness; see

--- a/apps/node-agent/internal/gateway/matrixadopt_test.go
+++ b/apps/node-agent/internal/gateway/matrixadopt_test.go
@@ -349,8 +349,9 @@ func TestAdoptNeverLogsTheTokenOnFailure(t *testing.T) {
 // `lifecycle` withheld (descriptor/hermes.go) because it is a VIEW onto the
 // agent the root gateway already runs, not a separately startable one —
 // starting it would put a second gateway on one messaging identity. Such a
-// station still has matrix_id != bridge_matrix_id, so the console offers it
-// the move; this verb used to call restart without ever asking.
+// station still answers as something other than the address its agent's handle
+// implies, so the console offers it the move; this verb used to call restart
+// without ever asking.
 //
 // The refusal is before the fetch, so a live single-use authorization is not
 // spent on a station that could never converge.

--- a/cloudflare/worker-v2/Dockerfile
+++ b/cloudflare/worker-v2/Dockerfile
@@ -15,7 +15,7 @@
 # bun base (Debian) for opencode, matching Dockerfile.opencode.
 FROM oven/bun:1-slim
 
-ARG AGENTPOD_VERSION=v0.1.31
+ARG AGENTPOD_VERSION=v0.1.32
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git procps \

--- a/docs/superpowers/plans/2026-09-01-uniform-matrix-identity-hermes.md
+++ b/docs/superpowers/plans/2026-09-01-uniform-matrix-identity-hermes.md
@@ -422,7 +422,16 @@ test("a station whose room choice is ambiguous refuses the move", async () => {
 ```
 
 - [ ] **Step 2: Run and watch fail.**
-- [ ] **Step 3: Implement.** `preJoinNewIdentity` invites as the old user then joins as the new one (invite-only rooms — agentpod#397). `onNodeReportedMatrixId` compares against `bridge_matrix_id` and only on equality calls `retireOldIdentity`.
+- [ ] **Step 3: Implement.** `preJoinNewIdentity` invites as the old user then joins as the new one (invite-only rooms — agentpod#397). `onNodeReportedMatrixId` compares against **the address the occupying principal's handle implies** — `bridgeUserId(handle, domain)` — and only on equality calls `retireOldIdentity`.
+
+  *Corrected 2026-09-01, after the live exit test.* This said "compares against
+  `bridge_matrix_id`", and so did the code written from it. That column is what
+  the appservice minted, and `provision.ts` fills it from `stationSpeaker`,
+  which for a harness station answers the harness's OWN mxid — so on the fleet
+  `matrix_id = bridge_matrix_id` on all 14 harness stations, every comparison
+  read "converged", and the move could not be started for any of them. The
+  target address is the one the handle implies, and only the handle answers
+  it. See spec §1.
 - [ ] **Step 4: A station mid-move must not read as healthy.** Spec §6. The sweep
   counts non-`sent` outcomes as of 2026-08-31, and a move must be distinguishable
   from a fault. Write this test first and watch it fail:
@@ -460,8 +469,13 @@ Five things in this codebase have been defined with no caller. A control is part
 
 ```typescript
 test("a station on a retired identity says so, naming both addresses", () => {
-  render(StationMatrixPanel, { station: { matrixId: OLD, bridgeMatrixId: NEW } });
-  expect(screen.getByText(/retired identity/i)).toBeTruthy();
+  // The panel is told where the station stands by the hub (`matrix/move-state`),
+  // NOT handed `bridgeMatrixId` — see Step 3 below.
+  render(StationMatrixPanel, {
+    station: { id: "station_1", matrixId: OLD },
+    moveState: async () => ({ status: "retired-identity", runningAs: OLD, willBecome: NEW }),
+  });
+  expect(await screen.findByText(/retired identity/i)).toBeTruthy();
   expect(screen.getByText(OLD)).toBeTruthy();
   expect(screen.getByText(NEW)).toBeTruthy();
 });
@@ -484,14 +498,37 @@ test("a 403 from the grant gate is shown verbatim", async () => {
   expect(await screen.findByText(/granting reach, which your grant does not permit/i)).toBeTruthy();
 });
 
-test("a converged station shows no control", () => {
-  render(StationMatrixPanel, { station: { matrixId: NEW, bridgeMatrixId: NEW } });
+test("a converged station shows no control", async () => {
+  render(StationMatrixPanel, {
+    station: { id: "station_1", matrixId: NEW },
+    moveState: async () => ({ status: "converged", mxid: NEW }),
+  });
+  expect(await screen.findByText(/identity has switched/i)).toBeTruthy();
   expect(screen.queryByRole("button", { name: /move to its own identity/i })).toBeNull();
 });
 ```
 
 - [ ] **Step 2: Run and watch fail.** `cd apps/console && pnpm vitest run`
-- [ ] **Step 3: Implement**, deriving the three states from §1's invariant: `matrix_id IS NULL` (bridge), `= bridge_matrix_id` (converged), `<> bridge_matrix_id` (retired identity).
+- [ ] **Step 3: Implement.** Only ONE state is derivable in the browser:
+  `matrix_id IS NULL` is bridge mode. The rest turn on the address the
+  occupying principal's handle implies, and the console holds neither the
+  handle nor the homeserver's domain — so it asks the hub
+  (`GET /api/stations/:id/matrix/move-state`) and renders the answer:
+  `converged`, `retired-identity`, `waiting`, or `no-agent` (a station nobody
+  occupies has no address to move to and is offered no move).
+
+  *Corrected 2026-09-01, after the live exit test.* This said "deriving the
+  three states from `matrix_id` vs `bridge_matrix_id`". Those two columns hold
+  the same value on every harness station on the fleet, so the panel called all
+  14 of them converged and rendered no control at all — the one operator
+  surface this slice exists for showed nothing to do. A state derived twice, in
+  two places, from a column that answers a different question, is the defect;
+  the hub answers once.
+
+  Also per-station: the route reuses one page across stations, so everything
+  the panel learned about the last one must be cleared when a new
+  `station.id` arrives, or B is rendered with A's target address and A's
+  move.
 - [ ] **Step 4: Run `pnpm vitest run` and `pnpm check`.** 132 pre-existing failures in the same 11 files; `svelte-check` 0 errors.
 - [ ] **Step 5: Commit.**
 
@@ -500,6 +537,8 @@ test("a converged station shows no control", () => {
 ## Verification before this slice is called done
 
 - [ ] hub **0 fail**, run twice with no reset and an explicit `DATABASE_URL`; console `svelte-check` 0 with its 132 pre-existing failures unchanged; `go test ./...` green in `apps/node-agent`
-- [ ] The §1 invariant query answers correctly for a station in each of the three states
+- [ ] The §1 invariant query answers correctly for a station in each of its states —
+      asked of the occupying principal's HANDLE, never of `bridge_matrix_id`, and
+      including the station with no occupant at all, which has no address to move to
 - [ ] Every failure case in §4's table lands where the table says, each proven by a test that fails when its guard is removed
 - [ ] **The exit test, by hand:** move one real Hermes station on the live fleet — **no SQL, no hand-run curl at any point** — and watch it answer in its room afterwards. That is the claim this slice exists to make true, and the room migration on 2026-08-31 is what happens when it is assumed instead of checked.

--- a/docs/superpowers/specs/2026-09-01-uniform-matrix-identity-design.md
+++ b/docs/superpowers/specs/2026-09-01-uniform-matrix-identity-design.md
@@ -28,29 +28,52 @@ says why they are distinct:
   this one, so nothing on the host can erase it."*
 - `matrix_id` — what the harness reports and the node agent owns.
 
-For a bridge-mode station only the first matters. For a harness-mode station today
-they disagree: the appservice minted `@agent_writer-quill` while the harness runs
-as `@agent_guild_hermes-writer-quill`.
+For a bridge-mode station only the first matters.
 
-**Uniform means they converge.** The account `@agent_<handle>` is minted once, by
-the appservice, exactly as now. Mode decides only who holds its credential.
+**This section said, until 2026-09-01, that for a harness-mode station the two
+columns disagree — "the appservice minted `@agent_writer-quill` while the harness
+runs as `@agent_guild_hermes-writer-quill`". They do not disagree, and that
+sentence is what made the first implementation of this design inert against every
+station on the fleet.** `provision.ts` fills `bridge_matrix_id` from `names.ts`'s
+`stationSpeaker`, and for a harness station `stationSpeaker` correctly answers the
+harness's OWN mxid. So the column holds *what this station already is*, not *what
+the appservice would mint for its occupant*: all 14 harness stations carry
+`matrix_id = bridge_matrix_id = @agent_guild_hermes-writer-quill`, and
+`@agent_writer-quill` appears in neither column.
 
-That yields a checkable invariant, with no new column:
+**Uniform means a station answers as the address its occupying principal's handle
+implies.** The account `@agent_<handle>` is minted once, by the appservice,
+exactly as now. Mode decides only who holds its credential.
+
+That yields a checkable invariant, with no new column — but the comparison is
+against the handle, not against the other column:
 
 | state | meaning |
 |---|---|
 | `matrix_id IS NULL` | bridge mode — the appservice speaks for it |
-| `matrix_id = bridge_matrix_id` | harness mode, converged |
-| `matrix_id <> bridge_matrix_id` | harness mode, mid-move or on a retired identity |
+| `matrix_id = bridgeUserId(handle)` | harness mode, converged |
+| `matrix_id <> bridgeUserId(handle)` | harness mode, mid-move or on a retired identity |
+| no occupying principal | no handle, so no address to move to: not movable |
+
+where `bridgeUserId(handle)` is `names.ts`'s derivation, `@agent_<clean(handle)>`,
+the same one the rest of the bridge uses. `bridge_matrix_id` keeps the meaning its
+schema comment gives it — the identity the appservice minted, which nothing on the
+host can erase — and is **not** redefined, backfilled, or read by the state
+machine. Redefining it would fight its stated purpose; comparing against it
+answers a different question than the one being asked.
 
 Verified against infra on 2026-09-01: 18 bridge stations, every one with
 `matrix_id` null; 14 harness stations, every one with it set; all 32 carrying a
-`bridge_matrix_id`. The table describes the fleet rather than proposing a scheme
+`bridge_matrix_id`, and every harness one carrying its own station-derived address
+in both columns. The table describes the fleet rather than proposing a scheme
 for it.
 
-The third row is the fleet's condition today, for all 14 harness stations. The
-invariant is therefore not only a design goal but the progress query — the one that
-was missing on 2026-08-31, when nothing could answer "how far has this got".
+The third row is the fleet's condition today, for all 14 harness stations — and
+under the two-column comparison every one of them read as the second row instead,
+so the console offered no station a move and nothing could ever start. The
+invariant is not only a design goal but the progress query — the one that was
+missing on 2026-08-31, when nothing could answer "how far has this got" — which
+makes asking it of the right thing the whole of the difference.
 
 ### Two consequences
 
@@ -120,8 +143,8 @@ On the deployed fleet Hermes reads its identity from `.env` as `MATRIX_USER_ID`;
 `auth.json` holds only `credential_pool`/`providers`, and `config.yaml` has no matrix
 section. A writer that chose `auth.json` because it is first would produce a file the
 harness never loads — and the reader would then find the new mxid there first and
-report it. The hub would see `matrix_id = bridge_matrix_id`, conclude the station had
-converged, and move the room. That is the 2026-08-31 outage reproduced with a green
+report it. The hub would see the station answering as the address its handle
+implies, conclude it had converged, and move the room. That is the 2026-08-31 outage reproduced with a green
 signal in front of it.
 
 **Each adapter names the authoritative location for its harness** — the file that
@@ -172,8 +195,8 @@ room while the old one is still there. So it goes in first:
    immediately.
 5. **The node reports the new mxid** in its answer to `matrix.adopt`, read back
    out of the profile it just wrote through the same reader a detect uses
-   (`descriptor.MatrixIDFromProfile`); the hub observes
-   `matrix_id = bridge_matrix_id`.
+   (`descriptor.MatrixIDFromProfile`); the hub observes that `matrix_id` is now
+   the address the occupying principal's handle implies (§1).
 
    *Corrected 2026-09-01, whole-branch review.* This said "on its next detect",
    and there is no next detect: step 3 restarts the **harness**, not the
@@ -251,9 +274,12 @@ An authorisation endpoint with no button would be the sixth.
 
 On a station's page in the console:
 
-- A station whose `matrix_id <> bridge_matrix_id` shows that it is **running under a
-  retired identity**, naming what it is now and what it will become. That is the 14,
-  visible for the first time.
+- A station whose `matrix_id` is not the address its agent's handle implies shows
+  that it is **running under a retired identity**, naming what it is now and what it
+  will become. That is the 14, visible for the first time. The console cannot derive
+  that address — it holds neither the handle nor the homeserver's domain — so the
+  hub answers the question through `matrix/move-state` and the panel renders the
+  answer rather than re-deriving it from columns.
 - One control, **Move to its own identity**, performing step 1 and surfacing the
   hub's own 403 verbatim when `mayGrantReach` refuses.
 - Then **waiting for the node** until convergence. A station stuck there is the

--- a/fly/node-image/Dockerfile
+++ b/fly/node-image/Dockerfile
@@ -26,7 +26,7 @@ FROM oven/bun:1-slim
 # overrides this with --build-arg, so what a published image carries is the
 # release resolved at build time; this default is what a local `docker build`
 # gets.
-ARG AGENTPOD_VERSION=v0.1.31
+ARG AGENTPOD_VERSION=v0.1.32
 
 # oven/bun:1-slim leaves USER unset, i.e. root, which is what everything below
 # needs: apt, the release download, and at runtime the wrapper replacing

--- a/fly/node-image/Dockerfile.pi
+++ b/fly/node-image/Dockerfile.pi
@@ -29,7 +29,7 @@ FROM debian:trixie-slim
 # fails CI on either half of that (a pin behind the latest release, or the two
 # files disagreeing). The publish workflow overrides this with --build-arg, so
 # this default is what a local `docker build` gets.
-ARG AGENTPOD_VERSION=v0.1.31
+ARG AGENTPOD_VERSION=v0.1.32
 
 # Debian trixie: the same userland the fleet's own base image uses, so the
 # harness install below behaves identically to the Docker Pi image.


### PR DESCRIPTION
Found by attempting the live exit test on the fleet. **The uniform-identity feature was inert against production** — and every test passed.

### What was wrong

The state machine compared `stations.matrix_id` against `stations.bridge_matrix_id`:

| state | meaning |
|---|---|
| `matrix_id IS NULL` | bridge mode |
| `matrix_id = bridge_matrix_id` | converged |
| `matrix_id <> bridge_matrix_id` | on a retired identity — offer the move |

On the live fleet **all 14 harness stations have both columns set to the same value — the old station-derived address**. Every one read "converged", the console offered no station a move, and nothing could start.

`bridge_matrix_id` is written from `stationSpeaker(...)`, which for a harness station correctly returns the harness's *own* mxid. The column holds "what this station already is", not "what the appservice would mint". The design assumed the latter.

**Every test passed because the fixtures set `bridge_matrix_id` to the handle-derived value** — which is what the design assumed and what production never does.

### The fix

The invariant asks the **handle**. `targetIdentity()` derives the address from the occupying principal and replaces every read of `bridge_matrix_id` in a decision path: the pre-join target, `retireOldIdentity`'s live-identity guard and its speaker fallback, `onNodeReportedMatrixId`'s convergence test, `moveState`, `moveInProgress`, four call sites in `gates.ts`.

`bridge_matrix_id` is **not** redefined or backfilled — its schema comment states it is what the appservice minted and that nothing on the host can erase it. Redefining it would fight the column's stated purpose.

A station with no occupying principal has no handle and so no target: it reports `no-agent` and is unmovable, rather than being offered a move it cannot complete.

The console no longer receives `bridge_matrix_id` at all. Every state but bridge mode comes from the hub, so the two cannot silently disagree.

### Fixtures now look like production

`bridge_matrix_id` holds the *station-derived* address with a differing handle — the shape the fleet is actually in. Reverting `targetIdentity` fails 20 hub tests, including `Expected: "retired-identity" / Received: "converged"` and a pre-join answering `already` with the station's own old address as its target.

### Also fixed

Stale hub state leaked across stations: `hubState` and `unanswered` were never reset when `station.id` changed, so one hub failure latched onto every station visited afterwards, and a stale answer rendered the **previous** station's target and offered its move — an operator could move the wrong station. Reproduced (`expected @agent_writer-quill… to be null` while viewing another station) and fixed.

The plan document still asserted the false invariant in four places. Corrected — a stale plan is how the next person rebuilds the same bug.

### Verification

- hub **1704 pass / 0 fail**, twice, with assertions running against a real tuwunel instance
- console 669 pass, `svelte-check` 0; the 132 failures are pre-existing, in the same 11 unrelated files, diffed file-for-file
- a never-registered `@agent_*` user accepts invite and join on tuwunel (probed), so a newly adopted harness station needs no `ensureUser`

### Known

The navigation tests use `rerender` rather than a real router transition: they prove the component resets, not that SvelteKit reuses the page component. If it remounts, the fix is harmless and the finding was theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr