### PR TITLE
Bound the readiness probe, not the run — reverting a deadline that would abandon work

### DIFF
--- a/apps/hub/src/services/bridge/dispatch.ts
+++ b/apps/hub/src/services/bridge/dispatch.ts
@@ -228,6 +228,49 @@ function whyNoAnswer(resolution: PermissionResolution): string {
   }
 }
 
+/**
+ * How long the readiness probe may take before the station counts as not ready.
+ *
+ * The probe asks a node over the broker whether its station can run work. That is a question
+ * about *right now*, so a slow answer is not a useful answer — and an unbounded one is worse
+ * than useless: on 2026-09-08 the bridge logged a single cycle and then nothing at all, for
+ * hours, because this call never returned. The loop was neither erroring nor idling; it was
+ * never coming back, which is the one failure shape that looks exactly like a quiet fleet.
+ *
+ * **A timed-out probe is a negative answer, not an error.** If a station cannot say it is ready
+ * within ten seconds, it is not ready, and the loop's ordinary not-ready backoff is the correct
+ * response. That keeps the failure inside the state machine that already handles it.
+ */
+export const READINESS_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Bounded readiness. Deliberately narrow: this is the ONE call in a cycle that must be fast.
+ *
+ * The claim itself is bounded by `fetchAdapter`'s own signal, and everything after it — the
+ * session, the prompt, the activity stream — is the agent's work, which legitimately takes as
+ * long as it takes. Bounding the whole cycle would abandon a running agent mid-task.
+ */
+async function probeReadiness(
+  acp: AcpPort,
+  agent: { stationId: string; hubUserId: string },
+): Promise<{ ready: boolean; reason?: string }> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<{ ready: boolean; reason?: string }>((resolve) => {
+    timer = setTimeout(
+      () => resolve({ ready: false, reason: `the station did not answer a readiness probe within ${READINESS_PROBE_TIMEOUT_MS}ms` }),
+      READINESS_PROBE_TIMEOUT_MS,
+    );
+  });
+  try {
+    return await Promise.race([
+      acp.stationReady({ stationId: agent.stationId, userId: agent.hubUserId }),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
 export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
   const { client, acp, agent, tenantId, source } = deps;
   const log = deps.log ?? (() => {});
@@ -237,7 +280,7 @@ export async function runOnce(deps: DispatchDeps): Promise<DispatchResult> {
   // minutes except by asking. Checking first is what removes the race entirely,
   // including the restart case that produced it — the bridge starts with the
   // hub, the node-agents dial back in seconds later.
-  const readiness = await acp.stationReady({ stationId: agent.stationId, userId: agent.hubUserId });
+  const readiness = await probeReadiness(acp, agent);
   if (!readiness.ready) {
     const reason = readiness.reason ?? "the station cannot run work right now";
     log("not claiming: the station is not ready", { station: agent.stationId, reason });

--- a/apps/hub/src/services/bridge/loop.test.ts
+++ b/apps/hub/src/services/bridge/loop.test.ts
@@ -237,63 +237,30 @@ describe("a credential kaambaan will not accept", () => {
   });
 });
 
-describe("a cycle that never comes back", () => {
+describe("a cycle is not bounded, and that is deliberate", () => {
   /**
-   * Observed on the live fleet, 2026-09-08. The bridge logged one cycle at 05:52:30 and then
-   * nothing at all — not an error, not an idle poll, nothing — while the process stayed healthy
-   * and its connection to Cloudflare stayed ESTABLISHED with both queues empty. A call had been
-   * sent and never answered, and `fetchAdapter` had no timeout, so the agent was gone.
+   * `runOnce` drives the claimed run to completion — session, prompt, activity stream,
+   * heartbeats — so a legitimate cycle lasts as long as the agent's work, and `permissionWaitMs`
+   * alone defaults to thirty minutes.
    *
-   * A hang is the worst of the three failure shapes: an error logs, a refusal halts, but a hang
-   * is indistinguishable from an idle fleet.
+   * A whole-cycle deadline was written on 2026-09-08 and reverted the same hour, because it
+   * would have abandoned a running agent mid-task. What must be fast is the readiness probe,
+   * and that is bounded in `dispatch.ts` where it is made. This test exists so the idea does
+   * not come back.
    */
-  test("does not block the loop forever", async () => {
-    let calls = 0;
-    const handle = startAgentLoop({
-      run: () => {
-        calls++;
-        if (calls >= 3) {
-          handle.stop();
-          return Promise.resolve({ status: "idle" } as DispatchResult);
-        }
-        return new Promise<DispatchResult>(() => {}); // never settles
-      },
-      log: () => {},
-      sleep: async () => {},
-      cycleTimeoutMs: 20,
-    });
-    await handle.done;
-    expect(calls).toBeGreaterThan(1); // it got past the hang
-  });
-
-  test("says so, rather than failing silently", async () => {
-    const lines: string[] = [];
-    const handle = startAgentLoop({
-      run: () => new Promise<DispatchResult>(() => {}),
-      log: (m) => {
-        lines.push(m);
-        if (lines.length >= 2) handle.stop();
-      },
-      sleep: async () => {},
-      cycleTimeoutMs: 10,
-    });
-    await handle.done;
-    expect(lines.some((l) => l.includes("exceeded its deadline"))).toBe(true);
-  });
-
-  test("a cycle that finishes in time is untouched by the deadline", async () => {
-    let calls = 0;
+  test("a long cycle is left alone", async () => {
+    let finished = false;
     const handle = startAgentLoop({
       run: async (): Promise<DispatchResult> => {
-        calls++;
-        if (calls >= 2) handle.stop();
+        await new Promise((r) => setTimeout(r, 120));
+        finished = true;
+        handle.stop();
         return { status: "idle" } as DispatchResult;
       },
       log: () => {},
       sleep: async () => {},
-      cycleTimeoutMs: 5_000,
     });
     await handle.done;
-    expect(calls).toBe(2);
+    expect(finished).toBe(true); // not cut short
   });
 });

--- a/apps/hub/src/services/bridge/loop.ts
+++ b/apps/hub/src/services/bridge/loop.ts
@@ -23,28 +23,6 @@ const DEFAULT_POLL_MS = 5_000;
 /** How long to wait after an error, so a broken board is not hammered. */
 const DEFAULT_BACKOFF_MS = 30_000;
 
-/**
- * The longest a single claim cycle may take before the loop stops waiting on it.
- *
- * A cycle awaits several things that can hang — the kaambaan call, the station readiness probe
- * over the node broker, an ACP session. Any one of them blocking forever takes the whole agent
- * with it, and produces **nothing in the log**: the loop is neither erroring nor idle, it is
- * simply never coming back. That is what happened on 2026-09-08, and it is the same failure
- * shape as the 401 retried eight thousand times a day — a fault that makes no sound.
- *
- * This is a liveness floor, not a policy on how long work may take: a claimed run is worked
- * through heartbeats, not inside one cycle.
- */
-const DEFAULT_CYCLE_TIMEOUT_MS = 120_000;
-
-/** Distinguishes a cycle that exceeded its deadline from one that threw. */
-class CycleTimeout extends Error {
-  constructor(readonly ms: number) {
-    super(`a claim cycle exceeded ${ms}ms`);
-    this.name = "CycleTimeout";
-  }
-}
-
 export interface AgentLoopOptions {
   /** One work cycle. Injected so the loop's control flow is testable alone. */
   run: () => Promise<DispatchResult>;
@@ -52,8 +30,6 @@ export interface AgentLoopOptions {
   backoffMs?: number;
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   onFault?: (result: DispatchResult) => void;
-  /** Longest a single cycle may take. Defaults to two minutes. */
-  cycleTimeoutMs?: number;
   log?: (message: string, meta?: Record<string, unknown>) => void;
 }
 
@@ -62,17 +38,6 @@ export interface LoopHandle {
   stop(): Promise<void>;
   /** Resolves when the loop exits on its own — a fault, or a stop. */
   done: Promise<void>;
-}
-
-/** Resolve with the promise, or reject with `CycleTimeout` when it takes too long. */
-function withDeadline<T>(p: Promise<T>, ms: number): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
-  return Promise.race([
-    p.finally(() => clearTimeout(timer)),
-    new Promise<never>((_, reject) => {
-      timer = setTimeout(() => reject(new CycleTimeout(ms)), ms);
-    }),
-  ]);
 }
 
 const defaultSleep = (ms: number, signal: AbortSignal): Promise<void> =>
@@ -103,16 +68,14 @@ export function startAgentLoop(opts: AgentLoopOptions): LoopHandle {
     while (!controller.signal.aborted) {
       let result: DispatchResult;
       try {
-        // Bounded, because everything this awaits is a call to something else. The underlying
-        // promise is not cancellable from here — `fetchAdapter` carries its own AbortSignal for
-        // that — so this restores the LOOP's liveness rather than the call's.
-        result = await withDeadline(opts.run(), opts.cycleTimeoutMs ?? DEFAULT_CYCLE_TIMEOUT_MS);
+        // NOT bounded by a deadline, and that is deliberate. `runOnce` drives the claimed run
+        // to completion — it creates the session, prompts, streams activities and heartbeats —
+        // so a legitimate cycle lasts as long as the agent's work, and `permissionWaitMs`
+        // alone defaults to thirty minutes. A cycle deadline here would abandon real work
+        // mid-run. What must be fast is the READINESS PROBE, and that is bounded where it is
+        // made, in `dispatch.ts`.
+        result = await opts.run();
       } catch (err) {
-        if (err instanceof CycleTimeout) {
-          log("a claim cycle exceeded its deadline; backing off", { ms: err.ms });
-          await sleep(opts.backoffMs ?? DEFAULT_BACKOFF_MS, controller.signal);
-          continue;
-        }
         // **An authentication failure is not retryable, and retrying hides it.**
         //
         // A 401 means kaambaan does not recognise this agent's credential; a 403 means it

--- a/apps/hub/src/services/bridge/readiness-probe.test.ts
+++ b/apps/hub/src/services/bridge/readiness-probe.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The readiness probe is the one call in a cycle that must be fast.
+ *
+ * On 2026-09-08 the bridge logged a single cycle and then nothing at all — not an error, not an
+ * idle poll — while the process stayed healthy. The probe asks a node over the broker whether
+ * its station can run work; it had no timeout, so when it never answered, the agent was gone.
+ * That is the one failure shape indistinguishable from a quiet fleet.
+ *
+ * The claim after it is bounded by `fetchAdapter`'s own signal. Everything after THAT is the
+ * agent's work, which legitimately runs for as long as it runs — so the bound belongs here and
+ * nowhere wider.
+ */
+import { describe, expect, test } from "bun:test";
+import { READINESS_PROBE_TIMEOUT_MS, runOnce } from "./dispatch";
+
+describe("READINESS_PROBE_TIMEOUT_MS", () => {
+  test("is short enough to be about *right now*, and not zero", () => {
+    // A readiness answer that takes a minute is not a readiness answer.
+    expect(READINESS_PROBE_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(READINESS_PROBE_TIMEOUT_MS).toBeLessThanOrEqual(30_000);
+  });
+});
+
+describe("a probe that never answers", () => {
+  const agent = {
+    key: "a",
+    boardId: "brd_x",
+    token: "kbn_x",
+    stationId: "station_x",
+    hubUserId: "usr_x",
+    mode: "full-auto" as const,
+  };
+
+  test("resolves as not-ready rather than hanging the cycle", async () => {
+    const never = new Promise<{ ready: boolean }>(() => {});
+    const result = await runOnce({
+      client: {
+        claim: async () => {
+          throw new Error("must not reach the claim: the station is not ready");
+        },
+      } as never,
+      acp: { stationReady: () => never } as never,
+      agent: agent as never,
+      tenantId: "tnt_x",
+      source: "kaambaan",
+      log: () => {},
+    } as never);
+
+    expect(result.status).toBe("not-ready");
+    expect(result.reason).toContain("readiness probe");
+  }, 20_000);
+
+  test("a prompt answer is passed through untouched", async () => {
+    const result = await runOnce({
+      client: { claim: async () => null } as never,
+      acp: { stationReady: async () => ({ ready: true }) } as never,
+      agent: agent as never,
+      tenantId: "tnt_x",
+      source: "kaambaan",
+      log: () => {},
+    } as never);
+    // ready → it went on to claim, and found nothing
+    expect(result.status).toBe("idle");
+  });
+});


### PR DESCRIPTION
**This corrects a mistake I shipped an hour ago in #411.**

## What was wrong

#411 bounded a whole claim cycle at two minutes. Checking what a cycle actually contains is what showed the error: `runOnce` **drives the claimed run to completion** — creates the ACP session, prompts, streams activities, heartbeats, awaits the chain.

So a legitimate cycle lasts as long as the agent's work, and `permissionWaitMs` alone defaults to **thirty minutes**. A two-minute deadline would have abandoned a running agent mid-task.

**No harm reached production.** Nothing has claimed since that deploy, because the bridge never got past the readiness check. The next successful claim would have been killed at 120 seconds.

## What should be bounded

Only the **readiness probe**. It asks a node over the broker whether its station can run work *right now* — a question about the present moment, where a slow answer is not a useful answer. It had no timeout, so when it never returned, the agent was gone: one cycle logged at 06:04:17 on 2026-09-08 and then nothing, process healthy, CPU at 6%.

`probeReadiness` bounds it at ten seconds and treats a timeout as a **negative answer, not an error**. If a station cannot say it is ready within ten seconds, it is not ready — and the loop's existing not-ready backoff is exactly the right response. The failure stays inside the state machine that already handles it.

## What survives from #411

`fetchAdapter`'s `AbortSignal.timeout(30s)` stays. That half was right: each individual HTTP request should be fast, and a heartbeat is a single request. It bounds the calls without bounding the work.

## Guarding the idea

A test now pins the decision *not* to bound a cycle:

> A whole-cycle deadline was written on 2026-09-08 and reverted the same hour, because it would have abandoned a running agent mid-task. This test exists so the idea does not come back.

That felt worth writing down, because "the loop stopped, add a timeout" is exactly the reasoning that produced the bug.

## Tests

1809 pass / 5 fail. The five are identical on main (1805/5) — all expiry and grace-window assertions that rot with the clock, not with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr