### PR TITLE
One line per bridge cycle, so a stopped agent leaves evidence

### DIFF
--- a/apps/hub/src/services/bridge/loop.ts
+++ b/apps/hub/src/services/bridge/loop.ts
@@ -65,7 +65,17 @@ export function startAgentLoop(opts: AgentLoopOptions): LoopHandle {
   const controller = new AbortController();
 
   const done = (async () => {
+    let cycle = 0;
     while (!controller.signal.aborted) {
+      // **Liveness, not decoration.** Twice now a bridge agent has stopped and left nothing
+      // behind: a 401 retried into noise, then a cycle that never came back. Both were invisible
+      // because a loop that is neither erroring nor idling logs nothing at all, and a silent
+      // agent is indistinguishable from a quiet board.
+      //
+      // One line per cycle at DEBUG-ish volume — a cycle is at minimum five seconds — is a cheap
+      // price for being able to answer "is it still going round?" without attaching a debugger
+      // to production, which is exactly the question that could not be answered on 2026-09-08.
+      log("cycle", { n: ++cycle });
       let result: DispatchResult;
       try {
         // NOT bounded by a deadline, and that is deliberate. `runOnce` drives the claimed run


### PR DESCRIPTION
Twice now a bridge agent has stopped and left nothing behind — a 401 retried into noise (#409), then a cycle that never came back (#411/#412). Both were invisible for the same reason: a loop that is neither erroring nor idling logs nothing, and a silent agent looks exactly like a quiet board.

The unit tests cycle correctly, including with the real `defaultSleep`, so the production difference is environmental and only the process can say which. This makes it say.

A cycle is at minimum five seconds, so one line per cycle is cheap — and it turns "is it still going round?" into a question you can answer from a log instead of a debugger attached to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr