### PR TITLE
hub: "this token names a agent"

### DIFF
--- a/apps/hub/src/routes/fleet-dispatchable.ts
+++ b/apps/hub/src/routes/fleet-dispatchable.ts
@@ -139,8 +139,8 @@ export function createDispatchableRoutes(deps: DispatchableDeps = {}) {
     if (claims.principalKind !== "human") {
       return c.json(
         refuse(
-          "Only a human principal may enumerate dispatchable agents. This token names a " +
-            `${typeof claims.principalKind === "string" ? claims.principalKind : "principal of unknown kind"}.`
+          "Only a human principal may enumerate dispatchable agents. This token's principal kind is " +
+            `${typeof claims.principalKind === "string" ? claims.principalKind : "not stated"}.`
         ),
         401
       );

--- a/docs-site/.astro/collections/docs.schema.json
+++ b/docs-site/.astro/collections/docs.schema.json
@@ -1,0 +1,643 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "editUrl": {
+      "default": true,
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "head": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "type": "string",
+            "enum": [
+              "title",
+              "base",
+              "link",
+              "style",
+              "meta",
+              "script",
+              "noscript",
+              "template"
+            ]
+          },
+          "attrs": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                },
+                {}
+              ]
+            }
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag"
+        ]
+      }
+    },
+    "tableOfContents": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "minHeadingLevel": {
+              "default": 2,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            },
+            "maxHeadingLevel": {
+              "default": 3,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            }
+          }
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "template": {
+      "default": "doc",
+      "type": "string",
+      "enum": [
+        "doc",
+        "splash"
+      ]
+    },
+    "hero": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "tagline": {
+          "type": "string"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "alt": {
+                  "default": "",
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "alt": {
+                  "default": "",
+                  "type": "string"
+                },
+                "dark": {
+                  "type": "string"
+                },
+                "light": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dark",
+                "light"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "html": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "html"
+              ]
+            }
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "variant": {
+                "default": "primary",
+                "type": "string",
+                "enum": [
+                  "primary",
+                  "secondary",
+                  "minimal"
+                ]
+              },
+              "icon": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "up-caret",
+                      "down-caret",
+                      "right-caret",
+                      "left-caret",
+                      "up-arrow",
+                      "down-arrow",
+                      "right-arrow",
+                      "left-arrow",
+                      "bars",
+                      "translate",
+                      "pencil",
+                      "pen",
+                      "document",
+                      "add-document",
+                      "setting",
+                      "link",
+                      "link-alt",
+                      "external",
+                      "download",
+                      "cloud-download",
+                      "moon",
+                      "sun",
+                      "clock",
+                      "laptop",
+                      "desktop",
+                      "mobile-android",
+                      "window",
+                      "database",
+                      "server",
+                      "code-branch",
+                      "open-book",
+                      "notes",
+                      "information",
+                      "magnifier",
+                      "forward-slash",
+                      "close",
+                      "error",
+                      "warning",
+                      "approve-check-circle",
+                      "approve-check",
+                      "question-circle",
+                      "question",
+                      "rocket",
+                      "star",
+                      "puzzle",
+                      "list-format",
+                      "analytics",
+                      "random",
+                      "padlock",
+                      "comment",
+                      "comment-alt",
+                      "heart",
+                      "github",
+                      "gitlab",
+                      "bitbucket",
+                      "forgejo",
+                      "codePen",
+                      "farcaster",
+                      "discord",
+                      "gitter",
+                      "twitter",
+                      "x.com",
+                      "mastodon",
+                      "codeberg",
+                      "youtube",
+                      "threads",
+                      "linkedin",
+                      "twitch",
+                      "azureDevOps",
+                      "microsoftTeams",
+                      "instagram",
+                      "stackOverflow",
+                      "telegram",
+                      "whatsApp",
+                      "rss",
+                      "facebook",
+                      "email",
+                      "phone",
+                      "reddit",
+                      "patreon",
+                      "signal",
+                      "slack",
+                      "matrix",
+                      "hackerOne",
+                      "openCollective",
+                      "blueSky",
+                      "discourse",
+                      "zulip",
+                      "pinterest",
+                      "tiktok",
+                      "goodreads",
+                      "hypothesis",
+                      "astro",
+                      "solidjs",
+                      "alpine",
+                      "pnpm",
+                      "biome",
+                      "bun",
+                      "mdx",
+                      "apple",
+                      "linux",
+                      "homebrew",
+                      "nix",
+                      "starlight",
+                      "pkl",
+                      "node",
+                      "cloudflare",
+                      "vercel",
+                      "netlify",
+                      "deno",
+                      "jsr",
+                      "nostr",
+                      "backstage",
+                      "confluence",
+                      "jira",
+                      "storybook",
+                      "vscode",
+                      "jetbrains",
+                      "zed",
+                      "vim",
+                      "figma",
+                      "sketch",
+                      "npm",
+                      "npmx",
+                      "sourcehut",
+                      "substack",
+                      "chrome",
+                      "edge",
+                      "firefox",
+                      "safari",
+                      "seti:folder",
+                      "seti:bsl",
+                      "seti:mdo",
+                      "seti:salesforce",
+                      "seti:asm",
+                      "seti:bicep",
+                      "seti:bazel",
+                      "seti:c",
+                      "seti:c-sharp",
+                      "seti:html",
+                      "seti:cpp",
+                      "seti:clojure",
+                      "seti:coldfusion",
+                      "seti:config",
+                      "seti:crystal",
+                      "seti:crystal_embedded",
+                      "seti:json",
+                      "seti:css",
+                      "seti:csv",
+                      "seti:xls",
+                      "seti:cu",
+                      "seti:cake",
+                      "seti:cake_php",
+                      "seti:d",
+                      "seti:word",
+                      "seti:elixir",
+                      "seti:elixir_script",
+                      "seti:hex",
+                      "seti:elm",
+                      "seti:favicon",
+                      "seti:f-sharp",
+                      "seti:git",
+                      "seti:go",
+                      "seti:godot",
+                      "seti:gradle",
+                      "seti:grails",
+                      "seti:graphql",
+                      "seti:hacklang",
+                      "seti:haml",
+                      "seti:mustache",
+                      "seti:haskell",
+                      "seti:haxe",
+                      "seti:jade",
+                      "seti:java",
+                      "seti:javascript",
+                      "seti:jinja",
+                      "seti:julia",
+                      "seti:karma",
+                      "seti:kotlin",
+                      "seti:dart",
+                      "seti:liquid",
+                      "seti:livescript",
+                      "seti:lua",
+                      "seti:markdown",
+                      "seti:argdown",
+                      "seti:info",
+                      "seti:clock",
+                      "seti:maven",
+                      "seti:nim",
+                      "seti:github",
+                      "seti:notebook",
+                      "seti:nunjucks",
+                      "seti:npm",
+                      "seti:ocaml",
+                      "seti:odata",
+                      "seti:perl",
+                      "seti:php",
+                      "seti:pipeline",
+                      "seti:pddl",
+                      "seti:plan",
+                      "seti:happenings",
+                      "seti:powershell",
+                      "seti:prisma",
+                      "seti:pug",
+                      "seti:puppet",
+                      "seti:purescript",
+                      "seti:python",
+                      "seti:react",
+                      "seti:rescript",
+                      "seti:R",
+                      "seti:ruby",
+                      "seti:rust",
+                      "seti:sass",
+                      "seti:spring",
+                      "seti:slim",
+                      "seti:smarty",
+                      "seti:sbt",
+                      "seti:scala",
+                      "seti:ethereum",
+                      "seti:stylus",
+                      "seti:svelte",
+                      "seti:swift",
+                      "seti:db",
+                      "seti:terraform",
+                      "seti:tex",
+                      "seti:default",
+                      "seti:twig",
+                      "seti:typescript",
+                      "seti:tsconfig",
+                      "seti:vala",
+                      "seti:vite",
+                      "seti:vue",
+                      "seti:wasm",
+                      "seti:wat",
+                      "seti:xml",
+                      "seti:yml",
+                      "seti:prolog",
+                      "seti:zig",
+                      "seti:zip",
+                      "seti:wgt",
+                      "seti:illustrator",
+                      "seti:photoshop",
+                      "seti:pdf",
+                      "seti:font",
+                      "seti:image",
+                      "seti:svg",
+                      "seti:sublime",
+                      "seti:code-search",
+                      "seti:shell",
+                      "seti:video",
+                      "seti:audio",
+                      "seti:windows",
+                      "seti:jenkins",
+                      "seti:babel",
+                      "seti:bower",
+                      "seti:docker",
+                      "seti:code-climate",
+                      "seti:eslint",
+                      "seti:firebase",
+                      "seti:firefox",
+                      "seti:gitlab",
+                      "seti:grunt",
+                      "seti:gulp",
+                      "seti:ionic",
+                      "seti:platformio",
+                      "seti:rollup",
+                      "seti:stylelint",
+                      "seti:yarn",
+                      "seti:webpack",
+                      "seti:lock",
+                      "seti:license",
+                      "seti:makefile",
+                      "seti:heroku",
+                      "seti:todo",
+                      "seti:ignored"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "format": "starts_with",
+                    "pattern": "^<svg.*"
+                  }
+                ]
+              },
+              "attrs": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "text",
+              "link"
+            ]
+          }
+        }
+      }
+    },
+    "lastUpdated": {
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "prev": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "link": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "next": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "link": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "sidebar": {
+      "default": {},
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string"
+        },
+        "hidden": {
+          "default": false,
+          "type": "boolean"
+        },
+        "badge": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "variant": {
+                  "default": "default",
+                  "type": "string",
+                  "enum": [
+                    "note",
+                    "danger",
+                    "success",
+                    "caution",
+                    "tip",
+                    "default"
+                  ]
+                },
+                "class": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "text"
+              ]
+            }
+          ]
+        },
+        "attrs": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {},
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "banner": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content"
+      ]
+    },
+    "pagefind": {
+      "default": true,
+      "type": "boolean"
+    },
+    "draft": {
+      "default": false,
+      "type": "boolean"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "title"
+  ]
+}

--- a/docs-site/.astro/content-assets.mjs
+++ b/docs-site/.astro/content-assets.mjs
@@ -1,0 +1,1 @@
+export default new Map();

--- a/docs-site/.astro/content-modules.mjs
+++ b/docs-site/.astro/content-modules.mjs
@@ -1,0 +1,4 @@
+
+export default new Map([
+["src/content/docs/index.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Findex.mdx&astroContentModuleFlag=true")]]);
+		

--- a/docs-site/.astro/content.d.ts
+++ b/docs-site/.astro/content.d.ts
@@ -1,0 +1,179 @@
+declare module 'astro:content' {
+	interface Render {
+		'.mdx': Promise<{
+			Content: import('astro').MDXContent;
+			headings: import('astro').MarkdownHeading[];
+			remarkPluginFrontmatter: Record<string, any>;
+			components: import('astro').MDXInstance<{}>['components'];
+		}>;
+	}
+}
+
+declare module 'astro:content' {
+	export interface RenderResult {
+		Content: import('astro/runtime/server/index.js').AstroComponentFactory;
+		headings: import('astro').MarkdownHeading[];
+		remarkPluginFrontmatter: Record<string, any>;
+	}
+	interface Render {
+		'.md': Promise<RenderResult>;
+	}
+
+	export interface RenderedContent {
+		html: string;
+		metadata?: {
+			imagePaths: Array<string>;
+			[key: string]: unknown;
+		};
+	}
+
+	type Flatten<T> = T extends { [K: string]: infer U } ? U : never;
+
+	export type CollectionKey = keyof DataEntryMap;
+	export type CollectionEntry<C extends CollectionKey> = Flatten<DataEntryMap[C]>;
+
+	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
+
+	export type ReferenceDataEntry<
+		C extends CollectionKey,
+		E extends keyof DataEntryMap[C] = string,
+	> = {
+		collection: C;
+		id: E;
+	};
+
+	export type ReferenceLiveEntry<C extends keyof LiveContentConfig['collections']> = {
+		collection: C;
+		id: string;
+	};
+
+	export function getCollection<C extends keyof DataEntryMap, E extends CollectionEntry<C>>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => entry is E,
+	): Promise<E[]>;
+	export function getCollection<C extends keyof DataEntryMap>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => unknown,
+	): Promise<CollectionEntry<C>[]>;
+
+	export function getLiveCollection<C extends keyof LiveContentConfig['collections']>(
+		collection: C,
+		filter?: LiveLoaderCollectionFilterType<C>,
+	): Promise<
+		import('astro').LiveDataCollectionResult<LiveLoaderDataType<C>, LiveLoaderErrorType<C>>
+	>;
+
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {}),
+	>(
+		entry: ReferenceDataEntry<C, E>,
+	): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {}),
+	>(
+		collection: C,
+		id: E,
+	): E extends keyof DataEntryMap[C]
+		? string extends keyof DataEntryMap[C]
+			? Promise<DataEntryMap[C][E]> | undefined
+			: Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getLiveEntry<C extends keyof LiveContentConfig['collections']>(
+		collection: C,
+		filter: string | LiveLoaderEntryFilterType<C>,
+	): Promise<import('astro').LiveDataEntryResult<LiveLoaderDataType<C>, LiveLoaderErrorType<C>>>;
+
+	/** Resolve an array of entry references from the same collection */
+	export function getEntries<C extends keyof DataEntryMap>(
+		entries: ReferenceDataEntry<C, keyof DataEntryMap[C]>[],
+	): Promise<CollectionEntry<C>[]>;
+
+	export function render<C extends keyof DataEntryMap>(
+		entry: DataEntryMap[C][string],
+	): Promise<RenderResult>;
+
+	export function render<C extends keyof LiveContentConfig['collections']>(
+		entry: import('astro').LiveDataEntry<LiveLoaderDataType<C>>,
+	): Promise<RenderResult>;
+
+	export function reference<
+		C extends
+			| keyof DataEntryMap
+			// Allow generic `string` to avoid excessive type errors in the config
+			// if `dev` is not running to update as you edit.
+			// Invalid collection names will be caught at build time.
+			| (string & {}),
+	>(
+		collection: C,
+	): import('astro/zod').ZodPipe<
+		import('astro/zod').ZodString,
+		import('astro/zod').ZodTransform<
+			C extends keyof DataEntryMap
+				? {
+						collection: C;
+						id: string;
+					}
+				: never,
+			string
+		>
+	>;
+
+	type ReturnTypeOrOriginal<T> = T extends (...args: any[]) => infer R ? R : T;
+	type InferEntrySchema<C extends keyof DataEntryMap> = import('astro/zod').infer<
+		ReturnTypeOrOriginal<Required<ContentConfig['collections'][C]>['schema']>
+	>;
+	type ExtractLoaderConfig<T> = T extends { loader: infer L } ? L : never;
+	type InferLoaderSchema<
+		C extends keyof DataEntryMap,
+		L = ExtractLoaderConfig<ContentConfig['collections'][C]>,
+	> = L extends { schema: import('astro/zod').ZodSchema }
+		? import('astro/zod').infer<L['schema']>
+		: any;
+
+	type DataEntryMap = {
+		"docs": Record<string, {
+  id: string;
+  body?: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">;
+  rendered?: RenderedContent;
+  filePath?: string;
+  digest?: string | number;
+}>;
+
+	};
+
+	type ExtractLoaderTypes<T> = T extends import('astro/loaders').LiveLoader<
+		infer TData,
+		infer TEntryFilter,
+		infer TCollectionFilter,
+		infer TError
+	>
+		? { data: TData; entryFilter: TEntryFilter; collectionFilter: TCollectionFilter; error: TError }
+		: { data: never; entryFilter: never; collectionFilter: never; error: never };
+	type ExtractEntryFilterType<T> = ExtractLoaderTypes<T>['entryFilter'];
+	type ExtractCollectionFilterType<T> = ExtractLoaderTypes<T>['collectionFilter'];
+	type ExtractErrorType<T> = ExtractLoaderTypes<T>['error'];
+	type ExtractDataType<T> = ExtractLoaderTypes<T>['data'];
+
+	type LiveLoaderDataType<C extends keyof LiveContentConfig['collections']> =
+		LiveContentConfig['collections'][C]['schema'] extends undefined
+			? ExtractDataType<LiveContentConfig['collections'][C]['loader']>
+			: import('astro/zod').infer<
+					Exclude<LiveContentConfig['collections'][C]['schema'], undefined>
+				>;
+	type LiveLoaderEntryFilterType<C extends keyof LiveContentConfig['collections']> =
+		ExtractEntryFilterType<LiveContentConfig['collections'][C]['loader']>;
+	type LiveLoaderCollectionFilterType<C extends keyof LiveContentConfig['collections']> =
+		ExtractCollectionFilterType<LiveContentConfig['collections'][C]['loader']>;
+	type LiveLoaderErrorType<C extends keyof LiveContentConfig['collections']> = ExtractErrorType<
+		LiveContentConfig['collections'][C]['loader']
+	>;
+
+	export type ContentConfig = typeof import("../src/content.config.js");
+	export type LiveContentConfig = never;
+}

--- a/docs-site/.astro/types.d.ts
+++ b/docs-site/.astro/types.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="astro/client" />
+/// <reference path="content.d.ts" />


### PR DESCRIPTION
The refusal from `GET /api/fleet/dispatchable` interpolated the principal kind straight after an indefinite article:

```
This token names a agent.
```

Found while documenting this endpoint for the published docs site (#424). It's the refusal a person sees when they point something at the hub with the wrong credential — worth it being a sentence.

## The fix

Restructured rather than branching on the word. Choosing the article per kind would need `a service` / `an agent` logic plus a third phrasing for the unknown case, for no gain:

```diff
-"Only a human principal may enumerate dispatchable agents. This token names a " +
-  `${typeof claims.principalKind === "string" ? claims.principalKind : "principal of unknown kind"}.`
+"Only a human principal may enumerate dispatchable agents. This token's principal kind is " +
+  `${typeof claims.principalKind === "string" ? claims.principalKind : "not stated"}.`
```

Now reads "This token's principal kind is agent." and, for the fallback, "…is not stated."

## Verification

No test asserted the old wording. `bun test tests/unit` — 331 pass.

The route's own tests (`src/routes/fleet-dispatchable.test.ts`) need Postgres, which isn't reachable on this machine — the Docker daemon is wedged. CI runs them against a real database.

**Unrelated thing I noticed:** the `test` npm script is `bun test tests/unit && bun test tests/integration`, but CI runs bare `bun test` in `apps/hub`, which also discovers `src/**/*.test.ts`. So `src/routes/*.test.ts` runs in CI and *not* under `bun run test` locally. Not touching it here, but it means a local green is weaker than it looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr