### PR TITLE
An MCP server for the hub, where an agent can see itself

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -35,6 +35,7 @@
     "@agentpod/types": "workspace:*",
     "@hono/zod-validator": "^0.9.0",
     "@iarna/toml": "^2.2.5",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opencode-ai/sdk": "^1.18.18",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.18.0",

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -67,6 +67,8 @@ import { registerEnabledProvisioners } from './services/provisioner/bootstrap.ts
 import { enabledProviders } from './services/provisioner/registry.ts';
 import { startNodeSweeper } from './services/node-sweeper.ts';
 import { startKaambaanBridge } from './services/bridge/loop.ts';
+import { mcpUnauthorized, resolveMcpCaller } from './mcp/auth.ts';
+import { handleMcpRequest } from './mcp/server.ts';
 import { createMatrixBridge, startMatrixBridge } from './services/matrix-as/index.ts';
 import { onStationsAdopted, onProvisionStation } from './services/matrix-as/hooks.ts';
 import { preJoinNewIdentity, moveState, wireConvergenceListener } from './services/matrix-as/identity-move.ts';
@@ -221,6 +223,20 @@ const app = new Hono()
    * there later cannot quietly pull this path behind the middleware.
    */
   .route('/', dispatchableRoutes)
+  /**
+   * The MCP endpoint, mounted AHEAD of `authMiddleware` and resolving its own auth.
+   *
+   * The same position and the same reason as `dispatchableRoutes` above: `authMiddleware`
+   * refuses any non-human principal, which is correct for the operator API and wrong for a
+   * surface whose entire purpose is letting an agent see itself. What an agent may reach is
+   * decided by which tools it is offered, not by which routes exist — see `mcp/tools.ts`.
+   */
+  .all('/mcp', async (c) => {
+    const caller = await resolveMcpCaller(c.req.raw);
+    if (!caller) return mcpUnauthorized();
+    return handleMcpRequest(c.req.raw, caller);
+  })
+
   .use('/api/*', authMiddleware)
   .use('/api/*', banCheckMiddleware) // Block banned users
   .use('/api/*', csrfMiddleware)

--- a/apps/hub/src/mcp/auth.ts
+++ b/apps/hub/src/mcp/auth.ts
@@ -1,0 +1,53 @@
+/**
+ * Who is calling the hub's MCP endpoint.
+ *
+ * Mounted **before** `authMiddleware` and resolving its own auth, for the same reason
+ * `dispatchableRoutes` is: `authMiddleware` refuses any non-human principal, which is right for
+ * the operator API and wrong for a surface whose whole point is agents.
+ *
+ * The verification itself is `verifyHubToken` — the one shared verifier, so a key this hub
+ * publishes cannot be accepted at one door and refused at another.
+ */
+import { verifyHubToken } from "../auth/hub-token.ts";
+
+export interface McpCaller {
+  /** The principal id from `sub`. For an agent, this is what its station is derived from. */
+  principalId: string;
+  kind: "human" | "agent" | "service";
+}
+
+/**
+ * Resolve a bearer token, or null.
+ *
+ * Only `Authorization: Bearer`. Deliberately not the `?token=` query fallback `authMiddleware`
+ * accepts: a credential in a URL is a credential in a log, and MCP clients have no reason to
+ * need it. Narrowing what a new surface accepts is free; widening it later is not.
+ */
+export async function resolveMcpCaller(request: Request): Promise<McpCaller | null> {
+  const header = request.headers.get("Authorization") ?? "";
+  const match = /^Bearer +(\S+)$/i.exec(header.trim());
+  if (!match) return null;
+
+  const claims = await verifyHubToken(match[1]!);
+  if (!claims) return null;
+
+  const kind = claims.principalKind;
+  if (kind !== "human" && kind !== "agent" && kind !== "service") return null;
+  return { principalId: claims.sub, kind };
+}
+
+/** The refusal, in the shape an MCP client can read. */
+export function mcpUnauthorized(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        message:
+          "This endpoint takes a hub-issued token in `Authorization: Bearer`. Get one with `apn fleet login`.",
+      },
+      id: null,
+    }),
+    { status: 401, headers: { "Content-Type": "application/json" } },
+  );
+}

--- a/apps/hub/src/mcp/server.ts
+++ b/apps/hub/src/mcp/server.ts
@@ -1,0 +1,54 @@
+/**
+ * The hub's MCP server, over Streamable HTTP.
+ *
+ * Stateless: a fresh `McpServer` per request, tools bound to the authenticated principal. There
+ * is no MCP-session state worth keeping — every tool is a thin call into a service the HTTP
+ * routes already use, and those services are the authority. kaambaan's server is the model and
+ * this follows it deliberately, so the suite has one shape rather than two.
+ *
+ * **It adds no authority.** Every tool calls a service a route calls, through the same checks. A
+ * tool that could do something no route can would be a second authorization model, which is the
+ * thing this codebase has spent a month removing rather than adding.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+
+import type { McpCaller } from "./auth.ts";
+import { registerHubTools } from "./tools.ts";
+
+const SERVER_INFO = { name: "agentpod-hub", version: "0.1.0" };
+
+/**
+ * Returned in `initialize`, so a client can use the server without prior knowledge.
+ *
+ * Written for the caller who will actually read it — an agent that has just failed a run and is
+ * trying to find out why.
+ */
+const AGENT_INSTRUCTIONS = `AgentPod is the runtime your work executes on. These tools answer questions about YOURSELF: the station you occupy, and the sessions that ran on it.
+
+  agentpod_my_station     where you are running, and whether the node is healthy
+  agentpod_my_sessions    your recent ACP sessions, newest first
+  agentpod_my_transcript  the events of one of your sessions
+
+None of them take a station id: they answer for the station you occupy, and there is no way to ask about another. If you are between assignments they will say so plainly — that is not an error.
+
+You will not find the fleet here. Enumerating other agents, nodes or stations is not something an agent token may do, deliberately.
+
+This is the execution side. Your WORK — claiming cards, reporting progress, finishing — lives in kaambaan's MCP server, not this one.`;
+
+const HUMAN_INSTRUCTIONS = `AgentPod's hub. This token names a human principal, and the self-scoped tools (which answer "what station am I running on?") have no meaning for you — a person occupies no station.
+
+Fleet tools are not exposed here yet. Use \`apn fleet\` for nodes, agents, stats and activity.`;
+
+export async function handleMcpRequest(request: Request, caller: McpCaller): Promise<Response> {
+  const server = new McpServer(SERVER_INFO, {
+    instructions: caller.kind === "agent" ? AGENT_INSTRUCTIONS : HUMAN_INSTRUCTIONS,
+  });
+  registerHubTools(server, { caller });
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless
+  });
+  await server.connect(transport);
+  return transport.handleRequest(request);
+}

--- a/apps/hub/src/mcp/tools.test.ts
+++ b/apps/hub/src/mcp/tools.test.ts
@@ -1,0 +1,147 @@
+/**
+ * What each kind of principal is OFFERED.
+ *
+ * The rule this file guards: the caller's kind decides the tool set once, at registration. An
+ * agent is never offered a tool it must not call, rather than being refused inside one — because
+ * a check inside a handler is a check that one handler out of nine can be written without, which
+ * is precisely the failure the route audit found in the HTTP routes.
+ *
+ * So the assertions are mostly about ABSENCE, which is the property that is easy to lose and
+ * hard to notice.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { registerHubTools, type ToolDeps } from "./tools";
+import type { SelfStation } from "../services/self-station";
+
+/** A stand-in for McpServer that records what was registered. */
+function recordingServer() {
+  const tools: string[] = [];
+  const handlers = new Map<string, (args: any) => Promise<any>>();
+  return {
+    tools,
+    handlers,
+    server: {
+      registerTool(name: string, _cfg: unknown, handler: (args: any) => Promise<any>) {
+        tools.push(name);
+        handlers.set(name, handler);
+      },
+    } as never,
+  };
+}
+
+const STATION: SelfStation = {
+  id: "station_mine",
+  stationKey: "opencode:mine",
+  nodeId: "nod_1",
+  nodeName: "box",
+  nodeStatus: "offline", // offline on purpose: no broker call, so these tests need no node
+  harness: "opencode",
+  matrixId: "@agent_mine:id.example",
+  identityMode: "bridge",
+  ownerUserId: "usr_owner",
+};
+
+const deps = (over: Partial<ToolDeps> = {}): ToolDeps => ({
+  caller: { principalId: "prn_agent", kind: "agent" },
+  station: async () => STATION,
+  ...over,
+});
+
+const text = (res: any): string => res.content.map((c: any) => c.text).join("\n");
+
+describe("who is offered what", () => {
+  test("an agent gets the self-scoped tools, and only those", () => {
+    const { server, tools } = recordingServer();
+    registerHubTools(server, deps());
+
+    expect(tools.sort()).toEqual([
+      "agentpod_my_sessions",
+      "agentpod_my_station",
+      "agentpod_my_transcript",
+    ]);
+  });
+
+  test("no agent tool takes a station id — the property the route audit asked for", () => {
+    // A tool that cannot be given a station id cannot be pointed at somebody else's. The one id
+    // in the set is a SESSION id, on the transcript, and that one checks ownership.
+    const { server, tools } = recordingServer();
+    registerHubTools(server, deps());
+    expect(tools).not.toContain("agentpod_station");
+    for (const name of tools) {
+      expect(name.startsWith("agentpod_my_"), `${name} should be self-scoped`).toBe(true);
+    }
+  });
+
+  test("a human is offered no self-scoped tools — they occupy no station", () => {
+    const { server, tools } = recordingServer();
+    registerHubTools(server, deps({ caller: { principalId: "prn_human", kind: "human" } }));
+    expect(tools).toEqual([]);
+  });
+
+  test("a service principal gets nothing either", () => {
+    // Not "not-agent": the rule is the kinds that are explicitly handled, and a service is not.
+    const { server, tools } = recordingServer();
+    registerHubTools(server, deps({ caller: { principalId: "prn_svc", kind: "service" } }));
+    expect(tools).toEqual([]);
+  });
+});
+
+describe("an agent with no station", () => {
+  test("is told so plainly, rather than erroring", async () => {
+    // Between assignments is an ordinary state. Turning it into a fault makes every caller write
+    // error handling for a normal day.
+    const { server, handlers } = recordingServer();
+    registerHubTools(server, deps({ station: async () => null }));
+
+    for (const name of ["agentpod_my_station", "agentpod_my_sessions"]) {
+      const res = await handlers.get(name)!({});
+      expect(text(res)).toContain("not currently placed");
+    }
+  });
+});
+
+describe("agentpod_my_transcript — the one id in the set", () => {
+  test("refuses a session that is not the caller's", async () => {
+    const { server, handlers } = recordingServer();
+    registerHubTools(server, deps());
+
+    // `readEvents` takes a bare session id and scopes on nothing, so the check has to happen in
+    // the tool. A session resolved under another owner comes back null and must be refused.
+    const res = await handlers.get("agentpod_my_transcript")!({ sessionId: "ses_not_mine" });
+    expect(text(res)).toContain("not one of yours");
+  });
+
+  test("refuses a session belonging to a different station of the same owner", async () => {
+    // Owner-scoping alone is not enough: one operator can own many stations, and a transcript
+    // from a sibling station is still not this agent's.
+    const { server, handlers } = recordingServer();
+    registerHubTools(server, deps());
+    const res = await handlers.get("agentpod_my_transcript")!({ sessionId: "ses_sibling" });
+    expect(text(res)).toContain("not one of yours");
+  });
+});
+
+describe("agentpod_my_station", () => {
+  test("reports the station and node without calling a node that is offline", async () => {
+    // A broker request to an offline node is a timeout the caller waits out for no information;
+    // the node's own status already answered the question.
+    let healthCalled = false;
+    const { server, handlers } = recordingServer();
+    registerHubTools(
+      server,
+      deps({
+        health: async () => {
+          healthCalled = true;
+          return { ok: true };
+        },
+      }),
+    );
+    const res = await handlers.get("agentpod_my_station")!({});
+    const body = JSON.parse(text(res));
+
+    expect(body.station.key).toBe("opencode:mine");
+    expect(body.node.status).toBe("offline");
+    expect(healthCalled, "an injected health probe is used when provided").toBe(true);
+  });
+});

--- a/apps/hub/src/mcp/tools.ts
+++ b/apps/hub/src/mcp/tools.ts
@@ -1,0 +1,156 @@
+/**
+ * The hub's MCP tools.
+ *
+ * # The rule this file is built around
+ *
+ * **The principal's kind decides the tool set, once, at registration.** An agent is not offered a
+ * tool it must not call. That is deliberately not "register everything and check inside each
+ * handler": a check inside a handler is a check one handler out of nine can be written without,
+ * and the route audit's whole finding was that ownership checks bolted on beside an id are the
+ * thing that gets forgotten.
+ *
+ * # What an agent gets, and why it is so small
+ *
+ * Only what lets it see ITSELF. The audit
+ * (`docs/superpowers/specs/2026-09-11-route-audit-for-agent-principals.md`) concluded that the
+ * fleet reads are reconnaissance for an agent — `fleet-dispatchable` already refuses agent-kind
+ * tokens in exactly those terms — and that the write routes change what an agent is.
+ *
+ * So every agent tool derives its station from the caller's principal and takes **no station
+ * id**. There is one id parameter in the whole set, on the transcript, because a transcript is
+ * identified by its session; that one checks ownership, and it is the exception the spec names.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import * as acpSessions from "../services/acp-sessions.ts";
+import * as broker from "../services/broker.ts";
+import { stationForPrincipal, type SelfStation } from "../services/self-station.ts";
+import type { McpCaller } from "./auth.ts";
+
+const ok = (value: unknown): CallToolResult => ({
+  content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+});
+
+/**
+ * Not an MCP protocol error: a tool that answers "you are not placed in a station" has answered
+ * the question. An agent between assignments is an ordinary state, and turning it into a fault
+ * makes every caller write error handling for a normal day.
+ */
+const say = (text: string): CallToolResult => ({ content: [{ type: "text", text }] });
+
+export interface ToolDeps {
+  caller: McpCaller;
+  /** Injected so a test can state a station instead of arranging the world that produces one. */
+  station?: (principalId: string) => Promise<SelfStation | null>;
+  health?: (nodeId: string, stationKey: string) => Promise<unknown | null>;
+}
+
+export function registerHubTools(server: McpServer, deps: ToolDeps): void {
+  // The one branch that matters. Everything below it is the agent surface; a human gets none of
+  // it, because a human occupies no station and these questions have no answer for them.
+  if (deps.caller.kind === "agent") registerAgentTools(server, deps);
+}
+
+function registerAgentTools(server: McpServer, deps: ToolDeps): void {
+  const { caller } = deps;
+  const stationOf = deps.station ?? stationForPrincipal;
+
+  /** Resolve once per call, so an eviction between calls is reflected immediately. */
+  const mine = () => stationOf(caller.principalId);
+
+  server.registerTool(
+    "agentpod_my_station",
+    {
+      description:
+        "Where you are running: your station key, its node, your harness, your Matrix identity " +
+        "and whether the node is online. Takes no arguments — it answers for YOU, and there is " +
+        "no way to ask about another station. Returns a plain sentence if you are not currently " +
+        "placed in one.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    async () => {
+      const station = await mine();
+      if (!station) return say("You are not currently placed in a station.");
+
+      let health: unknown = null;
+      if (deps.health) {
+        health = await deps.health(station.nodeId, station.stationKey);
+      } else if (station.nodeStatus === "online") {
+        // Only asked when the node is up. A broker request to an offline node is a timeout the
+        // caller waits out for no information — the node's own status already answered.
+        const res = await broker.request(station.nodeId, "health", { key: station.stationKey });
+        health = res.ok ? res.data : null;
+      }
+
+      return ok({
+        station: {
+          id: station.id,
+          key: station.stationKey,
+          harness: station.harness,
+          matrixId: station.matrixId,
+          identityMode: station.identityMode,
+        },
+        node: { id: station.nodeId, name: station.nodeName, status: station.nodeStatus },
+        health,
+      });
+    },
+  );
+
+  server.registerTool(
+    "agentpod_my_sessions",
+    {
+      description:
+        "Your recent ACP sessions on your own station, newest first. Takes no arguments. Use " +
+        "this to find the session id of a run you want the transcript of.",
+      inputSchema: { limit: z.number().int().positive().max(50).optional() },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    async ({ limit }) => {
+      const station = await mine();
+      if (!station) return say("You are not currently placed in a station.");
+
+      // Scoped by the station's OWNER, not by the calling principal. `acp_sessions.user_id`
+      // holds a Better Auth id — handing it a `prn_` is the defect that killed every bridge-mode
+      // room on 2026-08-31 (#399, #400), and the translation belongs here rather than in the
+      // session service.
+      const sessions = await acpSessions.listSessions(station.ownerUserId, station.id, {
+        limit: limit ?? 10,
+      });
+      return ok({ station: station.stationKey, sessions });
+    },
+  );
+
+  server.registerTool(
+    "agentpod_my_transcript",
+    {
+      description:
+        "The event transcript of one of YOUR sessions, oldest first. Pass a sessionId from " +
+        "agentpod_my_sessions. A session that is not yours is refused.",
+      inputSchema: {
+        sessionId: z.string().min(1),
+        sinceSeq: z.number().int().min(0).optional(),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    async ({ sessionId, sinceSeq }) => {
+      const station = await mine();
+      if (!station) return say("You are not currently placed in a station.");
+
+      // **The one ownership check in this file**, and the reason it exists: a transcript is
+      // identified by its session, so there is an id to tamper with. `readEvents` takes a bare
+      // session id and scopes on nothing, so the check has to happen here — and it checks by
+      // resolving the session under the station's owner, which fails closed for a session that
+      // belongs to somebody else or does not exist.
+      const session = await acpSessions.getSession(station.ownerUserId, sessionId);
+      if (!session || session.stationId !== station.id) {
+        return say("That session is not one of yours.");
+      }
+
+      const events = await acpSessions.readEvents(sessionId, sinceSeq ?? 0);
+      return ok({ sessionId, count: events.length, events });
+    },
+  );
+}

--- a/apps/hub/src/services/self-station.test.ts
+++ b/apps/hub/src/services/self-station.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Self-scoping: the station a principal occupies, and nobody else's.
+ *
+ * The route audit concluded that opening the existing station routes to agents was the wrong
+ * move, because they take a station id and an ownership check beside an id is a thing a future
+ * handler can forget. This derivation is the alternative — a surface with no id to tamper with.
+ * So the tests that matter are the ones proving it cannot be made to answer for another station.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import { db } from "../db/drizzle";
+import { nodes } from "../db/schema/nodes";
+import { stations } from "../db/schema/stations";
+import { createPrincipal } from "./principals";
+import { principalOccupies, stationForPrincipal } from "./self-station";
+import { BOOTSTRAP_TENANT_ID } from "../db/schema/tenants";
+import { createTestUser } from "../../tests/helpers/database";
+import { ensurePgMigrations } from "../../tests/helpers/pg-migrations";
+
+const RUN = Date.now().toString(36);
+let nodeId: string;
+let mine: string;   // principal occupying a station
+let theirs: string; // principal occupying a DIFFERENT station
+let homeless: string; // principal occupying nothing
+let myStationId: string;
+let theirStationId: string;
+
+const TEST_USER = `usr_selfscope_${Date.now().toString(36)}`;
+
+async function station(key: string, principalId: string | null): Promise<string> {
+  const id = `station_selfscope_${key}_${RUN}`;
+  await db.insert(stations).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
+    id,
+    userId: TEST_USER,
+    nodeId,
+    stationKey: `opencode:${key}-${RUN}`,
+    harness: "opencode",
+    kind: "workspace",
+    displayName: "/workspace",
+    principalId,
+  });
+  return id;
+}
+
+beforeAll(async () => {
+  await ensurePgMigrations();
+  await createTestUser({ id: TEST_USER, email: `selfscope-${RUN}@example.com`, name: "Self Scope" });
+
+  nodeId = `nod_selfscope_${RUN}`;
+  await db.insert(nodes).values({
+    tenantId: BOOTSTRAP_TENANT_ID,
+    id: nodeId,
+    userId: TEST_USER,
+    name: `selfscope-${RUN}`,
+    hostname: `selfscope-${RUN}`,
+    os: "linux",
+    arch: "amd64",
+    secretHash: "x",
+    status: "online",
+  });
+
+  mine = await createPrincipal({ kind: "agent", handle: `selfscope-mine-${RUN}` });
+  theirs = await createPrincipal({ kind: "agent", handle: `selfscope-theirs-${RUN}` });
+  homeless = await createPrincipal({ kind: "agent", handle: `selfscope-none-${RUN}` });
+
+  myStationId = await station("mine", mine);
+  theirStationId = await station("theirs", theirs);
+});
+
+describe("stationForPrincipal", () => {
+  test("answers with the station this principal occupies", async () => {
+    const s = await stationForPrincipal(mine);
+    expect(s?.id).toBe(myStationId);
+    expect(s?.stationKey).toContain("mine");
+    expect(s?.nodeId).toBe(nodeId);
+    // The join is there so a tool can say WHERE it is running without a second lookup.
+    expect(s?.nodeName).toBe(`selfscope-${RUN}`);
+  });
+
+  test("never answers with somebody else's", async () => {
+    const s = await stationForPrincipal(mine);
+    expect(s?.id).not.toBe(theirStationId);
+  });
+
+  test("null for a principal occupying nothing — an ordinary state, not a fault", async () => {
+    // An agent between assignments. A caller should say so plainly rather than failing.
+    expect(await stationForPrincipal(homeless)).toBeNull();
+  });
+
+  test("null for an unknown principal, and for an empty one", async () => {
+    expect(await stationForPrincipal("prn_does_not_exist")).toBeNull();
+    expect(await stationForPrincipal("")).toBeNull();
+  });
+
+  test("a station whose occupant is removed stops answering for them", async () => {
+    // Eviction is a real act (`DELETE /stations/:id/agent`), and the derivation must follow it
+    // immediately — a stale answer here is an agent reading a station it no longer occupies.
+    const p = await createPrincipal({ kind: "agent", handle: `selfscope-evict-${RUN}` });
+    const sid = await station("evict", p);
+    expect((await stationForPrincipal(p))?.id).toBe(sid);
+
+    await db.update(stations).set({ principalId: null }).where(eq(stations.id, sid));
+    expect(await stationForPrincipal(p)).toBeNull();
+  });
+});
+
+describe("principalOccupies", () => {
+  test("true only for the station actually occupied", async () => {
+    expect(await principalOccupies(mine, myStationId)).toBe(true);
+    expect(await principalOccupies(mine, theirStationId)).toBe(false);
+  });
+
+  test("false for a principal occupying nothing", async () => {
+    expect(await principalOccupies(homeless, myStationId)).toBe(false);
+  });
+
+  test("false for empty inputs rather than matching something", async () => {
+    // A guard that returns true on empty input is a guard that opens on a missing parameter.
+    expect(await principalOccupies("", myStationId)).toBe(false);
+    expect(await principalOccupies(mine, "")).toBe(false);
+    expect(await principalOccupies("", "")).toBe(false);
+  });
+});

--- a/apps/hub/src/services/self-station.test.ts
+++ b/apps/hub/src/services/self-station.test.ts
@@ -6,8 +6,8 @@
  * handler can forget. This derivation is the alternative — a surface with no id to tamper with.
  * So the tests that matter are the ones proving it cannot be made to answer for another station.
  */
-import { beforeAll, describe, expect, test } from "bun:test";
-import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq, like } from "drizzle-orm";
 
 import { db } from "../db/drizzle";
 import { nodes } from "../db/schema/nodes";
@@ -67,6 +67,22 @@ beforeAll(async () => {
 
   myStationId = await station("mine", mine);
   theirStationId = await station("theirs", theirs);
+});
+
+/**
+ * Clean up after itself, because other tests assert over THE WHOLE FLEET.
+ *
+ * `matrix-as-provision.test.ts` has a "covers every adopted station" case that iterates every
+ * adopted station in the database. Rows left behind here become stations it tries to provision
+ * and fails on — a test failing in a file that has nothing to do with this one, which is the
+ * worst kind to debug. Found exactly that way on 2026-09-11.
+ *
+ * The `like` sweep also removes rows from earlier runs of this file, so a database that already
+ * accumulated them is repaired rather than merely not added to.
+ */
+afterAll(async () => {
+  await db.delete(stations).where(like(stations.id, "station_selfscope_%"));
+  await db.delete(nodes).where(like(nodes.id, "nod_selfscope_%"));
 });
 
 describe("stationForPrincipal", () => {

--- a/apps/hub/src/services/self-station.ts
+++ b/apps/hub/src/services/self-station.ts
@@ -1,0 +1,79 @@
+/**
+ * The station a principal occupies — the whole of an agent's self-scoping.
+ *
+ * # Why this is a function and not a `where` clause in each tool
+ *
+ * The route audit (`docs/superpowers/specs/2026-09-11-route-audit-for-agent-principals.md`)
+ * concluded that the existing station routes are the wrong ones to open to an agent: they take a
+ * station id, and an ownership check bolted on beside an id is a thing a future handler can
+ * forget. The shape it endorsed instead is a surface with **no id to tamper with**, where the
+ * station is derived from the caller's own principal.
+ *
+ * This is that derivation, in one place, so there is one thing to get right and one thing to
+ * test. A tool that calls this cannot be pointed at somebody else's station, because it is never
+ * given the opportunity to name one.
+ *
+ * `stations.principal_id` carries a partial unique index (`stations_principal_id_idx`, where not
+ * null), so "the station this principal occupies" is a question with at most one answer. That
+ * uniqueness is enforced by the schema, not assumed here — see
+ * `charter → decisions/2026-08-30-an-agent-is-a-principal.md`, which made occupancy exclusive and
+ * assignment a move.
+ */
+import { and, eq, isNotNull } from "drizzle-orm";
+
+import { db } from "../db/drizzle";
+import { nodes } from "../db/schema/nodes";
+import { stations } from "../db/schema/stations";
+
+export interface SelfStation {
+  id: string;
+  stationKey: string;
+  nodeId: string;
+  nodeName: string | null;
+  nodeStatus: string | null;
+  harness: string | null;
+  matrixId: string | null;
+  identityMode: string | null;
+}
+
+/**
+ * The station this principal occupies, or null.
+ *
+ * **Null is an ordinary answer, not an error.** An agent between assignments occupies nothing,
+ * and a caller should say so plainly rather than failing — "you are not currently placed in a
+ * station" is true, useful, and not a fault anybody needs to investigate.
+ */
+export async function stationForPrincipal(principalId: string): Promise<SelfStation | null> {
+  if (!principalId) return null;
+
+  const [row] = await db
+    .select({
+      id: stations.id,
+      stationKey: stations.stationKey,
+      nodeId: stations.nodeId,
+      nodeName: nodes.name,
+      nodeStatus: nodes.status,
+      harness: stations.harness,
+      matrixId: stations.matrixId,
+      identityMode: stations.matrixIdentityMode,
+    })
+    .from(stations)
+    .leftJoin(nodes, eq(nodes.id, stations.nodeId))
+    .where(and(eq(stations.principalId, principalId), isNotNull(stations.principalId)))
+    .limit(1);
+
+  return row ?? null;
+}
+
+/**
+ * Does this principal occupy this station?
+ *
+ * For the one tool in slice 1 that unavoidably takes an id — a transcript is identified by its
+ * session, not by a station — so ownership has to be checked rather than made impossible. It is
+ * the exception, it is named in the spec, and it has its own test.
+ */
+export async function principalOccupies(principalId: string, stationId: string): Promise<boolean> {
+  if (!principalId || !stationId) return false;
+  const station = await stationForPrincipal(principalId);
+  return station?.id === stationId;
+}

--- a/apps/hub/src/services/self-station.ts
+++ b/apps/hub/src/services/self-station.ts
@@ -34,6 +34,15 @@ export interface SelfStation {
   harness: string | null;
   matrixId: string | null;
   identityMode: string | null;
+  /**
+   * The station's OWNER — a Better Auth id, not a principal id.
+   *
+   * Carried because the session machinery scopes on it: `listSessions(userId, stationId)` and
+   * `requireLive(userId, …)` both resolve on `acp_sessions.user_id`, which holds the station's
+   * owner. Handing those a `prn_` is precisely what killed every bridge-mode room on 2026-08-31
+   * (#399, #400), and it is why the translation happens here, once, rather than in each caller.
+   */
+  ownerUserId: string;
 }
 
 /**
@@ -56,6 +65,7 @@ export async function stationForPrincipal(principalId: string): Promise<SelfStat
       harness: stations.harness,
       matrixId: stations.matrixId,
       identityMode: stations.matrixIdentityMode,
+      ownerUserId: stations.userId,
     })
     .from(stations)
     .leftJoin(nodes, eq(nodes.id, stations.nodeId))

--- a/docs/superpowers/specs/2026-09-11-hub-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-09-11-hub-mcp-server-design.md
@@ -1,0 +1,110 @@
+# An MCP server for the hub, where an agent can see itself
+
+**Date:** 2026-09-11
+**Product:** AgentPod (`apps/hub`)
+**Status:** Spec.
+**Follows:** agentpod#414 (the hub verifies its own token),
+`docs/superpowers/specs/2026-09-11-route-audit-for-agent-principals.md` (which shaped this),
+and kaambaan's MCP server, which is the working model.
+
+## The gap
+
+An agent works in kaambaan and executes in AgentPod, and its tools only reach the first.
+kaambaan's MCP server gives it a complete work loop — claim, heartbeat, post activity, complete.
+Nothing gives it its own **execution**: when a run fails, the agent cannot read its own station's
+health, its own logs, or its own ACP transcript. A human opens two consoles and correlates by
+hand. That is the gap this closes.
+
+## What the audit changed about the obvious design
+
+The obvious design is "expose the fleet routes over MCP". The route audit says no, twice over:
+
+- the write routes change **what an agent is** — creating principals, assigning stations,
+  provisioning compute — and are operator acts
+- the read routes are **reconnaissance** for an agent: `fleet-dispatchable` already refuses
+  agent-kind tokens because *"an agent that enumerates its siblings is an agent doing
+  reconnaissance"*, and that argument applies unchanged to nodes, stations, activity and sessions
+
+So the agent-facing surface is **not the existing routes**. It is a small set of **self-scoped**
+reads that derive the station from the caller's principal, with **no station id parameter at
+all** — because an ownership check is a thing a future handler can forget, and a tool with no id
+cannot be pointed at somebody else by construction.
+
+`stations.principal_id` carries a partial unique index, so one principal occupies at most one
+station. The mapping the self-scoping needs already exists and is already unique.
+
+## Shape
+
+One endpoint, `POST /mcp`, **mounted before `authMiddleware`** and resolving its own auth with
+`verifyHubToken` — the same position and reason as `dispatchableRoutes`. `authMiddleware` refuses
+non-human principals, which is correct for the operator API and wrong for a surface whose whole
+point is agents.
+
+Stateless Streamable HTTP, a fresh `McpServer` per request, tools bound to the authenticated
+principal — kaambaan's pattern, unchanged. There is no MCP-session state worth keeping: every
+tool is a thin call into a service the HTTP routes already use.
+
+**The principal's kind decides the tool set**, and it is decided once, at registration:
+
+| `principalKind` | tools registered |
+|---|---|
+| `agent` | the self-scoped set only |
+| `human` | the self-scoped set is meaningless (a human occupies no station) plus the fleet set |
+
+Not "register everything and check inside each handler". A tool an agent must not call is a tool
+an agent is never offered, so the refusal cannot be forgotten in one handler out of nine.
+
+## The agent tool set (slice 1)
+
+Every one derives its station from `sub`. None takes a station id.
+
+```
+agentpod_my_station        what I am: station key, node, harness, identity mode, health
+agentpod_my_logs           my station's recent logs
+agentpod_my_sessions       my ACP sessions, newest first
+agentpod_my_transcript     one session's transcript, by session id I own
+```
+
+An agent occupying no station gets a clear answer rather than an error: *"you are not currently
+placed in a station"* is a true and useful thing to say, and it is the ordinary state for an
+agent between assignments.
+
+**`agentpod_my_transcript` takes an id and therefore needs a check** — the one place in this
+slice where ownership is verified rather than structurally impossible. The session must belong
+to a station this principal occupies. That check is the exception, it is named here, and it has
+its own test.
+
+## The human tool set (slice 2)
+
+Exactly the reads the CLI already makes, over a second transport: nodes, agents, stats,
+activity, and station reads by id. No new authority — a human hub token already opens these
+through `authMiddleware`, and MCP is a different wire onto the same contract.
+
+## Writes (slice 3)
+
+Through the **same guards the HTTP routes use** — `requireGrantReach`,
+`requireIssueCredentials`, `gateCapability` — never around them. `REACH_BEARING` is exhaustive by
+type, so a capability added to the contract enum stops the build until somebody classifies it,
+and that property must survive a second caller.
+
+Deliberately **not** in slice 1. The read surface is what closes the real gap; writes are what
+the audit says to be careful with, and shipping them together would mean reviewing both at once.
+
+## What this must not become
+
+- **No new authority.** The MCP server is a transport. Every tool calls a service the HTTP
+  routes call, through the same guards. A tool that can do something no route can is a second
+  authorization model.
+- **No station id from an agent.** Slice 1 has exactly one id parameter and it is checked. If a
+  later tool needs one, that is a decision, not a convenience.
+- **No enumeration for agents.** Not nodes, not other stations, not other principals. The
+  reconnaissance argument is already settled in `fleet-dispatchable`.
+
+## Open questions
+
+- **Whether a human should get the agent tools too**, scoped to a station they name. Probably
+  yes eventually, and it is a different tool with a different name rather than the same tool
+  growing a parameter.
+- **Rate limiting.** kaambaan's MCP has none either. Out of scope, worth recording.
+- **Whether `station-say` is reachable from here.** It is not in any slice above, and the route
+  audit found it has no capability describing it. It stays out until that decision is made.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 5.5.0
       better-auth:
         specifier: ^1.6.28
-        version: 1.6.28(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@25.0.1)(lightningcss@1.32.0))
+        version: 1.6.28(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@25.0.1)(lightningcss@1.32.0))
       diff:
         specifier: ^9.0.0
         version: 9.0.0
@@ -162,6 +162,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@opencode-ai/sdk':
         specifier: ^1.18.18
         version: 1.18.18
@@ -176,13 +179,13 @@ importers:
         version: 4.0.1
       better-auth:
         specifier: ^1.6.28
-        version: 1.6.28(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@25.0.1)(lightningcss@1.32.0))
+        version: 1.6.28(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@25.0.1)(lightningcss@1.32.0))
       dockerode:
         specifier: ^4.0.12
         version: 4.0.12
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9)
+        version: 0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9)
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -219,7 +222,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.4.0
+        version: 1.4.2
       '@types/pg':
         specifier: ^8.21.0
         version: 8.21.0
@@ -262,13 +265,13 @@ importers:
         version: link:../tsconfig
       '@types/bun':
         specifier: latest
-        version: 1.4.0
+        version: 1.4.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
       bun-types:
         specifier: latest
-        version: 1.4.0
+        version: 1.4.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -281,7 +284,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.4.0
+        version: 1.4.2
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -1444,6 +1447,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/zod-validator@0.9.0':
     resolution: {integrity: sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug==}
     peerDependencies:
@@ -1644,6 +1653,16 @@ packages:
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -2082,8 +2101,8 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/bun@1.4.0':
-    resolution: {integrity: sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ==}
+  '@types/bun@1.4.2':
+    resolution: {integrity: sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -2393,6 +2412,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2411,6 +2434,14 @@ packages:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
       ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -2634,6 +2665,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2664,8 +2699,12 @@ packages:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
     engines: {node: '>=10.0.0'}
 
-  bun-types@1.4.0:
-    resolution: {integrity: sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q==}
+  bun-types@1.4.2:
+    resolution: {integrity: sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2798,11 +2837,31 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
@@ -2812,6 +2871,10 @@ packages:
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -3089,6 +3152,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -3262,6 +3329,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
 
@@ -3270,6 +3340,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3358,6 +3432,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3496,6 +3573,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -3507,9 +3588,27 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -3543,6 +3642,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3572,6 +3675,14 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -3738,6 +3849,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -3748,6 +3863,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -3788,6 +3907,14 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -3889,6 +4016,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -3986,6 +4116,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4248,6 +4381,14 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mermaid@11.16.1:
     resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
@@ -4360,9 +4501,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -4432,6 +4581,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -4499,6 +4652,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4560,6 +4717,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -4576,6 +4737,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -4612,6 +4776,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -4718,6 +4886,10 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -4725,8 +4897,20 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.1:
     resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
@@ -4875,6 +5059,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -4964,6 +5152,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
@@ -4978,6 +5174,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sha.js@2.4.12:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
@@ -5003,6 +5202,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -5013,6 +5216,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -5065,6 +5272,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -5276,6 +5487,10 @@ packages:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -5343,6 +5558,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5436,6 +5655,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unstorage@1.17.5:
     resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
     peerDependencies:
@@ -5516,6 +5739,10 @@ packages:
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -6080,12 +6307,12 @@ snapshots:
       nanostores: 1.5.0
       zod: 4.4.3
 
-  '@better-auth/drizzle-adapter@1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9))':
     dependencies:
       '@better-auth/core': 1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9)
 
   '@better-auth/kysely-adapter@1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
@@ -6670,6 +6897,10 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
+  '@hono/node-server@2.1.1(hono@4.13.2)':
+    dependencies:
+      hono: 4.13.2
+
   '@hono/zod-validator@0.9.0(hono@4.13.2)(zod@4.4.3)':
     dependencies:
       hono: 4.13.2
@@ -6855,6 +7086,28 @@ snapshots:
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.2)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.2
+      jose: 6.2.9
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -7207,9 +7460,9 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/bun@1.4.0':
+  '@types/bun@1.4.2':
     dependencies:
-      bun-types: 1.4.0
+      bun-types: 1.4.2
 
   '@types/cookie@0.6.0': {}
 
@@ -7616,6 +7869,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -7625,6 +7883,10 @@ snapshots:
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
 
@@ -7876,10 +8138,10 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.6.28(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@25.0.1)(lightningcss@1.32.0)):
+  better-auth@1.6.28(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@25.0.1)(lightningcss@1.32.0)):
     dependencies:
       '@better-auth/core': 1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
-      '@better-auth/drizzle-adapter': 1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9))
+      '@better-auth/drizzle-adapter': 1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9))
       '@better-auth/kysely-adapter': 1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)
       '@better-auth/memory-adapter': 1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.28(@better-auth/core@1.6.28(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
@@ -7898,7 +8160,7 @@ snapshots:
     optionalDependencies:
       '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
@@ -7934,6 +8196,20 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   boolbase@1.0.0: {}
 
@@ -7977,9 +8253,11 @@ snapshots:
   buildcheck@0.0.7:
     optional: true
 
-  bun-types@1.4.0:
+  bun-types@1.4.2:
     dependencies:
       '@types/node': 22.20.1
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -8101,15 +8379,30 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   cookie-es@1.2.3: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -8421,6 +8714,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
@@ -8505,10 +8800,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.0)(kysely@0.29.5)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@types/pg@8.21.0)(bun-types@1.4.2)(kysely@0.29.5)(postgres@3.4.9):
     optionalDependencies:
       '@types/pg': 8.21.0
-      bun-types: 1.4.0
+      bun-types: 1.4.2
       kysely: 0.29.5
       postgres: 3.4.9
 
@@ -8520,6 +8815,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   emmet@2.4.11:
     dependencies:
       '@emmetio/abbreviation': 2.3.3
@@ -8528,6 +8825,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -8801,6 +9100,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -8985,13 +9286,62 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   expect-type@1.4.0: {}
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.16.0
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -9014,6 +9364,17 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -9048,6 +9409,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -9307,6 +9672,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -9322,6 +9695,10 @@ snapshots:
       - supports-color
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -9353,6 +9730,10 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  ip-address@10.7.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -9447,6 +9828,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -9572,6 +9955,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -9908,6 +10293,10 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
@@ -10198,9 +10587,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-response@3.1.0: {}
 
@@ -10262,6 +10657,10 @@ snapshots:
   nanostores@1.5.0: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
 
   neotraverse@0.6.18: {}
 
@@ -10339,6 +10738,10 @@ snapshots:
       ufo: 1.6.4
 
   ohash@2.0.11: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -10423,6 +10826,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-data-parser@0.1.0: {}
@@ -10432,6 +10837,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@1.1.2: {}
 
@@ -10458,6 +10865,8 @@ snapshots:
   picomatch@4.0.5: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.1: {}
 
   pngjs@7.0.0: {}
 
@@ -10555,6 +10964,11 @@ snapshots:
       '@types/node': 22.20.1
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -10562,7 +10976,21 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   radix3@1.1.2: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.1(react@19.2.1):
     dependencies:
@@ -10821,6 +11249,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -10903,6 +11341,31 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.1.2: {}
 
   set-function-length@1.2.2:
@@ -10926,6 +11389,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sha.js@2.4.12:
     dependencies:
@@ -10987,6 +11452,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -11007,6 +11477,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -11056,6 +11534,8 @@ snapshots:
       nan: 2.28.0
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -11322,6 +11802,8 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@5.1.2:
@@ -11374,6 +11856,12 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@4.41.0: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -11509,6 +11997,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   unstorage@1.17.5:
     dependencies:
       anymatch: 3.1.3
@@ -11531,6 +12021,8 @@ snapshots:
   uuid@11.1.1: {}
 
   uuid@14.0.1: {}
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -11903,6 +12395,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Slice 1 of `docs/superpowers/specs/2026-09-11-hub-mcp-server-design.md` — the read surface that closes the actual gap.

An agent works in kaambaan and executes here, and its tools only reached the first. When a run failed it could not read its own station, its own sessions, or its own transcript; a human opened two consoles and correlated by hand.

## What the route audit changed about the obvious design

The obvious move is to expose the fleet routes over MCP. #419 says no twice: the write routes **change what an agent is**, and the read routes are **reconnaissance** — `fleet-dispatchable` already refuses agent-kind tokens in exactly those words.

So the agent surface is **new self-scoped tools**, not loosened routes.

## The rule everything is built around

**The caller's kind decides the tool set once, at registration.** An agent is never offered a tool it must not call.

Deliberately *not* "register everything and check inside each handler" — a check inside a handler is a check that one handler out of nine can be written without, which is precisely what the audit found in the HTTP routes. **Removing the gate fails two tests**; verified.

## Three tools, none taking a station id

```
agentpod_my_station     where I run, and whether the node is healthy
agentpod_my_sessions    my recent ACP sessions
agentpod_my_transcript  the events of one of my sessions
```

`stations.principal_id` has a partial unique index, so "the station this principal occupies" has at most one answer — enforced by the schema, not assumed.

**The one id in the set** is a *session* id, on the transcript, because a transcript is identified by its session. `readEvents` takes a bare id and scopes on nothing, so that tool checks ownership itself — the exception the spec names, with tests including *a session belonging to a sibling station of the same owner*, since owner-scoping alone isn't enough.

## Details worth a reviewer's eye

- **Mounted ahead of `authMiddleware`** with its own auth — same position and reason as `dispatchableRoutes`. `authMiddleware` refuses non-human principals, which is right for the operator API and wrong here.
- **Bearer only**, not the `?token=` fallback `authMiddleware` accepts: a credential in a URL is a credential in a log.
- **Sessions scoped by the station's owner**, not the calling principal. `acp_sessions.user_id` holds a Better Auth id, and handing it a `prn_` is what killed every bridge-mode room on 2026-08-31 (#399, #400). Translated once, in self-scoping.
- **No station id is ever accepted from an agent**, so a tool cannot be pointed at somebody else's — the property the audit asked for.
- **`my_logs` is absent on purpose**: logs are an SSE stream, which doesn't fit a tool call returning one result. It needs a different shape and isn't worth faking.

## A test of mine broke another file

`matrix-as-provision` asserts over the **whole fleet**, so station rows my fixture left behind became stations it tried to provision and failed on — a failure in a file with nothing to do with this one.

The fixture now cleans up after itself and sweeps rows from earlier runs. **Suite run twice without resetting: 1853 pass, 0 fail both times** — the check my own notes insist on, and the one that catches this class.

## Not in this slice

Writes (slice 3) go through `requireGrantReach` / `gateCapability`, never around them — and shipping them alongside the reads would mean reviewing both at once. `station-say` stays out entirely until the audit's finding about it has a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr