### PR TITLE
A bridge cycle that never comes back takes the agent with it, silently

### DIFF
--- a/apps/hub/src/services/bridge/kaambaan.ts
+++ b/apps/hub/src/services/bridge/kaambaan.ts
@@ -58,8 +58,26 @@ export type Fetcher = (
  * the gate sweep reach a board through the same adapter — two of these would be
  * two places for a header or a status to be handled differently.
  */
+/**
+ * How long a single kaambaan call may take before it is abandoned.
+ *
+ * Generous, because a claim is allowed to be slow: it wakes a Durable Object, which can cold
+ * start. It exists to bound the pathological case, not to police the normal one — measured
+ * from infra, an ordinary refusal returns in about a third of a second.
+ */
+export const KAAMBAAN_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * A bare `fetch` here had no timeout, so a request that was sent and never answered blocked the
+ * bridge's claim loop **forever, and silently** — no log line, no error, no retry. Observed on
+ * 2026-09-08: one cycle at 05:52:30 and then nothing, with the connection to Cloudflare still
+ * ESTABLISHED and both queues empty.
+ *
+ * `AbortSignal.timeout` actually cancels the request rather than merely giving up waiting on it,
+ * so a hung call releases its socket instead of leaking one per cycle.
+ */
 export const fetchAdapter: Fetcher = async (url, init) => {
-  const res = await fetch(url, init);
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(KAAMBAAN_REQUEST_TIMEOUT_MS) });
   return { status: res.status, ok: res.ok, json: () => res.json() as Promise<unknown> };
 };
 

--- a/apps/hub/src/services/bridge/loop.test.ts
+++ b/apps/hub/src/services/bridge/loop.test.ts
@@ -236,3 +236,64 @@ describe("a credential kaambaan will not accept", () => {
     expect(calls).toBeGreaterThan(1);
   });
 });
+
+describe("a cycle that never comes back", () => {
+  /**
+   * Observed on the live fleet, 2026-09-08. The bridge logged one cycle at 05:52:30 and then
+   * nothing at all — not an error, not an idle poll, nothing — while the process stayed healthy
+   * and its connection to Cloudflare stayed ESTABLISHED with both queues empty. A call had been
+   * sent and never answered, and `fetchAdapter` had no timeout, so the agent was gone.
+   *
+   * A hang is the worst of the three failure shapes: an error logs, a refusal halts, but a hang
+   * is indistinguishable from an idle fleet.
+   */
+  test("does not block the loop forever", async () => {
+    let calls = 0;
+    const handle = startAgentLoop({
+      run: () => {
+        calls++;
+        if (calls >= 3) {
+          handle.stop();
+          return Promise.resolve({ status: "idle" } as DispatchResult);
+        }
+        return new Promise<DispatchResult>(() => {}); // never settles
+      },
+      log: () => {},
+      sleep: async () => {},
+      cycleTimeoutMs: 20,
+    });
+    await handle.done;
+    expect(calls).toBeGreaterThan(1); // it got past the hang
+  });
+
+  test("says so, rather than failing silently", async () => {
+    const lines: string[] = [];
+    const handle = startAgentLoop({
+      run: () => new Promise<DispatchResult>(() => {}),
+      log: (m) => {
+        lines.push(m);
+        if (lines.length >= 2) handle.stop();
+      },
+      sleep: async () => {},
+      cycleTimeoutMs: 10,
+    });
+    await handle.done;
+    expect(lines.some((l) => l.includes("exceeded its deadline"))).toBe(true);
+  });
+
+  test("a cycle that finishes in time is untouched by the deadline", async () => {
+    let calls = 0;
+    const handle = startAgentLoop({
+      run: async (): Promise<DispatchResult> => {
+        calls++;
+        if (calls >= 2) handle.stop();
+        return { status: "idle" } as DispatchResult;
+      },
+      log: () => {},
+      sleep: async () => {},
+      cycleTimeoutMs: 5_000,
+    });
+    await handle.done;
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/hub/src/services/bridge/loop.ts
+++ b/apps/hub/src/services/bridge/loop.ts
@@ -23,6 +23,28 @@ const DEFAULT_POLL_MS = 5_000;
 /** How long to wait after an error, so a broken board is not hammered. */
 const DEFAULT_BACKOFF_MS = 30_000;
 
+/**
+ * The longest a single claim cycle may take before the loop stops waiting on it.
+ *
+ * A cycle awaits several things that can hang — the kaambaan call, the station readiness probe
+ * over the node broker, an ACP session. Any one of them blocking forever takes the whole agent
+ * with it, and produces **nothing in the log**: the loop is neither erroring nor idle, it is
+ * simply never coming back. That is what happened on 2026-09-08, and it is the same failure
+ * shape as the 401 retried eight thousand times a day — a fault that makes no sound.
+ *
+ * This is a liveness floor, not a policy on how long work may take: a claimed run is worked
+ * through heartbeats, not inside one cycle.
+ */
+const DEFAULT_CYCLE_TIMEOUT_MS = 120_000;
+
+/** Distinguishes a cycle that exceeded its deadline from one that threw. */
+class CycleTimeout extends Error {
+  constructor(readonly ms: number) {
+    super(`a claim cycle exceeded ${ms}ms`);
+    this.name = "CycleTimeout";
+  }
+}
+
 export interface AgentLoopOptions {
   /** One work cycle. Injected so the loop's control flow is testable alone. */
   run: () => Promise<DispatchResult>;
@@ -30,6 +52,8 @@ export interface AgentLoopOptions {
   backoffMs?: number;
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   onFault?: (result: DispatchResult) => void;
+  /** Longest a single cycle may take. Defaults to two minutes. */
+  cycleTimeoutMs?: number;
   log?: (message: string, meta?: Record<string, unknown>) => void;
 }
 
@@ -38,6 +62,17 @@ export interface LoopHandle {
   stop(): Promise<void>;
   /** Resolves when the loop exits on its own — a fault, or a stop. */
   done: Promise<void>;
+}
+
+/** Resolve with the promise, or reject with `CycleTimeout` when it takes too long. */
+function withDeadline<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    p.finally(() => clearTimeout(timer)),
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new CycleTimeout(ms)), ms);
+    }),
+  ]);
 }
 
 const defaultSleep = (ms: number, signal: AbortSignal): Promise<void> =>
@@ -68,8 +103,16 @@ export function startAgentLoop(opts: AgentLoopOptions): LoopHandle {
     while (!controller.signal.aborted) {
       let result: DispatchResult;
       try {
-        result = await opts.run();
+        // Bounded, because everything this awaits is a call to something else. The underlying
+        // promise is not cancellable from here — `fetchAdapter` carries its own AbortSignal for
+        // that — so this restores the LOOP's liveness rather than the call's.
+        result = await withDeadline(opts.run(), opts.cycleTimeoutMs ?? DEFAULT_CYCLE_TIMEOUT_MS);
       } catch (err) {
+        if (err instanceof CycleTimeout) {
+          log("a claim cycle exceeded its deadline; backing off", { ms: err.ms });
+          await sleep(opts.backoffMs ?? DEFAULT_BACKOFF_MS, controller.signal);
+          continue;
+        }
         // **An authentication failure is not retryable, and retrying hides it.**
         //
         // A 401 means kaambaan does not recognise this agent's credential; a 403 means it


### PR DESCRIPTION
Re-pointing the bridge at a live agent fixed the 401 from #409 and revealed the next failure underneath it.

## What happened

The bridge logged **one cycle at 05:52:30 and then nothing at all** — not an error, not an idle poll, nothing — while:

- the process stayed healthy and kept serving (`GET /health 200`)
- CPU sat at 5.8%, so it was not spinning
- its connection to Cloudflare stayed `ESTABLISHED` with **both queues empty**

A request had been sent and never answered. `fetchAdapter` was a bare `fetch(url, init)` — no timeout, no signal — so the claim loop blocked forever.

Verified the loop itself is correct: a unit test driving `not-ready` repeatedly cycles fine. And verified the endpoint is not the problem: from infra, kaambaan answers a bogus token with **401 in 0.33s**.

## Why this is the worst of the three shapes

An error **logs**. A refusal **halts** — that was #409 last week. A hang is **indistinguishable from an idle fleet**, and it is the one that leaves nothing to find.

## The fix, at two levels

**`fetchAdapter` carries `AbortSignal.timeout(30s)`** — which actually *cancels* the request rather than giving up on waiting for it, so a hung call releases its socket instead of leaking one per cycle. Generous on purpose: a claim wakes a Durable Object that can cold start.

**The loop bounds a whole cycle at two minutes** and backs off. A cycle awaits several things that can hang — the kaambaan call, the station-readiness probe over the node broker, an ACP session — and the loop's liveness should not depend on every one of them being well behaved.

It is a **liveness floor, not a policy on how long work may take**: a claimed run is worked through heartbeats, not inside one cycle.

## Tests

1808 pass / 5 fail.

**The five are identical on main (1805/5)** and are all expiry and grace-window assertions — expired OAuth codes, a node's offline grace window, a stalled move past fifteen minutes. This suite was **1810 pass / 0 fail on 2026-09-05**, so they rot with the clock rather than with the code. Recorded here rather than fixed, because it is a separate problem and a real one: a suite that goes red on its own is a suite people learn to ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr