### PR TITLE
apn grows a fleet mode, split from node mode on the credential

### DIFF
--- a/apps/node-agent/cmd/agentpod-node/fleet.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet.go
@@ -1,0 +1,184 @@
+package main
+
+// `apn fleet …` — acting as a PRINCIPAL against a hub, rather than as this machine.
+//
+// The split between this and `apn node …` is the credential, not the verb list. Everything in
+// `node` authenticates as `<nodeId>:<nodeSecret>` from the node's own config; everything here
+// authenticates with a hub-issued token that a person or an agent holds.
+//
+// **A fleet command never falls back to the node's secret.** That rule lives in
+// `internal/fleetcred` with the test that pins it, and it is the whole reason these verbs can
+// ship inside the binary installed on every station: they are present, and useless without a
+// token the node does not have.
+//
+// This file adds no authority of its own and performs no client-side permission check. It
+// renders the hub's answer, including the hub's refusal. A client that pre-empts a server
+// decision is a client that will one day disagree with it.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/fleetcred"
+)
+
+const defaultHub = "https://hub.agentpod.dev"
+
+// hubBase is the hub a fleet command talks to: the environment, else the default.
+//
+// Deliberately NOT the node config's `hub` field. A machine enrolled against one hub does not
+// make that hub the one a person is signed in to, and quietly borrowing it would blur the very
+// boundary this mode exists to draw.
+func hubBase() string {
+	if h := strings.TrimSpace(os.Getenv(fleetcred.EnvHub)); h != "" {
+		return strings.TrimRight(h, "/")
+	}
+	return defaultHub
+}
+
+// fleetCmd dispatches `apn fleet <verb>`.
+func fleetCmd(args []string) {
+	if len(args) == 0 || helpRequested(args) {
+		fmt.Println(commandHelp("fleet"))
+		return
+	}
+	switch args[0] {
+	case "whoami":
+		fleetWhoami(args[1:])
+	case "logout":
+		fleetLogout()
+	case "nodes":
+		fleetGet("/api/nodes", args[1:])
+	case "agents":
+		fleetGet("/api/fleet/agents", args[1:])
+	case "stats":
+		fleetGet("/api/fleet/stats", args[1:])
+	case "activity":
+		fleetGet("/api/activity", args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown fleet command: %q\n\n%s\n", args[0], commandHelp("fleet"))
+		os.Exit(2)
+	}
+}
+
+// requireCredential resolves the fleet token or exits with a message naming the fix.
+//
+// It exits rather than returning an error because every caller's response is identical, and
+// because the one thing it must never do — reach for the node's credential — is easiest to
+// guarantee when there is a single place that can decide.
+func requireCredential() fleetcred.Credential {
+	c, err := fleetcred.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"Not signed in to a fleet.\n\n"+
+				"  apn fleet login            sign in and store a token\n"+
+				"  %s=…   supply one directly\n\n"+
+				"This is separate from `apn enroll`, which gives this MACHINE an identity.\n"+
+				"A node's credential is never used to act on the fleet.\n",
+			fleetcred.EnvToken)
+		os.Exit(1)
+	}
+	if claims, err := fleetcred.Inspect(c.Token); err == nil && claims.Expired() {
+		fmt.Fprintf(os.Stderr,
+			"Your session expired at %s.\n\n  apn fleet login\n",
+			claims.Expiry.Local().Format(time.RFC1123))
+		os.Exit(1)
+	}
+	return c
+}
+
+// fleetWhoami reports what the operator is carrying, without asking the hub.
+//
+// The point is to separate two failures that otherwise look identical from the outside: "not
+// signed in" and "signed in, not permitted". A 403 means the second; this command answers the
+// first, locally, in one line.
+func fleetWhoami(args []string) {
+	c := requireCredential()
+	claims, err := fleetcred.Inspect(c.Token)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "The stored credential is not a token this can read: %v\n", err)
+		os.Exit(1)
+	}
+	if wantsJSON(args) {
+		out := map[string]any{
+			"principal": claims.Subject,
+			"kind":      claims.PrincipalKind,
+			"source":    c.Source,
+			"hub":       hubBase(),
+		}
+		if !claims.Expiry.IsZero() {
+			out["expires"] = claims.Expiry.UTC().Format(time.RFC3339)
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return
+	}
+	fmt.Printf("principal  %s\n", claims.Subject)
+	fmt.Printf("kind       %s\n", claims.PrincipalKind)
+	fmt.Printf("hub        %s\n", hubBase())
+	fmt.Printf("token from %s\n", c.Source)
+	if !claims.Expiry.IsZero() {
+		fmt.Printf("expires    %s\n", claims.Expiry.Local().Format(time.RFC1123))
+	}
+}
+
+func fleetLogout() {
+	if err := fleetcred.Forget(); err != nil {
+		fmt.Fprintf(os.Stderr, "could not remove the stored token: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("signed out")
+}
+
+func wantsJSON(args []string) bool {
+	for _, a := range args {
+		if a == "--json" || a == "-json" {
+			return true
+		}
+	}
+	return false
+}
+
+// fleetGet performs an authenticated read and prints the hub's answer.
+//
+// The body is passed through rather than reformatted. A CLI that renders a summary of a payload
+// it does not fully model is a CLI that silently drops the field somebody needed — and `--json`
+// is the surface agents will depend on, so it stays the hub's own shape.
+func fleetGet(path string, args []string) {
+	c := requireCredential()
+	req, err := http.NewRequest("GET", hubBase()+path, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	res, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not reach %s: %v\n", hubBase(), err)
+		os.Exit(1)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+
+	if res.StatusCode == http.StatusForbidden {
+		// Distinguished from 401 on purpose: 401 means sign in, 403 means you may not. The hub
+		// refuses a non-human principal here, and an agent reading "sign in again" would loop.
+		fmt.Fprintf(os.Stderr, "Refused by the hub (403). %s\n", strings.TrimSpace(string(body)))
+		os.Exit(1)
+	}
+	if res.StatusCode == http.StatusUnauthorized {
+		fmt.Fprintf(os.Stderr, "The hub did not accept that token (401).\n\n  apn fleet login\n")
+		os.Exit(1)
+	}
+	if res.StatusCode >= 400 {
+		fmt.Fprintf(os.Stderr, "hub returned %d: %s\n", res.StatusCode, strings.TrimSpace(string(body)))
+		os.Exit(1)
+	}
+	fmt.Println(strings.TrimSpace(string(body)))
+}

--- a/apps/node-agent/cmd/agentpod-node/fleet_test.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// build compiles apn once per test binary and returns its path.
+func build(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "apn")
+	out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// run executes apn with a clean, isolated environment.
+func run(t *testing.T, bin string, env []string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	home := t.TempDir()
+	cmd.Env = append([]string{
+		"HOME=" + home,
+		"XDG_CONFIG_HOME=" + home,
+		"PATH=" + os.Getenv("PATH"),
+	}, env...)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("running apn: %v", err)
+	}
+	return string(out), code
+}
+
+func TestFleetWithoutCredentialRefusesAndSaysHow(t *testing.T) {
+	bin := build(t)
+	out, code := run(t, bin, nil, "fleet", "whoami")
+
+	if code == 0 {
+		t.Fatal("a fleet command with no credential must not succeed")
+	}
+	// It has to name the fix, and distinguish itself from enrolment — the two are routinely
+	// confused precisely because both are called "connecting to the hub".
+	for _, want := range []string{"Not signed in", "apn fleet login", "AGENTPOD_TOKEN", "MACHINE"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("refusal should mention %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestFleetNeverUsesTheNodeCredential(t *testing.T) {
+	bin := build(t)
+	home := t.TempDir()
+
+	// A fully enrolled machine, exactly as `apn enroll` leaves it.
+	nodeDir := filepath.Join(home, "agentpod-node")
+	if err := os.MkdirAll(nodeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := `{"hub":"https://hub.example","nodeId":"nod_x","nodeSecret":"s3cret-node"}`
+	if err := os.WriteFile(filepath.Join(nodeDir, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin, "fleet", "whoami")
+	cmd.Env = []string{"HOME=" + home, "XDG_CONFIG_HOME=" + home, "PATH=" + os.Getenv("PATH")}
+	out, _ := cmd.CombinedOutput()
+
+	// This is the property that lets fleet verbs ship in the binary installed on every station.
+	if !strings.Contains(string(out), "Not signed in") {
+		t.Fatalf("an enrolled machine must still be 'not signed in' for fleet:\n%s", out)
+	}
+	if strings.Contains(string(out), "s3cret-node") {
+		t.Fatal("the node secret leaked into a fleet command")
+	}
+}
+
+func TestFleetWhoamiReadsTheTokenWithoutAHub(t *testing.T) {
+	bin := build(t)
+	// A well-formed JWT payload, signed with nonsense. `whoami` reports what you carry; it is
+	// not an authorization decision, and it must not need the network to answer.
+	tok := "aGRy.eyJzdWIiOiJwcm5fYWJjIiwicHJpbmNpcGFsS2luZCI6Imh1bWFuIn0.c2ln"
+	out, code := run(t, bin, []string{"AGENTPOD_TOKEN=" + tok}, "fleet", "whoami")
+	if code != 0 {
+		t.Fatalf("whoami should succeed offline, got %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "prn_abc") || !strings.Contains(out, "human") {
+		t.Fatalf("whoami should report the principal and kind:\n%s", out)
+	}
+}
+
+func TestNodeIsAnAliasAndCannotDiverge(t *testing.T) {
+	bin := build(t)
+	// `apn version` and `apn node version` are the same command because `node` is a word
+	// stripped before one switch — not a second dispatch that could drift.
+	bare, c1 := run(t, bin, nil, "version")
+	viaNode, c2 := run(t, bin, nil, "node", "version")
+	if c1 != c2 || bare != viaNode {
+		t.Fatalf("`apn version` and `apn node version` differ:\n%q (%d)\n%q (%d)", bare, c1, viaNode, c2)
+	}
+}
+
+func TestHelpShowsBothModes(t *testing.T) {
+	bin := build(t)
+	out, _ := run(t, bin, nil, "help")
+	for _, want := range []string{"Fleet:", "fleet", "node"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("top-level help should mention %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFleetHelpExplainsTheCredentialBoundary(t *testing.T) {
+	bin := build(t)
+	out, _ := run(t, bin, nil, "help", "fleet")
+	// The boundary is the thing an operator most needs told, because both modes are reasonably
+	// described as "talking to the hub".
+	for _, want := range []string{"never falls back", "AGENTPOD_TOKEN", "MACHINE"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("fleet help should explain %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestUnknownFleetVerbExitsTwo(t *testing.T) {
+	bin := build(t)
+	_, code := run(t, bin, nil, "fleet", "nonsense")
+	if code != 2 {
+		t.Fatalf("unknown subcommand should exit 2, got %d", code)
+	}
+}

--- a/apps/node-agent/cmd/agentpod-node/help.go
+++ b/apps/node-agent/cmd/agentpod-node/help.go
@@ -16,6 +16,31 @@ var commands = []struct {
 	name, group, oneline, detail string
 }{
 	{
+		name: "fleet", group: "Fleet",
+		oneline: "Act on the fleet as a signed-in principal (whoami, nodes, agents, stats)",
+		detail: "apn fleet <verb> — act on the fleet as a PRINCIPAL, not as this machine.\n\n" +
+			"  apn fleet whoami [--json]   who the stored token says you are\n" +
+			"  apn fleet logout            forget the stored token\n" +
+			"  apn fleet nodes             the fleet's nodes\n" +
+			"  apn fleet agents            the agents you may dispatch\n" +
+			"  apn fleet stats             fleet totals\n" +
+			"  apn fleet activity          recent fleet activity\n\n" +
+			"The credential is separate from the node's, deliberately. `apn enroll` gives THIS\n" +
+			"MACHINE an identity; these verbs use a hub-issued token held by a person or an\n" +
+			"agent, from $AGENTPOD_TOKEN or the file `apn fleet login` writes. A fleet command\n" +
+			"never falls back to the node's credential — a node secret says 'I am this host',\n" +
+			"and it is not an authority to operate the fleet.\n\n" +
+			"Set $AGENTPOD_HUB to talk to a hub other than the default.",
+	},
+	{
+		name: "node", group: "Fleet",
+		oneline: "Explicit spelling for the machine-scoped verbs (apn node status, …)",
+		detail: "apn node <verb> — the explicit form of the machine-scoped verbs.\n\n" +
+			"Every verb in this help that is not under Fleet is a node verb, and both spellings\n" +
+			"work: `apn status` and `apn node status` are the same command. The bare forms are\n" +
+			"kept because existing runbooks name them.",
+	},
+	{
 		name: "status", group: "Service",
 		oneline: "Show local service + hub connection state (--json for scripts)",
 		detail: "apn status — show local service state and hub connection state.\n\n" +
@@ -142,7 +167,7 @@ var commands = []struct {
 
 // commandGroups lists the group names in the order they render in the
 // top-level help layout.
-var commandGroups = []string{"Service", "Node", "Maintenance"}
+var commandGroups = []string{"Fleet", "Service", "Node", "Maintenance"}
 
 // helpText renders the full top-level `apn help` layout: tool one-liner and
 // version, usage line, commands grouped by purpose, an examples block, and
@@ -166,7 +191,8 @@ func helpText(version string) string {
 	b.WriteString("Examples:\n")
 	b.WriteString("  apn status\n")
 	b.WriteString("  apn logs -f\n")
-	b.WriteString("  apn enroll --hub https://hub.example.com --token <TOKEN>\n\n")
+	b.WriteString("  apn enroll --hub https://hub.example.com --token <TOKEN>\n")
+	b.WriteString("  apn fleet whoami\n\n")
 	b.WriteString("Run 'apn help <command>' or 'apn <command> -h' for command details.")
 
 	return b.String()

--- a/apps/node-agent/cmd/agentpod-node/main.go
+++ b/apps/node-agent/cmd/agentpod-node/main.go
@@ -33,6 +33,19 @@ func main() {
 		fmt.Println(helpText(version))
 		os.Exit(0)
 	}
+	// `apn node <verb>` is the explicit spelling of the machine-scoped verbs; the bare forms
+	// stay because the estate's own documents name them (`apn enroll`, `apn update`), and a
+	// runbook that stops working is worse than a CLI with two spellings. Stripping the prefix
+	// here rather than dispatching separately means the two spellings CANNOT diverge: there is
+	// one switch, and `node` is only ever a word removed before it.
+	if os.Args[1] == "node" {
+		if len(os.Args) < 3 {
+			fmt.Println(commandHelp("node"))
+			os.Exit(0)
+		}
+		os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
+	}
+
 	switch os.Args[1] {
 	case "help", "-h", "--help":
 		if os.Args[1] == "help" && len(os.Args) > 2 {
@@ -99,6 +112,9 @@ func main() {
 			os.Exit(0)
 		}
 		runCmd() // implemented in Task 9
+	case "fleet":
+		// Acting as a principal, not as this machine. See fleet.go.
+		fleetCmd(os.Args[2:])
 	case "detect":
 		if maybeShowHelp(os.Stdout, "detect", os.Args[2:]) {
 			os.Exit(0)

--- a/apps/node-agent/internal/fleetcred/fleetcred.go
+++ b/apps/node-agent/internal/fleetcred/fleetcred.go
@@ -1,0 +1,164 @@
+// Package fleetcred resolves the credential `apn fleet` acts with.
+//
+// # Why this is a package and not three lines in main
+//
+// `apn` has two modes, and the boundary between them is the CREDENTIAL, not the verb list.
+// `apn node` acts as this machine, with `<nodeId>:<nodeSecret>` from the node's own config.
+// `apn fleet` acts as a principal — a person, or an agent — with a hub-issued token.
+//
+// The rule that makes it safe to ship fleet verbs in the binary installed on every station:
+// **neither mode may ever read the other's credential.** A fleet command with no token fails and
+// says how to get one. It must never fall back to the node secret, because a node secret is a
+// MACHINE identity, and letting it act on the fleet would be the CLI inventing an escalation no
+// hub guard asked for.
+//
+// The two live in different directories for the same reason — `agentpod-node/` and `agentpod/` —
+// so neither can be reached by a path mistake, and an operator can delete one without disturbing
+// the other.
+//
+// The consequence worth stating plainly: the fleet verbs are present on every station and
+// **useless without a token the node does not have**. Authority stays where it already is, in the
+// hub's own guards.
+package fleetcred
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrNoCredential is returned when no fleet token can be found. Callers print its message and
+// exit non-zero; they must NOT retry with anything else.
+var ErrNoCredential = errors.New("no fleet credential")
+
+// EnvToken is read first, so a CI job or an agent harness can supply a token without a file.
+const EnvToken = "AGENTPOD_TOKEN"
+
+// EnvHub overrides the hub a fleet command talks to.
+const EnvHub = "AGENTPOD_HUB"
+
+// Credential is a resolved fleet token and where it came from, so an error message can name the
+// thing the operator has to change.
+type Credential struct {
+	Token string
+	// Source is "env" or the file path. Never a node config path — see the package comment.
+	Source string
+}
+
+// Path is where `apn fleet login` stores its token.
+//
+// Deliberately NOT under `agentpod-node/`. A separate directory is what stops a future edit from
+// reaching the node's secret with a relative path, and it lets an operator remove one credential
+// without touching the other.
+func Path() string {
+	d, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(d, "agentpod", "token.json")
+}
+
+type stored struct {
+	Token string `json:"token"`
+	Hub   string `json:"hub,omitempty"`
+}
+
+// Load resolves the fleet credential: the environment first, then the login file.
+//
+// Returns ErrNoCredential when neither holds one. It does not look at the node's config, and a
+// test asserts that even when a node config exists beside it.
+func Load() (Credential, error) {
+	if t := strings.TrimSpace(os.Getenv(EnvToken)); t != "" {
+		return Credential{Token: t, Source: "env:" + EnvToken}, nil
+	}
+	p := Path()
+	if p == "" {
+		return Credential{}, ErrNoCredential
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return Credential{}, ErrNoCredential
+	}
+	var s stored
+	if err := json.Unmarshal(b, &s); err != nil || strings.TrimSpace(s.Token) == "" {
+		return Credential{}, ErrNoCredential
+	}
+	return Credential{Token: s.Token, Source: p}, nil
+}
+
+// Save writes the token for later `apn fleet` calls, 0600 inside a 0700 directory — the same
+// posture the node config is written with.
+func Save(token, hub string) error {
+	p := Path()
+	if p == "" {
+		return errors.New("cannot determine a config directory to store the token in")
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(stored{Token: token, Hub: hub}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, b, 0o600)
+}
+
+// Forget removes the stored token. Absent is success: `logout` twice is not an error.
+func Forget() error {
+	p := Path()
+	if p == "" {
+		return nil
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Claims is the little a CLI needs from a token it holds.
+//
+// Read WITHOUT verifying the signature, and that is correct here: this is not an authorization
+// decision, it is `whoami` telling an operator what they are carrying. The hub verifies; the CLI
+// never does, because a client that pre-empts a server's decision is a client that will one day
+// disagree with it.
+type Claims struct {
+	Subject       string
+	PrincipalKind string
+	Expiry        time.Time
+}
+
+// Expired reports whether the token is past its `exp`. A zero expiry is treated as not expired —
+// absence of a claim is not evidence of staleness, and the hub is the authority either way.
+func (c Claims) Expired() bool {
+	return !c.Expiry.IsZero() && time.Now().After(c.Expiry)
+}
+
+// Inspect decodes a JWT's payload. It does not and must not verify.
+func Inspect(token string) (Claims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return Claims{}, fmt.Errorf("not a JWT: expected three dot-separated parts, found %d", len(parts))
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return Claims{}, fmt.Errorf("the token's payload is not valid base64url: %w", err)
+	}
+	var p struct {
+		Sub           string `json:"sub"`
+		PrincipalKind string `json:"principalKind"`
+		Exp           int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return Claims{}, fmt.Errorf("the token's payload is not JSON: %w", err)
+	}
+	c := Claims{Subject: p.Sub, PrincipalKind: p.PrincipalKind}
+	if p.Exp > 0 {
+		c.Expiry = time.Unix(p.Exp, 0)
+	}
+	return c, nil
+}

--- a/apps/node-agent/internal/fleetcred/fleetcred_test.go
+++ b/apps/node-agent/internal/fleetcred/fleetcred_test.go
@@ -1,0 +1,171 @@
+package fleetcred
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withConfigDir points os.UserConfigDir at a temp directory for one test.
+func withConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir) // Linux
+	t.Setenv("HOME", dir)            // macOS resolves ~/Library/Application Support
+	t.Setenv(EnvToken, "")
+	return dir
+}
+
+// TestNeverReadsTheNodeCredential is the test this package exists for.
+//
+// `apn` ships fleet verbs in the binary installed on every station. That is only safe because a
+// fleet command cannot borrow the machine's identity: a node secret says "I am this host", and
+// letting it act on the fleet would be the CLI inventing an escalation no hub guard asked for.
+//
+// So: a node config sitting right there, fully populated, and Load must still refuse.
+func TestNeverReadsTheNodeCredential(t *testing.T) {
+	dir := withConfigDir(t)
+
+	// A complete node identity, in the place the node agent really keeps it.
+	nodeDir := filepath.Join(dir, "agentpod-node")
+	if err := os.MkdirAll(nodeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nodeCfg := map[string]string{
+		"hub":        "https://hub.example",
+		"nodeId":     "nod_real",
+		"nodeSecret": "a-real-node-secret",
+	}
+	b, _ := json.Marshal(nodeCfg)
+	if err := os.WriteFile(filepath.Join(nodeDir, "config.json"), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Load()
+	if err != ErrNoCredential {
+		t.Fatalf("want ErrNoCredential with only a node config present, got cred=%+v err=%v", got, err)
+	}
+	if strings.Contains(got.Token, "node-secret") {
+		t.Fatal("the node secret escaped into a fleet credential")
+	}
+}
+
+func TestEnvironmentWins(t *testing.T) {
+	withConfigDir(t)
+	t.Setenv(EnvToken, "  kbn-ish-token  ")
+	c, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Token != "kbn-ish-token" {
+		t.Fatalf("token not trimmed: %q", c.Token)
+	}
+	if !strings.HasPrefix(c.Source, "env:") {
+		t.Fatalf("source should name the environment, got %q", c.Source)
+	}
+}
+
+func TestSaveLoadForget(t *testing.T) {
+	withConfigDir(t)
+
+	if err := Save("tok_abc", "https://hub.example"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The file holds a credential; it must not be world-readable.
+	info, err := os.Stat(Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("token file mode = %o, want 600", perm)
+	}
+
+	c, err := Load()
+	if err != nil || c.Token != "tok_abc" {
+		t.Fatalf("round trip failed: %+v %v", c, err)
+	}
+	if c.Source != Path() {
+		t.Fatalf("source should name the file, got %q", c.Source)
+	}
+
+	if err := Forget(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); err != ErrNoCredential {
+		t.Fatal("Load should refuse after Forget")
+	}
+	// Twice is not an error: an operator running `logout` again has got what they asked for.
+	if err := Forget(); err != nil {
+		t.Fatalf("second Forget should be a no-op, got %v", err)
+	}
+}
+
+func TestStoredFileIsNotUnderTheNodeDirectory(t *testing.T) {
+	withConfigDir(t)
+	// Separate directories is what stops a future edit reaching the node's secret with a
+	// relative path, and lets an operator remove one credential without touching the other.
+	if strings.Contains(Path(), "agentpod-node") {
+		t.Fatalf("fleet token must not live under the node's config directory: %s", Path())
+	}
+}
+
+func jwt(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	b, _ := json.Marshal(payload)
+	return "aGVhZGVy." + base64.RawURLEncoding.EncodeToString(b) + ".c2ln"
+}
+
+func TestInspectReadsWithoutVerifying(t *testing.T) {
+	// Signature is nonsense on purpose: `whoami` reports what the operator is carrying, it does
+	// not make an authorization decision. The hub verifies; the CLI must never pre-empt it.
+	tok := jwt(t, map[string]any{
+		"sub":           "prn_abc",
+		"principalKind": "human",
+		"exp":           time.Now().Add(time.Hour).Unix(),
+	})
+	c, err := Inspect(tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Subject != "prn_abc" || c.PrincipalKind != "human" {
+		t.Fatalf("claims not read: %+v", c)
+	}
+	if c.Expired() {
+		t.Fatal("a token an hour from expiry is not expired")
+	}
+}
+
+func TestInspectDetectsExpiry(t *testing.T) {
+	tok := jwt(t, map[string]any{"sub": "prn_x", "exp": time.Now().Add(-time.Minute).Unix()})
+	c, err := Inspect(tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Expired() {
+		t.Fatal("a token that expired a minute ago is expired")
+	}
+}
+
+func TestInspectTreatsAMissingExpiryAsNotExpired(t *testing.T) {
+	// Absence of a claim is not evidence of staleness, and the hub is the authority either way.
+	c, err := Inspect(jwt(t, map[string]any{"sub": "prn_x"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Expired() {
+		t.Fatal("no exp claim must not read as expired")
+	}
+}
+
+func TestInspectRefusesNonJWT(t *testing.T) {
+	for _, bad := range []string{"", "not-a-jwt", "only.two"} {
+		if _, err := Inspect(bad); err == nil {
+			t.Fatalf("Inspect(%q) should fail", bad)
+		}
+	}
+}


### PR DESCRIPTION
Implements the mode split from #408. Builds on #414, which is what makes a hub token usable on an ordinary hub route at all.

## The split

`apn` is `agentpod-node`. Every verb it had acts on the machine it runs on and authenticates as that machine. On a laptop, in CI, or inside an agent's workspace it had nothing to act as.

| mode | acts as | credential |
|---|---|---|
| `apn node …` | this machine | `<nodeId>:<nodeSecret>` from `agentpod-node/config.json` |
| `apn fleet …` | a principal — human **or** agent | a hub token from `$AGENTPOD_TOKEN` or `agentpod/token.json` |

**Two and not three.** A human and an agent both use `fleet`; only the token differs, and the hub decides authority from it. A separate `agent` mode would be the CLI deciding what its caller *is* — the judgement that belongs to the issuer.

## The rule that makes this safe on every station

**Neither mode may read the other's credential.** A fleet command with no token fails naming `apn fleet login`; it never falls back to the node secret, because a node secret says *"I am this host"* and is not an authority to operate the fleet. The two live in different directories so neither can be reached by a path mistake.

So the fleet verbs are present on every station and **useless without a token the node does not have**. `internal/fleetcred` owns that rule, and the test that matters plants a *fully enrolled* node config beside it and asserts `Load` still refuses:

```go
// A complete node identity, in the place the node agent really keeps it.
…
got, err := Load()
if err != ErrNoCredential { t.Fatalf(…) }
```

## Backwards compatibility, made structural

`apn node <verb>` is the explicit spelling; the bare forms keep working, because the estate's own documents name `apn enroll` and `apn update` and a runbook that stops working is worse than a CLI with two spellings.

The prefix is **stripped before one switch** rather than dispatched separately, so the two spellings *cannot* diverge. A test pins that `apn version` and `apn node version` are byte-identical.

## Two deliberate choices

**`whoami` answers offline**, reading the token without verifying it. That separates *"not signed in"* from *"signed in, not permitted"* — two failures that look identical from outside — and a client that pre-empts the hub's decision will one day disagree with it. For the same reason a **403 is reported as a refusal and a 401 as "sign in"**, never conflated: an agent told to "sign in again" on a 403 would loop.

**Reads pass the hub's JSON through** rather than reformatting. `--json` is the surface agents will depend on, and a CLI that summarises a payload it does not fully model silently drops the field somebody needed.

## Not here

`apn fleet login` — the PKCE flow needs the hub's client registry entry with the loopback redirect rule (#408 spells out the RFC 8252 constraint), and that is its own change. Until then `$AGENTPOD_TOKEN` is the way in.

## Tests

`go build`, `go vet` and `go test ./...` all clean. Eight new CLI-level tests that build the real binary and run it in an isolated `HOME`, plus ten on the credential package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr