### PR TITLE
The hub verifies its own token — from a human, and only a human

### DIFF
--- a/apps/hub/src/auth/hub-token-middleware.test.ts
+++ b/apps/hub/src/auth/hub-token-middleware.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `authMiddleware` accepts a token this hub issued — from a human principal, and only a human.
+ *
+ * **What this closes.** The hub is the issuer for the whole suite and was the one plane that
+ * would not read its own tokens: exactly one route, `/api/fleet/dispatchable`, verified a hub
+ * JWT, and every other `/api/*` route took a session cookie, the static API_TOKEN, or a Better
+ * Auth session token. A client finishing the authorization-code flow got a credential that
+ * opened one endpoint.
+ *
+ * **What it deliberately does not open.** An agent-kind token is refused at the middleware
+ * rather than at each route. Most routes here have never had to consider a non-human caller;
+ * `requireGrantReach` guards the reach-bearing acts, but only on the routes that call it, and
+ * `runtimes`, `stations` and `station-acp` call nothing. Widening what a hub token REACHES must
+ * not silently widen WHO may hold one. A route audited and found correct for an agent can opt
+ * in later, from a default that was closed.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+
+import { auth } from "./drizzle-auth";
+import { authMiddleware } from "./middleware";
+import { BOOTSTRAP_TENANT_ID } from "./tenant";
+import { createPrincipal } from "../services/principals";
+
+let humanPrincipalId: string;
+let humanUserId: string;
+let agentPrincipalId: string;
+
+/** A minimal protected app: the middleware, and a route that reports who got through. */
+const app = new Hono()
+  .use("/api/*", authMiddleware)
+  .get("/api/whoami", (c) => {
+    const u = c.get("user");
+    return c.json({ id: u.id, authType: u.authType, tenantId: u.tenantId });
+  });
+
+async function tokenFor(sub: string, principalKind: string): Promise<string> {
+  const { token } = await auth.api.signJWT({
+    body: {
+      payload: {
+        iat: Math.floor(Date.now() / 1000),
+        sub,
+        principalKind,
+        tenant: BOOTSTRAP_TENANT_ID,
+        mayDispatch: [],
+        mayGrantReach: false,
+      },
+    },
+  });
+  return token;
+}
+
+const get = (token?: string) =>
+  app.request("/api/whoami", {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+
+beforeAll(async () => {
+  humanUserId = `usr_hubtok_${Date.now()}`;
+  humanPrincipalId = await createPrincipal({
+    kind: "human",
+    handle: `hubtok-human-${Date.now()}`,
+    userId: humanUserId,
+  });
+
+  agentPrincipalId = await createPrincipal({
+    kind: "agent",
+    handle: `hubtok-agent-${Date.now()}`,
+  });
+});
+
+describe("a hub-issued token on an ordinary route", () => {
+  test("a human principal is admitted, as its Better Auth user", async () => {
+    const res = await get(await tokenFor(humanPrincipalId, "human"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; authType: string; tenantId: string };
+
+    // The translation is the point. Everything below this layer resolves on a Better Auth id —
+    // `getStation(userId, …)`, `requireLive(userId, …)` — and handing those a `prn_` is the
+    // defect that killed every bridge-mode room on 2026-08-31 (#399, #400).
+    expect(body.id).toBe(humanUserId);
+    expect(body.id.startsWith("prn_")).toBe(false);
+    expect(body.authType).toBe("hub_token");
+    expect(body.tenantId).toBe(BOOTSTRAP_TENANT_ID);
+  });
+
+  test("an agent principal is refused, and told why", async () => {
+    const res = await get(await tokenFor(agentPrincipalId, "agent"));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("agent");
+  });
+
+  test("a service principal is refused too — the rule is human-only, not not-agent", async () => {
+    const res = await get(await tokenFor(humanPrincipalId, "service"));
+    expect(res.status).toBe(403);
+  });
+
+  test("a human principal with no account on this hub is refused", async () => {
+    // A principal row can exist with no `better-auth` identity linked. It cannot act on routes
+    // that scope by Better Auth id, and failing closed is the only safe answer.
+    const orphan = await createPrincipal({
+      kind: "human",
+      handle: `hubtok-orphan-${Date.now()}`,
+    });
+    const res = await get(await tokenFor(orphan, "human"));
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { message: string }).message).toContain("no account");
+  });
+});
+
+describe("what it does not accept", () => {
+  test("no token at all is still 401, not 403", async () => {
+    // The distinction matters to a CLI: 401 means sign in, 403 means you may not.
+    expect((await get()).status).toBe(401);
+  });
+
+  test("a garbage bearer is 401", async () => {
+    expect((await get("not-a-token")).status).toBe(401);
+  });
+
+  test("a token signed by a key this hub does not publish is 401", async () => {
+    // Same shape, wrong signer. Verified by the JWKS, not by the token's own header.
+    const foreign =
+      "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9." +
+      Buffer.from(JSON.stringify({ sub: humanPrincipalId, principalKind: "human" })).toString("base64url") +
+      ".c2lnbmF0dXJl";
+    expect((await get(foreign)).status).toBe(401);
+  });
+});

--- a/apps/hub/src/auth/hub-token.ts
+++ b/apps/hub/src/auth/hub-token.ts
@@ -1,0 +1,82 @@
+/**
+ * Verifying a token this hub itself issued.
+ *
+ * **The asymmetry this closes.** `charter → decisions/2026-08-15-one-issuer-and-offline-
+ * verification.md` makes the hub the issuer and has every other plane verify offline against a
+ * JWKS. kaambaan does exactly that. The hub did not: until now, exactly one route in this
+ * codebase — `/api/fleet/dispatchable`, built for the cross-domain handoff — would read a
+ * hub-issued token, and every other `/api/*` route went through `authMiddleware`, which accepts
+ * a session cookie, the static `API_TOKEN`, or a Better Auth session token, and none of those
+ * is a hub JWT.
+ *
+ * The practical consequence was that a client completing the authorization-code flow received a
+ * credential that opened a single endpoint. A CLI could sign in and then 401 on its first real
+ * request.
+ *
+ * **One verifier, deliberately.** This module exists so `fleet-dispatchable` and
+ * `authMiddleware` cannot drift: two implementations of "is this token ours" is precisely how a
+ * key published in one place comes to be rejected in another, and that failure reads as "you
+ * have no permission", which is the hardest kind to trace.
+ */
+import { createLocalJWKSet, jwtVerify, type JSONWebKeySet } from "jose";
+
+import { config } from "../config.ts";
+import { auth } from "./drizzle-auth.ts";
+import { servicePublicJwks } from "./service-signing.ts";
+
+/**
+ * Pinned, never read from the token's own header.
+ *
+ * `jose` would otherwise accept whatever the matched key admits, which lets a caller choose the
+ * algorithm — the classic JWT confusion attack.
+ */
+export const ALG = "EdDSA";
+
+/**
+ * Every key a token of ours may be signed with: Better Auth's, plus the service keys.
+ *
+ * Assembled from the same two sources as the `jwks` route, and they must agree — a key
+ * published there and refused here is a token that verifies everywhere in the suite except at
+ * this hub.
+ *
+ * Not cached. Both reads are local, and a cache would mean a service key minted a second ago
+ * (they are created lazily, on first use) verifying as a forgery until it expired.
+ */
+export async function publishedJwks(): Promise<JSONWebKeySet> {
+  const betterAuth = (await auth.api.getJwks()) as unknown as JSONWebKeySet;
+  return { keys: [...(betterAuth.keys ?? []), ...(await servicePublicJwks())] } as JSONWebKeySet;
+}
+
+export interface HubTokenClaims {
+  sub: string;
+  principalKind: "human" | "agent" | "service";
+  tenant?: string;
+  mayDispatch?: string[];
+  mayGrantReach?: boolean;
+  [claim: string]: unknown;
+}
+
+/**
+ * Verify a bearer string as a hub-issued token, or return null.
+ *
+ * Null for every failure — unknown key, foreign signature, expired, wrong issuer or audience,
+ * mangled — because a caller holding none of them learns nothing from being told which, and a
+ * legitimate caller's next move is the same either way: go back through the authorize flow.
+ */
+export async function verifyHubToken(
+  token: string,
+  jwks: () => Promise<JSONWebKeySet> = publishedJwks,
+): Promise<HubTokenClaims | null> {
+  try {
+    const verified = await jwtVerify(token, createLocalJWKSet(await jwks()), {
+      issuer: config.publicUrl,
+      audience: config.publicUrl,
+      algorithms: [ALG],
+    });
+    const claims = verified.payload as Record<string, unknown>;
+    if (typeof claims.sub !== "string" || typeof claims.principalKind !== "string") return null;
+    return claims as unknown as HubTokenClaims;
+  } catch {
+    return null;
+  }
+}

--- a/apps/hub/src/auth/middleware.ts
+++ b/apps/hub/src/auth/middleware.ts
@@ -14,6 +14,8 @@ import { auth, type Session, type User } from "./drizzle-auth";
 import { BOOTSTRAP_TENANT_ID } from "./tenant";
 import { config } from "../config";
 import { createLogger } from "../utils/logger";
+import { userIdForPrincipal } from "../services/principals";
+import { verifyHubToken } from "./hub-token";
 
 const log = createLogger("auth-middleware");
 
@@ -41,7 +43,7 @@ export interface AuthUser {
   email?: string;
   name?: string;
   image?: string;
-  authType: "better_auth" | "api_key";
+  authType: "better_auth" | "api_key" | "hub_token";
   /**
    * The isolation boundary this caller acts in.
    *
@@ -173,6 +175,53 @@ export const authMiddleware = createMiddleware(async (c: Context, next: Next) =>
       return next();
     }
     
+    // ── A token this hub issued ──────────────────────────────────────────────
+    //
+    // The hub is the issuer for the whole suite and, until now, was the one plane that would
+    // not read its own tokens: a client finishing the authorization-code flow got a credential
+    // that opened exactly one endpoint. This is that asymmetry closed.
+    //
+    // **Human principals only, and the refusal is explicit.** `mayDispatch` is the authority to
+    // ask an agent to work; it was never the authority to operate the fleet. Most routes under
+    // this middleware have never had to consider a non-human caller, and widening what a hub
+    // token reaches must not silently widen who may hold one. When a route is audited and found
+    // correct for an agent, it can opt in — from a position where the default was closed.
+    const hubClaims = await verifyHubToken(bearerToken);
+    if (hubClaims) {
+      if (hubClaims.principalKind !== "human") {
+        log.warn("Refused a non-human hub token", { kind: hubClaims.principalKind });
+        return c.json(
+          {
+            error: "Forbidden",
+            message:
+              `This endpoint takes a human principal. That token names a ${hubClaims.principalKind}.`,
+          },
+          403
+        );
+      }
+
+      // Translated to a Better Auth id HERE, once, because everything below resolves on one —
+      // `getStation(userId, …)`, `requireLive(userId, …)`. Passing a `prn_` down is the defect
+      // that killed every bridge-mode room on 2026-08-31 (#399, #400).
+      const userId = await userIdForPrincipal(hubClaims.sub);
+      if (!userId) {
+        log.warn("Hub token names a principal with no Better Auth identity", { sub: hubClaims.sub });
+        return c.json(
+          {
+            error: "Forbidden",
+            message: "That principal has no account on this hub.",
+          },
+          403
+        );
+      }
+
+      c.set("user", { id: userId, authType: "hub_token", tenantId: BOOTSTRAP_TENANT_ID });
+      c.set("session", null);
+      c.set("betterAuthUser", null);
+      log.debug("Authenticated via hub-issued token", { principal: hubClaims.sub, userId });
+      return next();
+    }
+
     // Try to validate as a Better Auth session token
     try {
       const session = await auth.api.getSession({

--- a/apps/hub/src/routes/fleet-dispatchable.ts
+++ b/apps/hub/src/routes/fleet-dispatchable.ts
@@ -30,8 +30,7 @@
 import { Hono } from "hono";
 import { createLocalJWKSet, jwtVerify, type JSONWebKeySet } from "jose";
 
-import { auth } from "../auth/drizzle-auth";
-import { servicePublicJwks } from "../auth/service-signing";
+import { ALG, publishedJwks } from "../auth/hub-token";
 import { config } from "../config";
 import { listPrincipals as defaultListPrincipals } from "../services/principals";
 
@@ -44,7 +43,6 @@ import { listPrincipals as defaultListPrincipals } from "../services/principals"
  * and "the token says which algorithm to check it with" is the shape of every
  * classic JWT confusion bug.
  */
-const ALG = "EdDSA";
 
 /**
  * The key set `GET /api/auth/jwks` publishes: Better Auth's keys plus this
@@ -68,10 +66,9 @@ const ALG = "EdDSA";
  * mean a service key minted a second ago (they are created lazily, on first
  * use) verifying as a forgery until it expired.
  */
-async function publishedJwks(): Promise<JSONWebKeySet> {
-  const betterAuth = (await auth.api.getJwks()) as unknown as JSONWebKeySet;
-  return { keys: [...(betterAuth.keys ?? []), ...(await servicePublicJwks())] } as JSONWebKeySet;
-}
+// `publishedJwks` now lives in `auth/hub-token.ts`, shared with `authMiddleware`, so a key
+// this hub publishes cannot be accepted in one place and refused in the other.
+
 
 /**
  * What the route needs from the rest of the hub.

--- a/apps/hub/src/services/principals.ts
+++ b/apps/hub/src/services/principals.ts
@@ -195,3 +195,33 @@ export async function listPrincipals(): Promise<
     suspendedAt: r.suspendedAt,
   }));
 }
+
+/**
+ * The Better Auth user a principal acts as, or null.
+ *
+ * The inverse of `principalForUser`, and the reason it is needed: a hub token's `sub` is a
+ * `prn_…`, while every station-scoped call in this hub resolves on a Better Auth id —
+ * `getStation(userId, …)`, `requireLive(userId, …)`. Handing a principal id to those is exactly
+ * the defect that killed every bridge-mode room on 2026-08-31 (agentpod#399, #400): it matched
+ * no row, for any room, for any sender, and the suite stayed green because the fakes accepted
+ * any id.
+ *
+ * So a hub token is translated to a Better Auth id **once, at the edge**, and everything below
+ * that layer keeps the meaning of `user.id` it already had.
+ *
+ * Null for an agent or a service, which have no Better Auth identity by construction. That is a
+ * refusal at the caller, not an error here.
+ */
+export async function userIdForPrincipal(principalId: string): Promise<string | null> {
+  const [identity] = await db
+    .select({ externalId: principalIdentities.externalId })
+    .from(principalIdentities)
+    .where(
+      and(
+        eq(principalIdentities.principalId, principalId),
+        eq(principalIdentities.system, "better-auth")
+      )
+    )
+    .limit(1);
+  return identity?.externalId ?? null;
+}


### PR DESCRIPTION
**A′ from #408.** The change that unblocks `apn fleet`, kept deliberately smaller than the full option A.

## The asymmetry this closes

`charter → 2026-08-15-one-issuer-and-offline-verification` makes the hub the issuer and has every other plane verify offline against a JWKS. kaambaan does exactly that.

**The hub did not.** Exactly one route — `/api/fleet/dispatchable`, built for the cross-domain handoff — would read a hub-issued token. Every other `/api/*` route goes through `authMiddleware`, which accepts a session cookie, the static `API_TOKEN`, or a Better Auth session token. None of those is a hub JWT.

So a client finishing the authorization-code flow received a credential that opened **exactly one endpoint**. A CLI could sign in and then 401 on its first real request.

## Human principals only, refused at the middleware

An agent-kind token gets **403 before any route sees it**. This is why A′ is smaller than A:

- most routes here have never had to consider a non-human caller
- `requireGrantReach` guards the reach-bearing acts — **but only on the routes that call it**
- `runtimes`, `stations` and `station-acp` call nothing

Widening what a hub token *reaches* must not silently widen *who* may hold one. A route audited and found correct for an agent can opt in later — from a default that was closed. That audit remains the deliverable it was in #408; this just stops it being a blocker.

## The translation, which is the part most likely to be got wrong

A hub token's `sub` is a `prn_…`. Every station-scoped call in this hub resolves on a **Better Auth id** — `getStation(userId, …)`, `requireLive(userId, …)`.

Handing those a principal id is precisely the defect that killed every bridge-mode room on 2026-08-31 (#399, #400): it matched no row, for any room, for any sender — and the suite stayed green because the fakes accepted any id.

So the token is translated **once, at the edge**, through `principal_identities`' `better-auth` row, and nothing below that layer sees a changed `user.id`. A principal with no such row is refused rather than admitted as itself. A test asserts the returned id is the Better Auth one and explicitly **not** a `prn_`.

## One verifier

`auth/hub-token.ts` is now shared with `fleet-dispatchable`. Two implementations of "is this token ours" is how a key published in one place comes to be refused in another — and that failure reads as *"you have no permission"*, the hardest kind to trace. The algorithm stays pinned rather than read from the token's own header.

## Verification

- 7 new tests; **reverting the `principalKind` check fails 2 of them**
- `fleet-dispatchable`'s existing 23 still pass after the refactor
- full suite **1816 pass / 5 fail** — the same five as main, all expiry and grace-window assertions that rot with the clock

## Next

`apn node` / `apn fleet` split, which this makes possible. #408 should be updated to record A′ as the chosen option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr