### PR TITLE
Docs: the two modes, the client registry, and a limitation in the honesty test

### DIFF
--- a/apps/hub/tests/unit/docs-claims.test.ts
+++ b/apps/hub/tests/unit/docs-claims.test.ts
@@ -68,6 +68,13 @@ const CODE_FILES = [
   "apps/hub/src/utils/validate-config.ts",
   "apps/console/vite.config.js",
   "apps/console/src/lib/api/client.ts",
+  // The CLI reads env vars too, and OPERATING.md is where an operator is told
+  // to set them. Added 2026-09-12 with `apn fleet`: without it, documenting
+  // AGENTPOD_TOKEN failed as "a variable nothing reads" — which was the test
+  // being right about its list and wrong about the codebase.
+  "apps/node-agent/cmd/agentpod-node/fleet.go",
+  "apps/node-agent/cmd/agentpod-node/fleet_login.go",
+  "apps/node-agent/internal/fleetcred/fleetcred.go",
   // A shell script an operator runs is code that reads env vars, and the ones
   // OPERATING.md §7e tells them to export are read here rather than by the hub.
   "scripts/onboard-agent.sh",
@@ -174,6 +181,18 @@ describe("environment variables the hub names in a boot message", () => {
     ]) {
       // A SCREAMING_SNAKE name inside a string literal in these files is,
       // without exception today, a variable being named to an operator.
+      //
+      // **"In these files" is load-bearing, and the list does not generalise.**
+      // Tried and reverted on 2026-09-12: adding `routes/auth-authorize.ts`,
+      // which refuses with "Fix HUB_OAUTH_CLIENTS.", catches nothing and
+      // introduces a false positive. `scanEnvNames` matches a name that is the
+      // WHOLE string literal, so a setting named inside a sentence is invisible
+      // to it, while `"S256"` — a PKCE method constant — reads as a variable.
+      //
+      // The consequence worth knowing: a variable this hub names only in the
+      // PROSE of a refusal is one nothing makes anybody document.
+      // HUB_OAUTH_CLIENTS went undocumented through three PRs and a production
+      // deploy that way, and was written up by hand rather than by this test.
       //
       // Comments are stripped first (#323): this could not tell a backticked
       // name in a JSDoc line from a string literal, so a comment about an

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -526,6 +526,47 @@ duplicate `key`.
 
 ---
 
+### The OAuth client registry
+
+A plane on its own domain cannot read the hub's session cookie: it is `SameSite=Lax`, and
+`kaambaan.dev` is a different site from `agentpod.dev`. The authorization-code flow
+(`GET /api/auth/authorize` → `POST /api/auth/token/exchange`) exists so a browser can *navigate*
+to the hub — which `Lax` permits — and hand the plane's server a one-time code.
+
+| Variable | Meaning |
+|---|---|
+| `HUB_OAUTH_CLIENTS` | Who may **receive** a token. Comma-separated `client\|redirect_uri`; repeat the client key for several URIs. **Empty by default**, and a hub that has not opted in refuses every authorize. |
+
+**This is deliberately not `ALLOWED_ORIGINS`.** They answer different questions: that list says
+who may *call* the hub from a browser; this one says who may *be handed a credential for whoever
+is signed in*. Being permitted to make a request must not by itself confer the right to receive a
+token, which is why the two are separate and this one starts empty.
+
+Redirect matching is **full-string equality**. Prefix or origin matching is how an authorize
+endpoint becomes a credential-minting open redirector: `https://k.dev/hub/callback/../../evil`
+shares an origin and a prefix with the registered URI and is not it.
+
+**One exception, for native apps.** A client may register the literal `loopback` instead of a URI
+— `apn|loopback` — which permits `http://127.0.0.1:<any port>/callback` and `[::1]`, and nothing
+else. A CLI cannot pin a port, so it cannot register an exact URI. Everything about that rule is
+narrow on purpose:
+
+- **`localhost` is refused.** It is a *name*, resolved through DNS and `/etc/hosts`, so whoever
+  can answer for it receives the authorization code. Only the IP literals are accepted.
+- the path must be exactly `/callback`; no query, no fragment, no userinfo, no scheme but `http`
+- it is **opt-in per client** — kaambaan registering a machine-local port would be a compromise,
+  not a feature
+
+A malformed entry is skipped rather than thrown, so a typo cannot stop the hub booting for a
+feature it may not use — but a skipped entry is simply not in the registry, and authorize refuses
+what it cannot find. The refusal names this variable.
+
+Example, registering the web plane and the CLI:
+
+```
+HUB_OAUTH_CLIENTS=kaambaan|https://kaambaan.dev/hub/callback,apn|loopback
+```
+
 ## 5. Hub — build + deploy
 
 ```bash

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -99,6 +99,74 @@ single-use (`enrollment_tokens.used_at`) and scoped to the operator account
 
 ---
 
+## 1a. Two modes: acting as a machine, or as yourself
+
+`apn` is the node agent, and every verb above acts on **the machine it runs on**, authenticating
+as that machine with the `<nodeId>:<nodeSecret>` written by `apn enroll`. On a laptop, in CI, or
+inside an agent's workspace there is nothing to act *as* — which is where `apn fleet` comes in.
+
+| mode | acts as | credential |
+|---|---|---|
+| `apn node …` | this machine | `<nodeId>:<nodeSecret>` from the node's config |
+| `apn fleet …` | you, or an agent | a hub token |
+
+`apn node <verb>` is the explicit spelling; the bare forms keep working, so `apn status` and
+`apn node status` are the same command and every existing runbook still reads correctly.
+
+### Signing in
+
+```sh
+apn fleet login          # opens a browser, stores a token
+apn fleet whoami         # who that token says you are, and when it expires
+apn fleet logout
+```
+
+`login` is authorization-code with PKCE against the hub, and the browser only ever performs a
+top-level navigation — which is what makes it work at all, since the hub's session cookie is
+`SameSite=Lax` and would not be sent on a cross-site fetch. The token is exchanged by `apn`
+itself, so it never enters a URL, your shell history, or a `Referer`.
+
+The hub must have the CLI registered — `apn|loopback` in `HUB_OAUTH_CLIENTS`, see
+[DEPLOYMENT.md](./DEPLOYMENT.md#the-oauth-client-registry). Without
+it, authorize refuses, which is the correct posture for a hub that has not opted in.
+
+### Reading the fleet
+
+```sh
+apn fleet nodes
+apn fleet agents
+apn fleet stats
+apn fleet activity
+```
+
+Output is the hub's own JSON, passed through rather than reformatted — a client that summarises a
+payload it does not fully model silently drops the field somebody needed.
+
+### Settings
+
+| Variable | Meaning |
+|---|---|
+| `AGENTPOD_TOKEN` | A hub token, used instead of the stored one. What CI and an agent harness set. |
+| `AGENTPOD_HUB` | The hub to talk to. Defaults to `https://hub.agentpod.dev`. |
+| `AGENTPOD_LOGIN_TIMEOUT` | How long `login` waits for the browser. Defaults to five minutes — right for a person, wrong for anything scripted. |
+| `BROWSER` | The command `login` opens. May carry arguments. `BROWSER=none` opens nothing and leaves the printed URL as the whole interface, which is what you want over SSH. |
+
+```sh
+AGENTPOD_TOKEN=… apn fleet nodes
+```
+
+### The rule worth knowing
+
+**A fleet command never falls back to the node's credential.** With no token it fails and tells
+you to sign in; it does not quietly act as the machine. A node secret says *"I am this host"* and
+is not an authority to operate the fleet — so the fleet verbs are present on every enrolled
+station and useless there without a token the node does not have.
+
+Two failures that look alike and are not: **401 means sign in**, **403 means your principal may
+not do this**. `apn` reports them differently on purpose. In particular a hub token naming an
+**agent** is refused from the operator API with 403 — agents reach the hub through its MCP
+endpoint, not these verbs.
+
 ## 2. Adopt stations
 
 After a node connects, AgentPod runs its harness descriptors to detect runtimes on the host. Each detected runtime appears as a **station** (what the design calls a cubicle) in the console's station list.


### PR DESCRIPTION
First pass of the docs work: **correct what shipped before publishing anything.** Publishing docs carrying the same class of false claims I found in kaambaan's `docs/01` would be worse than not publishing.

## What was missing

- `OPERATING.md` documented **nine `apn` verbs and neither of the two modes** the CLI now has
- `AGENTPOD_TOKEN` and `AGENTPOD_LOGIN_TIMEOUT` appeared **nowhere**
- **`HUB_OAUTH_CLIENTS`** — the registry deciding who may be handed a token for whoever is signed in — was documented in **no operator-facing file**, through three PRs and a production deploy

Now written down: the node/fleet split and the rule that a fleet command never falls back to the node's credential; `apn fleet login` and why a *top-level navigation* is what makes it work at all; the four settings; and that **401 and 403 mean different things**, since a hub token naming an agent is refused from the operator API by design.

`DEPLOYMENT.md` gains the client registry, including the loopback exception and **why `localhost` is refused where `127.0.0.1` is not** — it is a name, resolved through DNS, so whoever can answer for it receives the code.

## A limitation found by trying to enforce this — and reverted

The natural fix was to have `docs-claims` scan `routes/auth-authorize.ts`, which refuses with *"Fix HUB_OAUTH_CLIENTS."*

**It does not work.** `scanEnvNames` matches a name that is the *whole* string literal, so a setting named inside a sentence is invisible to it — while `"S256"`, a PKCE method constant, reads as a variable. The test's own qualifier — *"a SCREAMING_SNAKE name inside a string literal **in these files**"* — was load-bearing, and I hadn't read it closely enough before changing it.

Reverted, and the limitation recorded where the file list is so nobody repeats the attempt:

> a variable this hub names only in the PROSE of a refusal is one nothing makes anybody document

That is exactly how `HUB_OAUTH_CLIENTS` escaped, and it was written up by hand rather than by the test.

## One widening that is right

`CODE_FILES` now includes the CLI's Go sources. Documenting `AGENTPOD_TOKEN` failed as *"a variable nothing reads"* — the test being correct about its list and wrong about the codebase, since the node-agent is part of it.

## Checked and deliberately not changed

`"apn manage"` in OPERATING.md reads like a command. It is prose — *"let apn manage it as a persistent service"* — and no such verb exists. I checked before "fixing" it, and invented nothing to match.

1837 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr