### PR TITLE
apn: `fleet login` was implemented, dispatched, and missing from its own help

### DIFF
--- a/apps/node-agent/cmd/agentpod-node/help.go
+++ b/apps/node-agent/cmd/agentpod-node/help.go
@@ -19,6 +19,7 @@ var commands = []struct {
 		name: "fleet", group: "Fleet",
 		oneline: "Act on the fleet as a signed-in principal (whoami, nodes, agents, stats)",
 		detail: "apn fleet <verb> — act on the fleet as a PRINCIPAL, not as this machine.\n\n" +
+			"  apn fleet login            sign in and store a hub token\n" +
 			"  apn fleet whoami [--json]   who the stored token says you are\n" +
 			"  apn fleet logout            forget the stored token\n" +
 			"  apn fleet nodes             the fleet's nodes\n" +

--- a/apps/node-agent/cmd/agentpod-node/help_test.go
+++ b/apps/node-agent/cmd/agentpod-node/help_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -150,5 +152,42 @@ func TestMaybeShowHelpCoversEveryRegisteredCommand(t *testing.T) {
 				t.Errorf("maybeShowHelp(%q, [--json]) wrote output, want none:\n%s", c.name, buf.String())
 			}
 		})
+	}
+}
+
+// TestFleetHelpListsEveryVerb guards the gap that shipped: `login` was
+// implemented and dispatched in fleet.go, but `apn fleet` help listed six
+// verbs and not that one — so the single command a new operator needs first
+// was the one command help would not tell them about.
+//
+// The verbs are read out of fleet.go's own switch rather than restated here,
+// because a list maintained by hand beside the list it mirrors is the thing
+// that drifted in the first place.
+func TestFleetHelpListsEveryVerb(t *testing.T) {
+	src, err := os.ReadFile("fleet.go")
+	if err != nil {
+		t.Fatalf("read fleet.go: %v", err)
+	}
+
+	verbs := regexp.MustCompile(`(?m)^\tcase "([a-z]+)":`).FindAllStringSubmatch(string(src), -1)
+	if len(verbs) < 5 {
+		t.Fatalf("found only %d fleet verbs in fleet.go — the pattern stopped matching", len(verbs))
+	}
+
+	// Matched against the VERB LIST, not the whole help text. The detail block
+	// also mentions verbs in prose ("the file `apn fleet login` writes"), and a
+	// plain substring check is satisfied by that sentence — which is exactly how
+	// a missing verb passed an earlier version of this test.
+	listed := map[string]bool{}
+	for _, line := range strings.Split(commandHelp("fleet"), "\n") {
+		if m := regexp.MustCompile(`^  apn fleet ([a-z]+)`).FindStringSubmatch(line); m != nil {
+			listed[m[1]] = true
+		}
+	}
+
+	for _, v := range verbs {
+		if !listed[v[1]] {
+			t.Errorf("fleet verb %q is dispatched in fleet.go but not listed in `apn fleet` help", v[1])
+		}
 	}
 }


### PR DESCRIPTION
Found while auditing the CLI surface for the published docs.

`apn fleet` help lists its verbs:

```
apn fleet whoami [--json]   who the stored token says you are
apn fleet logout            forget the stored token
apn fleet nodes             the fleet's nodes
apn fleet agents            the agents you may dispatch
apn fleet stats             fleet totals
apn fleet activity          recent fleet activity
```

Six verbs. `fleet.go` dispatches **seven** — `login` has been there the whole time, and it's the one an operator needs before any of the others can work.

## Why it survived

The detail block already mentions it in passing, in a sentence about where the token is stored: *"from `$AGENTPOD_TOKEN` or the file `apn fleet login` writes"*. Anyone grepping for the string found it and moved on.

## The guard

`TestFleetHelpListsEveryVerb` reads the verbs out of `fleet.go`'s own switch rather than restating them — a hand-kept list beside the list it mirrors is exactly what drifted here.

**The first version of this test was vacuous.** It used `strings.Contains(help, "apn fleet "+verb)`, which the prose sentence above satisfies. I deleted the `login` line to watch it fail, and it passed. The committed version matches against the rendered verb list instead, and fails as it should:

```
--- FAIL: TestFleetHelpListsEveryVerb
    help_test.go:190: fleet verb "login" is dispatched in fleet.go but not listed in `apn fleet` help
```

## Verification

- `go test ./...` — all packages pass
- `apn help fleet` now lists `login` first, before `whoami`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr