### PR TITLE
apn login sent client_id; the hub reads client

### DIFF
--- a/apps/node-agent/cmd/agentpod-node/fleet_login.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_login.go
@@ -116,8 +116,12 @@ func fleetLogin(args []string) {
 	go func() { _ = srv.Serve(ln) }()
 	defer srv.Close()
 
+	// `client`, NOT `client_id`. The hub reads `c.req.query("client")`, and a name it does not
+	// recognise resolves to the empty string — which then fails as "this hub does not know that
+	// client", a message that sounds like a registry problem and is actually a spelling one.
+	// Exactly the hazard the ecosystem-identity corpus names: a claim's NAME is a contract.
 	authorize := hub + "/api/auth/authorize?" + url.Values{
-		"client_id":             {clientID},
+		"client":                {clientID},
 		"redirect_uri":          {redirectURI},
 		"response_type":         {"code"},
 		"state":                 {state},
@@ -170,11 +174,13 @@ func fleetLogin(args []string) {
 
 // exchange trades the code and verifier for a token, from this process rather than the browser.
 func exchange(hub, code, verifier, redirectURI string) (string, error) {
+	// No client id: the exchange identifies the client by which registered redirect URI the
+	// code was issued for. Sending one anyway would be a field the endpoint ignores, which is
+	// how a reader later concludes it matters.
 	body, err := json.Marshal(map[string]string{
 		"code":          code,
 		"code_verifier": verifier,
 		"redirect_uri":  redirectURI,
-		"client_id":     clientID,
 	})
 	if err != nil {
 		return "", err

--- a/apps/node-agent/cmd/agentpod-node/fleet_login_test.go
+++ b/apps/node-agent/cmd/agentpod-node/fleet_login_test.go
@@ -45,8 +45,23 @@ func newFakeHub(t *testing.T, issued string) (*httptest.Server, *fakeHub) {
 		if q.Get("code_challenge_method") != "S256" {
 			h.t.Errorf("PKCE method = %q, want S256", q.Get("code_challenge_method"))
 		}
-		if q.Get("client_id") != "apn" {
-			h.t.Errorf("client_id = %q", q.Get("client_id"))
+
+		// **Refuse the way the real hub refuses**, rather than merely asserting.
+		//
+		// The first version of this fake read `client_id`, because that is what the CLI sent —
+		// so the test agreed with the bug and the flow "worked" against a hub that does not
+		// exist. The real hub reads `client`, and an unknown name resolves to "" and fails as
+		// "this hub does not know that client": a message that sounds like a registry problem
+		// and is actually a spelling one. Caught on 2026-09-11 against the live hub, after the
+		// tests were green.
+		//
+		// A fake that only asserts is a fake that can be taught the implementation's mistakes.
+		// This one answers like the thing it stands in for, so getting the name wrong fails the
+		// flow instead of an assertion inside it.
+		if q.Get("client") != "apn" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("this hub does not know that client"))
+			return
 		}
 		u, err := url.Parse(h.redirect)
 		if err != nil || u.Hostname() != "127.0.0.1" || u.Path != "/callback" {


### PR DESCRIPTION
`apn fleet login` **could never have worked against a real hub**, and CI was green on everything.

## The bug

The authorize endpoint reads `c.req.query("client")`. The CLI sent `client_id`. An unrecognised name resolves to the empty string, so the hub answered:

> This hub does not know that client. A plane is added to the registry at deployment time, deliberately…

A message that sounds like a **registry** problem and is actually a **spelling** one. I spent a while checking the registry entry, the systemd environment, dotenv shadowing and the process env before reading the route and finding the parameter name.

## The part worth fixing properly

**The tests agreed with the bug.** The fake hub read `client_id` too — because that is what the CLI sent — so the flow "worked" against a hub that does not exist.

A fake that only *asserts* can be taught the implementation's mistakes. This one now **refuses the way the real hub refuses**:

```go
if q.Get("client") != "apn" {
    w.WriteHeader(http.StatusBadRequest)
    _, _ = w.Write([]byte("this hub does not know that client"))
    return
}
```

Reintroducing `client_id` now **fails the login flow** rather than an assertion buried inside it. Verified by doing exactly that.

This is the hazard `fixtures/ecosystem-identity/token_claims.json` names about claims, and it applies to query parameters for the same reason: *the name is the contract*, and getting it wrong fails in the direction that looks like "you have no permission".

## Also

Dropped `client_id` from the exchange body. The exchange identifies the client by **which registered redirect URI the code was issued for** and never reads one — and a field the endpoint ignores is how a later reader concludes it matters.

## Validated against the live hub

After deploying #416 and registering `apn|loopback`:

| request | result |
|---|---|
| `client=apn` + `http://127.0.0.1:5555/callback` | **accepted** — past both client and redirect checks |
| `client=apn` + `http://localhost:5555/callback` | refused: *"not registered for apn"* |
| `client=kaambaan` + loopback | refused: *"not registered for kaambaan"* — the marker is opt-in per client |

`go build`, `go vet`, `go test ./... -race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr