### PR TITLE
apn fleet login — PKCE, and a loopback rule that earns its exception

### DIFF
--- a/apps/hub/src/config.ts
+++ b/apps/hub/src/config.ts
@@ -424,7 +424,53 @@ export function findOAuthClient(
  * the registered URI and is not it.
  */
 export function isRegisteredRedirect(client: OAuthClient, redirectUri: string): boolean {
-  return client.redirectUris.includes(redirectUri);
+  if (client.redirectUris.includes(redirectUri)) return true;
+  // The one exception, and it is narrow by construction — see `LOOPBACK_MARKER`.
+  return client.redirectUris.includes(LOOPBACK_MARKER) && isLoopbackRedirect(redirectUri);
+}
+
+/**
+ * The literal a client registers instead of a URI to say "I am a native app on this machine".
+ *
+ * Registered as `apn|loopback`. A marker rather than a pattern language: `127.0.0.1:*` invites
+ * somebody to write `*.agentpod.dev` next, and a registry that accepts one wildcard has already
+ * lost the property that makes exact matching safe.
+ */
+export const LOOPBACK_MARKER = 'loopback';
+
+/**
+ * A redirect back to a listener on this machine, for a CLI that cannot pin a port.
+ *
+ * RFC 8252 §7.3's native-app rule, and every clause below is load-bearing:
+ *
+ * - **`http` only, and loopback only.** `127.0.0.1` and `[::1]` exactly. Never `localhost`,
+ *   which is a NAME — it resolves through DNS and `/etc/hosts`, so an attacker who can answer
+ *   for it receives the code. This is the clause people skip.
+ * - **Any port.** The whole reason the exception exists: a CLI binds an ephemeral one.
+ * - **The path is exactly `/callback`.** `URL` normalises `..` before we look, so
+ *   `/callback/../evil` arrives as `/evil` and is refused — but the equality is what refuses it,
+ *   not the normalisation.
+ * - **No query, no fragment, no userinfo.** `http://evil@127.0.0.1/callback` is a URL whose
+ *   host a human reads as the wrong thing, and a credential destination must not be ambiguous
+ *   to a person reading it in a browser bar.
+ *
+ * What does NOT change: a `redirect_uri` failing this still renders 400 and sends no `Location`.
+ * An authorize endpoint that redirects where it was not told to is a credential-minting open
+ * redirector, and that property is older than this exception.
+ */
+export function isLoopbackRedirect(redirectUri: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'http:') return false;
+  if (u.hostname !== '127.0.0.1' && u.hostname !== '[::1]' && u.hostname !== '::1') return false;
+  if (u.pathname !== '/callback') return false;
+  if (u.search !== '' || u.hash !== '') return false;
+  if (u.username !== '' || u.password !== '') return false;
+  return true;
 }
 
 /**

--- a/apps/hub/tests/unit/loopback-redirect.test.ts
+++ b/apps/hub/tests/unit/loopback-redirect.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The loopback exception to exact redirect matching.
+ *
+ * `isRegisteredRedirect` is full-string equality on purpose — prefix or origin matching is how
+ * an authorize endpoint becomes a credential-minting open redirector. A CLI cannot pin a port,
+ * so it needs an exception, and an exception to that rule earns this much scrutiny.
+ *
+ * Most of these tests are attacks. The one worth reading twice is `localhost`.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  LOOPBACK_MARKER,
+  isLoopbackRedirect,
+  isRegisteredRedirect,
+  parseOAuthClients,
+  type OAuthClient,
+} from "../../src/config";
+
+const cli: OAuthClient = { id: "apn", redirectUris: [LOOPBACK_MARKER] };
+const plane: OAuthClient = { id: "kaambaan", redirectUris: ["https://kaambaan.dev/hub/callback"] };
+
+describe("what a native app may register back to", () => {
+  test("any port on 127.0.0.1, which is the whole point", () => {
+    for (const port of [1024, 8080, 49152, 65535]) {
+      expect(isLoopbackRedirect(`http://127.0.0.1:${port}/callback`)).toBe(true);
+    }
+    expect(isLoopbackRedirect("http://127.0.0.1/callback")).toBe(true);
+  });
+
+  test("IPv6 loopback too", () => {
+    expect(isLoopbackRedirect("http://[::1]:9000/callback")).toBe(true);
+  });
+});
+
+describe("what it must refuse", () => {
+  test("`localhost` — the clause people skip", () => {
+    // `localhost` is a NAME. It resolves through DNS and /etc/hosts, so whoever can answer for
+    // it receives the authorization code. An IP literal cannot be answered for.
+    expect(isLoopbackRedirect("http://localhost:8080/callback")).toBe(false);
+    expect(isLoopbackRedirect("http://LOCALHOST:8080/callback")).toBe(false);
+  });
+
+  test("a host that merely starts with the loopback address", () => {
+    expect(isLoopbackRedirect("http://127.0.0.1.evil.com/callback")).toBe(false);
+    expect(isLoopbackRedirect("http://127.0.0.1evil.com/callback")).toBe(false);
+  });
+
+  test("path traversal, which URL normalises before we ever compare", () => {
+    // Arrives as `/evil`. The equality is what refuses it, not the normalisation.
+    expect(isLoopbackRedirect("http://127.0.0.1:8080/callback/../evil")).toBe(false);
+    expect(isLoopbackRedirect("http://127.0.0.1:8080/callbackevil")).toBe(false);
+    expect(isLoopbackRedirect("http://127.0.0.1:8080/")).toBe(false);
+  });
+
+  test("userinfo, which makes a human misread the host", () => {
+    expect(isLoopbackRedirect("http://evil.com@127.0.0.1/callback")).toBe(false);
+    expect(isLoopbackRedirect("http://127.0.0.1@evil.com/callback")).toBe(false);
+  });
+
+  test("a query or a fragment", () => {
+    expect(isLoopbackRedirect("http://127.0.0.1:8080/callback?next=https://evil.com")).toBe(false);
+    expect(isLoopbackRedirect("http://127.0.0.1:8080/callback#x")).toBe(false);
+  });
+
+  test("any scheme but http", () => {
+    for (const uri of [
+      "https://127.0.0.1:8080/callback",
+      "file:///callback",
+      "javascript:alert(1)//127.0.0.1/callback",
+      "data:text/html,127.0.0.1/callback",
+    ]) {
+      expect(isLoopbackRedirect(uri), uri).toBe(false);
+    }
+  });
+
+  test("a non-loopback address", () => {
+    expect(isLoopbackRedirect("http://10.0.0.5/callback")).toBe(false);
+    expect(isLoopbackRedirect("http://0.0.0.0/callback")).toBe(false);
+    expect(isLoopbackRedirect("http://169.254.169.254/callback")).toBe(false); // cloud metadata
+  });
+
+  test("nonsense", () => {
+    for (const uri of ["", "not a url", "127.0.0.1/callback"]) {
+      expect(isLoopbackRedirect(uri), uri).toBe(false);
+    }
+  });
+});
+
+describe("the marker is opt-in, per client", () => {
+  test("a client without it gets no loopback at all", () => {
+    // kaambaan is a web plane. If it ever asked to redirect to a machine-local port, that is a
+    // compromise, not a feature.
+    expect(isRegisteredRedirect(plane, "http://127.0.0.1:8080/callback")).toBe(false);
+  });
+
+  test("a client with it still gets its exact URIs honoured", () => {
+    const both: OAuthClient = { id: "x", redirectUris: [LOOPBACK_MARKER, "https://x.dev/cb"] };
+    expect(isRegisteredRedirect(both, "https://x.dev/cb")).toBe(true);
+    expect(isRegisteredRedirect(both, "http://127.0.0.1:1/callback")).toBe(true);
+    expect(isRegisteredRedirect(both, "https://x.dev/other")).toBe(false);
+  });
+
+  test("the marker itself is never a usable redirect destination", () => {
+    // A client registering `loopback` must not thereby be able to redirect to the string.
+    expect(isLoopbackRedirect(LOOPBACK_MARKER)).toBe(false);
+  });
+
+  test("and it parses from the registry env the ordinary way", () => {
+    const [apn] = parseOAuthClients("apn|loopback");
+    expect(apn!.id).toBe("apn");
+    expect(isRegisteredRedirect(apn!, "http://127.0.0.1:5555/callback")).toBe(true);
+    expect(isRegisteredRedirect(apn!, "http://localhost:5555/callback")).toBe(false);
+  });
+});

--- a/apps/node-agent/cmd/agentpod-node/fleet.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet.go
@@ -48,6 +48,8 @@ func fleetCmd(args []string) {
 		return
 	}
 	switch args[0] {
+	case "login":
+		fleetLogin(args[1:])
 	case "whoami":
 		fleetWhoami(args[1:])
 	case "logout":

--- a/apps/node-agent/cmd/agentpod-node/fleet_login.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_login.go
@@ -39,8 +39,18 @@ import (
 // authorize, which is the correct posture for a deployment that never asked for this door.
 const clientID = "apn"
 
-// loginTimeout bounds the wait for a human. Generous: it may include signing in.
-const loginTimeout = 5 * time.Minute
+// loginTimeout bounds the wait for a human. Generous by default, because it may include
+// signing in — and overridable, because five minutes is the wrong wait for anything scripted.
+const defaultLoginTimeout = 5 * time.Minute
+
+func loginTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv("AGENTPOD_LOGIN_TIMEOUT")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultLoginTimeout
+}
 
 func randomURLSafe(n int) (string, error) {
 	b := make([]byte, n)
@@ -121,8 +131,8 @@ func fleetLogin(args []string) {
 	var got loginResult
 	select {
 	case got = <-results:
-	case <-time.After(loginTimeout):
-		fmt.Fprintf(os.Stderr, "Timed out after %s waiting for the browser.\n", loginTimeout)
+	case <-time.After(loginTimeout()):
+		fmt.Fprintf(os.Stderr, "Timed out after %s waiting for the browser.\n", loginTimeout())
 		os.Exit(1)
 	}
 	if got.err != nil {
@@ -207,8 +217,20 @@ func exchange(hub, code, verifier, redirectURI string) (string, error) {
 }
 
 // openBrowser is best effort. A failure is not fatal: the URL was printed above, and a headless
-// host is a normal place to run this.
+// host — a server, a container, CI — is a normal place to run this.
+//
+// `$BROWSER` is honoured first, and is the conventional escape hatch on Unix: it may name a
+// command with arguments, so `BROWSER="firefox --private-window"` works. `BROWSER=none` opens
+// nothing and leaves the printed URL as the whole interface, which is what you want over SSH.
 func openBrowser(u string) {
+	if b := strings.TrimSpace(os.Getenv("BROWSER")); b != "" {
+		if b == "none" {
+			return
+		}
+		fields := strings.Fields(b)
+		_ = exec.Command(fields[0], append(fields[1:], u)...).Start()
+		return
+	}
 	var cmd string
 	var args []string
 	switch runtime.GOOS {

--- a/apps/node-agent/cmd/agentpod-node/fleet_login.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_login.go
@@ -1,0 +1,223 @@
+package main
+
+// `apn fleet login` — authorization code with PKCE, against the door agentpod#406 built.
+//
+// No new credential type and no new issuer. The CLI is an OAuth **public client**: it holds no
+// secret, which is why PKCE exists at all — the verifier proves the client redeeming the code is
+// the one that asked for it.
+//
+// The flow, and why each step is where it is:
+//
+//  1. bind a listener on 127.0.0.1 FIRST, so the redirect URI names a port that is already
+//     accepting. Asking for a port after sending the browser is a race the browser wins.
+//  2. open the browser to the hub's authorize endpoint. A top-level NAVIGATION is the point:
+//     the hub's session cookie is SameSite=Lax, which blocks a cross-site fetch and permits
+//     this. That asymmetry is the whole reason the flow exists.
+//  3. the hub redirects back with a one-time code.
+//  4. exchange code + verifier for a token, over HTTP from this process — never in the browser,
+//     so the token never enters a URL, history, or a Referer.
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/rakeshgangwar/agentpod/node-agent/internal/fleetcred"
+)
+
+// clientID is this CLI's entry in the hub's registry. A hub that has not opted in refuses every
+// authorize, which is the correct posture for a deployment that never asked for this door.
+const clientID = "apn"
+
+// loginTimeout bounds the wait for a human. Generous: it may include signing in.
+const loginTimeout = 5 * time.Minute
+
+func randomURLSafe(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+type loginResult struct {
+	code  string
+	state string
+	err   error
+}
+
+func fleetLogin(args []string) {
+	if helpRequested(args) {
+		fmt.Println(commandHelp("fleet"))
+		return
+	}
+	hub := hubBase()
+
+	// 1. Listen first. The redirect URI has to name a port that is already accepting.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not open a local listener: %v\n", err)
+		os.Exit(1)
+	}
+	defer ln.Close()
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", ln.Addr().(*net.TCPAddr).Port)
+
+	verifier, err := randomURLSafe(48)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	state, err := randomURLSafe(24)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	results := make(chan loginResult, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/callback" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		if e := q.Get("error"); e != "" {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			fmt.Fprintf(w, "Sign-in refused: %s\n\nYou can close this tab.", e)
+			results <- loginResult{err: fmt.Errorf("the hub refused: %s", e)}
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintln(w, "Signed in. You can close this tab and return to the terminal.")
+		results <- loginResult{code: q.Get("code"), state: q.Get("state")}
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	authorize := hub + "/api/auth/authorize?" + url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"response_type":         {"code"},
+		"state":                 {state},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+
+	fmt.Printf("Opening %s\n\nIf a browser does not open, visit:\n  %s\n\n", hub, authorize)
+	openBrowser(authorize)
+
+	var got loginResult
+	select {
+	case got = <-results:
+	case <-time.After(loginTimeout):
+		fmt.Fprintf(os.Stderr, "Timed out after %s waiting for the browser.\n", loginTimeout)
+		os.Exit(1)
+	}
+	if got.err != nil {
+		fmt.Fprintln(os.Stderr, got.err)
+		os.Exit(1)
+	}
+	// Checked before the code is spent. `state` is what ties this callback to the request this
+	// process made; without it another page could feed us a code obtained for someone else.
+	if got.state != state {
+		fmt.Fprintln(os.Stderr, "The callback did not carry the state this login sent. Nothing was exchanged.")
+		os.Exit(1)
+	}
+	if got.code == "" {
+		fmt.Fprintln(os.Stderr, "The callback carried no code.")
+		os.Exit(1)
+	}
+
+	token, err := exchange(hub, got.code, verifier, redirectURI)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := fleetcred.Save(token, hub); err != nil {
+		fmt.Fprintf(os.Stderr, "signed in, but could not store the token: %v\n", err)
+		os.Exit(1)
+	}
+
+	claims, _ := fleetcred.Inspect(token)
+	fmt.Printf("Signed in as %s", claims.Subject)
+	if claims.PrincipalKind != "" {
+		fmt.Printf(" (%s)", claims.PrincipalKind)
+	}
+	fmt.Printf("\nToken stored at %s\n", fleetcred.Path())
+}
+
+// exchange trades the code and verifier for a token, from this process rather than the browser.
+func exchange(hub, code, verifier, redirectURI string) (string, error) {
+	body, err := json.Marshal(map[string]string{
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  redirectURI,
+		"client_id":     clientID,
+	})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest("POST", hub+"/api/auth/token/exchange", strings.NewReader(string(body)))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Deliberately no Origin header: the exchange refuses any request carrying one, because a
+	// browser that can reach it is a browser that can spend somebody's code.
+	res, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("could not reach %s: %w", hub, err)
+	}
+	defer res.Body.Close()
+	var out struct {
+		Token            string `json:"token"`
+		AccessToken      string `json:"access_token"`
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("the hub's answer was not JSON (%d)", res.StatusCode)
+	}
+	if res.StatusCode != 200 {
+		if out.ErrorDescription != "" {
+			return "", fmt.Errorf("the hub refused the exchange: %s", out.ErrorDescription)
+		}
+		return "", fmt.Errorf("the hub refused the exchange (%d): %s", res.StatusCode, out.Error)
+	}
+	token := out.Token
+	if token == "" {
+		token = out.AccessToken
+	}
+	if token == "" {
+		return "", fmt.Errorf("the hub returned no token")
+	}
+	return token, nil
+}
+
+// openBrowser is best effort. A failure is not fatal: the URL was printed above, and a headless
+// host is a normal place to run this.
+func openBrowser(u string) {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "windows":
+		cmd, args = "rundll32", []string{"url.dll,FileProtocolHandler"}
+	default:
+		cmd = "xdg-open"
+	}
+	_ = exec.Command(cmd, append(args, u)...).Start()
+}

--- a/apps/node-agent/cmd/agentpod-node/fleet_login_test.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_login_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeHub stands in for the hub's authorize + exchange pair.
+//
+// It asserts the things the CLI is responsible for getting right, because those are invisible
+// from the CLI's own output: that the redirect is loopback, that PKCE is S256 and the verifier
+// really hashes to the challenge, and that the exchange carries no Origin.
+type fakeHub struct {
+	t          *testing.T
+	challenge  string
+	state      string
+	redirect   string
+	sawOrigin  bool
+	issued     string
+	exchanges  int
+	failExchg  bool
+}
+
+func newFakeHub(t *testing.T, issued string) (*httptest.Server, *fakeHub) {
+	h := &fakeHub{t: t, issued: issued}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/auth/authorize", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		h.challenge = q.Get("code_challenge")
+		h.state = q.Get("state")
+		h.redirect = q.Get("redirect_uri")
+
+		if q.Get("code_challenge_method") != "S256" {
+			h.t.Errorf("PKCE method = %q, want S256", q.Get("code_challenge_method"))
+		}
+		if q.Get("client_id") != "apn" {
+			h.t.Errorf("client_id = %q", q.Get("client_id"))
+		}
+		u, err := url.Parse(h.redirect)
+		if err != nil || u.Hostname() != "127.0.0.1" || u.Path != "/callback" {
+			h.t.Errorf("redirect_uri must be a loopback /callback, got %q", h.redirect)
+		}
+
+		back, _ := url.Parse(h.redirect)
+		qq := back.Query()
+		qq.Set("code", "one-time-code")
+		qq.Set("state", h.state)
+		back.RawQuery = qq.Encode()
+		http.Redirect(w, r, back.String(), http.StatusFound)
+	})
+
+	mux.HandleFunc("/api/auth/token/exchange", func(w http.ResponseWriter, r *http.Request) {
+		h.exchanges++
+		if r.Header.Get("Origin") != "" {
+			h.sawOrigin = true
+		}
+		var body struct {
+			Code        string `json:"code"`
+			Verifier    string `json:"code_verifier"`
+			RedirectURI string `json:"redirect_uri"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		// The verifier must actually hash to the challenge. A CLI that sent a fresh random
+		// string here would still "work" against a lax server, and be broken against a real one.
+		sum := sha256.Sum256([]byte(body.Verifier))
+		if got := base64.RawURLEncoding.EncodeToString(sum[:]); got != h.challenge {
+			h.t.Errorf("verifier does not hash to the challenge:\n got %s\nwant %s", got, h.challenge)
+		}
+		if body.RedirectURI != h.redirect {
+			h.t.Errorf("exchange redirect_uri = %q, want %q", body.RedirectURI, h.redirect)
+		}
+		if h.failExchg {
+			w.WriteHeader(400)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "invalid_grant", "error_description": "that code was already spent",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": h.issued})
+	})
+
+	return httptest.NewServer(mux), h
+}
+
+// jwtish builds a token whose payload `whoami` can read.
+func jwtish(sub, kind string) string {
+	p, _ := json.Marshal(map[string]string{"sub": sub, "principalKind": kind})
+	return "aGRy." + base64.RawURLEncoding.EncodeToString(p) + ".c2ln"
+}
+
+func runLogin(t *testing.T, bin, hub, home string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(bin, append([]string{"fleet"}, args...)...)
+	cmd.Env = []string{
+		"HOME=" + home,
+		"XDG_CONFIG_HOME=" + home,
+		"PATH=" + os.Getenv("PATH"),
+		"AGENTPOD_HUB=" + hub,
+		// Stop the real browser opening during tests.
+		"BROWSER=true",
+	}
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	}
+	return string(out), code
+}
+
+func TestLoginStoresATokenAndWhoamiReadsIt(t *testing.T) {
+	bin := build(t)
+	home := t.TempDir()
+	srv, hub := newFakeHub(t, jwtish("prn_login", "human"))
+	defer srv.Close()
+
+	out, code := runLogin(t, bin, srv.URL, home, "login")
+	if code != 0 {
+		t.Fatalf("login failed (%d):\n%s", code, out)
+	}
+	if !strings.Contains(out, "prn_login") {
+		t.Errorf("login should report who signed in:\n%s", out)
+	}
+
+	// The exchange must have happened from the CLI, without an Origin header — the hub refuses
+	// any request carrying one, because a browser that can reach it can spend somebody's code.
+	if hub.exchanges != 1 {
+		t.Errorf("exchanges = %d, want 1", hub.exchanges)
+	}
+	if hub.sawOrigin {
+		t.Error("the exchange must not send an Origin header")
+	}
+
+	// Stored, and only readable by the owner.
+	tokenPath := filepath.Join(home, ".config", "agentpod", "token.json")
+	if _, err := os.Stat(tokenPath); err != nil {
+		// macOS resolves elsewhere; fall back to finding it.
+		matches, _ := filepath.Glob(filepath.Join(home, "**", "agentpod", "token.json"))
+		if len(matches) == 0 {
+			t.Skip("could not locate the token file on this platform layout")
+		}
+		tokenPath = matches[0]
+	}
+	info, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("token file mode = %o, want 600", perm)
+	}
+
+	// And the credential is usable by the next command, which is the real acceptance test.
+	who, code := runLogin(t, bin, srv.URL, home, "whoami")
+	if code != 0 || !strings.Contains(who, "prn_login") {
+		t.Fatalf("whoami after login (%d):\n%s", code, who)
+	}
+}
+
+func TestLoginReportsARefusedExchangeWithoutStoringAnything(t *testing.T) {
+	bin := build(t)
+	home := t.TempDir()
+	srv, hub := newFakeHub(t, jwtish("prn_x", "human"))
+	hub.failExchg = true
+	defer srv.Close()
+
+	out, code := runLogin(t, bin, srv.URL, home, "login")
+	if code == 0 {
+		t.Fatal("a refused exchange must not succeed")
+	}
+	if !strings.Contains(out, "already spent") {
+		t.Errorf("the hub's own reason should reach the operator:\n%s", out)
+	}
+	// Nothing stored: a failed login must leave the previous state alone.
+	who, whoCode := runLogin(t, bin, srv.URL, home, "whoami")
+	if whoCode == 0 {
+		t.Fatalf("whoami should still be unauthenticated:\n%s", who)
+	}
+}
+
+func TestLogoutForgetsTheToken(t *testing.T) {
+	bin := build(t)
+	home := t.TempDir()
+	srv, _ := newFakeHub(t, jwtish("prn_bye", "human"))
+	defer srv.Close()
+
+	if _, code := runLogin(t, bin, srv.URL, home, "login"); code != 0 {
+		t.Fatal("setup login failed")
+	}
+	if out, code := runLogin(t, bin, srv.URL, home, "logout"); code != 0 {
+		t.Fatalf("logout failed:\n%s", out)
+	}
+	if _, code := runLogin(t, bin, srv.URL, home, "whoami"); code == 0 {
+		t.Fatal("whoami should fail after logout")
+	}
+}

--- a/apps/node-agent/cmd/agentpod-node/fleet_login_test.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_login_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeHub stands in for the hub's authorize + exchange pair.
@@ -20,14 +22,14 @@ import (
 // from the CLI's own output: that the redirect is loopback, that PKCE is S256 and the verifier
 // really hashes to the challenge, and that the exchange carries no Origin.
 type fakeHub struct {
-	t          *testing.T
-	challenge  string
-	state      string
-	redirect   string
-	sawOrigin  bool
-	issued     string
-	exchanges  int
-	failExchg  bool
+	t         *testing.T
+	challenge string
+	state     string
+	redirect  string
+	sawOrigin bool
+	issued    string
+	exchanges int
+	failExchg bool
 }
 
 func newFakeHub(t *testing.T, issued string) (*httptest.Server, *fakeHub) {
@@ -99,6 +101,17 @@ func jwtish(sub, kind string) string {
 	return "aGRy." + base64.RawURLEncoding.EncodeToString(p) + ".c2ln"
 }
 
+// runLogin runs `apn fleet …` and, for `login`, PLAYS THE BROWSER ITSELF.
+//
+// The first version of this test set `BROWSER=true` and trusted the platform to open a browser
+// that would follow the redirect. That passes on a developer's Mac, where `open` really works,
+// and hangs for five minutes in CI, where nothing opens anything — the fake hub's authorize
+// endpoint was simply never called. A test whose result depends on a desktop being present is
+// not testing the thing it claims to.
+//
+// So: `BROWSER=none` stops the CLI opening anything, the test scrapes the authorize URL the CLI
+// prints, and fetches it with a client that follows redirects — which is exactly what a browser
+// contributes to this flow and nothing more.
 func runLogin(t *testing.T, bin, hub, home string, args ...string) (string, int) {
 	t.Helper()
 	cmd := exec.Command(bin, append([]string{"fleet"}, args...)...)
@@ -107,15 +120,52 @@ func runLogin(t *testing.T, bin, hub, home string, args ...string) (string, int)
 		"XDG_CONFIG_HOME=" + home,
 		"PATH=" + os.Getenv("PATH"),
 		"AGENTPOD_HUB=" + hub,
-		// Stop the real browser opening during tests.
-		"BROWSER=true",
+		"BROWSER=none",
+		// Short, so a broken flow fails in seconds instead of stalling the package for five
+		// minutes and then panicking the whole binary on the 10-minute deadline.
+		"AGENTPOD_LOGIN_TIMEOUT=20s",
 	}
-	out, err := cmd.CombinedOutput()
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read as it comes, so the authorize URL can be acted on while the CLI is still waiting.
+	var buf strings.Builder
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			line := sc.Text()
+			buf.WriteString(line + "\n")
+			if u := strings.TrimSpace(line); strings.Contains(u, "/api/auth/authorize?") {
+				go visitAsBrowser(u)
+			}
+		}
+	}()
+
+	<-done
+	err = cmd.Wait()
 	code := 0
 	if ee, ok := err.(*exec.ExitError); ok {
 		code = ee.ExitCode()
 	}
-	return string(out), code
+	return buf.String(), code
+}
+
+// visitAsBrowser is the only thing a browser does for this flow: GET the URL and follow the
+// redirect back to the loopback listener.
+func visitAsBrowser(u string) {
+	res, err := (&http.Client{Timeout: 15 * time.Second}).Get(u)
+	if err == nil {
+		_ = res.Body.Close()
+	}
 }
 
 func TestLoginStoresATokenAndWhoamiReadsIt(t *testing.T) {


### PR DESCRIPTION
The last piece before `apn fleet` is usable without hand-placing a token. Two halves; the hub half is the one that needed care.

## The hub half: an exception to exact matching

`isRegisteredRedirect` is full-string equality **on purpose** — its own comment says prefix or origin matching is how an authorize endpoint becomes a credential-minting open redirector. A CLI cannot pin a port, so it needs an exception, and an exception to *that* rule earns scrutiny rather than a wildcard.

**A marker, not a pattern language.** A client registers the literal `loopback` (`apn|loopback`) instead of a URI. `127.0.0.1:*` invites somebody to write `*.agentpod.dev` next, and a registry that accepts one wildcard has already lost the property that makes exact matching safe. Opt-in per client: kaambaan registering a machine-local port would be a compromise, not a feature.

Every clause of `isLoopbackRedirect` is load-bearing:

| refused | why |
|---|---|
| **`localhost`** | **the clause people skip** — it is a *name*, resolved via DNS and `/etc/hosts`, so whoever can answer for it receives the code. Only IP literals are accepted. |
| `127.0.0.1.evil.com` | a host that merely *starts* with the loopback address |
| `/callback/../evil` | `URL` normalises it to `/evil`; the path equality is what refuses it |
| `http://evil.com@127.0.0.1/callback` | userinfo makes a human misread the host in their own browser bar |
| any query or fragment | a credential destination must not be steerable |
| any non-`http` scheme | including `javascript:` and `data:` |
| `169.254.169.254` | not loopback — cloud metadata |

**Fourteen new tests, most of them attacks.** The 57 existing authorize tests still pass, including the one proving a bad `redirect_uri` renders 400 and sends **no `Location`**. That property is older than this exception and had to survive it.

## The CLI half

A public client doing authorization-code + PKCE:

1. **bind the listener first** — asking for a port after sending the browser is a race the browser wins
2. open the browser to authorize — a top-level *navigation*, which `SameSite=Lax` permits where it blocks a fetch. That asymmetry is the whole reason this flow exists.
3. **check `state` before the code is spent**
4. exchange from this process, never the browser — so the token never enters a URL, history or a `Referer` — and **send no `Origin`**, which the hub refuses

The fake hub asserts what the CLI's own output cannot show: that the **verifier really hashes to the challenge** (a CLI sending a fresh random string would pass against a lax server and fail against a real one), that the redirect is loopback, and that no `Origin` is sent. A refused exchange **stores nothing** and leaves the previous credential alone.

## Deploying

Needs `apn|loopback` added to `HUB_OAUTH_CLIENTS` on the hub. Until then authorize refuses `apn`, which is the correct posture for a deployment that has not opted in.

## Tests

`go build`, `go vet`, `go test ./...` clean. Hub suite **0 fail** — the five expiry/grace-window tests that were red on 2026-09-08 are green again on their own, which confirms they track the clock rather than the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr