### PR TITLE
ci: deploy wrangler from a scratch directory, and ship a favicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,23 @@ jobs:
       # does not have, because docs-site is deliberately npm. kaambaan's identical
       # job failed exactly this way on its first real run, with "Unable to locate
       # executable file: pnpm", before it ever reached Cloudflare.
+      # Run from a scratch directory, NOT from docs-site and NOT from the repo root.
+      # Both were tried against the live account and both are wrong:
+      #
+      #   - in docs-site, wrangler's project detection SCAFFOLDS the project — it
+      #     added an @astrojs/cloudflare adapter and a wrangler devDependency, wrote
+      #     wrangler.jsonc, and rewrote astro.config.mjs and tsconfig.json. The Astro
+      #     build then failed on the Cloudflare vite plugin it had just installed.
+      #   - at the repo root it refuses outright: "application detection logic has
+      #     been run in the root of a workspace".
+      #
+      # From a neutral cwd with an absolute path it is clean, and leaves the checkout
+      # untouched. Verified by deploying both sites this way.
       - name: Deploy
-        working-directory: docs-site
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: npx --yes wrangler@4 pages deploy dist --project-name=agentpod-docs --branch=main
+        run: |
+          mkdir -p "$RUNNER_TEMP/wrangler-cwd"
+          cd "$RUNNER_TEMP/wrangler-cwd"
+          npx --yes wrangler@4 pages deploy "$GITHUB_WORKSPACE/docs-site/dist" \
+            --project-name=agentpod-docs --branch=main

--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="AgentPod">
+  <!-- A hub with three nodes dialling out to it. The lines point inward on
+       purpose: nothing ever dials in to a node, which is the architecture. -->
+  <rect width="32" height="32" rx="7" fill="#243b55"/>
+  <g stroke="#5fb3d4" stroke-width="1.6" stroke-linecap="round" opacity=".8">
+    <path d="M16 16 L8 9"/>
+    <path d="M16 16 L24.5 11"/>
+    <path d="M16 16 L11 24"/>
+  </g>
+  <g fill="#5fb3d4">
+    <circle cx="8" cy="9" r="2.4"/>
+    <circle cx="24.5" cy="11" r="2.4"/>
+    <circle cx="11" cy="24" r="2.4"/>
+  </g>
+  <circle cx="16" cy="16" r="4.2" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
Both found by actually publishing the site, and both apply identically in kaambaan (#65 there).

## The deploy job's working directory was wrong

I previously blamed `cloudflare/wrangler-action` picking pnpm. That was right about the symptom and **incomplete about the cause**. Dropping the action was necessary and not sufficient.

Running wrangler inside `docs-site` doesn't just deploy — its project detection **scaffolds the project**. Against the real account it:

- added an `@astrojs/cloudflare` adapter and a `wrangler` devDependency to `package.json`
- wrote a `wrangler.jsonc`
- rewrote `astro.config.mjs` and `tsconfig.json`

After which the Astro build failed on the Cloudflare vite plugin it had just installed itself.

Running at the repo root is refused outright:

```
The Cloudflare application detection logic has been run in the root of a
workspace instead of targeting a specific project.
```

From a scratch directory with an absolute path to `dist` it is clean and leaves the checkout untouched — which is how both sites were actually published. `git status` on the checkout stayed empty afterwards.

**Version was never the problem.** 4.131.1 works fine from a neutral cwd; I verified rather than pinning to a deprecated release.

## Every page 404'd on /favicon.svg

Starlight's HTML references it and the site shipped none, so every page load made a failing fetch and every browser tab showed a blank icon.

Invisible in the build — it only showed up crawling the live site for broken links: 17 distinct internal links, 16 good, that one bad. This is the `apps/landing` failure mode its own README records, caught this time.

The icon is a hub with three nodes, lines pointing **inward**, because nothing ever dials in to a node — the architecture the product rests on.

## Verification

Deployed and confirmed live:

- `https://docs.agentpod.dev/favicon.svg` → `200 image/svg+xml`
- 13 pages, 17 internal links, **0 broken**
- TLS valid, titles correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr