### PR TITLE
The blog was still wearing the shell the landing page rewrite removed

### DIFF
--- a/apps/landing/src/components/modern/Footer.astro
+++ b/apps/landing/src/components/modern/Footer.astro
@@ -1,54 +1,41 @@
 ---
-
+/**
+ * The blog's footer, matched to the landing page's.
+ *
+ * It previously linked /developers, /privacy and /terms — one deleted, two that never
+ * existed — and described the product as "Your AI agents, anywhere. Secure, portable,
+ * powerful", which is the framing the landing page rewrite removed.
+ */
 ---
 
-<footer class="border-t border-border bg-background" role="contentinfo">
-  <div class="container-wide mx-auto px-6 py-16">
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-12 mb-16">
-      <div class="col-span-2 md:col-span-1">
-        <a href="/" class="flex items-center gap-3 mb-5" aria-label="AgentPod home">
-          <div class="w-10 h-10 rounded-sm bg-accent-sienna flex items-center justify-center shadow-sm" aria-hidden="true">
-            <span class="font-bold text-base" style="font-family: var(--font-display); color: var(--deep-charcoal);">A</span>
-          </div>
-          <span class="font-semibold text-xl" style="font-family: var(--font-display); letter-spacing: -0.02em;">AgentPod</span>
-        </a>
-        <p class="text-foreground-muted text-sm leading-relaxed max-w-xs">
-          Your AI agents, anywhere. Secure, portable, powerful.
-        </p>
-      </div>
-      
-      <nav aria-label="Product links">
-        <h4 class="eyebrow mb-4">Product</h4>
-        <ul class="space-y-3 text-sm">
-          <li><a href="#features" class="text-foreground-muted hover:text-foreground transition-colors">Features</a></li>
-          <li><a href="#how-it-works" class="text-foreground-muted hover:text-foreground transition-colors">How it works</a></li>
-          <li><a href="https://docs.agentpod.dev" class="text-foreground-muted hover:text-foreground transition-colors">For Developers</a></li>
-        </ul>
-      </nav>
-      
-      <nav aria-label="Resource links">
-        <h4 class="eyebrow mb-4">Resources</h4>
-        <ul class="space-y-3 text-sm">
-          <li><a href="/blog" class="text-foreground-muted hover:text-foreground transition-colors">Blog</a></li>
-          <li><a href="https://github.com/rakeshgangwar/agentpod" target="_blank" rel="noopener noreferrer" class="text-foreground-muted hover:text-foreground transition-colors" aria-label="Visit AgentPod on GitHub (opens in new tab)">GitHub</a></li>
-          <li><a href="https://opencode.ai" target="_blank" rel="noopener noreferrer" class="text-foreground-muted hover:text-foreground transition-colors" aria-label="Visit OpenCode website (opens in new tab)">OpenCode</a></li>
-        </ul>
-      </nav>
-      
-      <nav aria-label="Legal links">
-        <h4 class="eyebrow mb-4">Legal</h4>
-        <ul class="space-y-3 text-sm">
-        </ul>
-      </nav>
-    </div>
-    
-    <div class="pt-8 border-t border-border flex flex-col sm:flex-row justify-between items-center gap-4">
-      <p class="text-foreground-muted text-sm">
-        &copy; {new Date().getFullYear()} AgentPod. Open source under MIT.
-      </p>
-      <p class="text-foreground-muted text-sm">
-        Powered by <a href="https://opencode.ai" target="_blank" rel="noopener noreferrer" class="text-foreground hover:text-accent-sienna transition-colors font-medium" aria-label="Visit OpenCode website (opens in new tab)">OpenCode</a>
-      </p>
-    </div>
+<footer>
+  <div class="wrap">
+    <span>AgentPod · self-hosted · MIT</span>
+    <span class="fnav">
+      <a href="https://docs.agentpod.dev">Documentation</a>
+      <a href="/blog">Blog</a>
+      <a href="https://github.com/SuperJackfruitLabs/agentpod">GitHub</a>
+      <a href="https://docs.kaambaan.dev">kaambaan</a>
+      <a href="https://docs.supermessage.dev">supermessage</a>
+    </span>
   </div>
 </footer>
+
+<style>
+  footer { border-top: 1px solid var(--border); }
+  .wrap {
+    width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 32px 24px 44px;
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+    font-size: 14.5px;
+    color: var(--foreground-muted);
+  }
+  .fnav { display: flex; gap: 20px; flex-wrap: wrap; }
+  a { color: var(--foreground-muted); text-decoration: none; }
+  a:hover { color: var(--foreground); }
+</style>

--- a/apps/landing/src/components/modern/Header.astro
+++ b/apps/landing/src/components/modern/Header.astro
@@ -1,121 +1,58 @@
 ---
+/**
+ * The blog's header.
+ *
+ * Rewritten 2026-09-12 to match the landing page. It previously carried a "Join Waitlist"
+ * button pointing at `#waitlist`, and nav links to `#features`, `#how-it-works` and
+ * `/developers` — an anchor to a form that discarded the address, and three destinations
+ * that no longer exist. The blog was the last place any of them survived.
+ *
+ * Deliberately plain markup with its own styles rather than the app's utility classes: the
+ * landing page is standalone, and this has to look like it.
+ */
 interface Props {
   variant?: 'transparent' | 'solid';
 }
-
 const { variant = 'transparent' } = Astro.props;
 ---
 
-<header class:list={[
-  "fixed top-0 left-0 right-0 z-50 transition-all duration-300 border-b",
-  variant === 'transparent' ? "bg-background/80 backdrop-blur-md border-transparent" : "bg-background/95 backdrop-blur-md border-border"
-]} id="header">
-  <nav class="container-wide mx-auto px-6 h-20 flex items-center justify-between" aria-label="Main navigation">
-    <a href="/" class="flex items-center gap-3 group" aria-label="AgentPod home">
-      <div class="w-10 h-10 rounded-sm bg-accent-sienna flex items-center justify-center shadow-sm" aria-hidden="true">
-        <span class="font-bold text-base" style="font-family: var(--font-display); color: var(--deep-charcoal);">A</span>
-      </div>
-      <span class="font-semibold text-xl text-foreground group-hover:text-accent-sienna transition-colors" style="font-family: var(--font-display); letter-spacing: -0.02em;">
-        AgentPod
-      </span>
-    </a>
-    
-    <div class="hidden md:flex items-center gap-1">
-      <a href="#features" class="nav-link">Features</a>
-      <a href="#how-it-works" class="nav-link">How it works</a>
-      <a href="/blog" class="nav-link">Blog</a>
-      <a href="https://github.com/rakeshgangwar/agentpod" target="_blank" rel="noopener noreferrer" class="nav-link" aria-label="Visit AgentPod on GitHub (opens in new tab)">
-        GitHub
-      </a>
-    </div>
-    
-    <div class="flex items-center gap-3">
-      <a href="https://docs.agentpod.dev" class="btn-ghost hidden sm:inline-flex">
-        For Developers
-      </a>
-      <a href="#waitlist" class="btn btn-primary">
-        Join Waitlist
-      </a>
-      
-      <button 
-        id="mobile-menu-button" 
-        class="md:hidden p-2 text-foreground hover:text-accent-sienna transition-colors"
-        aria-label="Toggle mobile menu"
-        aria-expanded="false"
-        aria-controls="mobile-menu"
-      >
-        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-          <path id="menu-icon" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16" />
-          <path id="close-icon" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-  </nav>
-  
-  <div 
-    id="mobile-menu" 
-    class="hidden md:hidden bg-background/98 backdrop-blur-lg border-b border-border"
-    role="navigation"
-    aria-label="Mobile navigation"
-  >
-    <div class="container-wide mx-auto px-6 py-4 space-y-2">
-      <a href="#features" class="block nav-link py-3">Features</a>
-      <a href="#how-it-works" class="block nav-link py-3">How it works</a>
-      <a href="/blog" class="block nav-link py-3">Blog</a>
-      <a href="https://github.com/rakeshgangwar/agentpod" target="_blank" rel="noopener noreferrer" class="block nav-link py-3" aria-label="Visit AgentPod on GitHub (opens in new tab)">
-        GitHub
-      </a>
-      <a href="https://docs.agentpod.dev" class="block nav-link py-3">For Developers</a>
-    </div>
+<header class:list={['mast', variant]}>
+  <div class="wrap">
+    <a class="brand" href="/" aria-label="AgentPod home">agent<span>pod</span></a>
+    <nav aria-label="Main navigation">
+      <a href="https://docs.agentpod.dev">Docs</a>
+      <a href="/blog">Blog</a>
+      <a href="https://github.com/SuperJackfruitLabs/agentpod">Source</a>
+    </nav>
   </div>
 </header>
 
-<script>
-  const header = document.getElementById('header');
-  const mobileMenuButton = document.getElementById('mobile-menu-button');
-  const mobileMenu = document.getElementById('mobile-menu');
-  const menuIcon = document.getElementById('menu-icon');
-  const closeIcon = document.getElementById('close-icon');
-  
-  if (header) {
-    window.addEventListener('scroll', () => {
-      const currentScroll = window.scrollY;
-      
-      if (currentScroll > 50) {
-        header.classList.add('bg-background/95', 'border-border');
-        header.classList.remove('border-transparent');
-      } else {
-        header.classList.remove('bg-background/95', 'border-border');
-        header.classList.add('border-transparent');
-      }
-    });
+<style>
+  .mast {
+    border-bottom: 1px solid var(--border);
+    background: var(--background);
   }
-  
-  if (mobileMenuButton && mobileMenu && menuIcon && closeIcon) {
-    mobileMenuButton.addEventListener('click', () => {
-      const isOpen = mobileMenu.classList.contains('hidden');
-      
-      if (isOpen) {
-        mobileMenu.classList.remove('hidden');
-        menuIcon.classList.add('hidden');
-        closeIcon.classList.remove('hidden');
-        mobileMenuButton.setAttribute('aria-expanded', 'true');
-      } else {
-        mobileMenu.classList.add('hidden');
-        menuIcon.classList.remove('hidden');
-        closeIcon.classList.add('hidden');
-        mobileMenuButton.setAttribute('aria-expanded', 'false');
-      }
-    });
-    
-    const mobileLinks = mobileMenu.querySelectorAll('a');
-    mobileLinks.forEach(link => {
-      link.addEventListener('click', () => {
-        mobileMenu.classList.add('hidden');
-        menuIcon.classList.remove('hidden');
-        closeIcon.classList.add('hidden');
-        mobileMenuButton.setAttribute('aria-expanded', 'false');
-      });
-    });
+  .mast.transparent { border-bottom-color: transparent; }
+  .wrap {
+    width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 26px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
   }
-</script>
+  .brand {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 21px;
+    letter-spacing: -0.02em;
+    color: var(--foreground);
+    text-decoration: none;
+  }
+  .brand span { color: var(--accent-sienna); }
+  nav { display: flex; gap: 22px; font-size: 15px; }
+  nav a { color: var(--foreground-muted); text-decoration: none; }
+  nav a:hover, nav a:focus-visible { color: var(--foreground); }
+</style>

--- a/apps/landing/src/layouts/ModernLayout.astro
+++ b/apps/landing/src/layouts/ModernLayout.astro
@@ -10,7 +10,14 @@ const {
   title, 
   description = "Your AI agents, anywhere. Run powerful AI agents in secure, portable sandboxes. Access from any device." 
 } = Astro.props;
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+// `build.format: 'file'` means the pathname carries `.html` at build time, so the
+// canonical was announcing https://agentpod.dev/blog.html — a URL that resolves only
+// because Cloudflare matches extensionless, and not the one anybody links to. Strip it,
+// and strip a trailing `index` so the home page canonicalises to `/`.
+const canonicalURL = new URL(
+  Astro.url.pathname.replace(/\.html$/, '').replace(/\/index$/, '/') || '/',
+  Astro.site,
+);
 ---
 
 <!doctype html>

--- a/apps/landing/src/pages/blog/index.astro
+++ b/apps/landing/src/pages/blog/index.astro
@@ -25,7 +25,7 @@ function formatDate(dateString: string): string {
 }
 ---
 
-<ModernLayout title="Blog — AgentPod" description="Thoughts on portable AI sandboxes, development tools, and building in public">
+<ModernLayout title="Blog — AgentPod" description="Notes on building AgentPod, and on running agents somewhere other than your laptop.">
   <Header slot="header" variant="solid" />
   
   <!-- Blog Header -->
@@ -35,7 +35,7 @@ function formatDate(dateString: string): string {
         <p class="eyebrow mb-4">Insights & Stories</p>
         <h1 class="display-lg mb-6">Blog</h1>
         <p class="subheadline max-w-2xl">
-          Thoughts on portable AI sandboxes, development patterns, and building in public.
+          Notes on building AgentPod, and on running agents somewhere other than your laptop.
         </p>
       </div>
     </div>

--- a/apps/landing/src/themes/modern/styles.css
+++ b/apps/landing/src/themes/modern/styles.css
@@ -23,17 +23,24 @@
   --radius-lg: 0.5rem;
   --radius-xl: 0.75rem;
   
-  /* Dark mode colors - Rich editorial palette */
-  --deep-charcoal: oklch(0.15 0.015 260);     /* Rich dark charcoal with blue undertone */
-  --charcoal-lighter: oklch(0.19 0.012 260);  /* Slightly lighter charcoal for cards */
-  --cream: oklch(0.92 0.015 85);              /* Warm cream text */
-  --cream-muted: oklch(0.68 0.012 85);        /* Muted cream for secondary text */
-  --cream-subtle: oklch(0.48 0.01 85);        /* Subtle cream for borders */
+  /* Palette, matched to the landing page (src/pages/index.astro) on 2026-09-12.
+     The blog was charcoal and burnt sienna while the page linking to it was navy and
+     cyan, so it read as a different site. These are the landing page's own hex values,
+     copied verbatim rather than re-expressed, so they cannot drift by rounding.
+
+     The variable NAMES still say charcoal and sienna. They are wrong and deliberately
+     left: renaming them means touching every rule in the 883 lines below for no visual
+     gain. Read them as "ground" and "accent". */
+  --deep-charcoal: #101c2b;     /* Rich dark charcoal with blue undertone */
+  --charcoal-lighter: #18293c;  /* Slightly lighter charcoal for cards */
+  --cream: #eef4fa;              /* Warm cream text */
+  --cream-muted: #93a8bf;        /* Muted cream for secondary text */
+  --cream-subtle: #2c4560;        /* Subtle cream for borders */
   
-  --accent-sienna: oklch(0.62 0.16 35);       /* Brighter burnt sienna (pops on dark) */
-  --accent-sienna-light: oklch(0.72 0.14 35); /* Light sienna for accents */
-  --accent-sienna-dark: oklch(0.48 0.14 35);  /* Darker sienna for hover */
-  --accent-gold: oklch(0.68 0.12 75);         /* Warm gold */
+  --accent-sienna: #5fb3d4;       /* Brighter burnt sienna (pops on dark) */
+  --accent-sienna-light: #8ccde4; /* Light sienna for accents */
+  --accent-sienna-dark: #3d8fae;  /* Darker sienna for hover */
+  --accent-gold: #63c9a0;         /* Warm gold */
   
   /* Semantic colors */
   --background: var(--deep-charcoal);
@@ -41,11 +48,11 @@
   --foreground: var(--cream);
   --foreground-muted: var(--cream-muted);
   
-  --card: oklch(0.18 0.012 260);
-  --card-hover: oklch(0.21 0.015 260);
-  --card-border: oklch(0.28 0.015 260);
+  --card: #18293c;
+  --card-hover: #21374e;
+  --card-border: #2c4560;
   
-  --border: oklch(0.26 0.012 260);
+  --border: #2c4560;
   --border-emphasis: var(--cream-subtle);
   
   /* Status colors - vibrant for dark background */
@@ -58,6 +65,30 @@
   --shadow-md: 0 4px 8px oklch(0.05 0 0 / 0.5), 0 2px 4px oklch(0.05 0 0 / 0.3);
   --shadow-lg: 0 12px 24px oklch(0.05 0 0 / 0.6), 0 4px 8px oklch(0.05 0 0 / 0.4);
 }
+/* Light, matched to the landing page's own light block.
+   The landing page answers prefers-color-scheme; this did not, so a visitor on a light
+   system got a light page and then a dark blog — the same mismatch the palette change
+   above was meant to remove. Values are the landing page's, copied verbatim. */
+@media (prefers-color-scheme: light) {
+  :root {
+    --deep-charcoal: #fbfcfe;
+    --charcoal-lighter: #eef3f8;
+    --cream: #101c29;
+    --cream-muted: #4b6076;
+    --cream-subtle: #ccdae7;
+
+    --accent-sienna: #1d6c8c;
+    --accent-sienna-light: #2a89ad;
+    --accent-sienna-dark: #14536b;
+    --accent-gold: #1c7a5b;
+
+    --card: #ffffff;
+    --card-hover: #eef3f8;
+    --card-border: #ccdae7;
+    --border: #ccdae7;
+  }
+}
+
 
 @theme inline {
   --color-background: var(--background);


### PR DESCRIPTION
You were right — and it was worse than a design mismatch.

Rewriting `index.astro` wasn't enough: the blog kept its own header, footer and palette, so it still carried the things the rewrite deleted.

| Still on the blog | Status |
|---|---|
| **"Join Waitlist"** button → `#waitlist` | the form that discarded the address |
| `#features`, `#how-it-works` | pages deleted in #428 |
| `/developers` in the footer | deleted |
| *"Thoughts on portable AI sandboxes"* | the framing the rewrite removed |
| charcoal + burnt sienna | vs the landing's navy + cyan |

**Why I missed it:** I grepped for `/features` and `/developers`. These were written as `#features` and `#how-it-works` — anchors, not paths. Looking at the rendered page would have found it in a second; grepping for the shape I expected did not.

## The fix

**Palette retargeted at the token level**, so the 883 lines of rules below follow without being touched. The variable names still say `charcoal` and `sienna` — they're wrong, deliberately left, with a comment saying to read them as *ground* and *accent* rather than rename every downstream rule for no visual gain.

**Header and footer rewritten** to the landing page's nav (Docs · Blog · Source) and footer.

**The light theme is the part that actually closes the gap.** Sharing a dark palette still left a light-preferring visitor with a light landing page and a dark blog. Verified in-browser against the live deploy — `--background: #fbfcfe`, `--accent-sienna: #1d6c8c`, identical to the landing's light values.

## One more, found while looking

`build.format: 'file'` puts `.html` in the pathname, so every canonical and `og:url` announced `https://agentpod.dev/blog.html` — a URL that resolves only because Cloudflare matches extensionless, and not the one anyone links to. Now `/blog`.

## Not touched

The post titles ("Why AgentPod: The Story Behind Portable AI Sandboxes"). They're dated pieces about how this started, and rewriting someone's published words to match today's positioning isn't a tidy-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L46xwyJqKTQxtVtJRsY1Yr