### PR TITLE
A credential in every log line, and a 401 retried eight thousand times a day

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
+import { redactUrlSecrets } from './utils/redact-url-secrets.ts';
 import { config, allowedOrigins, isAllowedOrigin } from './config.ts';
 import { validateConfig } from './utils/validate-config.ts';
 import { describeDatabase } from './utils/describe-database.ts';
@@ -100,7 +101,12 @@ const matrixBridge = createMatrixBridge();
 
 const app = new Hono()
   // Middleware
-  .use('*', logger())
+  //
+  // The print function is not decoration. The homeserver authenticates appservice
+  // transactions with `?access_token=…`, and Hono's logger prints the whole path — so every
+  // Matrix event wrote a live credential into journald in clear. Redacting here closes the
+  // recurrence; rotating the token alone would not (estate BACKLOG, 2026-09-01).
+  .use('*', logger((message, ...rest) => console.log(redactUrlSecrets(message), ...rest)))
   // CORS configuration - allow credentials for Better Auth cookies
   .use('*', cors({
     // Origin list lives in config.ts (corsAllowedOrigins) so station-terminal.ts

--- a/apps/hub/src/services/bridge/loop.test.ts
+++ b/apps/hub/src/services/bridge/loop.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { BRIDGE_ENV_FLAG } from "./config";
 import type { DispatchResult } from "./dispatch";
+import { KaambaanApiError } from "./kaambaan";
 import { startAgentLoop, startKaambaanBridge } from "./loop";
 
 const saved = process.env[BRIDGE_ENV_FLAG];
@@ -177,5 +178,61 @@ describe("off by default", () => {
 
     expect(await startKaambaanBridge({ acp })).toBeNull();
     expect(touched).toBe(false);
+  });
+});
+
+describe("a credential kaambaan will not accept", () => {
+  /**
+   * Found on the live fleet, 2026-09-04: the hub had been claiming against a board with a
+   * token whose agent was deleted three days earlier. Every thirty seconds, a 401, logged and
+   * retried — 8,640 identical lines a day, and no signal beyond noise nobody reads.
+   *
+   * A 401 does not improve by being asked again. It halts on the same terms as `foreign-run`:
+   * stop, say why once, make somebody look.
+   */
+  test("halts instead of retrying forever", async () => {
+    let calls = 0;
+    const lines: string[] = [];
+    const handle = startAgentLoop({
+      run: async () => {
+        calls++;
+        throw new KaambaanApiError(401, "/v1/boards/brd_x/claims", null, "a valid agent token is required");
+      },
+      log: (m) => lines.push(m),
+      sleep: async () => {},
+    });
+    await handle.done;
+
+    expect(calls).toBe(1); // not two, not forever
+    expect(lines.some((l) => l.includes("refused this agent's credential"))).toBe(true);
+  });
+
+  test("halts on a 403 too — a refusal is not a transient error", async () => {
+    let calls = 0;
+    const handle = startAgentLoop({
+      run: async () => {
+        calls++;
+        throw new KaambaanApiError(403, "/v1/boards/brd_x/claims", null, "forbidden");
+      },
+      log: () => {},
+      sleep: async () => {},
+    });
+    await handle.done;
+    expect(calls).toBe(1);
+  });
+
+  test("a 500 still backs off and retries, because that one can come right", async () => {
+    let calls = 0;
+    const handle = startAgentLoop({
+      run: async () => {
+        calls++;
+        if (calls >= 3) handle.stop();
+        throw new KaambaanApiError(500, "/v1/boards/brd_x/claims", null, "upstream exploded");
+      },
+      log: () => {},
+      sleep: async () => {},
+    });
+    await handle.done;
+    expect(calls).toBeGreaterThan(1);
   });
 });

--- a/apps/hub/src/services/bridge/loop.ts
+++ b/apps/hub/src/services/bridge/loop.ts
@@ -16,7 +16,7 @@ import { resolveTenantForUser } from "../../auth/tenant";
 import * as acpSessions from "../acp-sessions";
 import { isBridgeEnabled, loadBridgeConfig, type BridgeAgentConfig } from "./config";
 import { runOnce, type AcpPort, type DispatchResult } from "./dispatch";
-import { KaambaanClient, fetchAdapter } from "./kaambaan";
+import { KaambaanApiError, KaambaanClient, fetchAdapter } from "./kaambaan";
 
 /** How long to wait after a claim that found nothing. */
 const DEFAULT_POLL_MS = 5_000;
@@ -70,6 +70,31 @@ export function startAgentLoop(opts: AgentLoopOptions): LoopHandle {
       try {
         result = await opts.run();
       } catch (err) {
+        // **An authentication failure is not retryable, and retrying hides it.**
+        //
+        // A 401 means kaambaan does not recognise this agent's credential; a 403 means it
+        // refuses the act. Neither improves by being asked again, and the loop's own backoff
+        // turns a misconfiguration into an error line every thirty seconds forever — which is
+        // exactly what it did. On 2026-09-04 the hub was found polling a board with a token
+        // whose agent had been deleted three days earlier: 8,640 identical 401s a day, and no
+        // signal that anything was wrong beyond noise nobody reads.
+        //
+        // Halts on the same terms as `foreign-run` below: stop, say why once, and let
+        // `onFault` surface it. An operator has to change something, so make them look.
+        if (err instanceof KaambaanApiError && (err.status === 401 || err.status === 403)) {
+          log("halting: kaambaan refused this agent's credential", {
+            status: err.status,
+            path: err.path,
+            hint:
+              "the token no longer resolves to an agent on that board — re-mint it, or remove " +
+              "this agent from KAAMBAAN_BRIDGE_AGENTS",
+          });
+          // Deliberately NOT reported through `onFault`, which takes a DispatchResult: this
+          // is not a dispatch outcome, and inventing a status member for it from a catch
+          // block would put a fault into the enum every switch has to answer for. The halt
+          // is the signal — the agent stops claiming, and the line above says why.
+          return;
+        }
         log("a claim cycle threw", { error: String(err) });
         await sleep(opts.backoffMs ?? DEFAULT_BACKOFF_MS, controller.signal);
         continue;

--- a/apps/hub/src/utils/redact-url-secrets.ts
+++ b/apps/hub/src/utils/redact-url-secrets.ts
@@ -1,0 +1,52 @@
+/**
+ * Strip credentials out of a request log line.
+ *
+ * The homeserver authenticates its appservice transactions with the token as a **URL query
+ * parameter** — `PUT /_matrix/app/v1/transactions/xyz?access_token=…` — and Hono's `logger()`
+ * prints the whole path. So every transaction wrote a live appservice credential into journald
+ * in clear, at a rate of one line per Matrix event, for as long as the bridge has existed.
+ *
+ * That token can act as any user inside the appservice's namespace. It was recorded in the
+ * estate's backlog on 2026-09-01 with the note that **rotation alone does not close it** — the
+ * next token lands in the log the same way. This is the half that does: redact at the point of
+ * logging, so the recurrence stops rather than the current value being replaced.
+ *
+ * Not only the appservice token. `authMiddleware` reads `c.req.query("token")` as a bearer
+ * fallback, and the cross-domain handoff (agentpod#406) puts a one-time `code` in a redirect
+ * that comes back as a query parameter. Both are credentials, both arrive in URLs, and both
+ * were being logged.
+ *
+ * **Deny-list, not allow-list, and that is a deliberate weakness.** An allow-list of safe
+ * parameters would be stronger and would also redact half of every useful debugging line. The
+ * mitigation is that adding a credential-bearing query parameter to this codebase means adding
+ * it here, which is what the test asserts by naming each one.
+ */
+
+/** Query parameter names whose values are credentials. Compared case-insensitively. */
+export const SECRET_QUERY_PARAMS = [
+  "access_token", // Matrix appservice transactions — the one found in journald
+  "token", // authMiddleware's bearer fallback reads this
+  "code", // agentpod#406's one-time authorization code
+  "code_verifier", // the PKCE verifier, if a client ever misplaces it into a URL
+  "client_secret",
+  "api_key",
+  "apikey",
+  "password",
+  "secret",
+] as const;
+
+const PATTERN = new RegExp(
+  `([?&](?:${SECRET_QUERY_PARAMS.join("|")})=)([^&\\s]+)`,
+  "gi",
+);
+
+/**
+ * Replace the value of any credential-bearing query parameter with `***`.
+ *
+ * Operates on the whole log line rather than on a parsed URL, because that is what Hono hands
+ * a print function — and a line that cannot be parsed as a URL must still be redacted rather
+ * than passed through.
+ */
+export function redactUrlSecrets(line: string): string {
+  return line.replace(PATTERN, "$1***");
+}

--- a/apps/hub/tests/unit/redact-url-secrets.test.ts
+++ b/apps/hub/tests/unit/redact-url-secrets.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  redactUrlSecrets,
+  SECRET_QUERY_PARAMS,
+} from "../../src/utils/redact-url-secrets";
+
+describe("redactUrlSecrets", () => {
+  test("redacts the appservice token that was found in journald", () => {
+    // The exact shape observed on infra on 2026-09-04, one line per Matrix event.
+    const line =
+      "<-- PUT /_matrix/app/v1/transactions/u7zYJALs?access_token=fbb82681a1ec62113cff4737";
+    const out = redactUrlSecrets(line);
+    expect(out).toBe("<-- PUT /_matrix/app/v1/transactions/u7zYJALs?access_token=***");
+    expect(out).not.toContain("fbb82681");
+  });
+
+  test("redacts every name in the list, so adding one to the list is the whole change", () => {
+    for (const name of SECRET_QUERY_PARAMS) {
+      const out = redactUrlSecrets(`GET /x?${name}=super-secret-value`);
+      expect(out, `${name} must be redacted`).not.toContain("super-secret-value");
+      expect(out).toContain(`${name}=***`);
+    }
+  });
+
+  test("redacts a parameter that is not the first", () => {
+    expect(redactUrlSecrets("GET /x?a=1&token=abc&b=2")).toBe("GET /x?a=1&token=***&b=2");
+  });
+
+  test("redacts more than one on a line", () => {
+    expect(redactUrlSecrets("GET /x?token=a&code=b")).toBe("GET /x?token=***&code=***");
+  });
+
+  test("is case-insensitive on the name", () => {
+    expect(redactUrlSecrets("GET /x?Access_Token=abc")).not.toContain("abc");
+  });
+
+  test("leaves ordinary parameters alone, so the log stays useful", () => {
+    const line = "--> GET /api/nodes?limit=50&status=online 200 4ms";
+    expect(redactUrlSecrets(line)).toBe(line);
+  });
+
+  test("does not redact a parameter that merely CONTAINS a secret name", () => {
+    // `not_a_token` and `tokenCount` are not credentials; redacting them would
+    // quietly hide ordinary debugging information.
+    const line = "GET /x?not_a_token=visible&tokenCount=3";
+    expect(redactUrlSecrets(line)).toBe(line);
+  });
+
+  test("passes through a line with no query string", () => {
+    expect(redactUrlSecrets("<-- GET /health")).toBe("<-- GET /health");
+  });
+});


### PR DESCRIPTION
Both found by deploying #407 and reading what the hub actually says. Neither was caused by that deploy; both had been running for days.

## 1. The appservice token was in journald in clear

The homeserver authenticates appservice transactions with the token as a **URL query parameter**, and Hono's `logger()` prints the whole path. So every Matrix event wrote a live credential — one that can act as **any user inside the appservice's namespace** — into the system journal, one line per event, for as long as the bridge has existed.

The estate's backlog recorded this on 2026-09-01 and said the important part:

> Rotating tomorrow is agreed, and **rotation alone does not close it** — the next token lands the same way.

This is the half that closes it. `redactUrlSecrets` masks the value of any credential-bearing query parameter at the point of logging.

**Not only that token.** `authMiddleware` reads `c.req.query("token")` as a bearer fallback, and #406's handoff puts a one-time `code` in a redirect that comes back as a query parameter. Both are credentials, both arrive in URLs, both were being logged.

It is a **deny-list, and that is a deliberate weakness** — an allow-list would be stronger and would also redact half of every useful debugging line. The mitigation is that adding a credential-bearing query parameter to this codebase means adding it here, which the test asserts by iterating the list and naming each one.

## 2. The bridge retried an authentication failure forever

```
KaambaanApiError: POST /v1/boards/brd_53adff7d3a274fd9/claims
  failed with 401: a valid agent token is required
```

Every thirty seconds. **8,640 identical lines a day, three days running.**

Root cause, confirmed against both sides:

- the bridge agent is keyed `bridge-tester` — the agent removed from kaambaan on 2026-09-02
- its token's SHA-256 has **no row** in kaambaan's `agent_tokens` (`n=0`): deleted with the agent
- the board `brd_53adff7d3a274fd9` still exists, named *"Gate end-to-end"*

So the hub was polling a live test board with a credential deleted three days earlier, and nothing said so beyond noise nobody reads.

**A 401 does not improve by being asked again**, and neither does a 403. Both now halt that agent's loop on the same terms `foreign-run` already used — stop, say why once, make somebody look. A 500 still backs off and retries, because that one can come right.

Deliberately **not** routed through `onFault`, which takes a `DispatchResult`: an auth failure is not a dispatch outcome, and inventing a status member for it from a catch block would put a fault into an enum every `switch` has to answer for. The halt is the signal.

### The revert check is unusual and worth reading

Reverting the halt does not make the test *fail*. It makes it **hang, forever** — which is the production behaviour stated exactly.

## Still to do, operationally

This PR stops the class. The instance also needs `KAAMBAAN_BRIDGE_AGENTS` on infra corrected — the entry names an agent that no longer exists. Whether the bridge should then point at a real agent and board, or stay off, is a product decision rather than a fix.

## Verification

- hub **1810 pass / 0 fail**
- `tsc --noEmit`: 15 errors, unchanged baseline
- 8 new redaction tests, 3 new loop tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr