### PR TITLE
Serialise migrations, so two processes on a fresh database cannot race

### DIFF
--- a/apps/hub/src/db/drizzle.ts
+++ b/apps/hub/src/db/drizzle.ts
@@ -85,19 +85,61 @@ export async function enableVectorExtension(): Promise<void> {
 /**
  * Run pending database migrations
  */
+/**
+ * The advisory-lock key migrations serialise on.
+ *
+ * An arbitrary constant, and it only has to be stable and unlikely to collide: advisory locks
+ * share one namespace per database, so two subsystems picking the same number would block each
+ * other for no reason. Never change it — a new value means an old process and a new one no
+ * longer exclude one another, which is the exact failure this exists to stop.
+ */
+const MIGRATION_LOCK_KEY = 8_472_013_559_001; // < 2^53, so it survives JS number precision
+
+/**
+ * Run pending database migrations, one process at a time.
+ *
+ * **Why the lock.** Drizzle's migrator takes none. On a database that already has its tables
+ * that is harmless — every migration is skipped — but on a FRESH one, two processes both find
+ * nothing applied and both run migration 0000, and the loser dies on
+ * `relation "account" already exists`.
+ *
+ * That is not hypothetical. CI has a fresh Postgres per run, and
+ * `scripts/seed-agent-principals.test.ts` spawns the seed script as its own process while the
+ * test process is also starting up. It failed exactly that way on 2026-09-11, and the reason it
+ * never reproduced locally is that a developer's database is already migrated, so the race has
+ * nothing to race over.
+ *
+ * `pg_advisory_lock` is SESSION-scoped, so it must be taken on one reserved connection rather
+ * than through the pool — a pooled `client\`…\`` can take the lock on one connection and try to
+ * release it on another, which leaves the lock held until that session ends. The `finally`
+ * releases it, and the reservation is released even if the unlock itself fails, so a crash
+ * mid-migration cannot wedge every future boot.
+ */
 export async function runMigrations(): Promise<void> {
   log.info("Running database migrations...");
-  
+
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const migrationsFolder = join(currentDir, "drizzle-migrations");
+
+  const reserved = await client.reserve();
   try {
-    // Get the migrations folder path relative to this file
-    const currentDir = dirname(fileURLToPath(import.meta.url));
-    const migrationsFolder = join(currentDir, "drizzle-migrations");
-    
+    // Blocks rather than failing: the other process is doing the work, and when it finishes
+    // this one finds nothing pending. Waiting is the correct outcome, not an error.
+    await reserved`SELECT pg_advisory_lock(${MIGRATION_LOCK_KEY})`;
     await migrate(db, { migrationsFolder });
     log.info("Database migrations completed successfully");
   } catch (error) {
     log.error("Failed to run migrations", { error });
     throw error;
+  } finally {
+    try {
+      await reserved`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY})`;
+    } catch (error) {
+      // Releasing the connection ends the session, which drops the lock anyway. Worth a line,
+      // never worth masking the migration's own error by throwing from a finally.
+      log.warn("could not release the migration advisory lock", { error });
+    }
+    reserved.release();
   }
 }
 

--- a/apps/hub/tests/integration/migration-race.test.ts
+++ b/apps/hub/tests/integration/migration-race.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Migrations serialise, so two processes on a fresh database do not race.
+ *
+ * Drizzle's migrator takes no lock. On a database that already has its tables that is harmless —
+ * every migration is skipped — but on a FRESH one, two callers both find nothing applied, both
+ * run migration 0000, and the loser dies on `relation "account" already exists`.
+ *
+ * This is not hypothetical. CI gives the hub a fresh Postgres per run, and
+ * `scripts/seed-agent-principals.test.ts` spawns the seed script as its own process while the
+ * test process is starting. It failed exactly that way on 2026-09-11 — and never reproduced on
+ * a developer's machine, because a database that is already migrated has nothing to race over.
+ *
+ * The test therefore has to CREATE the race: a scratch database with no schema, and two
+ * migrations started at once.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+
+const BASE =
+  process.env.DATABASE_URL ??
+  "postgres://agentpod:agentpod-dev-password@localhost:5434/agentpod";
+
+const SCRATCH = `migration_race_${Date.now()}`;
+const adminUrl = BASE.replace(/\/[^/]+$/, "/postgres");
+const scratchUrl = BASE.replace(/\/[^/]+$/, `/${SCRATCH}`);
+const KEY = 8_472_013_559_001;
+
+let admin: ReturnType<typeof postgres>;
+
+beforeAll(async () => {
+  admin = postgres(adminUrl, { max: 1 });
+  await admin.unsafe(`CREATE DATABASE ${SCRATCH}`);
+});
+
+afterAll(async () => {
+  await admin.unsafe(`DROP DATABASE IF EXISTS ${SCRATCH} WITH (FORCE)`);
+  await admin.end();
+});
+
+describe("two processes migrating one fresh database", () => {
+  test("the advisory lock makes the second wait rather than collide", async () => {
+    // Two independent connections, standing in for two processes. The lock is session-scoped,
+    // so separate sessions is exactly the condition it has to survive.
+    const a = postgres(scratchUrl, { max: 2 });
+    const b = postgres(scratchUrl, { max: 2 });
+
+    // What runMigrations does, reduced to the part under test: take the lock on a RESERVED
+    // connection, do work that would collide, release.
+    const migrateLike = async (sql: ReturnType<typeof postgres>, tag: string) => {
+      const reserved = await sql.reserve();
+      try {
+        await reserved`SELECT pg_advisory_lock(${KEY})`;
+        const rows = await reserved`
+          SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                         WHERE table_name = 'race_probe') AS exists`;
+        if (!rows[0]!.exists) {
+          // The collision point: without the lock both callers reach here and the loser fails.
+          await reserved`CREATE TABLE race_probe (who text primary key)`;
+        }
+        await reserved`INSERT INTO race_probe (who) VALUES (${tag})
+                       ON CONFLICT (who) DO NOTHING`;
+      } finally {
+        await reserved`SELECT pg_advisory_unlock(${KEY})`;
+        reserved.release();
+      }
+    };
+
+    const results = await Promise.allSettled([migrateLike(a, "a"), migrateLike(b, "b")]);
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(
+      rejected.map((r) => String((r as PromiseRejectedResult).reason)),
+      "neither caller should fail: the second waits and finds the work done",
+    ).toEqual([]);
+
+    const count = await a`SELECT count(*)::int AS n FROM race_probe`;
+    expect(count[0]!.n, "both callers completed").toBe(2);
+
+    await a.end();
+    await b.end();
+  }, 30_000);
+
+  test("the lock is released, so a later caller is not blocked forever", async () => {
+    // The failure mode of a session-scoped lock taken on a POOLED connection: acquired on one,
+    // released on another, held until that session ends. This proves it came back.
+    const c = postgres(scratchUrl, { max: 1 });
+    const reserved = await c.reserve();
+    const got = await reserved`SELECT pg_try_advisory_lock(${KEY}) AS ok`;
+    expect(got[0]!.ok, "the lock should be free after the previous test").toBe(true);
+    await reserved`SELECT pg_advisory_unlock(${KEY})`;
+    reserved.release();
+    await c.end();
+  }, 15_000);
+});


### PR DESCRIPTION
The cause of the hub CI failures on #416 — and it was never that PR.

## What CI was actually telling us

Two runs, two different failing tests. The second gave the cause:

```
PostgresError: relation "account" already exists
  during: CREATE TABLE "account" (…)
```

**Drizzle's migrator takes no lock.** Against a database that already has its tables that's harmless — every migration is skipped. On a **fresh** one, two callers both find nothing applied, both run migration 0000, and the loser dies.

CI gives the hub a fresh Postgres per run, and `scripts/seed-agent-principals.test.ts` **spawns the seed script as its own process** while the test process is starting. Two processes, one empty database.

## Why it never reproduced locally

Including after I dropped and recreated the database by hand: a developer's database is migrated within milliseconds of being created and thereafter has nothing to race over. The window exists only on the first run against an empty schema — which is precisely the condition CI creates every time and a laptop almost never does.

That also explains the shape of it: **intermittent, and a different test each run**. Whoever loses.

## The fix

`pg_advisory_lock` around the migrate call. Blocking is the correct outcome rather than an error — the other process is doing the work, and when it finishes this one finds nothing pending.

Two details that are the difference between fixing it and moving it:

- **Taken on a reserved connection, not through the pool.** Advisory locks are session-scoped, so a pooled call can acquire on one connection and try to release on another — leaving the lock held until that session ends, turning a transient race into a permanent block.
- **The unlock cannot throw out of the `finally`.** Masking a migration's own error with a cleanup failure is how the real cause gets lost.

**This is not only a test fix.** Two hub instances booting together would have raced identically. It has simply never happened yet.

## What the test covers, and what it doesn't

It creates a scratch database and races two sessions through the acquire/collide/release pattern. **Removing the lock line fails it** — verified.

It does *not* drive `runMigrations` itself, which is bound to the module-level client and can't be pointed at a scratch database without rewriting import-time wiring. The pattern under test is the part that was wrong; I'd rather say that than imply more coverage than exists.

## Correcting the record

I first called this "the known flaky identity test" from the estate backlog. That was too confident — run 1 failed a different assertion, and a half-migrated schema explains it at least as well as an independent flake. Worth revisiting that backlog entry once this lands, since it may have been the same cause all along.

1837 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr